### PR TITLE
refactor: extract coverage state into separate Zustand store (#159)

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -20,6 +20,7 @@ import {
   type ProfileDraftSiteRequestDetail,
 } from "../lib/profileDraftEvent";
 import { useAppStore } from "../store/appStore";
+import { useCoverageStore } from "../store/coverageStore";
 import { TERRAIN_DATASET_LABEL } from "../lib/terrainDataset";
 import type { Link, PropagationEnvironment, Site } from "../types/radio";
 import { fetchMeshmapNodes, type MeshmapNode } from "../lib/meshtasticMqtt";
@@ -1031,7 +1032,7 @@ export function MapView({
   const setEndpointPickTarget = useAppStore((state) => state.setEndpointPickTarget);
   const requestSiteLibraryDraftAt = useAppStore((state) => state.requestSiteLibraryDraftAt);
   const requestOpenSiteLibraryEntry = useAppStore((state) => state.requestOpenSiteLibraryEntry);
-  const coverageSamples = useAppStore((state) => state.coverageSamples);
+  const coverageSamples = useCoverageStore((state) => state.coverageSamples);
   const srtmTiles = useAppStore((state) => state.srtmTiles);
   const terrainFetchStatus = useAppStore((state) => state.terrainFetchStatus);
   const terrainLoadingStartedAtMs = useAppStore((state) => state.terrainLoadingStartedAtMs);
@@ -1043,8 +1044,8 @@ export function MapView({
   const rxSensitivityTargetDbm = useAppStore((state) => state.rxSensitivityTargetDbm);
   const environmentLossDb = useAppStore((state) => state.environmentLossDb);
   const propagationEnvironment = useAppStore((state) => state.propagationEnvironment);
-  const isSimulationRecomputing = useAppStore((state) => state.isSimulationRecomputing);
-  const simulationProgress = useAppStore((state) => state.simulationProgress);
+  const isSimulationRecomputing = useCoverageStore((state) => state.isSimulationRecomputing);
+  const simulationProgress = useCoverageStore((state) => state.simulationProgress);
   const isTerrainFetching = useAppStore((state) => state.isTerrainFetching);
   const isTerrainRecommending = useAppStore((state) => state.isTerrainRecommending);
   const basemapProvider = useAppStore((state) => state.basemapProvider);

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
-import { buildCoverageAsync, clearTerrainLossCache } from "../lib/coverage";
+import { clearTerrainLossCache } from "../lib/coverage";
+import { setAppStoreBridge, useCoverageStore } from "./coverageStore";
 import { findPresetById } from "../lib/frequencyPlans";
 import { haversineDistanceKm } from "../lib/geo";
 import { getUiErrorMessage } from "../lib/uiError";
@@ -42,7 +43,6 @@ import type { UiColorTheme } from "../themes/types";
 import type { CloudUser } from "../lib/cloudUser";
 import type {
   CoverageMode,
-  CoverageSample,
   Link,
   LinkAnalysis,
   MapViewport,
@@ -56,14 +56,12 @@ import type {
 } from "../types/radio";
 
 const SYNC_DEBOUNCE_MS = 2500;
-const COVERAGE_RECOMPUTE_DEBOUNCE_MS = 140;
 const LAST_SIMULATION_REF_KEY = "rmw-last-simulation-ref-v1";
 const SYNC_SIGNATURE_KEY = "linksim-sync-signature-v1";
 const MIGRATION_DEFAULT_PRIVATE_KEY = "linksim-migration-default-private-v2";
 
 let hydrated = false;
 let syncTimer: number | null = null;
-let coverageRecomputeTimer: number | null = null;
 let syncInFlight = false;
 let localMutationRevision = 0;
 let syncedMutationRevision = 0;
@@ -305,10 +303,6 @@ type AppState = {
   systems: RadioSystem[];
   networks: Network[];
   srtmTiles: SrtmTile[];
-  coverageSamples: CoverageSample[];
-  isSimulationRecomputing: boolean;
-  simulationProgress: number;
-  simulationRunToken: string;
   isTerrainFetching: boolean;
   isTerrainRecommending: boolean;
   selectedLinkId: string;
@@ -501,7 +495,6 @@ type AppState = {
   recommendAndFetchTerrainForCurrentArea: () => Promise<void>;
   loadTerrainForCurrentArea: () => Promise<void>;
   clearTerrainCache: () => Promise<void>;
-  recomputeCoverage: () => void;
   getSelectedLink: () => Link;
   getSelectedSite: () => Site;
   getSelectedNetwork: () => Network;
@@ -1066,10 +1059,6 @@ export const useAppStore = create<AppState>((set, get) => ({
   systems: [],
   networks: [],
   srtmTiles: [],
-  coverageSamples: [],
-  isSimulationRecomputing: false,
-  simulationProgress: 0,
-  simulationRunToken: "",
   isTerrainFetching: false,
   isTerrainRecommending: false,
   selectedLinkId: "",
@@ -1605,7 +1594,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       siteLibrary: libraryBacked.siteLibrary,
     });
     writeStorage(LAST_SESSION_KEY, { selectedScenarioId: scenario.id, savedAtIso: new Date().toISOString() });
-    get().recomputeCoverage();
+    useCoverageStore.getState().recomputeCoverage();
   },
   setSelectedLinkId: (id) =>
     set((state) => {
@@ -1716,11 +1705,11 @@ export const useAppStore = create<AppState>((set, get) => ({
     }),
   setSelectedNetworkId: (id) => {
     set({ selectedNetworkId: id });
-    get().recomputeCoverage();
+    useCoverageStore.getState().recomputeCoverage();
   },
   setSelectedCoverageMode: (mode) => {
     set({ selectedCoverageMode: mode });
-    get().recomputeCoverage();
+    useCoverageStore.getState().recomputeCoverage();
     get().updateCurrentSimulationSnapshot();
   },
   setSelectedFrequencyPresetId: (id) => {
@@ -1737,7 +1726,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   },
   setAutoPropagationEnvironment: (value) => {
     set({ autoPropagationEnvironment: value });
-    get().recomputeCoverage();
+    useCoverageStore.getState().recomputeCoverage();
     get().updateCurrentSimulationSnapshot();
   },
   setPropagationEnvironment: (patch) => {
@@ -1749,7 +1738,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       autoPropagationEnvironment: false,
       propagationEnvironmentReason: "Manual override active.",
     }));
-    get().recomputeCoverage();
+    useCoverageStore.getState().recomputeCoverage();
     get().updateCurrentSimulationSnapshot();
   },
   applyClimateDefaults: (climate) => {
@@ -1758,7 +1747,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       autoPropagationEnvironment: false,
       propagationEnvironmentReason: "Manual climate defaults applied.",
     }));
-    get().recomputeCoverage();
+    useCoverageStore.getState().recomputeCoverage();
     get().updateCurrentSimulationSnapshot();
   },
   setTerrainDataset: (dataset) => {
@@ -1825,7 +1814,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         siteLibrary: nextLibrary,
       };
     });
-    get().recomputeCoverage();
+    useCoverageStore.getState().recomputeCoverage();
     get().updateCurrentSimulationSnapshot();
   },
   deleteSite: (siteId) => {
@@ -1890,7 +1879,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         })),
       };
     });
