### PR TITLE
refactor(onboarding): inline links for Simulation Library and Site Library (#152)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -82,6 +82,7 @@ export function AppShell() {
   const isInitializing = useAppStore((state) => state.isInitializing);
   const setShowSimulationLibraryRequest = useAppStore((state) => state.setShowSimulationLibraryRequest);
   const setShowNewSimulationRequest = useAppStore((state) => state.setShowNewSimulationRequest);
+  const setShowSiteLibraryRequest = useAppStore((state) => state.setShowSiteLibraryRequest);
 
   const [isMapExpanded, setIsMapExpanded] = useState(false);
   const [isProfileExpanded, setIsProfileExpanded] = useState(false);
@@ -859,7 +860,7 @@ export function AppShell() {
           </button>
         </div>
         <WelcomeModal onClose={closeWelcome} onCreateNewSimulation={createNewFromWelcome} onOpenLibrary={openLibraryFromWelcome} onOpenOnboarding={openWelcomeFromWelcome} open={showWelcomeModal} />
-        <OnboardingTutorialModal onClose={() => setShowOnboardingTutorial(false)} onOpenLibrary={() => setShowSimulationLibraryRequest(true)} open={showOnboardingTutorial} />
+        <OnboardingTutorialModal onClose={() => setShowOnboardingTutorial(false)} onOpenLibrary={() => setShowSimulationLibraryRequest(true)} onOpenSiteLibrary={() => setShowSiteLibraryRequest(true)} open={showOnboardingTutorial} />
       </main>
     );
   }
@@ -911,7 +912,7 @@ export function AppShell() {
           </button>
         </div>
         <WelcomeModal onClose={closeWelcome} onCreateNewSimulation={createNewFromWelcome} onOpenLibrary={openLibraryFromWelcome} onOpenOnboarding={openWelcomeFromWelcome} open={showWelcomeModal} />
-        <OnboardingTutorialModal onClose={() => setShowOnboardingTutorial(false)} onOpenLibrary={() => setShowSimulationLibraryRequest(true)} open={showOnboardingTutorial} />
+        <OnboardingTutorialModal onClose={() => setShowOnboardingTutorial(false)} onOpenLibrary={() => setShowSimulationLibraryRequest(true)} onOpenSiteLibrary={() => setShowSiteLibraryRequest(true)} open={showOnboardingTutorial} />
       </main>
     );
   }
