### PR TITLE
Reconcile main-only blank simulation fix into staging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linksim",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linksim",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "license": "GPL-3.0-only",
       "dependencies": {
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "linksim",
   "private": true,
-  "version": "0.10.2",
+  "version": "0.10.3",
   "license": "GPL-3.0-only",
   "type": "module",
   "scripts": {

--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -427,3 +427,47 @@ describe("appStore blank simulation loading", () => {
     expect(raw).toContain(createdId as string);
   });
 });
+
+describe("appStore blank simulation loading", () => {
+  beforeEach(() => {
+    storage.mock.clear();
+    vi.restoreAllMocks();
+    useAppStore.setState({
+      currentUser: {
+        id: "owner-1",
+        username: "owner",
+        avatarUrl: "",
+        role: "user",
+        accountState: "approved",
+        isApproved: true,
+        isAdmin: false,
+        isModerator: false,
+        createdAt: "",
+        updatedAt: null,
+        approvedAt: null,
+        approvedByUserId: null,
+        email: undefined,
+        emailPublic: true,
+        bio: "",
+      },
+      selectedScenarioId: "starter-default",
+      sites: [],
+      links: [],
+      simulationPresets: [],
+    });
+  });
+
+  it("persists last-session selection when loading a blank saved simulation", () => {
+    const createdId = useAppStore
+      .getState()
+      .createBlankSimulationPreset("Blank Session", { visibility: "private", ownerUserId: "owner-1" });
+    expect(createdId).toBeTruthy();
+
+    storage.mock.removeItem("linksim-last-session-v1");
+    useAppStore.getState().loadSimulationPreset(createdId as string);
+
+    const raw = storage.mock.getItem("linksim-last-session-v1");
+    expect(raw).toBeTruthy();
+    expect(raw).toContain(createdId as string);
+  });
+});


### PR DESCRIPTION
## Summary
- Cherry-pick main commit 0863752 into staging line to reduce branch drift
- Keeps current deep-link and calculate API behavior while restoring main-only appStore test/package updates
- Verified targeted regressions before merge

## Verification
- npm run test -- --run src/store/appStore.test.ts src/lib/deepLink.test.ts functions/api/v1/calculate.test.ts
- npm run build