### PR TITLE
fix: make mobile panel and attribution layout robust (#171)

### DIFF
--- a/src/components/UserAdminPanel.tsx
+++ b/src/components/UserAdminPanel.tsx
@@ -745,10 +745,14 @@ export function UserAdminPanel({ onOpenHelp }: UserAdminPanelProps) {
           title={syncIndicator.title}
           type="button"
         >
-          <SyncStatusIcon className={syncIndicator.state === "syncing" ? "sync-icon-spinning" : undefined} state={syncIndicator.state} />
+          <SyncStatusIcon
+            className={syncIndicator.state === "syncing" ? "sync-icon-spinning" : undefined}
+            state={syncIndicator.state}
+            title={syncIndicator.label}
+          />
         </button>
         <button aria-label="Open user settings" className="user-icon-button" onClick={() => setOpen(true)} type="button">
-          <SettingsIcon />
+          <SettingsIcon title="Settings" />
         </button>
         {onOpenHelp ? (
           <button aria-label="Open onboarding" className="user-icon-button" onClick={onOpenHelp} type="button">
@@ -786,7 +790,7 @@ export function UserAdminPanel({ onOpenHelp }: UserAdminPanelProps) {
               <div className="sync-status-display">
                 {syncPending ? (
                   <>
-                    <span className="sync-indicator-large sync-pending"><SyncStatusIcon state="pending" /></span>
+                    <span className="sync-indicator-large sync-pending"><SyncStatusIcon state="pending" title="Sync pending" /></span>
                     <div>
                       <p className="field-help">Sync pending</p>
                       <p className="field-help">{pendingChangesCount} change(s) queued for sync.</p>
@@ -794,7 +798,7 @@ export function UserAdminPanel({ onOpenHelp }: UserAdminPanelProps) {
                   </>
                 ) : syncStatus === "syncing" ? (
                   <>
-                    <span className="sync-indicator-large sync-syncing"><SyncStatusIcon className="sync-icon-spinning" state="syncing" /></span>
+                    <span className="sync-indicator-large sync-syncing"><SyncStatusIcon className="sync-icon-spinning" state="syncing" title="Syncing" /></span>
                     <div>
                       <p className="field-help">Syncing to cloud...</p>
                       {!lastSyncedAt && <p className="field-help">Initial sync in progress...</p>}
@@ -802,7 +806,7 @@ export function UserAdminPanel({ onOpenHelp }: UserAdminPanelProps) {
                   </>
                 ) : syncStatus === "synced" ? (
                   <>
-                    <span className="sync-indicator-large sync-synced"><SyncStatusIcon state="synced" /></span>
+                    <span className="sync-indicator-large sync-synced"><SyncStatusIcon state="synced" title="Synced" /></span>
                     <div>
                       <p className="field-help">Up to date</p>
                       {pendingChangesCount > 0 ? <p className="field-help">{pendingChangesCount} changes still pending.</p> : null}
@@ -810,7 +814,7 @@ export function UserAdminPanel({ onOpenHelp }: UserAdminPanelProps) {
                   </>
                 ) : syncStatus === "error" ? (
                   <>
-                    <span className="sync-indicator-large sync-error"><SyncStatusIcon state="error" /></span>
+                    <span className="sync-indicator-large sync-error"><SyncStatusIcon state="error" title="Sync failed" /></span>
                     <div>
                       <p className="field-help">Sync failed</p>
                       {syncErrorMessage && (
@@ -823,7 +827,9 @@ export function UserAdminPanel({ onOpenHelp }: UserAdminPanelProps) {
                   </>
                 ) : (
                   <>
-                    <span className={`sync-indicator-large ${syncIndicator.className}`}><SyncStatusIcon state={syncIndicator.state} /></span>
+                    <span className={`sync-indicator-large ${syncIndicator.className}`}>
+                      <SyncStatusIcon state={syncIndicator.state} title={syncIndicator.label} />
+                    </span>
                     <div>
                       <p className="field-help">{syncIndicator.label}</p>
                     </div>

--- a/src/components/icons/AppIcons.tsx
+++ b/src/components/icons/AppIcons.tsx
@@ -1,12 +1,14 @@
 type SyncStatusIconProps = {
   state: "local" | "offline" | "pending" | "syncing" | "synced" | "error";
   className?: string;
+  title: string;
 };
 
-export function SyncStatusIcon({ state, className }: SyncStatusIconProps) {
+export function SyncStatusIcon({ state, className, title }: SyncStatusIconProps) {
   if (state === "error" || state === "offline") {
     return (
-      <svg aria-hidden className={className} viewBox="0 0 20 20">
+      <svg aria-label={title} className={className} role="img" viewBox="0 0 20 20">
+        <title>{title}</title>
         <path d="M10 2.5l8 14H2l8-14z" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.8" />
         <path d="M10 7v4.8" fill="none" stroke="currentColor" strokeLinecap="round" strokeWidth="1.9" />
         <circle cx="10" cy="14.5" r="1" fill="currentColor" />
@@ -16,7 +18,8 @@ export function SyncStatusIcon({ state, className }: SyncStatusIconProps) {
 
   if (state === "pending") {
     return (
-      <svg aria-hidden className={className} viewBox="0 0 20 20">
+      <svg aria-label={title} className={className} role="img" viewBox="0 0 20 20">
+        <title>{title}</title>
         <circle cx="10" cy="10" r="7" fill="none" stroke="currentColor" strokeWidth="1.8" />
         <path d="M10 10V4" fill="none" stroke="currentColor" strokeLinecap="round" strokeWidth="1.9" />
         <path d="M10 10l4.2 2.4" fill="none" stroke="currentColor" strokeLinecap="round" strokeWidth="1.9" />
@@ -26,7 +29,8 @@ export function SyncStatusIcon({ state, className }: SyncStatusIconProps) {
 
   if (state === "syncing") {
     return (
-      <svg aria-hidden className={className} viewBox="0 0 20 20">
+      <svg aria-label={title} className={className} role="img" viewBox="0 0 20 20">
+        <title>{title}</title>
         <path d="M4 10a6 6 0 0 1 10.2-4.2" fill="none" stroke="currentColor" strokeLinecap="round" strokeWidth="1.8" />
         <path d="M14.4 3.6h2.6v2.6" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.8" />
         <path d="M16 10a6 6 0 0 1-10.2 4.2" fill="none" stroke="currentColor" strokeLinecap="round" strokeWidth="1.8" />
@@ -37,7 +41,8 @@ export function SyncStatusIcon({ state, className }: SyncStatusIconProps) {
 
   if (state === "local") {
     return (
-      <svg aria-hidden className={className} viewBox="0 0 20 20">
+      <svg aria-label={title} className={className} role="img" viewBox="0 0 20 20">
+        <title>{title}</title>
         <path d="M3 9.2L10 3l7 6.2v7H3v-7z" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.8" />
         <path d="M8 16.2v-4h4v4" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.8" />
       </svg>
@@ -45,7 +50,8 @@ export function SyncStatusIcon({ state, className }: SyncStatusIconProps) {
   }
 
   return (
-    <svg aria-hidden className={className} viewBox="0 0 20 20">
+    <svg aria-label={title} className={className} role="img" viewBox="0 0 20 20">
+      <title>{title}</title>
       <circle cx="10" cy="10" r="7" fill="none" stroke="currentColor" strokeWidth="1.8" />
       <path d="M6.6 10.1l2.3 2.3 4.5-4.6" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.9" />
     </svg>
@@ -54,11 +60,13 @@ export function SyncStatusIcon({ state, className }: SyncStatusIconProps) {
 
 type SettingsIconProps = {
   className?: string;
+  title: string;
 };
 
-export function SettingsIcon({ className }: SettingsIconProps) {
+export function SettingsIcon({ className, title }: SettingsIconProps) {
   return (
-    <svg aria-hidden className={className} viewBox="0 0 20 20">
+    <svg aria-label={title} className={className} role="img" viewBox="0 0 20 20">
+      <title>{title}</title>
       <path d="M10 4.2l1.2.3.8-1.4 2 1.2-.5 1.5.9.9 1.5-.5 1.2 2-.4.8-.4.8 1.3.9v2.4l-1.3.9.4.8.4.8-1.2 2-1.5-.5-.9.9.5 1.5-2 1.2-.8-1.4L10 15.8l-1.2.3-.8 1.4-2-1.2.5-1.5-.9-.9-1.5.5-1.2-2 .4-.8.4-.8-1.3-.9V9l1.3-.9-.4-.8-.4-.8 1.2-2 1.5.5.9-.9-.5-1.5 2-1.2.8 1.4L10 4.2z" fill="none" stroke="currentColor" strokeLinejoin="round" strokeWidth="1.5" />
       <circle cx="10" cy="10" r="2.4" fill="none" stroke="currentColor" strokeWidth="1.5" />
     </svg>

--- a/src/index.css
+++ b/src/index.css
@@ -1552,6 +1552,15 @@ input {
     --mobile-tabbar-offset: calc(12px + env(safe-area-inset-bottom));
     --mobile-tabbar-height: 38px;
     --mobile-panel-height: 36vh;
+    --mobile-panel-visible-height: 0px;
+    --mobile-attribution-gap: 16px;
+    --mobile-attribution-bottom: calc(
+      var(--mobile-tabbar-offset) + var(--mobile-tabbar-height) + var(--mobile-panel-visible-height) + var(--mobile-attribution-gap)
+    );
+  }
+
+  .app-shell.is-mobile-shell:not(.is-map-expanded) {
+    --mobile-panel-visible-height: var(--mobile-panel-height);
   }
 
   .app-shell.is-mobile-shell .mobile-workspace-tabs {
@@ -1604,6 +1613,7 @@ input {
   .mobile-workspace-panel {
     display: grid;
     height: var(--mobile-panel-height);
+    min-height: var(--mobile-panel-height);
     overflow: hidden;
     border: 0;
     border-radius: 0;
@@ -1618,6 +1628,7 @@ input {
     height: 100%;
     min-height: 100%;
     max-height: 100%;
+    grid-row: 1;
     overflow: auto;
   }
 
@@ -1788,16 +1799,7 @@ input {
   .app-shell.is-mobile-shell .map-panel .maplibregl-ctrl-bottom-left {
     left: 8px;
     right: auto;
-    bottom: calc(var(--mobile-tabbar-offset) + var(--mobile-tabbar-height) + 62px);
-  }
-
-  .app-shell.is-mobile-shell:not(.is-map-expanded).mobile-panel-sidebar .map-panel .maplibregl-ctrl-bottom-right,
-  .app-shell.is-mobile-shell:not(.is-map-expanded).mobile-panel-sidebar .map-panel .maplibregl-ctrl-bottom-left,
-  .app-shell.is-mobile-shell:not(.is-map-expanded).mobile-panel-profile .map-panel .maplibregl-ctrl-bottom-right,
-  .app-shell.is-mobile-shell:not(.is-map-expanded).mobile-panel-profile .map-panel .maplibregl-ctrl-bottom-left,
-  .app-shell.is-mobile-shell:not(.is-map-expanded).mobile-panel-inspector .map-panel .maplibregl-ctrl-bottom-right,
-  .app-shell.is-mobile-shell:not(.is-map-expanded).mobile-panel-inspector .map-panel .maplibregl-ctrl-bottom-left {
-    bottom: calc(var(--mobile-tabbar-offset) + var(--mobile-tabbar-height) + var(--mobile-panel-height) + 62px);
+    bottom: var(--mobile-attribution-bottom);
   }
 
   .workspace-panel:not(.is-profile-expanded) .map-inspector {


### PR DESCRIPTION
## Summary
- replace hardcoded mobile attribution offsets with shared computed mobile layout variables
- unify mobile panel height handling for Sidebar, Inspector, and Path Profile
- ensure icon components provide icon text/title for accessibility and reuse shared icon set

## Verification
- npm run build
- npm test