### PR TITLE
fix: stabilize iOS viewport sizing for full-screen mobile map (#171)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -412,6 +412,24 @@ export function AppShell() {
   }, []);
 
   useEffect(() => {
+    const applyDynamicViewportHeight = () => {
+      const viewportHeight = window.visualViewport?.height ?? window.innerHeight;
+      document.documentElement.style.setProperty("--app-dynamic-vh", `${Math.round(viewportHeight)}px`);
+    };
+    applyDynamicViewportHeight();
+    window.addEventListener("resize", applyDynamicViewportHeight);
+    window.addEventListener("orientationchange", applyDynamicViewportHeight);
+    window.visualViewport?.addEventListener("resize", applyDynamicViewportHeight);
+    window.visualViewport?.addEventListener("scroll", applyDynamicViewportHeight);
+    return () => {
+      window.removeEventListener("resize", applyDynamicViewportHeight);
+      window.removeEventListener("orientationchange", applyDynamicViewportHeight);
+      window.visualViewport?.removeEventListener("resize", applyDynamicViewportHeight);
+      window.visualViewport?.removeEventListener("scroll", applyDynamicViewportHeight);
+    };
+  }, []);
+
+  useEffect(() => {
     const isMobile = window.matchMedia("(max-width: 900px)").matches;
     if (!isMobile) return;
     try {

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1103,6 +1103,22 @@ export function MapView({
     zoom: number;
   } | null>(null);
   const mapRef = useRef<MapRef | null>(null);
+
+  useEffect(() => {
+    const handleViewportChange = () => {
+      mapRef.current?.resize();
+    };
+    window.addEventListener("resize", handleViewportChange);
+    window.addEventListener("orientationchange", handleViewportChange);
+    window.visualViewport?.addEventListener("resize", handleViewportChange);
+    window.visualViewport?.addEventListener("scroll", handleViewportChange);
+    return () => {
+      window.removeEventListener("resize", handleViewportChange);
+      window.removeEventListener("orientationchange", handleViewportChange);
+      window.visualViewport?.removeEventListener("resize", handleViewportChange);
+      window.visualViewport?.removeEventListener("scroll", handleViewportChange);
+    };
+  }, []);
   const hasNonAutoLinks = useMemo(
     () => links.some((link) => (link.name ?? "").trim().toLowerCase() !== "auto link"),
     [links],

--- a/src/index.css
+++ b/src/index.css
@@ -15,6 +15,7 @@
   --los: Highlight;
   --shadow: 0 16px 42px color-mix(in srgb, CanvasText 14%, transparent);
   --focus-outline: color-mix(in srgb, var(--accent) 62%, Canvas 18%);
+  --app-dynamic-vh: 100dvh;
 }
 
 * {
@@ -1543,8 +1544,8 @@ input {
   html,
   body,
   #root {
-    height: 100dvh;
-    min-height: 100dvh;
+    height: var(--app-dynamic-vh);
+    min-height: var(--app-dynamic-vh);
     overflow: hidden;
   }
 
@@ -1643,7 +1644,7 @@ input {
     --sidebar-overlay-width: 0px;
     padding: 12px;
     height: auto;
-    min-height: 100dvh;
+    min-height: var(--app-dynamic-vh);
     overflow: auto;
   }
 
@@ -1670,8 +1671,8 @@ input {
     grid-template-columns: minmax(0, 1fr);
     grid-template-rows: minmax(0, 1fr);
     gap: 12px;
-    height: 100dvh;
-    min-height: 100dvh;
+    height: var(--app-dynamic-vh);
+    min-height: var(--app-dynamic-vh);
     align-content: start;
     padding-bottom: 0;
   }
@@ -1709,7 +1710,7 @@ input {
     bottom: 0;
     left: 0;
     width: 100vw;
-    height: 100dvh;
+    height: var(--app-dynamic-vh);
     margin: 0;
     border: 0;
     border-radius: 0;


### PR DESCRIPTION
## Summary
- derive a dynamic viewport-height CSS variable from  (fallback )
- apply that variable to mobile root/shell/map sizing to avoid iOS viewport rectangle clipping
- trigger MapLibre resize on viewport/orientation changes to keep the map canvas synced with live viewport dimensions

## Verification
- npm run build