### PR TITLE
Enforce async jobs for terrain calculate requests

### DIFF
--- a/functions/api/v1/calculate.jobs.ts
+++ b/functions/api/v1/calculate.jobs.ts
@@ -217,7 +217,7 @@ export const onRequestPost = async ({ request, env, waitUntil }: Context) => {
         job_id: jobId,
         status: JOB_STATUS.QUEUED,
         message: "Job queued. Poll GET /api/v1/calculate/jobs/{job_id} for status.",
-      }),
+      }, { status: 202 }),
     );
   } catch (error) {
     return errorResponse(request, error, 400);

--- a/functions/api/v1/calculate.test.ts
+++ b/functions/api/v1/calculate.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { getClientAddressMock, takeRateLimitTokenMock, analyzeTerrainLinkMock } = vi.hoisted(() => ({
+const { getClientAddressMock, takeRateLimitTokenMock, analyzeTerrainLinkMock, terrainJobsPostMock } = vi.hoisted(() => ({
   getClientAddressMock: vi.fn(),
   takeRateLimitTokenMock: vi.fn(),
   analyzeTerrainLinkMock: vi.fn(),
+  terrainJobsPostMock: vi.fn(),
 }));
 
 vi.mock("../../_lib/rateLimit", () => ({
@@ -13,6 +14,10 @@ vi.mock("../../_lib/rateLimit", () => ({
 
 vi.mock("../../_lib/terrainAnalysis", () => ({
   analyzeTerrainLink: analyzeTerrainLinkMock,
+}));
+
+vi.mock("./calculate.jobs", () => ({
+  onRequestPost: terrainJobsPostMock,
 }));
 
 import { onRequestPost } from "./calculate";
@@ -42,6 +47,12 @@ beforeEach(() => {
     fromGroundM: 21,
     toGroundM: 11,
   });
+  terrainJobsPostMock.mockResolvedValue(
+    new Response(
+      JSON.stringify({ job_id: "calc_job_123", status: "queued", message: "Job queued." }),
+      { status: 202, headers: { "content-type": "application/json" } },
+    ),
+  );
 });
 
 describe("api/v1/calculate", () => {
@@ -172,5 +183,26 @@ describe("api/v1/calculate", () => {
     await expect(res.json()).resolves.toEqual({
       error: "Terrain tiles unavailable for this path. Please retry shortly or use /api/v1/calculate/jobs.",
     });
+  });
+
+  it("routes terrain mode requests through async jobs endpoint", async () => {
+    const req = new Request("https://linksim.link/api/v1/calculate", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        ...mkPayload(),
+        input: {
+          ...mkPayload().input,
+          mode: "terrain",
+        },
+      }),
+    });
+
+    const waitUntil = vi.fn();
+    const res = await onRequestPost(mkCtx(req, { DB: {} }) as Parameters<typeof onRequestPost>[0] & { waitUntil: typeof waitUntil });
+
+    expect(res.status).toBe(202);
+    await expect(res.json()).resolves.toMatchObject({ job_id: "calc_job_123", status: "queued" });
+    expect(terrainJobsPostMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/functions/api/v1/calculate.ts
+++ b/functions/api/v1/calculate.ts
@@ -1,6 +1,7 @@
 import { getClientAddress, takeRateLimitToken } from "../../_lib/rateLimit";
 import { errorResponse, handleOptions, json, withCors } from "../../_lib/http";
 import type { Env } from "../../_lib/types";
+import { onRequestPost as onRequestTerrainJobPost } from "./calculate.jobs";
 import {
   findEndpointNodes,
   haversineKm,
@@ -13,6 +14,7 @@ import { classifyPassFailState, passFailStateLabel } from "../../../src/lib/pass
 type Context = {
   request: Request;
   env: Env;
+  waitUntil?: (promise: Promise<unknown>) => void;
 };
 
 const MAX_SYNC_TERRAIN_SAMPLES = 72;
@@ -30,7 +32,8 @@ const estimateSyncSamples = (distanceKm: number): number => {
 
 export const onRequestOptions = async ({ request }: Context) => handleOptions(request);
 
-export const onRequestPost = async ({ request, env }: Context) => {
+export const onRequestPost = async (ctx: Context) => {
+  const { request, env, waitUntil } = ctx;
   try {
     const limitPerMinute = parsePerMinuteLimit(env.CALC_API_PROXY_RATE_LIMIT_PER_MINUTE, 120);
     const address = getClientAddress(request);
@@ -49,6 +52,10 @@ export const onRequestPost = async ({ request, env }: Context) => {
     }
 
     const payload = normalizeCalculationRequest(await request.json());
+    if (payload.input.mode === "terrain") {
+      return onRequestTerrainJobPost({ request, env, waitUntil });
+    }
+
     const { fromNode, toNode } = findEndpointNodes(payload);
     const distanceKm = haversineKm(fromNode, toNode);
     if (distanceKm > MAX_SYNC_DISTANCE_KM) {


### PR DESCRIPTION
## Summary
- Route terrain-mode calls from `/api/v1/calculate` to the async jobs handler
- Keep sync calculate endpoint for non-terrain requests
- Return queued `202` from jobs creation path
- Preserve native Cloudflare terrain logic (no external proxy, no Open-Meteo fallback)

## Verification
- npm run test -- --run src/lib/deepLink.test.ts functions/api/v1/calculate.test.ts src/store/appStore.test.ts
- npm run build
