### PR TITLE
fix #131: remove disabled Public option from access level dropdown

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2864,7 +2864,7 @@ export function Sidebar() {
               <label className="field-grid">
                 <span>
                   Access level{" "}
-                  <InfoTip text="Private: visible to owner/admin. Public/Shared: readable by everyone. Editing is limited to owner, admins, and explicit collaborators." />
+                  <InfoTip text="Private: visible to owner/admin. Shared: readable by everyone. Editing is limited to owner, admins, and explicit collaborators." />
                 </span>
                 <select
                   className="locale-select"
@@ -2878,9 +2878,6 @@ export function Sidebar() {
                   value={resourceAccessVisibility}
                 >
                   <option value="private">Private</option>
-                  <option value="public" disabled>
-                    Public (disabled)
-                  </option>
                   <option value="shared">Shared</option>
                 </select>
               </label>


### PR DESCRIPTION
Fix #131: removed disabled Public option from access level dropdown and updated tooltips to only reference Private and Shared.