### PR TITLE
Expand API and client test coverage batches

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -90,6 +90,12 @@ State: stabilization pass (no net-new product features unless explicitly approve
 ### Test discipline and TDD rollout
 - [x] Establish TDD framework baseline (strategy doc, test templates, and CI quality gates)
 - Progress: added CI workflow gate for PRs/non-main branches (`.github/workflows/ci-quality-gates.yml`), added PR TDD checklist template (`.github/pull_request_template.md`), and documented TDD workflow/templates in `docs/tdd-workflow.md` + `docs/templates/tdd-test-case-template.md`.
+- [x] Expand repository test coverage batch 1 (rate limit + geocode API + geocode client)
+- Progress: added focused test suites for limiter behavior (`functions/_lib/rateLimit.test.ts`), geocode edge endpoint behavior and cache/rate-limit paths (`functions/api/geocode.test.ts`), and geocode client local/fallback cache flows (`src/lib/geocode.test.ts`).
+- [x] Expand repository test coverage batch 2 (meshmap/ve2dbe proxies + elevation service)
+- Progress: added proxy behavior tests for method gating/rate-limit forwarding (`functions/meshmap/[[path]].test.ts`, `functions/ve2dbe/[[path]].test.ts`) plus chunking/error-path tests for elevation batching (`src/lib/elevationService.test.ts`).
+- [x] Expand repository test coverage batch 3 (library/changes/admin endpoints + cloud client libs)
+- Progress: added API endpoint coverage for library/changes/admin routes (`functions/api/library.test.ts`, `functions/api/changes.test.ts`, `functions/api/admin-audit-events.test.ts`, `functions/api/admin-ownership-tools.test.ts`) and client-path/error-shape tests for cloud libraries (`src/lib/cloudLibrary.test.ts`, `src/lib/cloudUser.test.ts`).
 
 ## Hardening execution paths (agreed, no further discussion required now)
 - [x] Runtime migrations

--- a/functions/_lib/rateLimit.test.ts
+++ b/functions/_lib/rateLimit.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { getClientAddress, takeRateLimitToken } from "./rateLimit";
+
+describe("rate limit helpers", () => {
+  it("extracts client address from Cloudflare and forwarded headers", () => {
+    const cfReq = new Request("https://example.test", {
+      headers: { "cf-connecting-ip": " 203.0.113.9 " },
+    });
+    expect(getClientAddress(cfReq)).toBe("203.0.113.9");
+
+    const fwdReq = new Request("https://example.test", {
+      headers: { "x-forwarded-for": "198.51.100.10, 10.0.0.2" },
+    });
+    expect(getClientAddress(fwdReq)).toBe("198.51.100.10");
+
+    const unknownReq = new Request("https://example.test");
+    expect(getClientAddress(unknownReq)).toBe("unknown");
+  });
+
+  it("enforces limits within a window and resets after expiry", () => {
+    const key = `test-limit-${Date.now()}-a`;
+    const first = takeRateLimitToken({ key, limit: 2, windowMs: 5_000, nowMs: 1_000 });
+    const second = takeRateLimitToken({ key, limit: 2, windowMs: 5_000, nowMs: 1_100 });
+    const blocked = takeRateLimitToken({ key, limit: 2, windowMs: 5_000, nowMs: 1_200 });
+    const afterWindow = takeRateLimitToken({ key, limit: 2, windowMs: 5_000, nowMs: 6_100 });
+
+    expect(first).toMatchObject({ allowed: true, remaining: 1, retryAfterSec: 0 });
+    expect(second).toMatchObject({ allowed: true, remaining: 0, retryAfterSec: 0 });
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.remaining).toBe(0);
+    expect(blocked.retryAfterSec).toBeGreaterThan(0);
+    expect(afterWindow).toMatchObject({ allowed: true, remaining: 1, retryAfterSec: 0 });
+  });
+
+  it("normalizes invalid limits to a minimum of one request", () => {
+    const key = `test-limit-${Date.now()}-b`;
+    const first = takeRateLimitToken({ key, limit: Number.NaN, nowMs: 10_000 });
+    const second = takeRateLimitToken({ key, limit: Number.NaN, nowMs: 10_100 });
+
+    expect(first.allowed).toBe(true);
+    expect(second.allowed).toBe(false);
+  });
+});

