### PR TITLE
fix: polish mobile tabs and panel/header UI details (#171)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1096,7 +1096,7 @@ export function AppShell() {
               role="tab"
               type="button"
             >
-              Map
+              Path Profile
             </button>
           </div>
         ) : null}

--- a/src/components/UserAdminPanel.tsx
+++ b/src/components/UserAdminPanel.tsx
@@ -47,6 +47,15 @@ const NOTIFICATION_POLL_MS = 30_000;
 const LOCAL_FORCE_READONLY_KEY = "linksim:local-force-readonly:v1";
 const OPEN_SYNC_MODAL_EVENT = "linksim:open-sync-modal";
 
+type SyncIndicatorState = "local" | "offline" | "pending" | "syncing" | "synced" | "error";
+
+type SyncIndicator = {
+  state: SyncIndicatorState;
+  className: string;
+  label: string;
+  title: string;
+};
+
 const readDismissedNotificationIds = (): Set<string> => {
   try {
     const raw = window.localStorage.getItem(NOTIFICATION_DISMISS_KEY);
@@ -667,19 +676,19 @@ export function UserAdminPanel({ onOpenHelp }: UserAdminPanelProps) {
     };
   }, []);
 
-  const getSyncIndicator = () => {
+  const getSyncIndicator = (): SyncIndicator => {
     const timeLabel = lastSyncedAt
       ? `Up to date (synced ${new Date(lastSyncedAt).toLocaleTimeString()})`
       : "Up to date";
 
     if (isLocalRuntime) {
-      return { icon: "🏠", class: "sync-local", label: "Local mode", title: "Local mode - no cloud sync available" };
+      return { state: "local", className: "sync-local", label: "Local mode", title: "Local mode - no cloud sync available" };
     }
 
     if (!isOnline) {
       return {
-        icon: "⚠",
-        class: "sync-offline",
+        state: "offline",
+        className: "sync-offline",
         label: "Offline",
         title: `Offline. ${pendingChangesCount} pending change${pendingChangesCount === 1 ? "" : "s"}. Open Sync Status for details.`,
       };
@@ -687,8 +696,8 @@ export function UserAdminPanel({ onOpenHelp }: UserAdminPanelProps) {
 
     if (syncPending) {
       return {
-        icon: "◐",
-        class: "sync-pending",
+        state: "pending",
+        className: "sync-pending",
         label: "Sync pending",
         title: `${timeLabel}. ${pendingChangesCount} pending change${pendingChangesCount === 1 ? "" : "s"}.`,
       };
@@ -696,18 +705,18 @@ export function UserAdminPanel({ onOpenHelp }: UserAdminPanelProps) {
 
     switch (syncStatus) {
       case "syncing":
-        return { icon: "↻", class: "sync-syncing", label: "Syncing...", title: timeLabel };
+        return { state: "syncing", className: "sync-syncing", label: "Syncing...", title: timeLabel };
       case "synced":
-        return { icon: "●", class: "sync-synced", label: "Up to date", title: `${timeLabel}. Click for details.` };
+        return { state: "synced", className: "sync-synced", label: "Up to date", title: `${timeLabel}. Click for details.` };
       case "error":
         return {
-          icon: "⚠",
-          class: "sync-error",
+          state: "error",
+          className: "sync-error",
           label: "Sync failed",
           title: `${timeLabel}. ${syncErrorMessage ?? "Open Sync Status for details."}`,
         };
       default:
-        return { icon: "●", class: "sync-synced", label: "Up to date", title: `${timeLabel}. Click for details.` };
+        return { state: "synced", className: "sync-synced", label: "Up to date", title: `${timeLabel}. Click for details.` };
     }
   };
 
@@ -718,37 +727,78 @@ export function UserAdminPanel({ onOpenHelp }: UserAdminPanelProps) {
     setSyncModalOpen(true);
   };
 
+  const renderSyncIcon = (state: SyncIndicatorState) => {
+    if (state === "error" || state === "offline") {
+      return (
+        <svg aria-hidden viewBox="0 0 20 20">
+          <path d="M10 2.5l8 14H2l8-14z" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.8" />
+          <path d="M10 7v4.8" fill="none" stroke="currentColor" strokeLinecap="round" strokeWidth="1.9" />
+          <circle cx="10" cy="14.5" r="1" fill="currentColor" />
+        </svg>
+      );
+    }
+    if (state === "pending") {
+      return (
+        <svg aria-hidden viewBox="0 0 20 20">
+          <circle cx="10" cy="10" r="7" fill="none" stroke="currentColor" strokeWidth="1.8" />
+          <path d="M10 10V4" fill="none" stroke="currentColor" strokeLinecap="round" strokeWidth="1.9" />
+          <path d="M10 10l4.2 2.4" fill="none" stroke="currentColor" strokeLinecap="round" strokeWidth="1.9" />
+        </svg>
+      );
+    }
+    if (state === "syncing") {
+      return (
+        <svg aria-hidden className="sync-icon-spinning" viewBox="0 0 20 20">
+          <path d="M4 10a6 6 0 0 1 10.2-4.2" fill="none" stroke="currentColor" strokeLinecap="round" strokeWidth="1.8" />
+          <path d="M14.4 3.6h2.6v2.6" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.8" />
+          <path d="M16 10a6 6 0 0 1-10.2 4.2" fill="none" stroke="currentColor" strokeLinecap="round" strokeWidth="1.8" />
+          <path d="M5.6 16.4H3v-2.6" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.8" />
+        </svg>
+      );
+    }
+    if (state === "local") {
+      return (
+        <svg aria-hidden viewBox="0 0 20 20">
+          <path d="M3 9.2L10 3l7 6.2v7H3v-7z" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.8" />
+          <path d="M8 16.2v-4h4v4" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.8" />
+        </svg>
+      );
+    }
+    return (
+      <svg aria-hidden viewBox="0 0 20 20">
+        <circle cx="10" cy="10" r="7" fill="none" stroke="currentColor" strokeWidth="1.8" />
+        <path d="M6.6 10.1l2.3 2.3 4.5-4.6" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.9" />
+      </svg>
+    );
+  };
+
   return (
     <>
       <div className="user-chip-row">
         <button className="user-chip" onClick={() => setOpen(true)} type="button">
           <ProfileAvatar avatarUrl={me?.avatarUrl ?? ""} name={me?.username ?? "User"} />
           <span className="user-chip-text">{me?.username ?? "Loading user..."}</span>
-          <span
-            aria-label={syncIndicator.label}
-            className={`sync-indicator ${syncIndicator.class}`}
-            title={syncIndicator.title}
-            onClick={handleSyncIndicatorClick}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.stopPropagation();
-                setSyncModalOpen(true);
-              }
-            }}
-            role="button"
-            tabIndex={0}
-          >
-            {syncIndicator.icon}
-          </span>
-          <span aria-hidden className="user-chip-settings-icon">
-            ⚙
-          </span>
           {canModerate && unreadNotifications.length > 0 ? (
             <span className="notification-badge">{unreadNotifications.length}</span>
           ) : null}
         </button>
+        <button
+          aria-label={syncIndicator.label}
+          className={`user-icon-button sync-indicator-button ${syncIndicator.className}`}
+          onClick={handleSyncIndicatorClick}
+          title={syncIndicator.title}
+          type="button"
+        >
+          {renderSyncIcon(syncIndicator.state)}
+        </button>
+        <button aria-label="Open user settings" className="user-icon-button" onClick={() => setOpen(true)} type="button">
+          <svg aria-hidden viewBox="0 0 20 20">
+            <path d="M10 4.2l1.2.3.8-1.4 2 1.2-.5 1.5.9.9 1.5-.5 1.2 2-.4.8-.4.8 1.3.9v2.4l-1.3.9.4.8.4.8-1.2 2-1.5-.5-.9.9.5 1.5-2 1.2-.8-1.4L10 15.8l-1.2.3-.8 1.4-2-1.2.5-1.5-.9-.9-1.5.5-1.2-2 .4-.8.4-.8-1.3-.9V9l1.3-.9-.4-.8-.4-.8 1.2-2 1.5.5.9-.9-.5-1.5 2-1.2.8 1.4L10 4.2z" fill="none" stroke="currentColor" strokeLinejoin="round" strokeWidth="1.5" />
+            <circle cx="10" cy="10" r="2.4" fill="none" stroke="currentColor" strokeWidth="1.5" />
+          </svg>
+        </button>
         {onOpenHelp ? (
-          <button aria-label="Open onboarding" className="user-help-button" onClick={onOpenHelp} type="button">
+          <button aria-label="Open onboarding" className="user-icon-button" onClick={onOpenHelp} type="button">
             ?
           </button>
         ) : null}
@@ -783,7 +833,7 @@ export function UserAdminPanel({ onOpenHelp }: UserAdminPanelProps) {
               <div className="sync-status-display">
                 {syncPending ? (
                   <>
-                    <span className="sync-indicator-large sync-pending">◐</span>
+                    <span className="sync-indicator-large sync-pending">{renderSyncIcon("pending")}</span>
                     <div>
                       <p className="field-help">Sync pending</p>
                       <p className="field-help">{pendingChangesCount} change(s) queued for sync.</p>
@@ -791,7 +841,7 @@ export function UserAdminPanel({ onOpenHelp }: UserAdminPanelProps) {
                   </>
                 ) : syncStatus === "syncing" ? (
                   <>
-                    <span className="sync-indicator-large sync-syncing">↻</span>
+                    <span className="sync-indicator-large sync-syncing">{renderSyncIcon("syncing")}</span>
                     <div>
                       <p className="field-help">Syncing to cloud...</p>
                       {!lastSyncedAt && <p className="field-help">Initial sync in progress...</p>}
@@ -799,7 +849,7 @@ export function UserAdminPanel({ onOpenHelp }: UserAdminPanelProps) {
                   </>
                 ) : syncStatus === "synced" ? (
                   <>
-                    <span className="sync-indicator-large sync-synced">●</span>
+                    <span className="sync-indicator-large sync-synced">{renderSyncIcon("synced")}</span>
                     <div>
                       <p className="field-help">Up to date</p>
                       {pendingChangesCount > 0 ? <p className="field-help">{pendingChangesCount} changes still pending.</p> : null}
@@ -807,7 +857,7 @@ export function UserAdminPanel({ onOpenHelp }: UserAdminPanelProps) {
                   </>
                 ) : syncStatus === "error" ? (
                   <>
-                    <span className="sync-indicator-large sync-error">⚠</span>
+                    <span className="sync-indicator-large sync-error">{renderSyncIcon("error")}</span>
                     <div>
                       <p className="field-help">Sync failed</p>
                       {syncErrorMessage && (
@@ -820,7 +870,7 @@ export function UserAdminPanel({ onOpenHelp }: UserAdminPanelProps) {
                   </>
                 ) : (
                   <>
-                    <span className={`sync-indicator-large ${syncIndicator.class}`}>{syncIndicator.icon}</span>
+                    <span className={`sync-indicator-large ${syncIndicator.className}`}>{renderSyncIcon(syncIndicator.state)}</span>
                     <div>
                       <p className="field-help">{syncIndicator.label}</p>
                     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -678,7 +678,7 @@ input {
   border: 1px solid var(--border);
   border-radius: 18px;
   overflow: hidden;
-  background: var(--surface);
+  background: linear-gradient(160deg, var(--surface), var(--surface-2));
   box-shadow: var(--shadow);
 }
 
@@ -829,10 +829,10 @@ input {
   bottom: auto;
   overflow: auto;
   border: 1px solid var(--border);
-  border-radius: 10px;
-  background: color-mix(in srgb, var(--surface-2) 95%, transparent);
-  box-shadow: var(--shadow-elev-2);
-  padding: 8px 10px 9px;
+  border-radius: 18px;
+  background: linear-gradient(160deg, var(--surface), var(--surface-2));
+  box-shadow: var(--shadow);
+  padding: 12px;
   display: grid;
   gap: 0;
   font-size: 0.76rem;
@@ -1612,6 +1612,16 @@ input {
   .mobile-workspace-panel .chart-panel {
     z-index: auto;
     height: 100%;
+    max-height: none;
+  }
+
+  .mobile-workspace-panel .chart-svg-wrap {
+    min-height: 0;
+  }
+
+  .mobile-workspace-panel .chart-panel svg {
+    min-height: 0;
+    max-height: none;
   }
 
   .mobile-workspace-panel-sidebar {
@@ -1771,7 +1781,7 @@ input {
   .app-shell.is-mobile-shell .map-panel .maplibregl-ctrl-bottom-left {
     left: 8px;
     right: auto;
-    bottom: calc(var(--mobile-tabbar-offset) + var(--mobile-tabbar-height) + 8px);
+    bottom: calc(var(--mobile-tabbar-offset) + var(--mobile-tabbar-height) + 38px);
   }
 
   .app-shell.is-mobile-shell:not(.is-map-expanded).mobile-panel-sidebar .map-panel .maplibregl-ctrl-bottom-right,
@@ -1780,7 +1790,7 @@ input {
   .app-shell.is-mobile-shell:not(.is-map-expanded).mobile-panel-profile .map-panel .maplibregl-ctrl-bottom-left,
   .app-shell.is-mobile-shell:not(.is-map-expanded).mobile-panel-inspector .map-panel .maplibregl-ctrl-bottom-right,
   .app-shell.is-mobile-shell:not(.is-map-expanded).mobile-panel-inspector .map-panel .maplibregl-ctrl-bottom-left {
-    bottom: calc(var(--mobile-tabbar-offset) + var(--mobile-tabbar-height) + var(--mobile-panel-height) + 8px);
+    bottom: calc(var(--mobile-tabbar-offset) + var(--mobile-tabbar-height) + var(--mobile-panel-height) + 38px);
   }
 
   .workspace-panel:not(.is-profile-expanded) .map-inspector {
@@ -1868,7 +1878,13 @@ input {
   gap: 8px;
 }
 
-.user-help-button {
+.user-chip-row .user-chip {
+  flex: 1 1 auto;
+  min-width: 0;
+  width: auto;
+}
+
+.user-icon-button {
   border: 1px solid color-mix(in srgb, var(--accent) 46%, var(--border));
   background: color-mix(in srgb, var(--accent-soft) 52%, var(--surface));
   border-radius: 12px;
@@ -1880,15 +1896,22 @@ input {
   color: var(--text);
   font-weight: 700;
   cursor: pointer;
+  flex: 0 0 auto;
 }
 
-.user-help-button:hover {
+.user-icon-button:hover {
   transform: translateY(-1px);
 }
 
-.user-help-button:focus-visible {
+.user-icon-button:focus-visible {
   outline: 2px solid var(--focus-outline);
   outline-offset: 2px;
+}
+
+.user-icon-button svg {
+  width: 18px;
+  height: 18px;
+  display: block;
 }
 
 .user-chip-text {
@@ -1900,22 +1923,12 @@ input {
   white-space: nowrap;
 }
 
-.user-chip-settings-icon {
-  margin-left: auto;
-  font-size: 0.95rem;
-  opacity: 0.85;
-}
-
 .user-chip .notification-badge {
   margin-left: 8px;
 }
 
-.sync-indicator {
-  margin-left: 4px;
-  font-size: 0.65rem;
-  line-height: 1;
-  cursor: pointer;
-  display: inline-block;
+.sync-indicator-button {
+  color: var(--muted);
 }
 
 .sync-synced {
@@ -1926,9 +1939,6 @@ input {
 .sync-syncing {
   color: var(--accent);
   text-shadow: 0 0 0 1px var(--bg), 0 0 0 2px color-mix(in srgb, var(--accent) 50%, transparent);
-  display: inline-block;
-  transform-origin: center;
-  animation: sync-spin 0.8s linear infinite;
 }
 
 .sync-pending {
@@ -1955,10 +1965,18 @@ input {
 }
 
 .sync-indicator-large {
-  font-size: 2rem;
-  display: block;
+  width: 36px;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   text-align: center;
   margin-bottom: 0.5rem;
+}
+
+.sync-indicator-large svg {
+  width: 28px;
+  height: 28px;
 }
 
 .sync-modal {
@@ -1983,7 +2001,10 @@ input {
 }
 
 .sync-indicator-large.sync-syncing {
-  display: inline-block;
+  display: inline-flex;
+}
+
+.sync-icon-spinning {
   transform-origin: center;
   animation: sync-spin 0.8s linear infinite;
 }


### PR DESCRIPTION
## Summary
- fix mobile tab label for Path Profile and keep three consistent tabs
- normalize bottom panel sizing so Sidebar/Inspector/Path Profile use the same mobile panel height behavior
- move attribution up on mobile to avoid low placement
- split sync and settings into separate header icon buttons next to help
- replace sync status glyphs with fixed-size SVG icons and flat non-emoji settings icon
- align inspector visual shell with sidebar/profile panel styling

## Verification
- npm run build
- npm test