-    get().recomputeCoverage();
+    useCoverageStore.getState().recomputeCoverage();
     get().updateCurrentSimulationSnapshot();
   },
   createLink: (fromSiteId, toSiteId, name) => {
@@ -1930,7 +1919,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       mapOverlayMode: defaultOverlayModeForSelectionCount(2),
       temporaryDirectionReversed: false,
     }));
-    get().recomputeCoverage();
+    useCoverageStore.getState().recomputeCoverage();
     get().updateCurrentSimulationSnapshot();
   },
   addSiteLibraryEntry: (
@@ -2051,7 +2040,7 @@ export const useAppStore = create<AppState>((set, get) => ({
           state.selectedLinkId === linkId ? false : state.temporaryDirectionReversed,
       };
     });
-    get().recomputeCoverage();
+    useCoverageStore.getState().recomputeCoverage();
     get().updateCurrentSimulationSnapshot();
   },
   insertSiteFromLibrary: (entryId) => {
@@ -2159,7 +2148,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         mapOverlayMode: defaultOverlayModeForSelectionCount(createdSiteIds.length ? 1 : state.selectedSiteIds.length),
       };
     });
-    get().recomputeCoverage();
+    useCoverageStore.getState().recomputeCoverage();
     get().updateCurrentSimulationSnapshot();
   },
   updateSiteLibraryEntry: (entryId, patch) => {
@@ -2202,7 +2191,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       );
       return { siteLibrary: next, sites: nextSites, links: nextLinks };
     });