--- a/functions/api/admin-audit-events.test.ts
+++ b/functions/api/admin-audit-events.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { verifyAuthMock, ensureUserMock, assertUserAccessMock, fetchUserProfileMock, listAdminAuditEventsMock } = vi.hoisted(
+  () => ({
+    verifyAuthMock: vi.fn(),
+    ensureUserMock: vi.fn(),
+    assertUserAccessMock: vi.fn(),
+    fetchUserProfileMock: vi.fn(),
+    listAdminAuditEventsMock: vi.fn(),
+  }),
+);
+
+vi.mock("../_lib/auth", () => ({ verifyAuth: verifyAuthMock }));
+vi.mock("../_lib/db", () => ({
+  ensureUser: ensureUserMock,
+  assertUserAccess: assertUserAccessMock,
+  fetchUserProfile: fetchUserProfileMock,
+  listAdminAuditEvents: listAdminAuditEventsMock,
+}));
+
+import { onRequestGet } from "./admin-audit-events";
+
+const env = { DB: {} } as unknown as { DB: D1Database };
+const mkCtx = (request: Request) => ({ request, env } as unknown as Parameters<typeof onRequestGet>[0]);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  verifyAuthMock.mockResolvedValue({ userId: "admin", tokenPayload: {}, source: "headers" });
+  ensureUserMock.mockResolvedValue(undefined);
+  assertUserAccessMock.mockResolvedValue(undefined);
+  fetchUserProfileMock.mockResolvedValue({ id: "admin", isAdmin: true });
+  listAdminAuditEventsMock.mockResolvedValue([{ id: 1, eventType: "x" }]);
+});
+
+describe("api/admin-audit-events", () => {
+  it("returns 403 for non-admin users", async () => {
+    fetchUserProfileMock.mockResolvedValueOnce({ id: "u1", isAdmin: false });
+    const res = await onRequestGet(mkCtx(new Request("https://example.test/api/admin-audit-events")));
+    expect(res.status).toBe(403);
+  });
+
+  it("uses default limit when query limit is invalid", async () => {
+    const res = await onRequestGet(mkCtx(new Request("https://example.test/api/admin-audit-events?limit=oops")));
+    expect(res.status).toBe(200);
+    expect(listAdminAuditEventsMock).toHaveBeenCalledWith(env, 120);
+  });
+});

--- a/functions/api/admin-ownership-tools.test.ts
+++ b/functions/api/admin-ownership-tools.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  verifyAuthMock,
+  ensureUserMock,
+  assertUserAccessMock,
+  fetchUserProfileMock,
+  reassignResourceOwnerMock,
+  bulkReassignOwnershipMock,
+} = vi.hoisted(() => ({
+  verifyAuthMock: vi.fn(),
+  ensureUserMock: vi.fn(),
+  assertUserAccessMock: vi.fn(),
+  fetchUserProfileMock: vi.fn(),
+  reassignResourceOwnerMock: vi.fn(),
+  bulkReassignOwnershipMock: vi.fn(),
+}));
+
+vi.mock("../_lib/auth", () => ({ verifyAuth: verifyAuthMock }));
+vi.mock("../_lib/db", () => ({
+  ensureUser: ensureUserMock,
+  assertUserAccess: assertUserAccessMock,
+  fetchUserProfile: fetchUserProfileMock,
+  reassignResourceOwner: reassignResourceOwnerMock,
+  bulkReassignOwnership: bulkReassignOwnershipMock,
+}));
+
+import { onRequestPost } from "./admin-ownership-tools";
+
+const env = { DB: {} } as unknown as { DB: D1Database };
+const mkCtx = (request: Request) => ({ request, env } as unknown as Parameters<typeof onRequestPost>[0]);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  verifyAuthMock.mockResolvedValue({ userId: "admin", tokenPayload: {}, source: "headers" });
+  ensureUserMock.mockResolvedValue(undefined);
+  assertUserAccessMock.mockResolvedValue(undefined);
+  fetchUserProfileMock.mockResolvedValue({ id: "admin", isAdmin: true });
+  reassignResourceOwnerMock.mockResolvedValue({ ok: true });
+  bulkReassignOwnershipMock.mockResolvedValue({ sitesUpdated: 1, simulationsUpdated: 2 });
+});
+
+describe("api/admin-ownership-tools", () => {
+  it("returns 400 for unknown action", async () => {
+    const req = new Request("https://example.test/api/admin-ownership-tools", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ action: "bad_action" }),
+    });
+    const res = await onRequestPost(mkCtx(req));
+    expect(res.status).toBe(400);
+  });
+
+  it("executes reassign owner action", async () => {
+    const req = new Request("https://example.test/api/admin-ownership-tools", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ action: "reassign_owner", kind: "site", resourceId: "s1", newOwnerUserId: "u2" }),
+    });
+    const res = await onRequestPost(mkCtx(req));
+    expect(res.status).toBe(200);
+    expect(reassignResourceOwnerMock).toHaveBeenCalledWith(env, "site", "s1", "u2", "admin");
+  });
+
+  it("executes bulk reassignment action", async () => {
+    const req = new Request("https://example.test/api/admin-ownership-tools", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ action: "bulk_reassign", fromUserId: "u1", toUserId: "u2" }),
+    });
+    const res = await onRequestPost(mkCtx(req));
+    expect(res.status).toBe(200);
+    expect(bulkReassignOwnershipMock).toHaveBeenCalledWith(env, "u1", "u2", "admin");
+  });
+});

