### PR TITLE
fix: mobile viewport fit for edge-to-edge map on iPhone (#171)

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <meta id="app-theme-color" name="theme-color" content="#0077ff" />
     <meta name="apple-mobile-web-app-title" content="LinkSim" />
     <meta name="application-name" content="LinkSim" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>LinkSim</title>
   </head>
   <body>

--- a/src/index.css
+++ b/src/index.css
@@ -1539,11 +1539,6 @@ input {
 }
 
 @media (max-width: 980px) {
-  .env-staging body::after,
-  .env-local body::after {
-    border-width: 0;
-  }
-
   .app-shell.is-mobile-shell {
     --mobile-tabbar-offset: calc(12px + env(safe-area-inset-bottom));
     --mobile-tabbar-height: 38px;


### PR DESCRIPTION
## Summary
- enable  in the document viewport meta so iOS can render content into notch/home-indicator areas
- keep existing staging/local environment frame styling on mobile

## Verification
- npm run build