### PR TITLE
Fix emoji and Korean deep-link matching behavior

### DIFF
--- a/src/lib/deepLink.test.ts
+++ b/src/lib/deepLink.test.ts
@@ -135,19 +135,39 @@ describe("deepLink", () => {
     expect(url).toBe("https://linksim.pages.dev/Høgevarde/Fyrisjøen~HOEG-ROUTER");
   });
 
+  it("builds and parses korean simulation/site paths", () => {
+    const url = buildDeepLinkUrl(
+      {
+        version: 2,
+        simulationId: "sim-kor",
+        simulationSlug: "한국조선",
+        selectedSiteSlugs: ["남산-서울-타워", "평양텔레비죤탑"],
+      },
+      "https://linksim.pages.dev",
+    );
+    expect(url).toBe("https://linksim.pages.dev/한국조선/남산-서울-타워+평양텔레비죤탑");
+
+    const parsed = parseDeepLinkFromLocation({ pathname: "/한국조선/남산-서울-타워+평양텔레비죤탑", search: "" });
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(parsed.payload.simulationSlug).toBe("한국조선");
+    expect(parsed.payload.selectedSiteSlugs).toEqual(["남산-서울-타워", "평양텔레비죤탑"]);
+  });
+
   it("slugifies names preserving unicode and case, stripping delimiters", () => {
     expect(slugifyName(" NOR HØGEVARDE / test ")).toBe("NOR-HØGEVARDE-test");
     expect(slugifyName("site+name")).toBe("sitename");
     expect(slugifyName("site<>name")).toBe("sitename");
     expect(slugifyName("site~name")).toBe("sitename");
     expect(slugifyName("site/name")).toBe("sitename");
-    expect(slugifyName("🏝️")).toBe("🏝");
+    expect(slugifyName("🏝️")).toBe("🏝️");
   });
 
   it("canonicalizes keys for matching existing normalized slugs", () => {
     expect(canonicalizeDeepLinkKey("Blefjell")).toBe("blefjell");
-    expect(canonicalizeDeepLinkKey("Høgevarde")).toBe("hogevarde");
-    expect(canonicalizeDeepLinkKey("%F0%9F%92%A9")).toBe("");
+    expect(canonicalizeDeepLinkKey("Høgevarde")).toBe("høgevarde");
+    expect(canonicalizeDeepLinkKey("%F0%9F%92%A9")).toBe("💩");
+    expect(canonicalizeDeepLinkKey("한국조선")).toBe("한국조선");
   });
 
   it("handles query-only old format with sim_slug", () => {

--- a/src/lib/deepLink.ts
+++ b/src/lib/deepLink.ts
@@ -48,9 +48,7 @@ export const slugifyName = (value: string): string =>
   value
     .trim()
     .normalize("NFKC")
-    .replace(/[\uFE0E\uFE0F]/g, "")
     .replace(DELIMITER_CHARS, "")
-    .normalize("NFKD")
     .replace(/\s+/g, "-")
     .replace(/^-+|-+$/g, "")
     .replace(/-{2,}/g, "-");
@@ -58,16 +56,10 @@ export const slugifyName = (value: string): string =>
 export const canonicalizeDeepLinkKey = (value: string): string =>
   safeDecodeURIComponent(value)
     .trim()
-    .replace(/[\uFE0E\uFE0F]/g, "")
     .toLocaleLowerCase()
     .normalize("NFKC")
-    .replace(/ß/g, "ss")
-    .replace(/æ/g, "ae")
-    .replace(/ø/g, "o")
-    .replace(/å/g, "a")
-    .normalize("NFKD")
-    .replace(/\p{M}+/gu, "")
-    .replace(/[^a-z0-9]+/g, "-")
+    .replace(DELIMITER_CHARS, "")
+    .replace(/\s+/g, "-")
     .replace(/^-+|-+$/g, "")
     .replace(/-{2,}/g, "-");
 


### PR DESCRIPTION
## Summary
- Preserve Unicode/emoji semantics in deep-link slug generation and matching keys
- Remove ASCII-only canonical collapse that caused ambiguous emoji matches
- Add regression tests for emoji and Korean simulation/site paths

## Verification
- npm run test -- --run src/lib/deepLink.test.ts functions/api/v1/calculate.test.ts src/store/appStore.test.ts
- npm run build