--- a/functions/api/changes.test.ts
+++ b/functions/api/changes.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { verifyAuthMock, ensureUserMock, assertUserAccessMock, fetchResourceChangesMock } = vi.hoisted(() => ({
+  verifyAuthMock: vi.fn(),
+  ensureUserMock: vi.fn(),
+  assertUserAccessMock: vi.fn(),
+  fetchResourceChangesMock: vi.fn(),
+}));
+
+vi.mock("../_lib/auth", () => ({ verifyAuth: verifyAuthMock }));
+vi.mock("../_lib/db", () => ({
+  ensureUser: ensureUserMock,
+  assertUserAccess: assertUserAccessMock,
+  fetchResourceChanges: fetchResourceChangesMock,
+}));
+
+import { onRequestGet } from "./changes";
+
+const env = { DB: {} } as unknown as { DB: D1Database };
+const mkCtx = (request: Request) => ({ request, env } as unknown as Parameters<typeof onRequestGet>[0]);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  verifyAuthMock.mockResolvedValue({ userId: "u1", tokenPayload: {}, source: "headers" });
+  ensureUserMock.mockResolvedValue(undefined);
+  assertUserAccessMock.mockResolvedValue(undefined);
+  fetchResourceChangesMock.mockResolvedValue([{ id: 1, action: "updated" }]);
+});
+
+describe("api/changes", () => {
+  it("returns 401 when not authenticated", async () => {
+    verifyAuthMock.mockResolvedValueOnce(null);
+    const res = await onRequestGet(mkCtx(new Request("https://example.test/api/changes?kind=site&id=s1")));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when kind or id are missing/invalid", async () => {
+    const res = await onRequestGet(mkCtx(new Request("https://example.test/api/changes?kind=bad&id=")));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns changes for valid kind and id", async () => {
+    const res = await onRequestGet(mkCtx(new Request("https://example.test/api/changes?kind=simulation&id=sim-1")));
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ changes: [{ id: 1, action: "updated" }] });
+    expect(fetchResourceChangesMock).toHaveBeenCalledWith(env, "simulation", "sim-1");
+  });
+});

