### PR TITLE
fix: map background overlays and inspector consolidation (#88)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1013,37 +1013,35 @@ export function AppShell() {
           {shareStatus ? <span className="field-help">{shareStatus}</span> : null}
           {deepLinkNotice ? <span className="field-help">{deepLinkNotice}</span> : null}
         </div>
-        {!isProfileExpanded ? (
-          <MapView
-            isMapExpanded={isMapExpanded}
-            canPersist={canPersistWorkspace}
-            onShare={
-              accessState === "granted"
-                ? () => {
-                    setShareStatus(null);
-                    if (!activeSimulation) {
-                      setShareStatus(
-                        "Open a saved simulation first. Unsaved workspace state cannot be shared as a deep link.",
-                      );
-                      return;
-                    }
-                    if (toVisibility(activeSimulation.visibility) === "private") {
-                      setShowShareModal(true);
-                      return;
-                    }
-                    void copyCurrentLink()
-                      .then(() => setShareStatus("Copied to clipboard."))
-                      .catch((error) => setShareStatus(getUiErrorMessage(error)));
+        <MapView
+          isMapExpanded={isMapExpanded}
+          canPersist={canPersistWorkspace}
+          onShare={
+            accessState === "granted"
+              ? () => {
+                  setShareStatus(null);
+                  if (!activeSimulation) {
+                    setShareStatus(
+                      "Open a saved simulation first. Unsaved workspace state cannot be shared as a deep link.",
+                    );
+                    return;
                   }
-                : undefined
-            }
-            readOnly={!canPersistWorkspace}
-            onToggleMapExpanded={() => {
-              setIsProfileExpanded(false);
-              setIsMapExpanded((prev) => !prev);
-            }}
-          />
-        ) : null}
+                  if (toVisibility(activeSimulation.visibility) === "private") {
+                    setShowShareModal(true);
+                    return;
+                  }
+                  void copyCurrentLink()
+                    .then(() => setShareStatus("Copied to clipboard."))
+                    .catch((error) => setShareStatus(getUiErrorMessage(error)));
+                }
+              : undefined
+          }
+          readOnly={!canPersistWorkspace}
+          onToggleMapExpanded={() => {
+            setIsProfileExpanded(false);
+            setIsMapExpanded((prev) => !prev);
+          }}
+        />
         {!isMapExpanded ? (
           <LinkProfileChart
             isExpanded={isProfileExpanded}

--- a/src/components/LinkProfileChart.tsx
+++ b/src/components/LinkProfileChart.tsx
@@ -804,13 +804,13 @@ export function LinkProfileChart({ isExpanded, onToggleExpanded }: LinkProfileCh
           Flip Direction
         </button>
         <button
-          aria-label={isExpanded ? "Exit profile fullscreen" : "Profile fullscreen"}
+          aria-label={isExpanded ? "Exit full screen" : "Full screen"}
           className={`chart-endpoint-swap ${isExpanded ? "is-active" : ""}`}
           onClick={onToggleExpanded}
-          title={isExpanded ? "Exit fullscreen" : "Fullscreen"}
+          title={isExpanded ? "Exit full screen" : "Full screen"}
           type="button"
         >
-          {isExpanded ? "Exit Fullscreen" : "Fullscreen"}
+          {isExpanded ? "Exit Full screen" : "Full screen"}
         </button>
         <div className="chart-hover-state">
           {cursorPoint && footerCursorState ? (

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1915,13 +1915,7 @@ export function MapView({
   }
   if (endpointPickTarget && endpointPickError) inspectorLines.push(endpointPickError);
   if (siteDraftStatus) inspectorLines.push(siteDraftStatus);
-  const showInspector =
-    Boolean(inspectorPrimary) ||
-    inspectorLines.length > 0 ||
-    Boolean(pendingNewSiteDraft) ||
-    Boolean(mqttDuplicatePrompt) ||
-    isSimulationRecomputing ||
-    isBackgroundBusy;
+  const showInspector = true;
 
   return (
     <div className={hasMinimumTopology ? "map-panel" : "map-panel map-panel-empty"}>
@@ -2049,7 +2043,7 @@ export function MapView({
         </div>
         <div className="map-controls-group map-controls-group-utility">
           <button className="map-control-btn" onClick={onToggleMapExpanded} type="button">
-            {isMapExpanded ? "Exit Fullscreen" : "Fullscreen"}
+            {isMapExpanded ? "Show Panels" : "Hide Panels"}
           </button>
           <button className="map-control-btn" onClick={fitToNodes} type="button">
             Fit
@@ -2197,75 +2191,12 @@ export function MapView({
               </span>
             </div>
           ) : null}
-        </aside>
-      ) : null}
-      <aside className="map-sim-summary" aria-live="polite">
-        <div className="map-sim-summary-header">
-          <h3>Simulation Sources</h3>
-          <button
-            className="map-control-btn map-summary-toggle"
-            onClick={() => setShowSimulationSummary((current) => !current)}
-            type="button"
+          <details
+            className="compact-details map-inspector-details"
+            onToggle={(event) => setShowOverlayGuide(event.currentTarget.open)}
+            open={showOverlayGuide}
           >
-            {showSimulationSummary ? "Hide" : "Show"}
-          </button>
-        </div>
-        {showSimulationSummary ? (
-          <>
-            <p>
-              Model: {propagationModel} / {selectedCoverageMode} / View: {coverageVizMode}
-            </p>
-            <p>
-              Network: {selectedNetwork?.name ?? "n/a"} @{" "}
-              {(selectedNetwork?.frequencyOverrideMHz ?? selectedNetwork?.frequencyMHz ?? 0).toFixed(3)} MHz
-            </p>
-            <p>
-              Terrain dataset: {TERRAIN_DATASET_LABEL[terrainDataset]} ({selectedDatasetTileCount} matching tile
-              {selectedDatasetTileCount === 1 ? "" : "s"}, {srtmTiles.length} total loaded)
-            </p>
-            {terrainSourceSummary.length ? (
-              <ul className="map-sim-sources">
-                {terrainSourceSummary.map((entry) => (
-                  <li key={entry.label}>
-                    {entry.label}: {entry.count}
-                  </li>
-                ))}
-              </ul>
-            ) : (
-              <p>Terrain source: simulation/manual site elevations only</p>
-            )}
-            <p>Site elevations: Simulation values</p>
-            <p>Resolution: Auto ({overlayDimensions.width}x{overlayDimensions.height})</p>
-            <p>Overlay area diagonal: {analysisBoundsDiagonalKm.toFixed(0)} km</p>
-            <p>Optimization thresholds (by simulation area): &gt;250 km, &gt;400 km, &gt;600 km.</p>
-            {largeAreaOptimizationActive ? (
-              <p>
-                Large-area optimization active (preview resolution scale {Math.round(overlayResolutionScale * 100)}%).
-                Zoom in or narrow site spread for higher detail.
-              </p>
-            ) : (
-              <p>Large-area optimization inactive at this simulation extent.</p>
-            )}
-            <p>
-              Coverage values are terrain-aware when ITM model is selected and terrain tiles are loaded.
-            </p>
-            <p>Terrain overlay: {showTerrainOverlay ? "Visible" : "Hidden"} (simulation still uses loaded terrain)</p>
-          </>
-        ) : null}
-      </aside>
-      <aside className="map-overlay-guide" aria-live="polite">
-        <div className="map-sim-summary-header">
-          <h3>Overlay Guide</h3>
-          <button
-            className="map-control-btn map-summary-toggle"
-            onClick={() => setShowOverlayGuide((current) => !current)}
-            type="button"
-          >
-            {showOverlayGuide ? "Hide" : "Show"}
-          </button>
-        </div>
-        {showOverlayGuide ? (
-          <>
+            <summary>Overlay Guide</summary>
             <p>
               Mode: <strong>{overlayGuideTitle}</strong>
             </p>
@@ -2273,8 +2204,8 @@ export function MapView({
             {coverageVizMode === "heatmap" ? (
               <>
                 <p>
-                  Shows overall coverage strength from your current simulation sites. Think of it as “how good signal
-                  should feel if you stand here”.
+                  Shows overall coverage strength from your current simulation sites. Think of it as "how good signal
+                  should feel if you stand here".
                 </p>
                 <div className="overlay-inline-controls">
                   <span>Style</span>
@@ -2400,9 +2331,54 @@ export function MapView({
                 <p className="overlay-scale-help">Left side is worse relay quality. Right side is better relay quality.</p>
               </>
             ) : null}
-          </>
-        ) : null}
-      </aside>
+          </details>
+          <details
+            className="compact-details map-inspector-details"
+            onToggle={(event) => setShowSimulationSummary(event.currentTarget.open)}
+            open={showSimulationSummary}
+          >
+            <summary>Simulation Sources</summary>
+            <p>
+              Model: {propagationModel} / {selectedCoverageMode} / View: {coverageVizMode}
+            </p>
+            <p>
+              Network: {selectedNetwork?.name ?? "n/a"} @ {" "}
+              {(selectedNetwork?.frequencyOverrideMHz ?? selectedNetwork?.frequencyMHz ?? 0).toFixed(3)} MHz
+            </p>
+            <p>
+              Terrain dataset: {TERRAIN_DATASET_LABEL[terrainDataset]} ({selectedDatasetTileCount} matching tile
+              {selectedDatasetTileCount === 1 ? "" : "s"}, {srtmTiles.length} total loaded)
+            </p>
+            {terrainSourceSummary.length ? (
+              <ul className="map-sim-sources">
+                {terrainSourceSummary.map((entry) => (
+                  <li key={entry.label}>
+                    {entry.label}: {entry.count}
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p>Terrain source: simulation/manual site elevations only</p>
+            )}
+            <p>Site elevations: Simulation values</p>
+            <p>Resolution: Auto ({overlayDimensions.width}x{overlayDimensions.height})</p>
+            <p>Overlay area diagonal: {analysisBoundsDiagonalKm.toFixed(0)} km</p>
+            <p>Optimization thresholds (by simulation area): &gt;250 km, &gt;400 km, &gt;600 km.</p>
+            {largeAreaOptimizationActive ? (
+              <p>
+                Large-area optimization active (preview resolution scale {Math.round(overlayResolutionScale * 100)}%).
+                Zoom in or narrow site spread for higher detail.
+              </p>
+            ) : (
+              <p>Large-area optimization inactive at this simulation extent.</p>
+            )}
+            <p>
+              Coverage values are terrain-aware when ITM model is selected and terrain tiles are loaded.
+            </p>
+            <p>Terrain overlay: {showTerrainOverlay ? "Visible" : "Hidden"} (simulation still uses loaded terrain)</p>
+          </details>
+        </aside>
+      ) : null}
       <Map
         ref={mapRef}
         longitude={activeViewState.longitude}

--- a/src/index.css
+++ b/src/index.css
@@ -99,8 +99,12 @@ input {
 .app-shell {
   display: grid;
   grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
+  --sidebar-overlay-width: clamp(280px, 30vw, 360px);
+  --workspace-panel-gap: 18px;
   gap: 18px;
   padding: 18px;
+  position: relative;
+  isolation: isolate;
   height: 100dvh;
   min-height: 100dvh;
   overflow: hidden;
@@ -146,6 +150,8 @@ input {
   border-radius: 18px;
   box-shadow: var(--shadow);
   padding: 18px;
+  position: relative;
+  z-index: 40;
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -531,8 +537,14 @@ input {
   position: relative;
   display: grid;
   grid-template-rows: minmax(0, 1fr) minmax(220px, 32vh);
-  gap: 18px;
+  gap: var(--workspace-panel-gap);
   min-height: 0;
+  z-index: 30;
+  pointer-events: none;
+}
+
+.workspace-panel > * {
+  pointer-events: auto;
 }
 
 .workspace-header-actions {
@@ -667,7 +679,12 @@ input {
 }
 
 .map-panel {
-  position: relative;
+  position: fixed;
+  inset: 0;
+  z-index: 1;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
 }
 
 .map-panel-empty .maplibregl-map {
@@ -693,9 +710,9 @@ input {
 
 .map-controls {
   position: absolute;
-  top: 12px;
-  left: 12px;
-  right: 12px;
+  top: 18px;
+  left: 18px;
+  right: 18px;
   z-index: 5;
   display: flex;
   flex-wrap: nowrap;
@@ -706,8 +723,12 @@ input {
   scrollbar-width: thin;
 }
 
+.app-shell:not(.is-map-expanded) .map-controls {
+  left: calc(var(--sidebar-overlay-width) + 30px);
+}
+
 .map-controls-unified {
-  z-index: 7;
+  z-index: 60;
 }
 
 .map-controls-group-provider {
@@ -764,7 +785,7 @@ input {
   position: absolute;
   top: 66px;
   right: 12px;
-  z-index: 30;
+  z-index: 60;
   padding: 6px 9px;
   border-radius: 8px;
   border: 1px solid color-mix(in srgb, var(--selection) 45%, var(--border));
@@ -792,9 +813,12 @@ input {
 .map-inspector {
   position: absolute;
   top: 66px;
-  right: 12px;
-  z-index: 6;
-  width: min(420px, calc(100% - 24px));
+  right: 18px;
+  z-index: 60;
+  width: min(var(--sidebar-overlay-width), calc(100% - 36px));
+  max-height: calc(100dvh - 84px);
+  bottom: auto;
+  overflow: auto;
   border: 1px solid var(--border);
   border-radius: 10px;
   background: color-mix(in srgb, var(--surface-2) 95%, transparent);
@@ -803,6 +827,69 @@ input {
   display: grid;
   gap: 0;
   font-size: 0.76rem;
+}
+
+.workspace-panel:not(.is-map-expanded):not(.is-profile-expanded) .map-inspector {
+  bottom: auto;
+  max-height: calc(100dvh - 66px - 18px - (32vh + var(--workspace-panel-gap)));
+}
+
+.workspace-panel:not(.is-map-expanded):not(.is-profile-expanded) .map-panel .maplibregl-ctrl-bottom-right,
+.workspace-panel:not(.is-map-expanded):not(.is-profile-expanded) .map-panel .maplibregl-ctrl-bottom-left {
+  bottom: calc(220px + var(--workspace-panel-gap));
+}
+
+.workspace-panel:not(.is-map-expanded) .map-panel .maplibregl-ctrl-bottom-right,
+.workspace-panel:not(.is-map-expanded) .map-panel .maplibregl-ctrl-bottom-left {
+  left: calc(var(--sidebar-overlay-width) + 30px);
+  right: auto;
+}
+
+.workspace-panel:not(.is-map-expanded):not(.is-profile-expanded) .map-panel .maplibregl-ctrl-bottom-right,
+.workspace-panel:not(.is-map-expanded):not(.is-profile-expanded) .map-panel .maplibregl-ctrl-bottom-left {
+  bottom: calc(max(220px, 32vh) + var(--workspace-panel-gap) + 18px);
+}
+
+.workspace-panel.is-map-expanded .map-panel .maplibregl-ctrl-bottom-right,
+.workspace-panel.is-map-expanded .map-panel .maplibregl-ctrl-bottom-left,
+.workspace-panel.is-profile-expanded .map-panel .maplibregl-ctrl-bottom-right,
+.workspace-panel.is-profile-expanded .map-panel .maplibregl-ctrl-bottom-left {
+  left: 12px;
+  right: auto;
+  bottom: 12px;
+}
+
+.map-panel .maplibregl-ctrl-attrib {
+  border: 1px solid color-mix(in srgb, var(--border) 86%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--surface-2) 94%, var(--surface));
+  color: var(--text);
+  box-shadow: var(--shadow-elev-2);
+  font-size: 0.7rem;
+  line-height: 1.2;
+  padding: 3px 8px;
+}
+
+.map-panel .maplibregl-ctrl-attrib.maplibregl-compact {
+  min-height: 24px;
+  display: inline-flex;
+  align-items: center;
+}
+
+.map-panel .maplibregl-ctrl-attrib a {
+  color: var(--text);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.map-panel .maplibregl-ctrl-attrib a:hover {
+  color: var(--accent);
+}
+
+.map-panel .maplibregl-ctrl-attrib a:focus-visible {
+  outline: 2px solid var(--focus-outline);
+  outline-offset: 2px;
+  border-radius: 4px;
 }
 
 .map-inspector-primary {
@@ -826,6 +913,10 @@ input {
 
 .map-inspector-section + .map-inspector-section {
   border-top: 1px solid color-mix(in srgb, var(--border) 84%, transparent);
+}
+
+.map-inspector-details {
+  margin-top: 8px;
 }
 
 .map-progress {
@@ -874,7 +965,7 @@ input {
   position: absolute;
   left: 12px;
   bottom: 12px;
-  z-index: 5;
+  z-index: 60;
   max-width: 320px;
   border: 1px solid var(--border);
   border-radius: 10px;
@@ -888,7 +979,7 @@ input {
   position: absolute;
   right: 12px;
   bottom: 12px;
-  z-index: 5;
+  z-index: 60;
   max-width: 340px;
   border: 1px solid var(--border);
   border-radius: 10px;
@@ -1144,6 +1235,13 @@ input {
   flex-direction: column;
   gap: 8px;
   min-height: 0;
+  position: relative;
+  z-index: 35;
+  grid-row: 2;
+}
+
+.workspace-panel.is-profile-expanded .chart-panel {
+  grid-row: 1;
 }
 
 .chart-panel-empty {
@@ -1436,6 +1534,7 @@ input {
   .app-shell {
     grid-template-columns: 1fr;
     grid-template-rows: auto auto;
+    --sidebar-overlay-width: 0px;
     padding: 12px;
     height: auto;
     min-height: 100dvh;
@@ -1454,6 +1553,7 @@ input {
   }
 
   .workspace-panel {
+    --workspace-panel-gap: 12px;
     grid-template-rows: minmax(420px, 62vh) minmax(190px, 30vh);
     gap: 12px;
     height: auto;
@@ -1485,9 +1585,13 @@ input {
   .map-controls {
     flex-direction: column;
     align-items: stretch;
-    left: 8px;
-    right: 8px;
+    left: 12px;
+    right: 12px;
     gap: 8px;
+  }
+
+  .app-shell:not(.is-map-expanded) .map-controls {
+    left: 12px;
   }
 
   .map-provider-field .locale-select {
@@ -1497,6 +1601,23 @@ input {
   .map-controls-group,
   .map-controls-group-utility {
     justify-content: flex-start;
+  }
+
+  .map-inspector {
+    right: 12px;
+    width: min(420px, calc(100% - 24px));
+    max-height: calc(100dvh - 84px);
+  }
+
+  .workspace-panel:not(.is-profile-expanded) .map-inspector {
+    max-height: calc(100dvh - 84px);
+    bottom: auto;
+  }
+
+  .workspace-panel:not(.is-map-expanded) .map-panel .maplibregl-ctrl-bottom-right,
+  .workspace-panel:not(.is-map-expanded) .map-panel .maplibregl-ctrl-bottom-left {
+    left: 8px;
+    bottom: 8px;
   }
 }
 


### PR DESCRIPTION
## Summary
- keep the map mounted as a full-viewport background layer while sidebar and path profile act as overlays
- replace map/profile fullscreen wording with panel/focus behavior and align controls with overlay layout
- merge Overlay Guide and Simulation Sources into expandable sections inside the inspector, with inspector scrolling and attribution positioning tuned for overlay mode

## Verification
- npm test
- npm run build