### PR TITLE
Fix emoji variation selector deep-link matching

### DIFF
--- a/src/lib/deepLink.test.ts
+++ b/src/lib/deepLink.test.ts
@@ -160,13 +160,14 @@ describe("deepLink", () => {
     expect(slugifyName("site<>name")).toBe("sitename");
     expect(slugifyName("site~name")).toBe("sitename");
     expect(slugifyName("site/name")).toBe("sitename");
-    expect(slugifyName("🏝️")).toBe("🏝️");
+    expect(slugifyName("🏝️")).toBe("🏝");
   });
 
   it("canonicalizes keys for matching existing normalized slugs", () => {
     expect(canonicalizeDeepLinkKey("Blefjell")).toBe("blefjell");
     expect(canonicalizeDeepLinkKey("Høgevarde")).toBe("høgevarde");
     expect(canonicalizeDeepLinkKey("%F0%9F%92%A9")).toBe("💩");
+    expect(canonicalizeDeepLinkKey("🏝️")).toBe("🏝");
     expect(canonicalizeDeepLinkKey("한국조선")).toBe("한국조선");
   });
 

--- a/src/lib/deepLink.ts
+++ b/src/lib/deepLink.ts
@@ -1,4 +1,5 @@
 const DELIMITER_CHARS = /[+<>~\/]/g;
+const VARIATION_SELECTORS = /[\uFE0E\uFE0F]/g;
 const PRIMARY_LINK_DELIMITER = "~";
 const LEGACY_LINK_DELIMITER = "<>";
 
@@ -48,6 +49,7 @@ export const slugifyName = (value: string): string =>
   value
     .trim()
     .normalize("NFKC")
+    .replace(VARIATION_SELECTORS, "")
     .replace(DELIMITER_CHARS, "")
     .replace(/\s+/g, "-")
     .replace(/^-+|-+$/g, "")
@@ -58,6 +60,7 @@ export const canonicalizeDeepLinkKey = (value: string): string =>
     .trim()
     .toLocaleLowerCase()
     .normalize("NFKC")
+    .replace(VARIATION_SELECTORS, "")
     .replace(DELIMITER_CHARS, "")
     .replace(/\s+/g, "-")
     .replace(/^-+|-+$/g, "")


### PR DESCRIPTION
## Summary
- Normalize FE0E/FE0F variation selectors in deep-link key generation
- Ensure emoji URLs that serialize variation selectors still resolve to the intended site selection
- Add regression assertion coverage in deep-link tests

## Verification
- npm run test -- --run src/lib/deepLink.test.ts functions/api/v1/calculate.test.ts src/store/appStore.test.ts
- npm run build