--- a/functions/api/geocode.test.ts
+++ b/functions/api/geocode.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getClientAddressMock, takeRateLimitTokenMock } = vi.hoisted(() => ({
+  getClientAddressMock: vi.fn(),
+  takeRateLimitTokenMock: vi.fn(),
+}));
+
+vi.mock("../_lib/rateLimit", () => ({
+  getClientAddress: getClientAddressMock,
+  takeRateLimitToken: takeRateLimitTokenMock,
+}));
+
+import { onRequestGet } from "./geocode";
+
+const env = { DB: {} } as unknown as { DB: D1Database; GEOCODE_RATE_LIMIT_PER_MINUTE?: string };
+
+const mkCtx = (request: Request) => ({ request, env } as unknown as Parameters<typeof onRequestGet>[0]);
+
+type CacheLike = {
+  match: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+};
+
+const setCache = (cache: CacheLike) => {
+  Object.defineProperty(globalThis, "caches", {
+    configurable: true,
+    value: { default: cache },
+  });
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getClientAddressMock.mockReturnValue("203.0.113.1");
+  takeRateLimitTokenMock.mockReturnValue({ allowed: true, remaining: 19, retryAfterSec: 0 });
+  setCache({
+    match: vi.fn().mockResolvedValue(undefined),
+    put: vi.fn().mockResolvedValue(undefined),
+  });
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+describe("api/geocode", () => {
+  it("returns empty results for blank query", async () => {
+    const req = new Request("https://example.test/api/geocode?q=");
+    const res = await onRequestGet(mkCtx(req));
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ results: [] });
+  });
+
+  it("returns 400 for short query", async () => {
+    const req = new Request("https://example.test/api/geocode?q=ab");
+    const res = await onRequestGet(mkCtx(req));
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({ error: "Search query must be at least 3 characters." });
+  });
+
+  it("returns 429 when limiter denies request", async () => {
+    takeRateLimitTokenMock.mockReturnValueOnce({ allowed: false, remaining: 0, retryAfterSec: 7 });
+    const req = new Request("https://example.test/api/geocode?q=oslo");
+    const res = await onRequestGet(mkCtx(req));
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get("retry-after")).toBe("7");
+    await expect(res.json()).resolves.toMatchObject({ error: "Geocode rate limit reached. Please wait and try again." });
+  });
+
+  it("serves cached response without upstream fetch", async () => {
+    const cached = new Response(JSON.stringify({ results: [{ id: "1", label: "Cached", lat: 59.9, lon: 10.7 }] }), {
+      headers: { "content-type": "application/json" },
+    });
+    const cache = {
+      match: vi.fn().mockResolvedValue(cached),
+      put: vi.fn().mockResolvedValue(undefined),
+    };
+    setCache(cache);
+
+    const req = new Request("https://example.test/api/geocode?q=Oslo");
+    const res = await onRequestGet(mkCtx(req));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ results: [{ id: "1", label: "Cached" }] });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(cache.put).not.toHaveBeenCalled();
+  });
+
+  it("maps upstream payload and writes edge cache", async () => {
+    const cache = {
+      match: vi.fn().mockResolvedValue(undefined),
+      put: vi.fn().mockResolvedValue(undefined),
+    };
+    setCache(cache);
+
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify([
+          { place_id: 101, display_name: "Oslo, Norway", lat: "59.91", lon: "10.75" },
+          { place_id: 102, display_name: "Invalid", lat: "oops", lon: "10.75" },
+        ]),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const req = new Request("https://example.test/api/geocode?q=Oslo");
+    const res = await onRequestGet(mkCtx(req));
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toContain("max-age=300");
+    await expect(res.json()).resolves.toEqual({
+      results: [{ id: "101", label: "Oslo, Norway", lat: 59.91, lon: 10.75 }],
+    });
+    expect(cache.put).toHaveBeenCalledTimes(1);
+  });
+});

--- a/functions/api/library.test.ts
+++ b/functions/api/library.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  verifyAuthMock,
+  ensureUserMock,
+  assertUserAccessMock,
+  fetchLibraryForUserMock,
+  upsertLibrarySnapshotMock,
+} = vi.hoisted(() => ({
+  verifyAuthMock: vi.fn(),
+  ensureUserMock: vi.fn(),
+  assertUserAccessMock: vi.fn(),
+  fetchLibraryForUserMock: vi.fn(),
+  upsertLibrarySnapshotMock: vi.fn(),
+}));
+
+vi.mock("../_lib/auth", () => ({ verifyAuth: verifyAuthMock }));
+vi.mock("../_lib/db", () => ({
+  ensureUser: ensureUserMock,
+  assertUserAccess: assertUserAccessMock,
+  fetchLibraryForUser: fetchLibraryForUserMock,
+  upsertLibrarySnapshot: upsertLibrarySnapshotMock,
+}));
+
+import { onRequestGet, onRequestPut } from "./library";
+
+const env = { DB: {} } as unknown as { DB: D1Database };
+const mkCtx = (request: Request) => ({ request, env } as unknown as Parameters<typeof onRequestGet>[0]);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  verifyAuthMock.mockResolvedValue({ userId: "u1", tokenPayload: {}, source: "headers" });
+  ensureUserMock.mockResolvedValue(undefined);
+  assertUserAccessMock.mockResolvedValue({ id: "u1", isAdmin: false, isModerator: false });
+  fetchLibraryForUserMock.mockResolvedValue({ siteLibrary: [{ id: "s1" }], simulationPresets: [] });
+  upsertLibrarySnapshotMock.mockResolvedValue({ siteLibrary: [], simulationPresets: [], conflicts: [] });
+});
+
+describe("api/library", () => {
+  it("returns 401 when unauthenticated", async () => {
+    verifyAuthMock.mockResolvedValueOnce(null);
+    const res = await onRequestGet(mkCtx(new Request("https://example.test/api/library")));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns user library payload on GET", async () => {
+    const res = await onRequestGet(mkCtx(new Request("https://example.test/api/library")));
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ userId: "u1", siteLibrary: [{ id: "s1" }] });
+  });
+
+  it("normalizes non-array payloads on PUT", async () => {
+    const req = new Request("https://example.test/api/library", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ siteLibrary: { bad: true }, simulationPresets: null }),
+    });
+
+    const res = await onRequestPut(mkCtx(req));
+    expect(res.status).toBe(200);
+    expect(upsertLibrarySnapshotMock).toHaveBeenCalledWith(
+      env,
+      expect.objectContaining({ id: "u1" }),
+      { siteLibrary: [], simulationPresets: [] },
+    );
+  });
+});

