### PR TITLE
feat: mobile tabbed workspace overlays for simulation viewing (#171)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -23,6 +23,7 @@ const MOBILE_WARNING_DISMISS_KEY = "linksim:mobile-warning-dismissed:v1";
 const LOCAL_FORCE_READONLY_KEY = "linksim:local-force-readonly:v1";
 const OPEN_SYNC_MODAL_EVENT = "linksim:open-sync-modal";
 const ACCESS_CHECK_TIMEOUT_MS = 10_000;
+type MobileWorkspacePanel = "map" | "profile" | "inspector" | "sidebar";
 
 const toVisibility = (value: unknown): "private" | "public" | "shared" =>
   value === "shared" || value === "public" ? value : "private";
@@ -98,6 +99,8 @@ export function AppShell() {
   const [copyToast, setCopyToast] = useState<string | null>(null);
   const [deepLinkNotice, setDeepLinkNotice] = useState<string | null>(null);
   const [showMobileWarning, setShowMobileWarning] = useState(false);
+  const [isMobileViewport, setIsMobileViewport] = useState(false);
+  const [mobileActivePanel, setMobileActivePanel] = useState<MobileWorkspacePanel>("profile");
   const [localDevStatus, setLocalDevStatus] = useState<string | null>(null);
   const [offlineBannerDismissed, setOfflineBannerDismissed] = useState(false);
   const deepLinkAppliedRef = useRef(false);
@@ -399,6 +402,14 @@ export function AppShell() {
     },
     [],
   );
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(max-width: 980px)");
+    const applyViewport = () => setIsMobileViewport(mediaQuery.matches);
+    applyViewport();
+    mediaQuery.addEventListener("change", applyViewport);
+    return () => mediaQuery.removeEventListener("change", applyViewport);
+  }, []);
 
   useEffect(() => {
     const isMobile = window.matchMedia("(max-width: 900px)").matches;
@@ -950,9 +961,13 @@ export function AppShell() {
     <main
       className={`app-shell ${isMapExpanded || isProfileExpanded ? "is-map-expanded" : ""} ${
         accessState === "readonly" ? "is-readonly-shell" : ""
+      } ${
+        isMobileViewport ? "is-mobile-shell" : ""
+      } ${
+        isMobileViewport ? `mobile-panel-${mobileActivePanel}` : ""
       }`}
     >
-      {!isMapExpanded && !isProfileExpanded && (accessState === "granted" || accessState === "readonly") ? <Sidebar /> : null}
+      {!isMobileViewport && !isMapExpanded && !isProfileExpanded && (accessState === "granted" || accessState === "readonly") ? <Sidebar /> : null}
       <section className={`workspace-panel ${isMapExpanded ? "is-map-expanded" : ""} ${isProfileExpanded ? "is-profile-expanded" : ""}`}>
         {!isOnline && !offlineBannerDismissed ? (
           <div className="offline-banner" role="status">
@@ -1015,6 +1030,7 @@ export function AppShell() {
         </div>
         <MapView
           isMapExpanded={isMapExpanded}
+          showInspector={!isMobileViewport || mobileActivePanel === "inspector"}
           canPersist={canPersistWorkspace}
           onShare={
             accessState === "granted"
@@ -1039,10 +1055,69 @@ export function AppShell() {
           readOnly={!canPersistWorkspace}
           onToggleMapExpanded={() => {
             setIsProfileExpanded(false);
-            setIsMapExpanded((prev) => !prev);
+            setIsMapExpanded((prev) => {
+              const next = !prev;
+              if (isMobileViewport) {
+                setMobileActivePanel(next ? "map" : "profile");
+              }
+              return next;
+            });
           }}
         />
-        {!isMapExpanded ? (
+        {isMobileViewport ? (
+          <div className="mobile-workspace-tabs" role="tablist" aria-label="Mobile workspace panels">
+            <button
+              aria-selected={mobileActivePanel === "sidebar"}
+              className={`mobile-workspace-tab ${mobileActivePanel === "sidebar" ? "is-active" : ""}`}
+              onClick={() => {
+                setIsMapExpanded(false);
+                setMobileActivePanel("sidebar");
+              }}
+              role="tab"
+              type="button"
+            >
+              Sidebar
+            </button>
+            <button
+              aria-selected={mobileActivePanel === "inspector"}
+              className={`mobile-workspace-tab ${mobileActivePanel === "inspector" ? "is-active" : ""}`}
+              onClick={() => {
+                setIsMapExpanded(false);
+                setMobileActivePanel("inspector");
+              }}
+              role="tab"
+              type="button"
+            >
+              Inspector
+            </button>
+            <button
+              aria-selected={mobileActivePanel === "profile"}
+              className={`mobile-workspace-tab ${mobileActivePanel === "profile" ? "is-active" : ""}`}
+              onClick={() => {
+                setIsMapExpanded(false);
+                setMobileActivePanel("profile");
+              }}
+              role="tab"
+              type="button"
+            >
+              Path Profile
+            </button>
+            <button
+              aria-selected={mobileActivePanel === "map"}
+              className={`mobile-workspace-tab ${mobileActivePanel === "map" ? "is-active" : ""}`}
+              onClick={() => {
+                setIsProfileExpanded(false);
+                setIsMapExpanded(true);
+                setMobileActivePanel("map");
+              }}
+              role="tab"
+              type="button"
+            >
+              Map
+            </button>
+          </div>
+        ) : null}
+        {!isMobileViewport && !isMapExpanded ? (
           <LinkProfileChart
             isExpanded={isProfileExpanded}
             onToggleExpanded={() => {
@@ -1050,6 +1125,22 @@ export function AppShell() {
               setIsProfileExpanded((prev) => !prev);
             }}
           />
+        ) : null}
+        {isMobileViewport && !isMapExpanded && mobileActivePanel === "profile" ? (
+          <div className="mobile-workspace-panel" role="tabpanel" aria-label="Path profile panel">
+            <LinkProfileChart
+              isExpanded={isProfileExpanded}
+              onToggleExpanded={() => {
+                setIsMapExpanded(false);
+                setIsProfileExpanded((prev) => !prev);
+              }}
+            />
+          </div>
+        ) : null}
+        {isMobileViewport && !isMapExpanded && mobileActivePanel === "sidebar" ? (
+          <div className="mobile-workspace-panel mobile-workspace-panel-sidebar" role="tabpanel" aria-label="Sidebar panel">
+            {(accessState === "granted" || accessState === "readonly") ? <Sidebar /> : null}
+          </div>
         ) : null}
       </section>
       <div className="floating-help-cluster">

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -971,6 +971,7 @@ const computeFitViewport = (
 
 type MapViewProps = {
   isMapExpanded: boolean;
+  showInspector?: boolean;
   readOnly?: boolean;
   canPersist?: boolean;
   onToggleMapExpanded: () => void;
@@ -1002,6 +1003,7 @@ const DEFAULT_MAP_VIEWPORT = {
 
 export function MapView({
   isMapExpanded,
+  showInspector = true,
   readOnly = false,
   canPersist = true,
   onToggleMapExpanded,
@@ -1915,8 +1917,6 @@ export function MapView({
   }
   if (endpointPickTarget && endpointPickError) inspectorLines.push(endpointPickError);
   if (siteDraftStatus) inspectorLines.push(siteDraftStatus);
-  const showInspector = true;
-
   return (
     <div className={hasMinimumTopology ? "map-panel" : "map-panel map-panel-empty"}>
       <div className="map-controls map-controls-unified">

--- a/src/index.css
+++ b/src/index.css
@@ -547,6 +547,14 @@ input {
   pointer-events: auto;
 }
 
+.mobile-workspace-tabs {
+  display: none;
+}
+
+.mobile-workspace-panel {
+  display: none;
+}
+
 .workspace-header-actions {
   position: absolute;
   top: 26px;
@@ -1531,6 +1539,95 @@ input {
 }
 
 @media (max-width: 980px) {
+  .app-shell.is-mobile-shell {
+    --mobile-tabbar-offset: calc(12px + env(safe-area-inset-bottom));
+    --mobile-tabbar-height: 38px;
+    --mobile-panel-height: 36vh;
+  }
+
+  .app-shell.is-mobile-shell .mobile-workspace-tabs {
+    position: fixed;
+    left: 12px;
+    right: 12px;
+    bottom: var(--mobile-tabbar-offset);
+    z-index: 90;
+  }
+
+  .app-shell.is-mobile-shell .mobile-workspace-panel {
+    position: fixed;
+    left: 12px;
+    right: 12px;
+    bottom: calc(var(--mobile-tabbar-offset) + var(--mobile-tabbar-height));
+    z-index: 85;
+  }
+
+  .mobile-workspace-tabs {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 8px;
+    padding: 0;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
+  }
+
+  .mobile-workspace-tab {
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: color-mix(in srgb, var(--surface-2) 90%, transparent);
+    color: var(--text);
+    min-height: 34px;
+    font-size: 0.74rem;
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .mobile-workspace-tab.is-active {
+    border-color: var(--accent);
+    background: var(--accent-soft);
+  }
+
+  .mobile-workspace-panel {
+    display: grid;
+    height: var(--mobile-panel-height);
+    overflow: visible;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
+    padding: 0;
+    z-index: 45;
+  }
+
+  .mobile-workspace-panel .chart-panel {
+    z-index: auto;
+    height: 100%;
+  }
+
+  .mobile-workspace-panel-sidebar {
+    padding: 0;
+  }
+
+  .mobile-workspace-panel-sidebar .sidebar-panel,
+  .mobile-workspace-panel .sidebar-panel {
+    height: 100%;
+    max-height: none;
+    min-height: auto;
+    overflow: auto;
+  }
+
+  .app-shell.is-mobile-shell.mobile-panel-map .mobile-workspace-panel,
+  .app-shell.is-mobile-shell.mobile-panel-inspector .mobile-workspace-panel {
+    display: none;
+  }
+
+  .app-shell.is-mobile-shell.mobile-panel-sidebar .map-inspector,
+  .app-shell.is-mobile-shell.mobile-panel-profile .map-inspector,
+  .app-shell.is-mobile-shell.mobile-panel-map .map-inspector {
+    display: none;
+  }
+
   .app-shell {
     grid-template-columns: 1fr;
     grid-template-rows: auto auto;
@@ -1539,6 +1636,12 @@ input {
     height: auto;
     min-height: 100dvh;
     overflow: auto;
+  }
+
+  .app-shell.is-mobile-shell {
+    grid-template-rows: minmax(0, 1fr);
+    padding: 0;
+    overflow: hidden;
   }
 
   .app-shell.is-map-expanded {
@@ -1554,10 +1657,13 @@ input {
 
   .workspace-panel {
     --workspace-panel-gap: 12px;
-    grid-template-rows: minmax(420px, 62vh) minmax(190px, 30vh);
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: minmax(0, 1fr);
     gap: 12px;
-    height: auto;
-    min-height: 0;
+    height: 100dvh;
+    min-height: 100dvh;
+    align-content: start;
+    padding-bottom: 0;
   }
 
   .workspace-header-actions {
@@ -1579,6 +1685,10 @@ input {
   }
 
   .workspace-panel.is-profile-expanded {
+    grid-template-rows: minmax(0, 1fr);
+  }
+
+  .app-shell.is-mobile-shell .workspace-panel.is-profile-expanded {
     grid-template-rows: minmax(0, 1fr);
   }
 
@@ -1609,16 +1719,44 @@ input {
     max-height: calc(100dvh - 84px);
   }
 
+  .app-shell.is-mobile-shell .map-inspector {
+    display: none;
+  }
+
+  .app-shell.is-mobile-shell.mobile-panel-inspector .map-inspector {
+    display: grid;
+    position: fixed;
+    top: auto;
+    right: 12px;
+    left: 12px;
+    bottom: calc(var(--mobile-tabbar-offset) + var(--mobile-tabbar-height));
+    width: auto;
+    height: var(--mobile-panel-height);
+    max-height: none;
+    z-index: 85;
+  }
+
+  .app-shell.is-mobile-shell .map-panel .maplibregl-ctrl-bottom-right,
+  .app-shell.is-mobile-shell .map-panel .maplibregl-ctrl-bottom-left {
+    left: 8px;
+    right: auto;
+    bottom: calc(var(--mobile-tabbar-offset) + var(--mobile-tabbar-height) + 8px);
+  }
+
+  .app-shell.is-mobile-shell.mobile-panel-sidebar .map-panel .maplibregl-ctrl-bottom-right,
+  .app-shell.is-mobile-shell.mobile-panel-sidebar .map-panel .maplibregl-ctrl-bottom-left,
+  .app-shell.is-mobile-shell.mobile-panel-profile .map-panel .maplibregl-ctrl-bottom-right,
+  .app-shell.is-mobile-shell.mobile-panel-profile .map-panel .maplibregl-ctrl-bottom-left,
+  .app-shell.is-mobile-shell.mobile-panel-inspector .map-panel .maplibregl-ctrl-bottom-right,
+  .app-shell.is-mobile-shell.mobile-panel-inspector .map-panel .maplibregl-ctrl-bottom-left {
+    bottom: calc(var(--mobile-tabbar-offset) + var(--mobile-tabbar-height) + var(--mobile-panel-height) + 8px);
+  }
+
   .workspace-panel:not(.is-profile-expanded) .map-inspector {
     max-height: calc(100dvh - 84px);
     bottom: auto;
   }
 
-  .workspace-panel:not(.is-map-expanded) .map-panel .maplibregl-ctrl-bottom-right,
-  .workspace-panel:not(.is-map-expanded) .map-panel .maplibregl-ctrl-bottom-left {
-    left: 8px;
-    bottom: 8px;
-  }
 }
 
 .locale-select {


### PR DESCRIPTION
## Summary
- add mobile-only bottom tab bar with tabs for Sidebar, Inspector, Path Profile, and Map
- keep map full-screen on mobile and render sidebar/profile/inspector as bottom overlays for viewing workflows
- unify bottom panel sizing and spacing, with attribution offsets adjusted to remain visible across tabs and map mode

## Verification
- npm test
- npm run build