### PR TITLE
refactor(onboarding): compact welcome card, simple onboarding modal (#152)

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -14,13 +14,12 @@
 - Drag existing sites to test alternative positions instantly, then use **Save Positions** or **Dismiss** to commit or revert.
 
 ## Links and Site Selection
-- **Select multiple sites** on the map or sidebar using **Ctrl/Cmd+Click** to view a link between them.
+- **Select multiple sites** on the map or sidebar using **{{MODIFIER}}+Click** to view a link between them.
 - The map overlay automatically adjusts based on your selection:
   - **No selection** — Heatmap (quality overview)
   - **One site** — Pass/Fail (threshold + terrain context)
   - **Two sites** — Relay (best relay-candidate regions)
 - To save a link permanently, select two sites and press **Save** in the map inspector.
-- Links let you compare multiple candidate paths in one simulation.
 
 ## Channel and Model Settings
 - **Channel**: frequency, bandwidth, SF, coding rate, TX power, gains, cable loss, environment loss.
@@ -40,27 +39,5 @@
 | Terrain overlay | Terrain raster used by simulation in current area | Confirm what elevation input the model is actually using |
 | Path profile | Elevation profile + link geometry between selected endpoints | Validate LOS/Fresnel context and understand obstructions |
 
-- Basemap providers:
-  - **CARTO** is the global baseline and fallback.
-  - **MapTiler** and **Stadia** are available when admin-configured API keys are present.
-  - **Kartverket** is listed under regional providers and is optional.
-  - If a selected provider fails (network/quota/style error), LinkSim auto-falls back to CARTO and shows a warning banner.
-
-- Practical workflow:
-  1. Start with **Pass/Fail** for decision clarity.
-  2. Switch to **Heatmap/Contours** for quality gradients.
-  3. Use **Relay** to locate candidate repeater sites.
-  4. Confirm terrain and inspect **Path profile** before finalizing.
-
 ## Sharing and Permissions
 - Everything is **private by default**. Share simulations and sites with specific users when you're ready to collaborate.
-- User roles: **Pending**, **User**, **Moderator**, **Admin**.
-- Important: treat all content in LinkSim as potentially visible to other users and operators. Do not store passwords, private keys, API secrets, or other sensitive material in sites/simulations/profile fields.
-
-## Recommended Workflow
-1. Open or create a simulation.
-2. Add sites from Site Library.
-3. Select two sites with Ctrl/Cmd+Click to view a link.
-4. Auto-fetch terrain data.
-5. Set channel + model, then inspect map + path profile.
-6. Save the simulation and share/collaborate as needed.

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -11,6 +11,7 @@ import { useAppStore } from "../store/appStore";
 import { LinkProfileChart } from "./LinkProfileChart";
 import { MapView } from "./MapView";
 import { ModalOverlay } from "./ModalOverlay";
+import OnboardingTutorialModal from "./OnboardingTutorialModal";
 import WelcomeModal from "./WelcomeModal";
 import { Sidebar } from "./Sidebar";
 import { UserAdminPanel } from "./UserAdminPanel";
@@ -80,6 +81,7 @@ export function AppShell() {
   const setIsOnline = useAppStore((state) => state.setIsOnline);
   const isInitializing = useAppStore((state) => state.isInitializing);
   const setShowSimulationLibraryRequest = useAppStore((state) => state.setShowSimulationLibraryRequest);
+  const setShowNewSimulationRequest = useAppStore((state) => state.setShowNewSimulationRequest);
 
   const [isMapExpanded, setIsMapExpanded] = useState(false);
   const [isProfileExpanded, setIsProfileExpanded] = useState(false);
@@ -87,7 +89,7 @@ export function AppShell() {
   const [accessDiagnosticMessage, setAccessDiagnosticMessage] = useState<string | null>(null);
   const [activeUserId, setActiveUserId] = useState("");
   const [showWelcomeModal, setShowWelcomeModal] = useState(false);
-  const [welcomeExpandOnboarding, setWelcomeExpandOnboarding] = useState(false);
+  const [showOnboardingTutorial, setShowOnboardingTutorial] = useState(false);
   const [libraryAutoOpened, setLibraryAutoOpened] = useState(false);
   const [showShareModal, setShowShareModal] = useState(false);
   const [shareBusy, setShareBusy] = useState(false);
@@ -277,7 +279,6 @@ export function AppShell() {
           const seen = localStorage.getItem(`${ONBOARDING_SEEN_KEY_PREFIX}${profile.id}`);
           if (!seen && !deepLinkParse.ok) {
             setShowWelcomeModal(true);
-            setWelcomeExpandOnboarding(false);
           }
         } catch {
           // ignore storage errors
@@ -689,14 +690,28 @@ export function AppShell() {
     }
   };
 
-  const openWelcomeExpanded = () => {
-    setWelcomeExpandOnboarding(true);
-    setShowWelcomeModal(true);
+  const openOnboardingTutorial = () => {
+    setShowOnboardingTutorial(true);
   };
 
-  const loadSimulationFromWelcome = (presetId: string) => {
-    loadSimulationPreset(presetId);
+  const openWelcomeFromWelcome = () => {
     setShowWelcomeModal(false);
+    setShowOnboardingTutorial(true);
+  };
+
+  const openLibraryFromWelcome = () => {
+    setShowWelcomeModal(false);
+    setShowSimulationLibraryRequest(true);
+    try {
+      if (activeUserId) localStorage.setItem(`${ONBOARDING_SEEN_KEY_PREFIX}${activeUserId}`, "1");
+    } catch {
+      // ignore
+    }
+  };
+
+  const createNewFromWelcome = () => {
+    setShowWelcomeModal(false);
+    setShowNewSimulationRequest(true);
     try {
       if (activeUserId) localStorage.setItem(`${ONBOARDING_SEEN_KEY_PREFIX}${activeUserId}`, "1");
     } catch {
@@ -837,13 +852,14 @@ export function AppShell() {
           <button
             aria-label="Open onboarding"
             className="floating-help-button"
-            onClick={openWelcomeExpanded}
+            onClick={openOnboardingTutorial}
             type="button"
           >
             ?
           </button>
         </div>
-        <WelcomeModal expandOnboarding={welcomeExpandOnboarding} onClose={closeWelcome} onLoadSimulation={loadSimulationFromWelcome} open={showWelcomeModal} />
+        <WelcomeModal onClose={closeWelcome} onCreateNewSimulation={createNewFromWelcome} onOpenLibrary={openLibraryFromWelcome} onOpenOnboarding={openWelcomeFromWelcome} open={showWelcomeModal} />
+        <OnboardingTutorialModal onClose={() => setShowOnboardingTutorial(false)} onOpenLibrary={() => setShowSimulationLibraryRequest(true)} open={showOnboardingTutorial} />
       </main>
     );
   }
@@ -888,13 +904,14 @@ export function AppShell() {
           <button
             aria-label="Open onboarding"
             className="floating-help-button"
-            onClick={openWelcomeExpanded}
+            onClick={openOnboardingTutorial}
             type="button"
           >
             ?
           </button>
         </div>
-        <WelcomeModal expandOnboarding={welcomeExpandOnboarding} onClose={closeWelcome} onLoadSimulation={loadSimulationFromWelcome} open={showWelcomeModal} />
+        <WelcomeModal onClose={closeWelcome} onCreateNewSimulation={createNewFromWelcome} onOpenLibrary={openLibraryFromWelcome} onOpenOnboarding={openWelcomeFromWelcome} open={showWelcomeModal} />
+        <OnboardingTutorialModal onClose={() => setShowOnboardingTutorial(false)} onOpenLibrary={() => setShowSimulationLibraryRequest(true)} open={showOnboardingTutorial} />
       </main>
     );
   }
@@ -1012,13 +1029,14 @@ export function AppShell() {
         <button
           aria-label="Open onboarding"
           className="floating-help-button"
-          onClick={openWelcomeExpanded}
+          onClick={openOnboardingTutorial}
           type="button"
         >
           ?
         </button>
       </div>
-      <WelcomeModal expandOnboarding={welcomeExpandOnboarding} onClose={closeWelcome} onLoadSimulation={loadSimulationFromWelcome} open={showWelcomeModal} />
+      <WelcomeModal onClose={closeWelcome} onCreateNewSimulation={createNewFromWelcome} onOpenLibrary={openLibraryFromWelcome} onOpenOnboarding={openWelcomeFromWelcome} open={showWelcomeModal} />
+      <OnboardingTutorialModal onClose={() => setShowOnboardingTutorial(false)} onOpenLibrary={() => setShowSimulationLibraryRequest(true)} open={showOnboardingTutorial} />
       {showMobileWarning ? (
         <ModalOverlay aria-label="Mobile support notice" onClose={() => setShowMobileWarning(false)} tier="raised">
           <div className="library-manager-card mobile-warning-modal-card">

--- a/src/components/OnboardingTutorialModal.tsx
+++ b/src/components/OnboardingTutorialModal.tsx
@@ -1,0 +1,84 @@
+import { useMemo } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import onboardingMarkdown from "../../docs/onboarding.md?raw";
+import { ModalOverlay } from "./ModalOverlay";
+
+const FEEDBACK_ISSUES_URL = "https://github.com/wilhel1812/LinkSim/issues/new/choose";
+const PRIVACY_URL = "https://github.com/wilhel1812/LinkSim/blob/main/docs/legal/PRIVACY.md";
+const TERMS_URL = "https://github.com/wilhel1812/LinkSim/blob/main/docs/legal/TERMS.md";
+
+const isMac = (() => {
+  try {
+    return navigator.platform.toUpperCase().indexOf("MAC") >= 0;
+  } catch {
+    return false;
+  }
+})();
+
+type OnboardingTutorialModalProps = {
+  open: boolean;
+  onClose: () => void;
+  onOpenLibrary?: () => void;
+};
+
+export default function OnboardingTutorialModal({ open, onClose, onOpenLibrary }: OnboardingTutorialModalProps) {
+  const processedMarkdown = useMemo(() => {
+    return onboardingMarkdown.replace(/\{\{MODIFIER\}\}/g, isMac ? "Cmd" : "Ctrl");
+  }, []);
+
+  if (!open) return null;
+  return (
+    <ModalOverlay aria-label="Onboarding Tutorial" onClose={onClose} tier="raised">
+      <div className="library-manager-card tutorial-modal-card">
+        <div className="library-manager-header">
+          <h2>Getting Started</h2>
+          <div className="chip-group">
+            <button className="inline-action" onClick={onClose} type="button">
+              Close
+            </button>
+          </div>
+        </div>
+        <div className="tutorial-markdown">
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm]}
+            components={{
+              strong({ children, ...props }) {
+                if (typeof children === "string" && children === "SIMULATION_LIBRARY_BUTTON") {
+                  return (
+                    <button
+                      className="inline-action"
+                      onClick={() => onOpenLibrary?.()}
+                      type="button"
+                    >
+                      Simulation Library
+                    </button>
+                  );
+                }
+                return <strong {...props}>{children}</strong>;
+              },
+            }}
+          >
+            {processedMarkdown.replace(
+              /\*\*Simulation Library\*\*/,
+              "**SIMULATION_LIBRARY_BUTTON**",
+            )}
+          </ReactMarkdown>
+        </div>
+        <div className="tutorial-report-cta">
+          <a className="inline-action tutorial-report-button" href={FEEDBACK_ISSUES_URL} rel="noreferrer" target="_blank">
+            Report Issue or Suggestion
+          </a>
+          <div className="asset-list">
+            <a href={PRIVACY_URL} rel="noreferrer" target="_blank">
+              Privacy Notice
+            </a>
+            <a href={TERMS_URL} rel="noreferrer" target="_blank">
+              Terms & Acceptable Use
+            </a>
+          </div>
+        </div>
+      </div>
+    </ModalOverlay>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -402,6 +402,8 @@ export function Sidebar() {
   const model = useAppStore((state) => state.propagationModel);
   const showSimulationLibraryRequest = useAppStore((state) => state.showSimulationLibraryRequest);
   const setShowSimulationLibraryRequest = useAppStore((state) => state.setShowSimulationLibraryRequest);
+  const showNewSimulationRequest = useAppStore((state) => state.showNewSimulationRequest);
+  const setShowNewSimulationRequest = useAppStore((state) => state.setShowNewSimulationRequest);
   const selectedLink = useMemo(
     () => getSelectedLink(),
     [getSelectedLink, links, selectedLinkId, sites, networks, selectedNetworkId],
@@ -737,6 +739,15 @@ export function Sidebar() {
       setShowSimulationLibraryRequest(false);
     }
   }, [showSimulationLibraryRequest, setShowSimulationLibraryRequest]);
+  useEffect(() => {
+    if (showNewSimulationRequest) {
+      setNewSimulationName("");
+      setNewSimulationDescription("");
+      setNewSimulationNameError("");
+      setShowNewSimulationModal(true);
+      setShowNewSimulationRequest(false);
+    }
+  }, [showNewSimulationRequest, setShowNewSimulationRequest]);
   useEffect(() => {
     persistLibraryFilterState(SITE_LIBRARY_FILTERS_KEY, siteLibraryFilters);
   }, [siteLibraryFilters]);

--- a/src/components/WelcomeModal.tsx
+++ b/src/components/WelcomeModal.tsx
@@ -1,74 +1,52 @@
-import { useState } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import onboardingMarkdown from "../../docs/onboarding.md?raw";
 import { ModalOverlay } from "./ModalOverlay";
-import SimulationLibraryPanel from "./SimulationLibraryPanel";
-
-const FEEDBACK_ISSUES_URL = "https://github.com/wilhel1812/LinkSim/issues/new/choose";
-const PRIVACY_URL = "https://github.com/wilhel1812/LinkSim/blob/main/docs/legal/PRIVACY.md";
-const TERMS_URL = "https://github.com/wilhel1812/LinkSim/blob/main/docs/legal/TERMS.md";
 
 type WelcomeModalProps = {
   open: boolean;
   onClose: () => void;
-  onLoadSimulation: (presetId: string) => void;
-  expandOnboarding?: boolean;
+  onOpenOnboarding: () => void;
+  onOpenLibrary: () => void;
+  onCreateNewSimulation: () => void;
 };
 
 export default function WelcomeModal({
   open,
   onClose,
-  onLoadSimulation,
-  expandOnboarding = false,
+  onOpenOnboarding,
+  onOpenLibrary,
+  onCreateNewSimulation,
 }: WelcomeModalProps) {
-  const [onboardingExpanded, setOnboardingExpanded] = useState(expandOnboarding);
-
   if (!open) return null;
 
   return (
     <ModalOverlay aria-label="Welcome" onClose={onClose} tier="raised">
-      <div className="library-manager-card welcome-modal-card">
-        <div className="library-manager-header">
-          <h2>Welcome to LinkSim</h2>
-          <button className="inline-action" onClick={onClose} type="button">
-            Close
-          </button>
-        </div>
-
-        <div className="welcome-modal-onboarding-section">
+      <div className="welcome-compact-card">
+        <h2>Welcome to LinkSim</h2>
+        <p>
+          LinkSim helps you plan and visualize radio links between sites. Get started by opening
+          an existing simulation, creating a new one, or reading the getting started guide.
+        </p>
+        <div className="welcome-compact-actions">
           <button
-            className="inline-action welcome-modal-onboarding-toggle"
-            onClick={() => setOnboardingExpanded((prev) => !prev)}
+            className="inline-action welcome-compact-button"
+            onClick={onOpenLibrary}
             type="button"
           >
-            Getting Started {onboardingExpanded ? "▾" : "▸"}
+            Open Simulation Library
           </button>
-          {onboardingExpanded ? (
-            <div className="tutorial-markdown welcome-modal-onboarding-content">
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>{onboardingMarkdown}</ReactMarkdown>
-            </div>
-          ) : null}
-        </div>
-
-        <SimulationLibraryPanel
-          hideSaveCopy
-          onClose={onClose}
-          onLoadSimulation={onLoadSimulation}
-        />
-
-        <div className="tutorial-report-cta">
-          <a className="inline-action tutorial-report-button" href={FEEDBACK_ISSUES_URL} rel="noreferrer" target="_blank">
-            Report Issue or Suggestion
-          </a>
-          <div className="asset-list">
-            <a href={PRIVACY_URL} rel="noreferrer" target="_blank">
-              Privacy Notice
-            </a>
-            <a href={TERMS_URL} rel="noreferrer" target="_blank">
-              Terms & Acceptable Use
-            </a>
-          </div>
+          <button
+            className="inline-action welcome-compact-button"
+            onClick={onCreateNewSimulation}
+            type="button"
+          >
+            Create New Simulation
+          </button>
+          <button
+            className="inline-action welcome-compact-button"
+            onClick={onOpenOnboarding}
+            type="button"
+          >
+            Read Getting Started
+          </button>
         </div>
       </div>
     </ModalOverlay>

--- a/src/index.css
+++ b/src/index.css
@@ -2135,26 +2135,46 @@ input {
   background: color-mix(in srgb, var(--surface) 86%, transparent);
 }
 
-.welcome-modal-card {
-  width: min(1320px, 98vw);
-  height: min(94vh, 1100px);
-  max-height: min(94vh, 1100px);
-  grid-template-rows: auto auto 1fr auto;
-  overflow: hidden;
+.welcome-compact-card {
+  width: min(440px, 92vw);
+  padding: 24px 28px;
+  border-radius: 12px;
+  background: var(--surface-2);
+  color: var(--text);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
-.welcome-modal-onboarding-section {
-  margin-bottom: 8px;
+.welcome-compact-card h2 {
+  margin: 0;
+  font-size: 1.2rem;
 }
 
-.welcome-modal-onboarding-toggle {
-  font-weight: 600;
-  cursor: pointer;
+.welcome-compact-card p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.92rem;
+  line-height: 1.5;
 }
 
-.welcome-modal-onboarding-content {
-  margin-top: 8px;
-  max-height: 40vh;
+.welcome-compact-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.welcome-compact-button {
+  padding: 10px 16px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  text-align: left;
+  font-size: 0.92rem;
+}
+
+.welcome-compact-button:hover {
+  background: color-mix(in srgb, var(--accent) 12%, var(--surface));
 }
 
 .welcome-modal-new-simulation-backdrop {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -343,6 +343,7 @@ type AppState = {
   siteDragPreview: Record<string, { position: { lat: number; lon: number }; groundElevationM: number }>;
   endpointPickTarget: "from" | "to" | null;
   showSimulationLibraryRequest: boolean;
+  showNewSimulationRequest: boolean;
   pendingSiteLibraryDraft:
     | { lat: number; lon: number; token: string; suggestedName?: string; sourceMeta?: SiteLibraryEntry["sourceMeta"] }
     | null;
@@ -481,6 +482,7 @@ type AppState = {
   ) => void;
   clearPendingSiteLibraryDraft: () => void;
   setShowSimulationLibraryRequest: (show: boolean) => void;
+  setShowNewSimulationRequest: (show: boolean) => void;
   requestOpenSiteLibraryEntry: (entryId: string) => void;
   clearOpenSiteLibraryEntryRequest: () => void;
   setMapOverlayMode: (mode: MapOverlayMode) => void;
@@ -1101,6 +1103,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   endpointPickTarget: null,
   pendingSiteLibraryDraft: null,
   showSimulationLibraryRequest: false,
+  showNewSimulationRequest: false,
   pendingSiteLibraryOpenEntryId: null,
   scenarioOptions: BUILTIN_SCENARIOS.map((scenario) => ({ id: scenario.id, name: scenario.name })),
   mapOverlayMode: "heatmap",
@@ -2809,6 +2812,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     }),
   clearPendingSiteLibraryDraft: () => set({ pendingSiteLibraryDraft: null }),
   setShowSimulationLibraryRequest: (show) => set({ showSimulationLibraryRequest: show }),
+  setShowNewSimulationRequest: (show) => set({ showNewSimulationRequest: show }),
   requestOpenSiteLibraryEntry: (entryId) =>
     set({
       pendingSiteLibraryOpenEntryId: entryId.trim() ? entryId : null,


### PR DESCRIPTION
## Summary
- Welcome modal: compact card (not full-screen) with 3 action buttons
- Onboarding: restored as simple text modal (no library, no collapsible)
- OS detection for Cmd/Ctrl in onboarding text
- Trimmed onboarding content per feedback

## Changes
- `docs/onboarding.md`: Removed basemap providers, practical workflow, user roles, security note, recommended workflow. Added {{MODIFIER}} placeholder.
- `src/components/WelcomeModal.tsx`: Rewritten as compact card with Open Library / Create New / Read Getting Started buttons
- `src/components/OnboardingTutorialModal.tsx`: Restored as simple text modal with Simulation Library button link
- `src/components/AppShell.tsx`: Wired separate welcome and onboarding modals
- `src/components/Sidebar.tsx`: Bridges showNewSimulationRequest from store to local New Simulation modal
- `src/store/appStore.ts`: Added showNewSimulationRequest state
- `src/index.css`: Compact welcome card styles

## Verification
- npm test: 32 passed, 2 failed (pre-existing)
- npm run build: success