--- a/functions/meshmap/[[path]].test.ts
+++ b/functions/meshmap/[[path]].test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getClientAddressMock, takeRateLimitTokenMock } = vi.hoisted(() => ({
+  getClientAddressMock: vi.fn(),
+  takeRateLimitTokenMock: vi.fn(),
+}));
+
+vi.mock("../_lib/rateLimit", () => ({
+  getClientAddress: getClientAddressMock,
+  takeRateLimitToken: takeRateLimitTokenMock,
+}));
+
+import { onRequest } from "./[[path]]";
+
+const env = { DB: {}, PROXY_RATE_LIMIT_PER_MINUTE: "120" } as unknown as {
+  DB: D1Database;
+  PROXY_RATE_LIMIT_PER_MINUTE?: string;
+};
+
+const mkCtx = (request: Request) => ({ request, env } as unknown as Parameters<typeof onRequest>[0]);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getClientAddressMock.mockReturnValue("198.51.100.10");
+  takeRateLimitTokenMock.mockReturnValue({ allowed: true, remaining: 119, retryAfterSec: 0 });
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+describe("meshmap proxy", () => {
+  it("rejects methods other than GET/HEAD", async () => {
+    const req = new Request("https://example.test/meshmap/nodes.json", { method: "POST", body: "{}" });
+    const res = await onRequest(mkCtx(req));
+
+    expect(res.status).toBe(405);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("returns 429 when rate limiter blocks request", async () => {
+    takeRateLimitTokenMock.mockReturnValueOnce({ allowed: false, remaining: 0, retryAfterSec: 9 });
+    const req = new Request("https://example.test/meshmap/nodes.json");
+    const res = await onRequest(mkCtx(req));
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get("retry-after")).toBe("9");
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("forwards allowed GET requests to meshmap upstream", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } }),
+    );
+    const req = new Request("https://example.test/meshmap/nodes.json?region=no", {
+      headers: { accept: "application/json" },
+    });
+
+    const res = await onRequest(mkCtx(req));
+
+    expect(res.status).toBe(200);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(String(vi.mocked(globalThis.fetch).mock.calls[0]?.[0])).toBe("https://meshmap.net/nodes.json?region=no");
+    expect(vi.mocked(globalThis.fetch).mock.calls[0]?.[1]).toMatchObject({
+      method: "GET",
+      headers: { accept: "application/json" },
+    });
+  });
+});

