### PR TITLE
Fix deep-link share mode regression with stale link selection

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -136,11 +136,19 @@ export function AppShell() {
     const selectedSites = selectedSiteIds
       .map((id) => sites.find((site) => site.id === id))
       .filter((site): site is NonNullable<typeof site> => Boolean(site));
+    const selectedSiteIdSet = new Set(selectedSiteIds);
 
     let selectedLinkSlugs: string[] | undefined;
     let selectedSiteSlugs: string[] | undefined;
 
-    if (selectedLink) {
+    const hasExplicitLinkSelection =
+      Boolean(selectedLink) &&
+      selectedSiteIds.length === 2 &&
+      selectedLink !== null &&
+      selectedSiteIdSet.has(selectedLink.fromSiteId) &&
+      selectedSiteIdSet.has(selectedLink.toSiteId);
+
+    if (hasExplicitLinkSelection && selectedLink) {
       selectedLinkSlugs = [selectedLink.fromSiteId, selectedLink.toSiteId]
         .map((id) => sites.find((s) => s.id === id)?.name)
         .filter((name): name is string => Boolean(name));

--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -382,6 +382,34 @@ describe("appStore auth guards", () => {
     expect(useAppStore.getState().sites.length).toBe(beforeSiteCount);
     expect(warnSpy).toHaveBeenCalled();
   });
+
+  it("clears selectedLinkId when switching to single-site selection", () => {
+    useAppStore.setState({
+      selectedLinkId: "lnk-1",
+      selectedSiteId: "site-1",
+      selectedSiteIds: ["site-1", "site-2"],
+    });
+
+    useAppStore.getState().setSelectedSiteId("site-2");
+
+    const state = useAppStore.getState();
+    expect(state.selectedLinkId).toBe("");
+    expect(state.selectedSiteIds).toEqual(["site-2"]);
+  });
+
+  it("clears selectedLinkId when toggling additive site selection", () => {
+    useAppStore.setState({
+      selectedLinkId: "lnk-1",
+      selectedSiteId: "site-1",
+      selectedSiteIds: ["site-1", "site-2"],
+    });
+
+    useAppStore.getState().selectSiteById("site-1", true);
+
+    const state = useAppStore.getState();
+    expect(state.selectedLinkId).toBe("");
+    expect(state.selectedSiteIds).toEqual(["site-2"]);
+  });
 });
 
 describe("appStore blank simulation loading", () => {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1638,6 +1638,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       const nextOverlay = defaultOverlayModeForSelectionCount(selection.length);
       if (
         state.selectedSiteId === nextSelectedSiteId &&
+        state.selectedLinkId === "" &&
         state.mapOverlayMode === nextOverlay &&
         sameSiteSelection(state.selectedSiteIds, selection)
       ) {
@@ -1646,6 +1647,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       return {
         selectedSiteId: nextSelectedSiteId,
         selectedSiteIds: selection,
+        selectedLinkId: "",
         mapOverlayMode: nextOverlay,
       };
     });
@@ -1668,6 +1670,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       const nextOverlay = defaultOverlayModeForSelectionCount(normalizedSelection.length);
       if (
         state.selectedSiteId === nextSelectedSiteId &&
+        state.selectedLinkId === "" &&
         state.mapOverlayMode === nextOverlay &&
         sameSiteSelection(state.selectedSiteIds, normalizedSelection)
       ) {
@@ -1676,6 +1679,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       return {
         selectedSiteIds: normalizedSelection,
         selectedSiteId: nextSelectedSiteId,
+        selectedLinkId: "",
         mapOverlayMode: nextOverlay,
       };
     });


### PR DESCRIPTION
## Summary
- Fix share-link mode selection so site-selection URLs are not overridden by stale link selection
- Clear `selectedLinkId` when users select sites directly
- Emit link-style deep links only when selected site IDs exactly match selected link endpoints
- Add store regression tests for link-selection clearing behavior

## Verification
- npm run test -- --run src/lib/deepLink.test.ts functions/api/v1/calculate.test.ts src/store/appStore.test.ts
- npm run build
