### PR TITLE
fix: force true full-viewport mobile map sizing (#171)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -26,7 +26,8 @@ body,
 #root {
   margin: 0;
   width: 100%;
-  min-height: 100%;
+  height: 100%;
+  min-height: 100dvh;
 }
 
 body {
@@ -1539,6 +1540,14 @@ input {
 }
 
 @media (max-width: 980px) {
+  html,
+  body,
+  #root {
+    height: 100dvh;
+    min-height: 100dvh;
+    overflow: hidden;
+  }
+
   .app-shell.is-mobile-shell {
     --mobile-tabbar-offset: calc(12px + env(safe-area-inset-bottom));
     --mobile-tabbar-height: 38px;
@@ -1691,6 +1700,20 @@ input {
 
   .app-shell.is-mobile-shell .workspace-panel.is-profile-expanded {
     grid-template-rows: minmax(0, 1fr);
+  }
+
+  .app-shell.is-mobile-shell .map-panel {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: 100vw;
+    height: 100dvh;
+    margin: 0;
+    border: 0;
+    border-radius: 0;
+    box-shadow: none;
   }
 
   .map-controls {


### PR DESCRIPTION
## Summary
- force mobile  to full viewport height and hidden overflow for stable iOS viewport behavior
- force mobile map panel to explicit fixed viewport bounds (, , )
- keep mobile overlay/tab system unchanged while removing rectangle-constrained map rendering

## Verification
- npm run build