--- a/functions/ve2dbe/[[path]].test.ts
+++ b/functions/ve2dbe/[[path]].test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getClientAddressMock, takeRateLimitTokenMock } = vi.hoisted(() => ({
+  getClientAddressMock: vi.fn(),
+  takeRateLimitTokenMock: vi.fn(),
+}));
+
+vi.mock("../_lib/rateLimit", () => ({
+  getClientAddress: getClientAddressMock,
+  takeRateLimitToken: takeRateLimitTokenMock,
+}));
+
+import { onRequest } from "./[[path]]";
+
+const env = { DB: {}, PROXY_RATE_LIMIT_PER_MINUTE: "120" } as unknown as {
+  DB: D1Database;
+  PROXY_RATE_LIMIT_PER_MINUTE?: string;
+};
+
+const mkCtx = (request: Request) => ({ request, env } as unknown as Parameters<typeof onRequest>[0]);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getClientAddressMock.mockReturnValue("203.0.113.9");
+  takeRateLimitTokenMock.mockReturnValue({ allowed: true, remaining: 119, retryAfterSec: 0 });
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+describe("ve2dbe proxy", () => {
+  it("allows tile-list POST and forwards content-type/body", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response("ok", { status: 200, headers: { "content-type": "text/plain" } }),
+    );
+    const req = new Request("https://example.test/ve2dbe/geodata/gettile.asp", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded", accept: "text/plain" },
+      body: "lat=59&lon=10",
+    });
+
+    const res = await onRequest(mkCtx(req));
+
+    expect(res.status).toBe(200);
+    expect(takeRateLimitTokenMock).not.toHaveBeenCalled();
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(String(vi.mocked(globalThis.fetch).mock.calls[0]?.[0])).toBe("https://www.ve2dbe.com/geodata/gettile.asp");
+    expect(vi.mocked(globalThis.fetch).mock.calls[0]?.[1]).toMatchObject({
+      method: "POST",
+      headers: {
+        accept: "text/plain",
+        "content-type": "application/x-www-form-urlencoded",
+      },
+    });
+    expect((vi.mocked(globalThis.fetch).mock.calls[0]?.[1] as { body?: unknown })?.body).toBeTruthy();
+  });
+
+  it("rejects unsupported methods on non tile-list endpoints", async () => {
+    const req = new Request("https://example.test/ve2dbe/geodata/srtm/file.zip", {
+      method: "POST",
+      body: "payload",
+    });
+    const res = await onRequest(mkCtx(req));
+
+    expect(res.status).toBe(405);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("returns 429 when limiter blocks non tile-list requests", async () => {
+    takeRateLimitTokenMock.mockReturnValueOnce({ allowed: false, remaining: 0, retryAfterSec: 4 });
+    const req = new Request("https://example.test/ve2dbe/geodata/n59e010.hgt.zip");
+    const res = await onRequest(mkCtx(req));
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get("retry-after")).toBe("4");
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("forwards allowed GET requests to upstream with query string", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response("zip", { status: 200, headers: { "content-type": "application/octet-stream" } }),
+    );
+
+    const req = new Request("https://example.test/ve2dbe/geodata/n59e010.hgt.zip?dataset=srtm", {
+      headers: { accept: "application/octet-stream" },
+    });
+    const res = await onRequest(mkCtx(req));
+
+    expect(res.status).toBe(200);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(String(vi.mocked(globalThis.fetch).mock.calls[0]?.[0])).toBe(
+      "https://www.ve2dbe.com/geodata/n59e010.hgt.zip?dataset=srtm",
+    );
+    expect(takeRateLimitTokenMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/cloudLibrary.test.ts
+++ b/src/lib/cloudLibrary.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchCloudLibrary, pushCloudLibrary } from "./cloudLibrary";
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+describe("cloudLibrary client", () => {
+  it("returns normalized arrays from API payload", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ siteLibrary: [{ id: "s1" }], simulationPresets: null }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const result = await fetchCloudLibrary();
+    expect(result).toEqual({ siteLibrary: [{ id: "s1" }], simulationPresets: [] });
+  });
+
+  it("throws conflict-specific error for private site reference conflicts", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: false, conflicts: ["simulation_private_site_reference"] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    await expect(pushCloudLibrary({ siteLibrary: [], simulationPresets: [] })).rejects.toThrow(
+      "Cannot publish/shared a simulation that references private library sites.",
+    );
+  });
+
+  it("throws parsed API error for non-OK responses", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "Forbidden" }), { status: 403, statusText: "Forbidden" }),
+    );
+
+    await expect(fetchCloudLibrary()).rejects.toThrow("403 Forbidden: Forbidden");
+  });
+});

--- a/src/lib/cloudUser.test.ts
+++ b/src/lib/cloudUser.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  fetchMe,
+  fetchUsers,
+  fetchResourceChanges,
+  fetchAdminAuditEvents,
+  updateUserRole,
+} from "./cloudUser";
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+describe("cloudUser client", () => {
+  it("fetchMe returns user payload", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ user: { id: "u1", username: "U", bio: "", avatarUrl: "", isAdmin: false, isApproved: true, createdAt: "x", updatedAt: "x" } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const result = await fetchMe();
+    expect(result.id).toBe("u1");
+  });
+
+  it("normalizes non-array users and changes payloads", async () => {
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(new Response(JSON.stringify({ users: null }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ changes: null }), { status: 200 }));
+
+    await expect(fetchUsers()).resolves.toEqual([]);
+    await expect(fetchResourceChanges("site", "s1")).resolves.toEqual([]);
+  });
+
+  it("fetchAdminAuditEvents defaults to empty list when payload shape is unexpected", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(new Response(JSON.stringify({ events: {} }), { status: 200 }));
+    await expect(fetchAdminAuditEvents()).resolves.toEqual([]);
+  });
+
+  it("surfaces parsed JSON error messages", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "Invalid role." }), { status: 400, statusText: "Bad Request" }),
+    );
+
+    await expect(updateUserRole("u1", "admin")).rejects.toThrow("400 Bad Request: Invalid role.");
+  });
+});

