### PR TITLE
Fix deep-link overwrite by startup initialization race

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -96,6 +96,8 @@ export function AppShell() {
   const [localDevStatus, setLocalDevStatus] = useState<string | null>(null);
   const [offlineBannerDismissed, setOfflineBannerDismissed] = useState(false);
   const deepLinkAppliedRef = useRef(false);
+  const cloudInitSeenRef = useRef(false);
+  const cloudInitSettledRef = useRef(false);
 
   const { theme, variant } = useThemeVariant();
   const runtimeEnvironment = getCurrentRuntimeEnvironment();
@@ -374,7 +376,18 @@ export function AppShell() {
   }, []);
 
   useEffect(() => {
+    if (isInitializing) {
+      cloudInitSeenRef.current = true;
+      return;
+    }
+    if (cloudInitSeenRef.current) {
+      cloudInitSettledRef.current = true;
+    }
+  }, [isInitializing]);
+
+  useEffect(() => {
     if ((accessState !== "granted" && accessState !== "readonly") || deepLinkAppliedRef.current || isInitializing) return;
+    if (!cloudInitSettledRef.current) return;
     if (!deepLinkParse.ok) {
       if (deepLinkParse.reason !== "missing_sim") {
         setDeepLinkNotice(


### PR DESCRIPTION
## Summary
- Delay deep-link application until the cloud initialization cycle has been observed and settled
- Prevent startup hydration from overwriting already-applied deep-link site/link selections
- Keep current deep-link matching instrumentation for traceability while validating fix

## Verification
- npm run test -- --run src/lib/deepLink.test.ts src/store/appStore.test.ts functions/api/v1/calculate.test.ts
- npm run build
