### PR TITLE
chore: migrate domain references to linksim.link

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,11 +41,11 @@
   - Same commit must use the same base version `X.Y.Z` in all environments.
 - Require a SemVer bump before every production release.
 - Deploys must use guarded npm scripts only:
-  - `npm run deploy:staging` → https://staging.linksim.wilhelmfrancke.com
+  - `npm run deploy:staging` → https://staging.linksim.link
   - `npm run deploy:staging:preview` → Preview URL
-  - `npm run deploy:prod:main` → https://linksim.wilhelmfrancke.com
+  - `npm run deploy:prod:main` → https://linksim.link
 - Staging deploy default:
-  - Use `npm run deploy:staging` (any branch) to deploy to https://staging.linksim.wilhelmfrancke.com
+  - Use `npm run deploy:staging` (any branch) to deploy to https://staging.linksim.link
   - Use `npm run deploy:staging:preview` only for side-by-side comparisons with preview URL
 - Never run raw `wrangler pages deploy` for release operations.
 - If a guarded deploy fails, fix the script/preflight issue and re-run the guarded script. Do not bypass with manual Wrangler deploys.

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -10,9 +10,9 @@
 
 2. Live test (staging)
 - Deploy code to staging using `npm run deploy:staging`.
-- Verify at https://staging.linksim.wilhelmfrancke.com
+- Verify at https://staging.linksim.link
 - Use explicit guarded commands only:
-  - Staging deploy: `npm run deploy:staging` (deploys current branch to main → served by staging.linksim.wilhelmfrancke.com)
+  - Staging deploy: `npm run deploy:staging` (deploys current branch to main → served by staging.linksim.link)
   - Preview URL: `npm run deploy:staging:preview` (separate preview URL for side-by-side comparison)
 
 3. Production
@@ -53,7 +53,7 @@
   1. Implement in local test.
   2. Verify (`npm test`, `npm run build`, manual QA).
   3. Commit and push.
-  4. Deploy to staging using `npm run deploy:staging` and verify at https://staging.linksim.wilhelmfrancke.com.
+  4. Deploy to staging using `npm run deploy:staging` and verify at https://staging.linksim.link.
   5. Promote to production only with explicit approval.
 - No hidden scope changes during promotion; if code changes after staging verification, restart the loop.
 
@@ -67,6 +67,6 @@
 ## Deploy Targets Reference
 | Target | URL | Description |
 |--------|-----|-------------|
-| `deploy:staging` | https://staging.linksim.wilhelmfrancke.com | Test environment (main branch) |
+| `deploy:staging` | https://staging.linksim.link | Test environment (main branch) |
 | `deploy:staging:preview` | Preview URL | Side-by-side comparison |
-| `deploy:prod:main` | https://linksim.wilhelmfrancke.com | Production release |
+| `deploy:prod:main` | https://linksim.link | Production release |

--- a/docs/staging-environment.md
+++ b/docs/staging-environment.md
@@ -7,7 +7,7 @@ This project supports a separate staging stack with production-like data.
 - Staging Worker environment in [`wrangler.staging.toml`](/Users/wilhelmfrancke/Applications/CodexSandboxGeneric/LinkSim/wrangler.staging.toml)
 - Staging avatar fallback to production origin while staging R2 catches up
 - Staging scripts in [`package.json`](/Users/wilhelmfrancke/Applications/CodexSandboxGeneric/LinkSim/package.json)
-- Custom domain: https://staging.linksim.wilhelmfrancke.com
+- Custom domain: https://staging.linksim.link
 - Refresh scripts:
   - [`scripts/refresh-staging-d1.sh`](/Users/wilhelmfrancke/Applications/CodexSandboxGeneric/LinkSim/scripts/refresh-staging-d1.sh)
   - [`scripts/refresh-staging-r2.sh`](/Users/wilhelmfrancke/Applications/CodexSandboxGeneric/LinkSim/scripts/refresh-staging-r2.sh)
@@ -20,7 +20,7 @@ This project supports a separate staging stack with production-like data.
 npm run deploy:staging
 ```
 
-This deploys the current branch to `main` branch in Cloudflare Pages, which is served by https://staging.linksim.wilhelmfrancke.com
+This deploys the current branch to `main` branch in Cloudflare Pages, which is served by https://staging.linksim.link
 
 ### Deploy to preview (side-by-side comparison)
 
@@ -62,7 +62,7 @@ npm run refresh-and-deploy:staging
 
 ## Recommended cadence
 
-- Every commit/PR: `npm run deploy:staging` → test at https://staging.linksim.wilhelmfrancke.com
+- Every commit/PR: `npm run deploy:staging` → test at https://staging.linksim.link
 - Before acceptance/regression testing: `npm run refresh-and-deploy:staging`
 
 ## Safety notes
@@ -76,6 +76,6 @@ npm run refresh-and-deploy:staging
 
 | Environment | URL | Access |
 |------------|-----|--------|
-| Staging (test) | https://staging.linksim.wilhelmfrancke.com | ✅ Works with Access |
+| Staging (test) | https://staging.linksim.link | ✅ Works with Access |
 | Preview | Preview URL (shown after deploy) | May require configuration |
-| Production | https://linksim.wilhelmfrancke.com | ✅ Works with Access |
+| Production | https://linksim.link | ✅ Works with Access |

--- a/functions/api/health.ts
+++ b/functions/api/health.ts
@@ -4,7 +4,7 @@ import { APP_BUILD_LABEL, APP_COMMIT, APP_VERSION } from "../_lib/buildInfo";
 
 export const onRequestOptions: PagesFunction<Env> = async ({ request }) => handleOptions(request);
 
-const PROD_HOSTS = new Set(["linksim.wilhelmfrancke.com", "linksim.pages.dev"]);
+const PROD_HOSTS = new Set(["linksim.link", "linksim.wilhelmfrancke.com", "linksim.pages.dev"]);
 
 const normalizeHost = (host: string): string => host.trim().toLowerCase();
 

--- a/src/lib/environment.ts
+++ b/src/lib/environment.ts
@@ -1,6 +1,6 @@
 export type RuntimeEnvironment = "local" | "staging" | "production";
 
-const PROD_HOSTS = new Set(["linksim.wilhelmfrancke.com", "linksim.pages.dev"]);
+const PROD_HOSTS = new Set(["linksim.link", "linksim.wilhelmfrancke.com", "linksim.pages.dev"]);
 
 const normalizeHost = (host: string): string => host.trim().toLowerCase();
 


### PR DESCRIPTION
Updates hardcoded domain references throughout the codebase to linksim.link.