-    get().recomputeCoverage();
+    useCoverageStore.getState().recomputeCoverage();
   },
   deleteSiteLibraryEntry: (entryId) => {
     get().deleteSiteLibraryEntries([entryId]);
@@ -2551,7 +2540,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         terrainFetchStatus: `Loaded simulation preset: ${preset.name}`,
       });
       writeStorage(LAST_SESSION_KEY, { selectedScenarioId: preset.id, savedAtIso: loadedAtIso });
-      get().recomputeCoverage();
+      useCoverageStore.getState().recomputeCoverage();
       return;
     }
     const recovered = ensureMinimumTopology(
@@ -2616,7 +2605,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       writeStorage(SITE_LIBRARY_KEY, libraryBacked.siteLibrary);
     }
     writeStorage(LAST_SESSION_KEY, { selectedScenarioId: preset.id, savedAtIso: new Date().toISOString() });
-    get().recomputeCoverage();
+    useCoverageStore.getState().recomputeCoverage();
   },
   renameSimulationPreset: (presetId, name) => {
     const { currentUser } = get();
@@ -2763,7 +2752,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       simulationPresets: nextSimulationPresets,
       sites: syncedSites,
     });
-    get().recomputeCoverage();
+    useCoverageStore.getState().recomputeCoverage();
     return {
       siteCount: nextSiteLibrary.length - siteCountBefore,
       simulationCount: nextSimulationPresets.length - simCountBefore,
@@ -2857,12 +2846,12 @@ export const useAppStore = create<AppState>((set, get) => ({
       ),
       links: state.links.map((link) => ({ ...link, frequencyMHz: preset.frequencyMHz })),
     }));
-    get().recomputeCoverage();
+    useCoverageStore.getState().recomputeCoverage();
     get().updateCurrentSimulationSnapshot();
   },
   setPropagationModel: (model) => {
     set({ propagationModel: model });
-    get().recomputeCoverage();
+    useCoverageStore.getState().recomputeCoverage();
     get().updateCurrentSimulationSnapshot();
   },
   updateSite: (id, patch) => {
@@ -2907,7 +2896,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       writeStorage(SITE_LIBRARY_KEY, nextLibrary);
       return { sites: nextSites, siteLibrary: nextLibrary };
     });
-    get().recomputeCoverage();
+    useCoverageStore.getState().recomputeCoverage();
     get().updateCurrentSimulationSnapshot();
   },
   setSiteDragPreview: (id, preview) =>
@@ -2951,7 +2940,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         return stripRedundantLinkRadioOverrides(next, fromSite, toSite);
       }),
     }));
-    get().recomputeCoverage();
+    useCoverageStore.getState().recomputeCoverage();
     get().updateCurrentSimulationSnapshot();
   },
   updateMapViewport: (patch) =>
@@ -2989,7 +2978,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         isTerrainFetching: false,
       }));
       clearTerrainLossCache();