@@ -1036,7 +1037,7 @@ export function AppShell() {
         </button>
       </div>
       <WelcomeModal onClose={closeWelcome} onCreateNewSimulation={createNewFromWelcome} onOpenLibrary={openLibraryFromWelcome} onOpenOnboarding={openWelcomeFromWelcome} open={showWelcomeModal} />
-      <OnboardingTutorialModal onClose={() => setShowOnboardingTutorial(false)} onOpenLibrary={() => setShowSimulationLibraryRequest(true)} open={showOnboardingTutorial} />
+      <OnboardingTutorialModal onClose={() => setShowOnboardingTutorial(false)} onOpenLibrary={() => setShowSimulationLibraryRequest(true)} onOpenSiteLibrary={() => setShowSiteLibraryRequest(true)} open={showOnboardingTutorial} />
       {showMobileWarning ? (
         <ModalOverlay aria-label="Mobile support notice" onClose={() => setShowMobileWarning(false)} tier="raised">
           <div className="library-manager-card mobile-warning-modal-card">

--- a/src/components/OnboardingTutorialModal.tsx
+++ b/src/components/OnboardingTutorialModal.tsx
@@ -20,11 +20,20 @@ type OnboardingTutorialModalProps = {
   open: boolean;
   onClose: () => void;
   onOpenLibrary?: () => void;
+  onOpenSiteLibrary?: () => void;
 };
 
-export default function OnboardingTutorialModal({ open, onClose, onOpenLibrary }: OnboardingTutorialModalProps) {
+export default function OnboardingTutorialModal({
+  open,
+  onClose,
+  onOpenLibrary,
+  onOpenSiteLibrary,
+}: OnboardingTutorialModalProps) {
   const processedMarkdown = useMemo(() => {
-    return onboardingMarkdown.replace(/\{\{MODIFIER\}\}/g, isMac ? "Cmd" : "Ctrl");
+    return onboardingMarkdown
+      .replace(/\{\{MODIFIER\}\}/g, isMac ? "Cmd" : "Ctrl")
+      .replace(/\*\*Simulation Library\*\*/, "**SIMULATION_LIBRARY_LINK**")
+      .replace(/\*\*Site Library\*\*/, "**SITE_LIBRARY_LINK**");
   }, []);
 
   if (!open) return null;
@@ -44,25 +53,39 @@ export default function OnboardingTutorialModal({ open, onClose, onOpenLibrary }
             remarkPlugins={[remarkGfm]}
             components={{
               strong({ children, ...props }) {
-                if (typeof children === "string" && children === "SIMULATION_LIBRARY_BUTTON") {
+                if (typeof children === "string" && children === "SIMULATION_LIBRARY_LINK") {
                   return (
-                    <button
-                      className="inline-action"
-                      onClick={() => onOpenLibrary?.()}
-                      type="button"
+                    <a
+                      className="tutorial-inline-link"
+                      href="#"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        onOpenLibrary?.();
+                      }}
                     >
                       Simulation Library
-                    </button>
+                    </a>
+                  );
+                }
+                if (typeof children === "string" && children === "SITE_LIBRARY_LINK") {
+                  return (
+                    <a
+                      className="tutorial-inline-link"
+                      href="#"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        onOpenSiteLibrary?.();
+                      }}
+                    >
+                      Site Library
+                    </a>
                   );
                 }
                 return <strong {...props}>{children}</strong>;
               },
             }}
           >
-            {processedMarkdown.replace(
-              /\*\*Simulation Library\*\*/,
-              "**SIMULATION_LIBRARY_BUTTON**",
-            )}
+            {processedMarkdown}
           </ReactMarkdown>
         </div>
         <div className="tutorial-report-cta">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -404,6 +404,8 @@ export function Sidebar() {
   const setShowSimulationLibraryRequest = useAppStore((state) => state.setShowSimulationLibraryRequest);
   const showNewSimulationRequest = useAppStore((state) => state.showNewSimulationRequest);
   const setShowNewSimulationRequest = useAppStore((state) => state.setShowNewSimulationRequest);
+  const showSiteLibraryRequest = useAppStore((state) => state.showSiteLibraryRequest);
+  const setShowSiteLibraryRequest = useAppStore((state) => state.setShowSiteLibraryRequest);
   const selectedLink = useMemo(
     () => getSelectedLink(),
     [getSelectedLink, links, selectedLinkId, sites, networks, selectedNetworkId],
@@ -748,6 +750,12 @@ export function Sidebar() {
       setShowNewSimulationRequest(false);
     }
   }, [showNewSimulationRequest, setShowNewSimulationRequest]);
+  useEffect(() => {
+    if (showSiteLibraryRequest) {
+      setShowSiteLibraryManager(true);
+      setShowSiteLibraryRequest(false);
+    }
+  }, [showSiteLibraryRequest, setShowSiteLibraryRequest]);
   useEffect(() => {
     persistLibraryFilterState(SITE_LIBRARY_FILTERS_KEY, siteLibraryFilters);
   }, [siteLibraryFilters]);

--- a/src/index.css
+++ b/src/index.css
@@ -2135,6 +2135,17 @@ input {
   background: color-mix(in srgb, var(--surface) 86%, transparent);
 }
 
+.tutorial-inline-link {
+  color: var(--accent);
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.tutorial-inline-link:hover {
+  opacity: 0.8;
+}
+
 .welcome-compact-card {
   width: min(440px, 92vw);
   padding: 24px 28px;

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -344,6 +344,7 @@ type AppState = {
   endpointPickTarget: "from" | "to" | null;
   showSimulationLibraryRequest: boolean;
   showNewSimulationRequest: boolean;
+  showSiteLibraryRequest: boolean;
   pendingSiteLibraryDraft:
     | { lat: number; lon: number; token: string; suggestedName?: string; sourceMeta?: SiteLibraryEntry["sourceMeta"] }
     | null;
@@ -483,6 +484,7 @@ type AppState = {
   clearPendingSiteLibraryDraft: () => void;
   setShowSimulationLibraryRequest: (show: boolean) => void;
   setShowNewSimulationRequest: (show: boolean) => void;
+  setShowSiteLibraryRequest: (show: boolean) => void;
   requestOpenSiteLibraryEntry: (entryId: string) => void;
   clearOpenSiteLibraryEntryRequest: () => void;
   setMapOverlayMode: (mode: MapOverlayMode) => void;
@@ -1104,6 +1106,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   pendingSiteLibraryDraft: null,
   showSimulationLibraryRequest: false,
   showNewSimulationRequest: false,
+  showSiteLibraryRequest: false,
   pendingSiteLibraryOpenEntryId: null,
   scenarioOptions: BUILTIN_SCENARIOS.map((scenario) => ({ id: scenario.id, name: scenario.name })),
   mapOverlayMode: "heatmap",
@@ -2813,6 +2816,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   clearPendingSiteLibraryDraft: () => set({ pendingSiteLibraryDraft: null }),
   setShowSimulationLibraryRequest: (show) => set({ showSimulationLibraryRequest: show }),
   setShowNewSimulationRequest: (show) => set({ showNewSimulationRequest: show }),
+  setShowSiteLibraryRequest: (show) => set({ showSiteLibraryRequest: show }),
   requestOpenSiteLibraryEntry: (entryId) =>
     set({
       pendingSiteLibraryOpenEntryId: entryId.trim() ? entryId : null,


### PR DESCRIPTION
- Changed 'Simulation Library' from button to inline link in onboarding text
- Added inline link for 'Site Library' in the Sites section
- Added showSiteLibraryRequest store state to trigger Site Library from onboarding
- CSS: .tutorial-inline-link styles for subtle underlined accent-colored links