### PR TITLE
Route terrain sync calculate requests to async jobs

### DIFF
--- a/functions/api/v1/calculate.jobs.ts
+++ b/functions/api/v1/calculate.jobs.ts
@@ -181,44 +181,56 @@ const processTerrainJob = async (env: Env, jobId: string, requestUrl: string): P
   }
 };
 
+export const queueTerrainCalculationJob = async (
+  request: Request,
+  env: Env,
+  payload: CalculationRequest,
+  waitUntil?: (promise: Promise<unknown>) => void,
+): Promise<Response> => {
+  await ensureCalculationJobsTable(env);
+  const limitPerMinute = parsePerMinuteLimit(env.CALC_API_PROXY_RATE_LIMIT_PER_MINUTE, 60);
+  const address = getClientAddress(request);
+  const limiter = takeRateLimitToken({ key: `calc-jobs:${address}`, limit: limitPerMinute });
+  if (!limiter.allowed) {
+    return withCors(
+      request,
+      json(
+        { error: "Calculation jobs rate limit reached. Please wait and try again." },
+        { status: 429, headers: { "retry-after": String(limiter.retryAfterSec) } },
+      ),
+    );
+  }
+
+  if (payload.input.mode !== "terrain") {
+    throw new Error("Only terrain mode is supported on /api/v1/calculate/jobs.");
+  }
+  validateTerrainRequest(payload);
+
+  const jobId = generateJobId();
+  await createJob(env, jobId, JSON.stringify(payload));
+  const processing = processTerrainJob(env, jobId, request.url);
+  if (waitUntil) waitUntil(processing);
+  else await processing;
+
+  return withCors(
+    request,
+    json(
+      {
+        job_id: jobId,
+        status: JOB_STATUS.QUEUED,
+        message: "Job queued. Poll GET /api/v1/calculate/jobs/{job_id} for status.",
+      },
+      { status: 202 },
+    ),
+  );
+};
+
 export const onRequestOptions = async ({ request }: Context) => handleOptions(request);
 
 export const onRequestPost = async ({ request, env, waitUntil }: Context) => {
   try {
-    await ensureCalculationJobsTable(env);
-    const limitPerMinute = parsePerMinuteLimit(env.CALC_API_PROXY_RATE_LIMIT_PER_MINUTE, 60);
-    const address = getClientAddress(request);
-    const limiter = takeRateLimitToken({ key: `calc-jobs:${address}`, limit: limitPerMinute });
-    if (!limiter.allowed) {
-      return withCors(
-        request,
-        json(
-          { error: "Calculation jobs rate limit reached. Please wait and try again." },
-          { status: 429, headers: { "retry-after": String(limiter.retryAfterSec) } },
-        ),
-      );
-    }
-
     const payload = normalizeCalculationRequest(await request.json());
-    if (payload.input.mode !== "terrain") {
-      throw new Error("Only terrain mode is supported on /api/v1/calculate/jobs.");
-    }
-    validateTerrainRequest(payload);
-
-    const jobId = generateJobId();
-    await createJob(env, jobId, JSON.stringify(payload));
-    const processing = processTerrainJob(env, jobId, request.url);
-    if (waitUntil) waitUntil(processing);
-    else await processing;
-
-    return withCors(
-      request,
-      json({
-        job_id: jobId,
-        status: JOB_STATUS.QUEUED,
-        message: "Job queued. Poll GET /api/v1/calculate/jobs/{job_id} for status.",
-      }, { status: 202 }),
-    );
+    return queueTerrainCalculationJob(request, env, payload, waitUntil);
   } catch (error) {
     return errorResponse(request, error, 400);
   }

--- a/functions/api/v1/calculate.test.ts
+++ b/functions/api/v1/calculate.test.ts
@@ -17,7 +17,7 @@ vi.mock("../../_lib/terrainAnalysis", () => ({
 }));
 
 vi.mock("./calculate.jobs", () => ({
-  onRequestPost: terrainJobsPostMock,
+  queueTerrainCalculationJob: terrainJobsPostMock,
 }));
 
 import { onRequestPost } from "./calculate";
@@ -199,7 +199,7 @@ describe("api/v1/calculate", () => {
     });
 
     const waitUntil = vi.fn();
-    const res = await onRequestPost(mkCtx(req, { DB: {} }) as Parameters<typeof onRequestPost>[0] & { waitUntil: typeof waitUntil });
+    const res = await onRequestPost({ request: req, env: { DB: {} } as TestEnv, waitUntil } as Parameters<typeof onRequestPost>[0]);
 
     expect(res.status).toBe(202);
     await expect(res.json()).resolves.toMatchObject({ job_id: "calc_job_123", status: "queued" });

--- a/functions/api/v1/calculate.ts
+++ b/functions/api/v1/calculate.ts
@@ -1,7 +1,7 @@
 import { getClientAddress, takeRateLimitToken } from "../../_lib/rateLimit";
 import { errorResponse, handleOptions, json, withCors } from "../../_lib/http";
 import type { Env } from "../../_lib/types";
-import { onRequestPost as onRequestTerrainJobPost } from "./calculate.jobs";
+import { queueTerrainCalculationJob } from "./calculate.jobs";
 import {
   findEndpointNodes,
   haversineKm,
@@ -53,7 +53,7 @@ export const onRequestPost = async (ctx: Context) => {
 
     const payload = normalizeCalculationRequest(await request.json());
     if (payload.input.mode === "terrain") {
-      return onRequestTerrainJobPost({ request, env, waitUntil });
+      return queueTerrainCalculationJob(request, env, payload, waitUntil);
     }
 
     const { fromNode, toNode } = findEndpointNodes(payload);


### PR DESCRIPTION
## Summary
- Route `mode=terrain` requests on `/api/v1/calculate` into the async jobs queue path
- Keep sync `/api/v1/calculate` for non-terrain mode
- Return `202` queued responses for terrain-mode requests
- Preserve native Cloudflare terrain stack with no external proxy and no Open-Meteo fallback

## Verification
- npm run test -- --run src/lib/deepLink.test.ts functions/api/v1/calculate.test.ts src/store/appStore.test.ts
- npm run build
