### PR TITLE
fix #102: guard elevation sync against stale site state

### DIFF
--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -31,12 +31,32 @@ vi.mock("../lib/coverage", () => ({
   buildCoverage: vi.fn(() => []),
 }));
 
+vi.mock("../lib/elevationService", () => ({
+  fetchElevations: vi.fn(),
+}));
+
+import { fetchElevations } from "../lib/elevationService";
 import { useAppStore } from "./appStore";
+
+const mockedFetchElevations = vi.mocked(fetchElevations);
+
+const makeSite = (id: string, lat: number, lon: number, groundElevationM: number) => ({
+  id,
+  name: id,
+  position: { lat, lon },
+  groundElevationM,
+  antennaHeightM: 2,
+  txPowerDbm: 20,
+  txGainDbi: 2,
+  rxGainDbi: 2,
+  cableLossDb: 1,
+});
 
 describe("appStore auth guards", () => {
   beforeEach(() => {
     storage.mock.clear();
     vi.restoreAllMocks();
+    mockedFetchElevations.mockReset();
     useAppStore.setState({
       currentUser: null,
       siteLibrary: [
@@ -351,5 +371,62 @@ describe("appStore auth guards", () => {
     useAppStore.getState().insertSitesFromLibrary(["lib-3"]);
     expect(useAppStore.getState().sites.length).toBe(beforeSiteCount);
     expect(warnSpy).toHaveBeenCalled();
+  });
+});
+
+describe("appStore elevation sync", () => {
+  beforeEach(() => {
+    mockedFetchElevations.mockReset();
+    useAppStore.setState({
+      hasOnlineElevationSync: false,
+      sites: [makeSite("site-1", 1, 1, 100), makeSite("site-2", 2, 2, 120)],
+    });
+  });
+
+  it("applies fetched elevations by site id when site order changes mid-request", async () => {
+    let resolveFetch: (values: number[]) => void = () => undefined;
+    mockedFetchElevations.mockImplementationOnce(
+      () =>
+        new Promise<number[]>((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+
+    const syncPromise = useAppStore.getState().syncSiteElevationsOnline();
+    useAppStore.setState({
+      sites: [makeSite("site-2", 2, 2, 120), makeSite("site-1", 1, 1, 100)],
+    });
+
+    resolveFetch([111.2, 222.7]);
+    await syncPromise;
+
+    const sites = useAppStore.getState().sites;
+    expect(sites.find((site) => site.id === "site-1")?.groundElevationM).toBe(111);
+    expect(sites.find((site) => site.id === "site-2")?.groundElevationM).toBe(223);
+    expect(useAppStore.getState().hasOnlineElevationSync).toBe(true);
+  });
+
+  it("ignores stale responses when the sites list is replaced", async () => {
+    let resolveFetch: (values: number[]) => void = () => undefined;
+    mockedFetchElevations.mockImplementationOnce(
+      () =>
+        new Promise<number[]>((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+
+    const syncPromise = useAppStore.getState().syncSiteElevationsOnline();
+    useAppStore.setState({
+      hasOnlineElevationSync: false,
+      sites: [makeSite("site-a", 59.92, 10.75, 100), makeSite("site-b", 59.95, 10.82, 120)],
+    });
+
+    resolveFetch([501.4, 502.4]);
+    await syncPromise;
+
+    const sites = useAppStore.getState().sites;
+    expect(sites.find((site) => site.id === "site-a")?.groundElevationM).toBe(100);
+    expect(sites.find((site) => site.id === "site-b")?.groundElevationM).toBe(120);
+    expect(useAppStore.getState().hasOnlineElevationSync).toBe(false);
   });
 });

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -2759,19 +2759,57 @@ export const useAppStore = create<AppState>((set, get) => ({
   },
   syncSiteElevationsOnline: async () => {
     const sites = get().sites;
+    const requestSites = sites.map((site) => ({
+      id: site.id,
+      position: site.position,
+    }));
+    const requestById = new Map(requestSites.map((site) => [site.id, site]));
     set({ isElevationSyncing: true });
     try {
-      const elevations = await fetchElevations(sites.map((site) => site.position));
+      const elevations = await fetchElevations(requestSites.map((site) => site.position));
+      const elevationById = new Map<string, number>();
+      requestSites.forEach((site, index) => {
+        const elevation = elevations[index];
+        if (Number.isFinite(elevation)) {
+          elevationById.set(site.id, Math.round(elevation));
+        }
+      });
 
-      set((state) => ({
-        sites: state.sites.map((site, index) => ({
-          ...site,
-          groundElevationM: Number.isFinite(elevations[index])
-            ? Math.round(elevations[index])
-            : site.groundElevationM,
-        })),
-        hasOnlineElevationSync: true,
-      }));
+      set((state) => {
+        const isStale =
+          state.sites.length !== requestSites.length ||
+          state.sites.some((site) => {
+            const requested = requestById.get(site.id);
+            return (
+              !requested ||
+              requested.position.lat !== site.position.lat ||
+              requested.position.lon !== site.position.lon
+            );
+          });
+        if (isStale) {
+          return {};
+        }
+
+        let appliedAny = false;
+        const nextSites = state.sites.map((site) => {
+          const nextElevation = elevationById.get(site.id);
+          if (typeof nextElevation !== "number") return site;
+          appliedAny = true;
+          return {
+            ...site,
+            groundElevationM: nextElevation,
+          };
+        });
+
+        if (!appliedAny) {
+          return {};
+        }
+
+        return {
+          sites: nextSites,
+          hasOnlineElevationSync: true,
+        };
+      });
     } finally {
       set({ isElevationSyncing: false });
     }


### PR DESCRIPTION
Fix #102: prevents elevation sync from running against sites that have been removed from the current simulation.