--- a/src/lib/elevationService.test.ts
+++ b/src/lib/elevationService.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchElevations } from "./elevationService";
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+describe("fetchElevations", () => {
+  it("returns empty output for empty coordinate lists", async () => {
+    await expect(fetchElevations([])).resolves.toEqual([]);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("chunks coordinates and merges elevation responses", async () => {
+    const coords = Array.from({ length: 55 }, (_, index) => ({
+      lat: 59.0 + index * 0.001,
+      lon: 10.0 + index * 0.001,
+    }));
+
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ elevation: Array.from({ length: 50 }, (_, i) => 100 + i) }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ elevation: [200, 201, 202, 203, 204] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+    const result = await fetchElevations(coords);
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    expect(String(vi.mocked(globalThis.fetch).mock.calls[0]?.[0])).toContain("latitude=");
+    expect(String(vi.mocked(globalThis.fetch).mock.calls[1]?.[0])).toContain("longitude=");
+    expect(result).toHaveLength(55);
+    expect(result[0]).toBe(100);
+    expect(result[54]).toBe(204);
+  });
+
+  it("throws useful error on upstream failures", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(new Response("fail", { status: 503 }));
+
+    await expect(fetchElevations([{ lat: 59.9, lon: 10.7 }])).rejects.toThrow("Elevation API failed with status 503");
+  });
+});

--- a/src/lib/geocode.test.ts
+++ b/src/lib/geocode.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const loadSearchLocations = async () => {
+  const module = await import("./geocode");
+  return module.searchLocations;
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: { location: { origin: "https://app.example.test" } },
+  });
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+describe("searchLocations", () => {
+  it("returns empty results for blank and too-short queries", async () => {
+    const searchLocations = await loadSearchLocations();
+
+    await expect(searchLocations("")).resolves.toEqual([]);
+    await expect(searchLocations("ab")).resolves.toEqual([]);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("uses local API and reuses in-memory cache", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ results: [{ id: "1", label: "Oslo", lat: 59.91, lon: 10.75 }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const searchLocations = await loadSearchLocations();
+    const first = await searchLocations("Oslo");
+    const second = await searchLocations("oslo");
+
+    expect(first).toEqual([{ id: "1", label: "Oslo", lat: 59.91, lon: 10.75 }]);
+    expect(second).toEqual(first);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to upstream nominatim when local endpoint is unavailable", async () => {
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(new Response("Not found", { status: 404 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([{ place_id: 7, display_name: "Bergen", lat: "60.39", lon: "5.32" }]), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+    const searchLocations = await loadSearchLocations();
+    const results = await searchLocations("Bergen");
+
+    expect(results).toEqual([{ id: "7", label: "Bergen", lat: 60.39, lon: 5.32 }]);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    expect(String(vi.mocked(globalThis.fetch).mock.calls[1]?.[0])).toContain("nominatim.openstreetmap.org/search");
+  });
+
+  it("surfaces local rate-limit responses without upstream fallback", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(new Response("Too many requests", { status: 429 }));
+    const searchLocations = await loadSearchLocations();
+
+    await expect(searchLocations("Trondheim")).rejects.toThrow("Search rate limit reached. Please wait a moment.");
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Add targeted tests across proxy, geocode, library, changes, admin, and cloud client paths to strengthen TDD regression safety for core edge and client integrations.

## What changed

- Added a bunch of tests to make sure we do not diverge from the current working setup

## Why this change

- Improve test coverage

## TDD Checklist

- [x] I started with a failing automated test (or updated a failing existing test) that captures the intended behavior.
- [x] I implemented only the minimum code needed to make the test pass.
- [x] I refactored with tests still green.
- [x] I ran `npm test` and `npm run build` locally.

## Verification

- [x] Tests: `npm test`
- [x] Build: `npm run build`
