### PR TITLE
feat: mobile panel toggle tabs and map multi-select mode (#171)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -23,7 +23,7 @@ const MOBILE_WARNING_DISMISS_KEY = "linksim:mobile-warning-dismissed:v1";
 const LOCAL_FORCE_READONLY_KEY = "linksim:local-force-readonly:v1";
 const OPEN_SYNC_MODAL_EVENT = "linksim:open-sync-modal";
 const ACCESS_CHECK_TIMEOUT_MS = 10_000;
-type MobileWorkspacePanel = "map" | "profile" | "inspector" | "sidebar";
+type MobileWorkspacePanel = "profile" | "inspector" | "sidebar";
 
 const toVisibility = (value: unknown): "private" | "public" | "shared" =>
   value === "shared" || value === "public" ? value : "private";
@@ -109,7 +109,6 @@ export function AppShell() {
 
   const { theme, variant } = useThemeVariant();
   const runtimeEnvironment = getCurrentRuntimeEnvironment();
-  const envBadgeLabel = runtimeEnvironment === "local" ? "LOCAL" : runtimeEnvironment === "staging" ? "STAGING" : "";
   const isLocalRuntime = runtimeEnvironment === "local";
 
   const deepLinkParse = useMemo(() => parseDeepLinkFromLocation(window.location), []);
@@ -888,17 +887,6 @@ export function AppShell() {
           ) : null}
            {localDevStatus ? <p className="field-help">{localDevStatus}</p> : null}
         </section>
-        <div className="floating-help-cluster">
-          {envBadgeLabel ? <span className="floating-env-badge">{envBadgeLabel}</span> : null}
-          <button
-            aria-label="Open onboarding"
-            className="floating-help-button"
-            onClick={openOnboardingTutorial}
-            type="button"
-          >
-            ?
-          </button>
-        </div>
         <WelcomeModal onClose={closeWelcome} onCreateNewSimulation={createNewFromWelcome} onOpenLibrary={openLibraryFromWelcome} onOpenOnboarding={openWelcomeFromWelcome} open={showWelcomeModal} />
         <OnboardingTutorialModal onClose={() => setShowOnboardingTutorial(false)} onOpenLibrary={() => setShowSimulationLibraryRequest(true)} onOpenSiteLibrary={() => setShowSiteLibraryRequest(true)} open={showOnboardingTutorial} />
       </main>
@@ -940,17 +928,6 @@ export function AppShell() {
           </div>
           {localDevStatus ? <p className="field-help">{localDevStatus}</p> : null}
         </section>
-        <div className="floating-help-cluster">
-          {envBadgeLabel ? <span className="floating-env-badge">{envBadgeLabel}</span> : null}
-          <button
-            aria-label="Open onboarding"
-            className="floating-help-button"
-            onClick={openOnboardingTutorial}
-            type="button"
-          >
-            ?
-          </button>
-        </div>
         <WelcomeModal onClose={closeWelcome} onCreateNewSimulation={createNewFromWelcome} onOpenLibrary={openLibraryFromWelcome} onOpenOnboarding={openWelcomeFromWelcome} open={showWelcomeModal} />
         <OnboardingTutorialModal onClose={() => setShowOnboardingTutorial(false)} onOpenLibrary={() => setShowSimulationLibraryRequest(true)} onOpenSiteLibrary={() => setShowSiteLibraryRequest(true)} open={showOnboardingTutorial} />
       </main>
@@ -967,7 +944,9 @@ export function AppShell() {
         isMobileViewport ? `mobile-panel-${mobileActivePanel}` : ""
       }`}
     >
-      {!isMobileViewport && !isMapExpanded && !isProfileExpanded && (accessState === "granted" || accessState === "readonly") ? <Sidebar /> : null}
+      {!isMobileViewport && !isMapExpanded && !isProfileExpanded && (accessState === "granted" || accessState === "readonly") ? (
+        <Sidebar onOpenHelp={openOnboardingTutorial} />
+      ) : null}
       <section className={`workspace-panel ${isMapExpanded ? "is-map-expanded" : ""} ${isProfileExpanded ? "is-profile-expanded" : ""}`}>
         {!isOnline && !offlineBannerDismissed ? (
           <div className="offline-banner" role="status">
@@ -1030,7 +1009,7 @@ export function AppShell() {
         </div>
         <MapView
           isMapExpanded={isMapExpanded}
-          showInspector={!isMobileViewport || mobileActivePanel === "inspector"}
+          showInspector={!isMobileViewport || (!isMapExpanded && mobileActivePanel === "inspector")}
           canPersist={canPersistWorkspace}
           onShare={
             accessState === "granted"
@@ -1058,7 +1037,9 @@ export function AppShell() {
             setIsMapExpanded((prev) => {
               const next = !prev;
               if (isMobileViewport) {
-                setMobileActivePanel(next ? "map" : "profile");
+                if (!next) {
+                  setMobileActivePanel("profile");
+                }
               }
               return next;
             });
@@ -1070,6 +1051,11 @@ export function AppShell() {
               aria-selected={mobileActivePanel === "sidebar"}
               className={`mobile-workspace-tab ${mobileActivePanel === "sidebar" ? "is-active" : ""}`}
               onClick={() => {
+                setIsProfileExpanded(false);
+                if (!isMapExpanded && mobileActivePanel === "sidebar") {
+                  setIsMapExpanded(true);
+                  return;
+                }
                 setIsMapExpanded(false);
                 setMobileActivePanel("sidebar");
               }}
@@ -1082,6 +1068,11 @@ export function AppShell() {
               aria-selected={mobileActivePanel === "inspector"}
               className={`mobile-workspace-tab ${mobileActivePanel === "inspector" ? "is-active" : ""}`}
               onClick={() => {
+                setIsProfileExpanded(false);
+                if (!isMapExpanded && mobileActivePanel === "inspector") {
+                  setIsMapExpanded(true);
+                  return;
+                }
                 setIsMapExpanded(false);
                 setMobileActivePanel("inspector");
               }}
@@ -1094,21 +1085,13 @@ export function AppShell() {
               aria-selected={mobileActivePanel === "profile"}
               className={`mobile-workspace-tab ${mobileActivePanel === "profile" ? "is-active" : ""}`}
               onClick={() => {
+                if (!isMapExpanded && mobileActivePanel === "profile") {
+                  setIsMapExpanded(true);
+                  setIsProfileExpanded(false);
+                  return;
+                }
                 setIsMapExpanded(false);
                 setMobileActivePanel("profile");
-              }}
-              role="tab"
-              type="button"
-            >
-              Path Profile
-            </button>
-            <button
-              aria-selected={mobileActivePanel === "map"}
-              className={`mobile-workspace-tab ${mobileActivePanel === "map" ? "is-active" : ""}`}
-              onClick={() => {
-                setIsProfileExpanded(false);
-                setIsMapExpanded(true);
-                setMobileActivePanel("map");
               }}
               role="tab"
               type="button"
@@ -1139,21 +1122,10 @@ export function AppShell() {
         ) : null}
         {isMobileViewport && !isMapExpanded && mobileActivePanel === "sidebar" ? (
           <div className="mobile-workspace-panel mobile-workspace-panel-sidebar" role="tabpanel" aria-label="Sidebar panel">
-            {(accessState === "granted" || accessState === "readonly") ? <Sidebar /> : null}
+            {(accessState === "granted" || accessState === "readonly") ? <Sidebar onOpenHelp={openOnboardingTutorial} /> : null}
           </div>
         ) : null}
       </section>
-      <div className="floating-help-cluster">
-        {envBadgeLabel ? <span className="floating-env-badge">{envBadgeLabel}</span> : null}
-        <button
-          aria-label="Open onboarding"
-          className="floating-help-button"
-          onClick={openOnboardingTutorial}
-          type="button"
-        >
-          ?
-        </button>
-      </div>
       <WelcomeModal onClose={closeWelcome} onCreateNewSimulation={createNewFromWelcome} onOpenLibrary={openLibraryFromWelcome} onOpenOnboarding={openWelcomeFromWelcome} open={showWelcomeModal} />
       <OnboardingTutorialModal onClose={() => setShowOnboardingTutorial(false)} onOpenLibrary={() => setShowSimulationLibraryRequest(true)} onOpenSiteLibrary={() => setShowSiteLibraryRequest(true)} open={showOnboardingTutorial} />
       {showMobileWarning ? (

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1078,6 +1078,7 @@ export function MapView({
   const [bandStepMode, setBandStepMode] = useState<BandStepMode>("auto");
   const [showTerrainOverlay, setShowTerrainOverlay] = useState(false);
   const [showSimulationSummary, setShowSimulationSummary] = useState(false);
+  const [isMultiSelectMode, setIsMultiSelectMode] = useState(false);
   const [showOverlayGuide, setShowOverlayGuide] = useState(true);
   const [endpointPickError, setEndpointPickError] = useState<string | null>(null);
   const [pendingNewSiteDraft, setPendingNewSiteDraft] = useState<PendingNewSiteDraft | null>(null);
@@ -2057,6 +2058,13 @@ export function MapView({
           <button className="map-control-btn" onClick={onToggleMapExpanded} type="button">
             {isMapExpanded ? "Show Panels" : "Hide Panels"}
           </button>
+          <button
+            className={`map-control-btn ${isMultiSelectMode ? "is-selected" : ""}`}
+            onClick={() => setIsMultiSelectMode((current) => !current)}
+            type="button"
+          >
+            {isMultiSelectMode ? "Multi-select On" : "Multi-select Off"}
+          </button>
           <button className="map-control-btn" onClick={fitToNodes} type="button">
             Fit
           </button>
@@ -2420,6 +2428,9 @@ export function MapView({
         }}
         interactiveLayerIds={["link-lines"]}
         onClick={onMapClick}
+        onTouchStart={() => {
+          mapRef.current?.getMap().stop();
+        }}
         onMove={(event) =>
           setInteractionViewState({
             longitude: event.viewState.longitude,
@@ -2504,12 +2515,12 @@ export function MapView({
                 onClick={(event) => {
                   stopMapClickBubbling(event);
                   const nativeEvent = event as unknown as { ctrlKey?: boolean; metaKey?: boolean };
-                  onSiteClick(site.id, Boolean(nativeEvent.ctrlKey || nativeEvent.metaKey));
+                  onSiteClick(site.id, isMultiSelectMode || Boolean(nativeEvent.ctrlKey || nativeEvent.metaKey));
                 }}
                 onKeyDown={(event) => {
                   if (event.key === "Enter" || event.key === " ") {
                     stopMapClickBubbling(event);
-                    onSiteClick(site.id);
+                    onSiteClick(site.id, isMultiSelectMode);
                   }
                 }}
                 role="button"

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -328,7 +328,11 @@ const formatMqttSourceMeta = (value: unknown): string[] => {
 
 const getSnapshotCount = (_key: string): number => 0;
 
-export function Sidebar() {
+type SidebarProps = {
+  onOpenHelp?: () => void;
+};
+
+export function Sidebar({ onOpenHelp }: SidebarProps) {
   const { theme, colorTheme, variant } = useThemeVariant();
   const runtimeEnvironment = getCurrentRuntimeEnvironment();
   const buildChannel = runtimeEnvironment === "production" ? "stable" : runtimeEnvironment === "staging" ? "beta" : "alpha";
@@ -1955,7 +1959,7 @@ export function Sidebar() {
 
   return (
     <aside className="sidebar-panel">
-      <UserAdminPanel />
+      <UserAdminPanel onOpenHelp={onOpenHelp} />
       <header>
         <h1>{t(locale, "appTitle")}</h1>
         <p>{t(locale, "workspaceSubtitle")}</p>

--- a/src/components/UserAdminPanel.tsx
+++ b/src/components/UserAdminPanel.tsx
@@ -118,7 +118,11 @@ const resizeAvatarFileToDataUrl = async (file: File): Promise<{ originalDataUrl:
   return { originalDataUrl, thumbDataUrl };
 };
 
-export function UserAdminPanel() {
+type UserAdminPanelProps = {
+  onOpenHelp?: () => void;
+};
+
+export function UserAdminPanel({ onOpenHelp }: UserAdminPanelProps) {
   const runtimeEnvironment = getCurrentRuntimeEnvironment();
   const isLocalRuntime = runtimeEnvironment === "local";
   const uiThemePreference = useAppStore((state) => state.uiThemePreference);
@@ -716,32 +720,39 @@ export function UserAdminPanel() {
 
   return (
     <>
-      <button className="user-chip" onClick={() => setOpen(true)} type="button">
-        <ProfileAvatar avatarUrl={me?.avatarUrl ?? ""} name={me?.username ?? "User"} />
-        <span className="user-chip-text">{me?.username ?? "Loading user..."}</span>
-        <span
-          aria-label={syncIndicator.label}
-          className={`sync-indicator ${syncIndicator.class}`}
-          title={syncIndicator.title}
-          onClick={handleSyncIndicatorClick}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" || e.key === " ") {
-              e.stopPropagation();
-              setSyncModalOpen(true);
-            }
-          }}
-          role="button"
-          tabIndex={0}
-        >
-          {syncIndicator.icon}
-        </span>
-        <span aria-hidden className="user-chip-settings-icon">
-          ⚙
-        </span>
-        {canModerate && unreadNotifications.length > 0 ? (
-          <span className="notification-badge">{unreadNotifications.length}</span>
+      <div className="user-chip-row">
+        <button className="user-chip" onClick={() => setOpen(true)} type="button">
+          <ProfileAvatar avatarUrl={me?.avatarUrl ?? ""} name={me?.username ?? "User"} />
+          <span className="user-chip-text">{me?.username ?? "Loading user..."}</span>
+          <span
+            aria-label={syncIndicator.label}
+            className={`sync-indicator ${syncIndicator.class}`}
+            title={syncIndicator.title}
+            onClick={handleSyncIndicatorClick}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.stopPropagation();
+                setSyncModalOpen(true);
+              }
+            }}
+            role="button"
+            tabIndex={0}
+          >
+            {syncIndicator.icon}
+          </span>
+          <span aria-hidden className="user-chip-settings-icon">
+            ⚙
+          </span>
+          {canModerate && unreadNotifications.length > 0 ? (
+            <span className="notification-badge">{unreadNotifications.length}</span>
+          ) : null}
+        </button>
+        {onOpenHelp ? (
+          <button aria-label="Open onboarding" className="user-help-button" onClick={onOpenHelp} type="button">
+            ?
+          </button>
         ) : null}
-      </button>
+      </div>
 
       {syncModalOpen ? (
         <ModalOverlay aria-label="Sync Status" onClose={() => setSyncModalOpen(false)}>

--- a/src/index.css
+++ b/src/index.css
@@ -1572,7 +1572,7 @@ input {
 
   .mobile-workspace-tabs {
     display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 8px;
     padding: 0;
     border: 0;
@@ -1626,14 +1626,14 @@ input {
     overflow: auto;
   }
 
-  .app-shell.is-mobile-shell.mobile-panel-map .mobile-workspace-panel,
+  .app-shell.is-mobile-shell.is-map-expanded .mobile-workspace-panel,
   .app-shell.is-mobile-shell.mobile-panel-inspector .mobile-workspace-panel {
     display: none;
   }
 
   .app-shell.is-mobile-shell.mobile-panel-sidebar .map-inspector,
   .app-shell.is-mobile-shell.mobile-panel-profile .map-inspector,
-  .app-shell.is-mobile-shell.mobile-panel-map .map-inspector {
+  .app-shell.is-mobile-shell.is-map-expanded .map-inspector {
     display: none;
   }
 
@@ -1747,7 +1747,7 @@ input {
     display: none;
   }
 
-  .app-shell.is-mobile-shell.mobile-panel-inspector .map-inspector {
+  .app-shell.is-mobile-shell:not(.is-map-expanded).mobile-panel-inspector .map-inspector {
     display: grid;
     position: fixed;
     top: auto;
@@ -1774,12 +1774,12 @@ input {
     bottom: calc(var(--mobile-tabbar-offset) + var(--mobile-tabbar-height) + 8px);
   }
 
-  .app-shell.is-mobile-shell.mobile-panel-sidebar .map-panel .maplibregl-ctrl-bottom-right,
-  .app-shell.is-mobile-shell.mobile-panel-sidebar .map-panel .maplibregl-ctrl-bottom-left,
-  .app-shell.is-mobile-shell.mobile-panel-profile .map-panel .maplibregl-ctrl-bottom-right,
-  .app-shell.is-mobile-shell.mobile-panel-profile .map-panel .maplibregl-ctrl-bottom-left,
-  .app-shell.is-mobile-shell.mobile-panel-inspector .map-panel .maplibregl-ctrl-bottom-right,
-  .app-shell.is-mobile-shell.mobile-panel-inspector .map-panel .maplibregl-ctrl-bottom-left {
+  .app-shell.is-mobile-shell:not(.is-map-expanded).mobile-panel-sidebar .map-panel .maplibregl-ctrl-bottom-right,
+  .app-shell.is-mobile-shell:not(.is-map-expanded).mobile-panel-sidebar .map-panel .maplibregl-ctrl-bottom-left,
+  .app-shell.is-mobile-shell:not(.is-map-expanded).mobile-panel-profile .map-panel .maplibregl-ctrl-bottom-right,
+  .app-shell.is-mobile-shell:not(.is-map-expanded).mobile-panel-profile .map-panel .maplibregl-ctrl-bottom-left,
+  .app-shell.is-mobile-shell:not(.is-map-expanded).mobile-panel-inspector .map-panel .maplibregl-ctrl-bottom-right,
+  .app-shell.is-mobile-shell:not(.is-map-expanded).mobile-panel-inspector .map-panel .maplibregl-ctrl-bottom-left {
     bottom: calc(var(--mobile-tabbar-offset) + var(--mobile-tabbar-height) + var(--mobile-panel-height) + 8px);
   }
 
@@ -1860,6 +1860,35 @@ input {
   cursor: pointer;
   width: 100%;
   color: var(--text);
+}
+
+.user-chip-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.user-help-button {
+  border: 1px solid color-mix(in srgb, var(--accent) 46%, var(--border));
+  background: color-mix(in srgb, var(--accent-soft) 52%, var(--surface));
+  border-radius: 12px;
+  width: 38px;
+  height: 38px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text);
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.user-help-button:hover {
+  transform: translateY(-1px);
+}
+
+.user-help-button:focus-visible {
+  outline: 2px solid var(--focus-outline);
+  outline-offset: 2px;
 }
 
 .user-chip-text {


### PR DESCRIPTION
## Summary
- remove the mobile Map tab and make tapping the active tab hide/show the bottom panel
- add map Multi-select mode button to support additive site selection on mobile without modifier keys
- move onboarding help button beside the user/settings chip at the top of the Sidebar (desktop + mobile)
- stop map motion on touch start to reduce inertial blocking between touch drags

## Verification
- npm run build
- npm test