-      get().recomputeCoverage();
+      useCoverageStore.getState().recomputeCoverage();
     } finally {
       set({ isTerrainFetching: false });
     }
@@ -3084,7 +3073,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       set((state) => ({
         srtmTiles: mergeSrtmTiles(state.srtmTiles, result.tiles),
       }));
-      get().recomputeCoverage();
+      useCoverageStore.getState().recomputeCoverage();
     };
 
     const mergeLoadResults = (left: CopernicusLoadResult, right: CopernicusLoadResult): CopernicusLoadResult => ({
@@ -3272,7 +3261,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       set((state) => ({
         srtmTiles: mergeSrtmTiles(state.srtmTiles, result.tiles),
       }));
-      get().recomputeCoverage();
+      useCoverageStore.getState().recomputeCoverage();
     };
 
     const mergeLoadResults = (left: CopernicusLoadResult, right: CopernicusLoadResult): CopernicusLoadResult => ({
@@ -3368,147 +3357,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       terrainLoadEpoch: 0,
       terrainFetchStatus: "Terrain source caches cleared.",
     }));
-    get().recomputeCoverage();
-  },
-  recomputeCoverage: () => {
-    const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-    set({
-      simulationRunToken: runId,
-      isSimulationRecomputing: true,
-      simulationProgress: 3,
-    });
-
-    if (coverageRecomputeTimer !== null) {
-      window.clearTimeout(coverageRecomputeTimer);
-      coverageRecomputeTimer = null;
-    }
-
-    coverageRecomputeTimer = window.setTimeout(() => {
-      coverageRecomputeTimer = null;
-      const startedAt = Date.now();
-      if (get().simulationRunToken !== runId) return;
-
-      const runComputation = async () => {
-        const state = get();
-        if (state.simulationRunToken !== runId) return;
-
-        const {
-          selectedCoverageMode,
-          networks,
-          selectedNetworkId,
-          sites,
-          systems,
-          propagationModel,
-          srtmTiles,
-          links,
-          selectedLinkId,
-          autoPropagationEnvironment,
-          propagationEnvironment,
-          terrainLoadEpoch,
-        } = state;
-        const network = networks.find((n) => n.id === selectedNetworkId);
-        if (!network) {
-          const finalize = () => {
-            if (get().simulationRunToken !== runId) return;
-            set({
-              coverageSamples: [],
-              isSimulationRecomputing: false,
-              simulationProgress: 100,
-            });
-            window.setTimeout(() => {
-              if (get().simulationRunToken === runId) {
-                set({ simulationProgress: 0, simulationRunToken: "" });
-              }
-            }, 260);
-          };
-          const waitMs = Math.max(0, 600 - (Date.now() - startedAt));
-          window.setTimeout(finalize, waitMs);
-          return;
-        }
-
-        const selectedLink = links.find((link) => link.id === selectedLinkId) ?? links[0] ?? null;
-        const fromSite = selectedLink ? sites.find((site) => site.id === selectedLink.fromSiteId) ?? null : null;
-        const toSite = selectedLink ? sites.find((site) => site.id === selectedLink.toSiteId) ?? null : null;
-        const autoDerived =
-          autoPropagationEnvironment && fromSite && toSite
-            ? deriveDynamicPropagationEnvironment({
-                from: fromSite.position,
-                to: toSite.position,
-                fromGroundM: fromSite.groundElevationM,
-                toGroundM: toSite.groundElevationM,
-                terrainSampler: ({ lat, lon }) => sampleSrtmElevation(srtmTiles, lat, lon),
-              })
-            : null;
-        const effectiveEnvironment = autoDerived?.environment ?? propagationEnvironment;
-        if (autoDerived) {
-          if (
-            state.propagationEnvironmentReason !== autoDerived.reason ||
-            state.propagationEnvironment.clutterHeightM !== autoDerived.environment.clutterHeightM ||
-            state.propagationEnvironment.polarization !== autoDerived.environment.polarization ||
-            state.propagationEnvironment.groundDielectric !== autoDerived.environment.groundDielectric ||
-            state.propagationEnvironment.groundConductivity !== autoDerived.environment.groundConductivity ||
-            state.propagationEnvironment.radioClimate !== autoDerived.environment.radioClimate ||
-            state.propagationEnvironment.atmosphericBendingNUnits !== autoDerived.environment.atmosphericBendingNUnits
-          ) {
-            set({
-              propagationEnvironment: autoDerived.environment,
-              propagationEnvironmentReason: autoDerived.reason,
-            });
-          }
-        }
-
-        set({ simulationProgress: 8 });
-        let lastProgress = 8;
-        const coverageSamples = await buildCoverageAsync(
-          selectedCoverageMode,
-          network,
-          sites,
-          systems,
-          propagationModel,
-          effectiveEnvironment,
-          ({ lat, lon }) => sampleSrtmElevation(srtmTiles, lat, lon),
-          {
-            sampleMultiplier: 1,
-            terrainSamples: 20,
-            onProgress: (progress) => {
-              if (get().simulationRunToken !== runId) return;
-              const next = Math.round(8 + progress * 84);
-              if (next - lastProgress >= 2 || next >= 99) {
-                lastProgress = next;
-                set({ simulationProgress: next });
-              }
-            },
-            terrainCacheKey: `${selectedCoverageMode}|${selectedNetworkId}|${propagationModel}|${terrainLoadEpoch}`,
-          },
-        );
-        if (get().simulationRunToken !== runId) return;
-        const finalize = () => {
-          if (get().simulationRunToken === runId) {
-            set({
-              coverageSamples,
-              isSimulationRecomputing: false,
-              simulationProgress: 100,
-            });
-            window.setTimeout(() => {
-              if (get().simulationRunToken === runId) {
-                set({ simulationProgress: 0, simulationRunToken: "" });
-              }
-            }, 320);
-          }
-        };
-        const waitMs = Math.max(0, 600 - (Date.now() - startedAt));
-        window.setTimeout(finalize, waitMs);
-      };
-
-      // Let the browser paint the progress bar before starting heavy recomputation work.
-      if (typeof window !== "undefined" && typeof window.requestAnimationFrame === "function") {
-        window.requestAnimationFrame(() => {
-          window.requestAnimationFrame(runComputation);
-        });
-      } else {
-        window.setTimeout(runComputation, 0);
-      }
-    }, COVERAGE_RECOMPUTE_DEBOUNCE_MS);
+    useCoverageStore.getState().recomputeCoverage();
   },
   getSelectedLink: () => {
     const { links, selectedLinkId, sites, networks, selectedNetworkId } = get();
@@ -3669,4 +3518,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   },
 }));
 
