### PR TITLE
Fix deep-link share mode selection fallback

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -109,7 +109,7 @@ export function AppShell() {
     accessState === "granted" && (!activeSimulation || canEditResource(activeSimulation));
   const workspaceState = emptyWorkspaceState(sites.length, Boolean(activeSimulation));
   const selectedLink = useMemo(
-    () => links.find((link) => link.id === selectedLinkId) ?? links[0] ?? null,
+    () => links.find((link) => link.id === selectedLinkId) ?? null,
     [links, selectedLinkId],
   );
   const referencedPrivateSites = useMemo(() => {


### PR DESCRIPTION
## Summary
- Stop defaulting to the first link when no link is selected in the workspace
- Generate deep-link URL mode from the real current selection state
- Preserve simulation-only and multi-site share URL formats when no explicit link is selected

## Verification
- npm run test -- --run src/lib/deepLink.test.ts
- npm run build