### PR TITLE
fix: use layout viewport sizing for iOS full-bleed map (#171)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -412,24 +412,6 @@ export function AppShell() {
   }, []);
 
   useEffect(() => {
-    const applyDynamicViewportHeight = () => {
-      const viewportHeight = window.visualViewport?.height ?? window.innerHeight;
-      document.documentElement.style.setProperty("--app-dynamic-vh", `${Math.round(viewportHeight)}px`);
-    };
-    applyDynamicViewportHeight();
-    window.addEventListener("resize", applyDynamicViewportHeight);
-    window.addEventListener("orientationchange", applyDynamicViewportHeight);
-    window.visualViewport?.addEventListener("resize", applyDynamicViewportHeight);
-    window.visualViewport?.addEventListener("scroll", applyDynamicViewportHeight);
-    return () => {
-      window.removeEventListener("resize", applyDynamicViewportHeight);
-      window.removeEventListener("orientationchange", applyDynamicViewportHeight);
-      window.visualViewport?.removeEventListener("resize", applyDynamicViewportHeight);
-      window.visualViewport?.removeEventListener("scroll", applyDynamicViewportHeight);
-    };
-  }, []);
-
-  useEffect(() => {
     const isMobile = window.matchMedia("(max-width: 900px)").matches;
     if (!isMobile) return;
     try {

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1110,13 +1110,9 @@ export function MapView({
     };
     window.addEventListener("resize", handleViewportChange);
     window.addEventListener("orientationchange", handleViewportChange);
-    window.visualViewport?.addEventListener("resize", handleViewportChange);
-    window.visualViewport?.addEventListener("scroll", handleViewportChange);
     return () => {
       window.removeEventListener("resize", handleViewportChange);
       window.removeEventListener("orientationchange", handleViewportChange);
-      window.visualViewport?.removeEventListener("resize", handleViewportChange);
-      window.visualViewport?.removeEventListener("scroll", handleViewportChange);
     };
   }, []);
   const hasNonAutoLinks = useMemo(

--- a/src/index.css
+++ b/src/index.css
@@ -15,7 +15,6 @@
   --los: Highlight;
   --shadow: 0 16px 42px color-mix(in srgb, CanvasText 14%, transparent);
   --focus-outline: color-mix(in srgb, var(--accent) 62%, Canvas 18%);
-  --app-dynamic-vh: 100dvh;
 }
 
 * {
@@ -28,7 +27,7 @@ body,
   margin: 0;
   width: 100%;
   height: 100%;
-  min-height: 100dvh;
+  min-height: 100lvh;
 }
 
 body {
@@ -1544,8 +1543,8 @@ input {
   html,
   body,
   #root {
-    height: var(--app-dynamic-vh);
-    min-height: var(--app-dynamic-vh);
+    height: 100lvh;
+    min-height: 100lvh;
     overflow: hidden;
   }
 
@@ -1644,7 +1643,7 @@ input {
     --sidebar-overlay-width: 0px;
     padding: 12px;
     height: auto;
-    min-height: var(--app-dynamic-vh);
+    min-height: 100lvh;
     overflow: auto;
   }
 
@@ -1671,8 +1670,8 @@ input {
     grid-template-columns: minmax(0, 1fr);
     grid-template-rows: minmax(0, 1fr);
     gap: 12px;
-    height: var(--app-dynamic-vh);
-    min-height: var(--app-dynamic-vh);
+    height: 100lvh;
+    min-height: 100lvh;
     align-content: start;
     padding-bottom: 0;
   }
@@ -1710,7 +1709,7 @@ input {
     bottom: 0;
     left: 0;
     width: 100vw;
-    height: var(--app-dynamic-vh);
+    height: 100lvh;
     margin: 0;
     border: 0;
     border-radius: 0;


### PR DESCRIPTION
## Summary
- remove -driven height clamping that can constrain content to safe-area rectangle
- use layout viewport sizing () for mobile root/shell/map height handling
- keep viewport-fit=cover and safe-area offsets for overlays

## Verification
- npm run build