### PR TITLE
chore: sync staging with main after v0.11.0

### DIFF
--- a/functions/_lib/buildInfo.ts
+++ b/functions/_lib/buildInfo.ts
@@ -1,5 +1,5 @@
-export const APP_VERSION = "0.10.3";
-export const APP_COMMIT = "d4ece8e8";
+export const APP_VERSION = "0.11.0";
+export const APP_COMMIT = "87f75a57";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {

--- a/src/lib/buildInfo.ts
+++ b/src/lib/buildInfo.ts
@@ -1,5 +1,5 @@
-export const APP_VERSION = "0.10.3";
-export const APP_COMMIT = "d4ece8e8";
+export const APP_VERSION = "0.11.0";
+export const APP_COMMIT = "87f75a57";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {


### PR DESCRIPTION
Bring staging to parity with main (v0.11.0 release + blank simulation fix)