### PR TITLE
fix: update simulation snapshot after library entry edit (#91)

### DIFF
--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -2192,6 +2192,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       return { siteLibrary: next, sites: nextSites, links: nextLinks };
     });
     useCoverageStore.getState().recomputeCoverage();
+    get().updateCurrentSimulationSnapshot();
   },
   deleteSiteLibraryEntry: (entryId) => {
     get().deleteSiteLibraryEntries([entryId]);


### PR DESCRIPTION
## Summary

- `updateSiteLibraryEntry` was missing the `updateCurrentSimulationSnapshot()` call that every other mutation function (`updateSite`, `updateLink`, `setPropagationModel`, etc.) makes. This caused gain, power, cable loss, antenna height, and other fields edited via the resource details popup to not be reflected in the simulation preset snapshot until a full page reload.

## Root Cause

After editing a library entry's gain (or any field), the store's live `sites` array was correctly updated via `syncLibraryLinkedSiteValues`, but the simulation preset snapshot retained stale values. On reload or cross-device sync, the old values would surface.

## Fix

Added `get().updateCurrentSimulationSnapshot()` to `updateSiteLibraryEntry` at `src/store/appStore.ts:2195`, matching the pattern used by all other mutation functions.

## Verification

- [x] `npm test` — all 178 tests pass
- [x] `npm run build` — compiles successfully
- [ ] Manual QA on staging: edit gain via Library → Edit → verify EIRP/RX/link margin update immediately

Closes #91