-useAppStore.getState().recomputeCoverage();
+setAppStoreBridge({
+  getState: () => useAppStore.getState() as unknown as Record<string, unknown>,
+  setState: (patch) => useAppStore.setState(patch as Parameters<typeof useAppStore.setState>[0]),
+});

--- a/src/store/coverageStore.ts
+++ b/src/store/coverageStore.ts
@@ -1,0 +1,181 @@
+import { create } from "zustand";
+import { buildCoverageAsync } from "../lib/coverage";
+import {
+  deriveDynamicPropagationEnvironment,
+} from "../lib/propagationEnvironment";
+import { sampleSrtmElevation } from "../lib/srtm";
+import type { CoverageSample } from "../types/radio";
+
+const COVERAGE_RECOMPUTE_DEBOUNCE_MS = 140;
+
+let coverageRecomputeTimer: number | null = null;
+
+type AppStoreBridge = {
+  getState: () => Record<string, unknown>;
+  setState: (patch: Record<string, unknown>) => void;
+};
+
+let appStoreBridge: AppStoreBridge | null = null;
+
+export function setAppStoreBridge(bridge: AppStoreBridge): void {
+  appStoreBridge = bridge;
+}
+
+export type CoverageState = {
+  coverageSamples: CoverageSample[];
+  isSimulationRecomputing: boolean;
+  simulationProgress: number;
+  simulationRunToken: string;
+  recomputeCoverage: () => void;
+};
+
+export const useCoverageStore = create<CoverageState>((set, get) => ({
+  coverageSamples: [],
+  isSimulationRecomputing: false,
+  simulationProgress: 0,
+  simulationRunToken: "",
+  recomputeCoverage: () => {
+    if (!appStoreBridge) return;
+
+    const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    set({
+      simulationRunToken: runId,
+      isSimulationRecomputing: true,
+      simulationProgress: 3,
+    });
+
+    if (coverageRecomputeTimer !== null) {
+      window.clearTimeout(coverageRecomputeTimer);
+      coverageRecomputeTimer = null;
+    }
+
+    coverageRecomputeTimer = window.setTimeout(() => {
+      coverageRecomputeTimer = null;
+      const startedAt = Date.now();
+      if (get().simulationRunToken !== runId) return;
+
+      const runComputation = async () => {
+        if (get().simulationRunToken !== runId) return;
+
+        const appState = appStoreBridge!.getState();
+        const selectedCoverageMode = appState.selectedCoverageMode as string;
+        const networks = appState.networks as Array<{ id: string; [key: string]: unknown }>;
+        const selectedNetworkId = appState.selectedNetworkId as string;
+        const sites = appState.sites as Array<{ id: string; [key: string]: unknown }>;
+        const systems = appState.systems as unknown[];
+        const propagationModel = appState.propagationModel as string;
+        const srtmTiles = appState.srtmTiles as Parameters<typeof sampleSrtmElevation>[0];
+        const links = appState.links as Array<{ id: string; fromSiteId: string; toSiteId: string; [key: string]: unknown }>;
+        const selectedLinkId = appState.selectedLinkId as string;
+        const autoPropagationEnvironment = appState.autoPropagationEnvironment as boolean;
+        const propagationEnvironment = appState.propagationEnvironment as Record<string, unknown>;
+        const propagationEnvironmentReason = appState.propagationEnvironmentReason as string;
+        const terrainLoadEpoch = appState.terrainLoadEpoch as number;
+
+        const network = networks.find((n) => n.id === selectedNetworkId);
+        if (!network) {
+          const finalize = () => {
+            if (get().simulationRunToken !== runId) return;
+            set({
+              coverageSamples: [],
+              isSimulationRecomputing: false,
+              simulationProgress: 100,
+            });
+            window.setTimeout(() => {
+              if (get().simulationRunToken === runId) {
+                set({ simulationProgress: 0, simulationRunToken: "" });
+              }
+            }, 260);
+          };
+          const waitMs = Math.max(0, 600 - (Date.now() - startedAt));
+          window.setTimeout(finalize, waitMs);
+          return;
+        }
+
+        const selectedLink = links.find((link) => link.id === selectedLinkId) ?? links[0] ?? null;
+        const fromSite = selectedLink ? sites.find((site) => site.id === selectedLink.fromSiteId) ?? null : null;
+        const toSite = selectedLink ? sites.find((site) => site.id === selectedLink.toSiteId) ?? null : null;
+        const autoDerived =
+          autoPropagationEnvironment && fromSite && toSite
+            ? deriveDynamicPropagationEnvironment({
+                from: fromSite.position as { lat: number; lon: number },
+                to: toSite.position as { lat: number; lon: number },
+                fromGroundM: fromSite.groundElevationM as number,
+                toGroundM: toSite.groundElevationM as number,
+                terrainSampler: ({ lat, lon }: { lat: number; lon: number }) =>
+                  sampleSrtmElevation(srtmTiles, lat, lon),
+              })
+            : null;
+        const effectiveEnvironment = autoDerived?.environment ?? propagationEnvironment;
+        if (autoDerived) {
+          if (
+            propagationEnvironmentReason !== autoDerived.reason ||
+            propagationEnvironment.clutterHeightM !== autoDerived.environment.clutterHeightM ||
+            propagationEnvironment.polarization !== autoDerived.environment.polarization ||
+            propagationEnvironment.groundDielectric !== autoDerived.environment.groundDielectric ||
+            propagationEnvironment.groundConductivity !== autoDerived.environment.groundConductivity ||
+            propagationEnvironment.radioClimate !== autoDerived.environment.radioClimate ||
+            propagationEnvironment.atmosphericBendingNUnits !== autoDerived.environment.atmosphericBendingNUnits
+          ) {
+            appStoreBridge!.setState({
+              propagationEnvironment: autoDerived.environment,
+              propagationEnvironmentReason: autoDerived.reason,
+            });
+          }
+        }
+
+        set({ simulationProgress: 8 });
+        let lastProgress = 8;
+        const coverageSamples = await buildCoverageAsync(
+          selectedCoverageMode as Parameters<typeof buildCoverageAsync>[0],
+          network as Parameters<typeof buildCoverageAsync>[1],
+          sites as Parameters<typeof buildCoverageAsync>[2],
+          systems as Parameters<typeof buildCoverageAsync>[3],
+          propagationModel as Parameters<typeof buildCoverageAsync>[4],
+          effectiveEnvironment as Parameters<typeof buildCoverageAsync>[5],
+          ({ lat, lon }: { lat: number; lon: number }) =>
+            sampleSrtmElevation(srtmTiles, lat, lon),
+          {
+            sampleMultiplier: 1,
+            terrainSamples: 20,
+            onProgress: (progress: number) => {
+              if (get().simulationRunToken !== runId) return;
+              const next = Math.round(8 + progress * 84);
+              if (next - lastProgress >= 2 || next >= 99) {
+                lastProgress = next;
+                set({ simulationProgress: next });
+              }
+            },
+            terrainCacheKey: `${selectedCoverageMode}|${selectedNetworkId}|${propagationModel}|${terrainLoadEpoch}`,
+          },
+        );
+        if (get().simulationRunToken !== runId) return;
+        const finalize = () => {
+          if (get().simulationRunToken === runId) {
+            set({
+              coverageSamples,
+              isSimulationRecomputing: false,
+              simulationProgress: 100,
+            });
+            window.setTimeout(() => {
+              if (get().simulationRunToken === runId) {
+                set({ simulationProgress: 0, simulationRunToken: "" });
+              }
+            }, 320);
+          }
+        };
+        const waitMs = Math.max(0, 600 - (Date.now() - startedAt));
+        window.setTimeout(finalize, waitMs);
+      };
+
+      // Let the browser paint the progress bar before starting heavy recomputation work.
+      if (typeof window !== "undefined" && typeof window.requestAnimationFrame === "function") {
+        window.requestAnimationFrame(() => {
+          window.requestAnimationFrame(runComputation);
+        });
+      } else {
+        window.setTimeout(runComputation, 0);
+      }
+    }, COVERAGE_RECOMPUTE_DEBOUNCE_MS);
+  },
+}));


### PR DESCRIPTION
## Summary
- Extract coverage state (`coverageSamples`, `isSimulationRecomputing`, `simulationProgress`, `simulationRunToken`) and `recomputeCoverage` action from `appStore.ts` into a new `coverageStore.ts`
- `MapView.tsx` now subscribes to `useCoverageStore` for coverage fields instead of `useAppStore`
- 23 `recomputeCoverage` call sites in `appStore.ts` updated to call via `useCoverageStore.getState().recomputeCoverage()`
- Bridge pattern (`setAppStoreBridge`) resolves circular dependency between the two stores

## Verification
- `npm test` passed (178 tests)
- `npm run build` passed

Closes #159