### PR TITLE
fix: measured mobile attribution clearance and env badge visibility (#171)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { type CSSProperties, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { fetchDeepLinkStatus, fetchMe, setLocalDevRole } from "../lib/cloudUser";
 import { fetchCloudLibrary, fetchPublicSimulationLibrary, pushCloudLibrary } from "../lib/cloudLibrary";
 import { buildDeepLinkPathname, buildDeepLinkUrl, canonicalizeDeepLinkKey, parseDeepLinkFromLocation, slugifyName } from "../lib/deepLink";
@@ -101,11 +101,13 @@ export function AppShell() {
   const [showMobileWarning, setShowMobileWarning] = useState(false);
   const [isMobileViewport, setIsMobileViewport] = useState(false);
   const [mobileActivePanel, setMobileActivePanel] = useState<MobileWorkspacePanel>("profile");
+  const [mobileBottomOccupied, setMobileBottomOccupied] = useState(0);
   const [localDevStatus, setLocalDevStatus] = useState<string | null>(null);
   const [offlineBannerDismissed, setOfflineBannerDismissed] = useState(false);
   const deepLinkAppliedRef = useRef(false);
   const cloudInitSeenRef = useRef(false);
   const cloudInitSettledRef = useRef(false);
+  const appShellRef = useRef<HTMLElement | null>(null);
 
   const { theme, variant } = useThemeVariant();
   const runtimeEnvironment = getCurrentRuntimeEnvironment();
@@ -409,6 +411,60 @@ export function AppShell() {
     mediaQuery.addEventListener("change", applyViewport);
     return () => mediaQuery.removeEventListener("change", applyViewport);
   }, []);
+
+  useEffect(() => {
+    if (!isMobileViewport) {
+      setMobileBottomOccupied(0);
+      return;
+    }
+
+    const shell = appShellRef.current;
+    if (!shell) return;
+
+    let frameId = 0;
+
+    const measureHeight = (selector: string) => {
+      const element = shell.querySelector<HTMLElement>(selector);
+      if (!element) return 0;
+      const style = window.getComputedStyle(element);
+      if (style.display === "none" || style.visibility === "hidden") return 0;
+      return Math.ceil(element.getBoundingClientRect().height);
+    };
+
+    const recompute = () => {
+      const tabsHeight = measureHeight(".mobile-workspace-tabs");
+      const panelHeight = measureHeight(".mobile-workspace-panel");
+      const inspectorHeight = measureHeight(".map-inspector");
+      const nextValue = tabsHeight + Math.max(panelHeight, inspectorHeight);
+      setMobileBottomOccupied((current) => (current === nextValue ? current : nextValue));
+    };
+
+    const schedule = () => {
+      if (frameId) {
+        window.cancelAnimationFrame(frameId);
+      }
+      frameId = window.requestAnimationFrame(recompute);
+    };
+
+    schedule();
+
+    const observer = new ResizeObserver(schedule);
+    observer.observe(shell);
+    shell.querySelectorAll<HTMLElement>(".mobile-workspace-tabs, .mobile-workspace-panel, .map-inspector").forEach((element) => {
+      observer.observe(element);
+    });
+    window.addEventListener("resize", schedule);
+    window.addEventListener("orientationchange", schedule);
+
+    return () => {
+      if (frameId) {
+        window.cancelAnimationFrame(frameId);
+      }
+      observer.disconnect();
+      window.removeEventListener("resize", schedule);
+      window.removeEventListener("orientationchange", schedule);
+    };
+  }, [isMobileViewport, isMapExpanded, isProfileExpanded, mobileActivePanel]);
 
   useEffect(() => {
     const isMobile = window.matchMedia("(max-width: 900px)").matches;
@@ -841,6 +897,13 @@ export function AppShell() {
     }
   }, [activeSimulation, copyCurrentLink, currentUser, referencedPrivateSites, updateSimulationPresetEntry, updateSiteLibraryEntry]);
 
+  const shellStyle = useMemo<CSSProperties | undefined>(() => {
+    if (!isMobileViewport) return undefined;
+    return {
+      ["--mobile-bottom-occupied" as string]: `${mobileBottomOccupied}px`,
+    };
+  }, [isMobileViewport, mobileBottomOccupied]);
+
   if (accessState === "checking") {
     return (
       <main className="app-shell access-locked-shell">
@@ -936,6 +999,7 @@ export function AppShell() {
 
   return (
     <main
+      ref={appShellRef}
       className={`app-shell ${isMapExpanded || isProfileExpanded ? "is-map-expanded" : ""} ${
         accessState === "readonly" ? "is-readonly-shell" : ""
       } ${
@@ -943,6 +1007,7 @@ export function AppShell() {
       } ${
         isMobileViewport ? `mobile-panel-${mobileActivePanel}` : ""
       }`}
+      style={shellStyle}
     >
       {!isMobileViewport && !isMapExpanded && !isProfileExpanded && (accessState === "granted" || accessState === "readonly") ? (
         <Sidebar onOpenHelp={openOnboardingTutorial} />

--- a/src/components/UserAdminPanel.tsx
+++ b/src/components/UserAdminPanel.tsx
@@ -134,6 +134,7 @@ type UserAdminPanelProps = {
 
 export function UserAdminPanel({ onOpenHelp }: UserAdminPanelProps) {
   const runtimeEnvironment = getCurrentRuntimeEnvironment();
+  const envBadgeLabel = runtimeEnvironment === "local" ? "LOCAL" : runtimeEnvironment === "staging" ? "STAGING" : "";
   const isLocalRuntime = runtimeEnvironment === "local";
   const uiThemePreference = useAppStore((state) => state.uiThemePreference);
   const setUiThemePreference = useAppStore((state) => state.setUiThemePreference);
@@ -738,6 +739,7 @@ export function UserAdminPanel({ onOpenHelp }: UserAdminPanelProps) {
             <span className="notification-badge">{unreadNotifications.length}</span>
           ) : null}
         </button>
+        {envBadgeLabel ? <span className="user-env-badge">{envBadgeLabel}</span> : null}
         <button
           aria-label={syncIndicator.label}
           className={`user-icon-button sync-indicator-button ${syncIndicator.className}`}

--- a/src/index.css
+++ b/src/index.css
@@ -1552,17 +1552,9 @@ input {
     --mobile-tabbar-offset: calc(12px + env(safe-area-inset-bottom));
     --mobile-tabbar-height: 38px;
     --mobile-panel-height: 36vh;
+    --mobile-bottom-occupied: var(--mobile-tabbar-height);
     --mobile-attribution-gap: 16px;
-    --mobile-attribution-extra-panel: 0px;
-    --mobile-attribution-bottom: calc(var(--mobile-tabbar-offset) + var(--mobile-tabbar-height) + var(--mobile-attribution-extra-panel) + var(--mobile-attribution-gap));
-  }
-
-  .app-shell.is-mobile-shell:not(.is-map-expanded) {
-    --mobile-attribution-extra-panel: calc(var(--mobile-panel-height) + 12px);
-  }
-
-  .app-shell.is-mobile-shell.mobile-panel-profile {
-    --mobile-attribution-extra-panel: calc(var(--mobile-panel-height) + 12px);
+    --mobile-attribution-bottom: calc(var(--mobile-tabbar-offset) + var(--mobile-bottom-occupied) + var(--mobile-attribution-gap));
   }
 
   .app-shell.is-mobile-shell .mobile-workspace-tabs {
@@ -1625,6 +1617,11 @@ input {
     z-index: 45;
   }
 
+  .mobile-workspace-panel > * {
+    height: 100%;
+    min-height: 0;
+  }
+
   .mobile-workspace-panel .chart-panel {
     z-index: auto;
     height: 100%;
@@ -1635,6 +1632,7 @@ input {
   }
 
   .mobile-workspace-panel .chart-svg-wrap {
+    height: 100%;
     min-height: 0;
   }
 
@@ -1898,6 +1896,18 @@ input {
   flex: 1 1 auto;
   min-width: 0;
   width: auto;
+}
+
+.user-env-badge {
+  border: 1px solid color-mix(in srgb, var(--accent) 38%, var(--border));
+  background: color-mix(in srgb, var(--accent-soft) 44%, var(--surface));
+  border-radius: 9px;
+  padding: 3px 7px;
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: var(--text);
+  flex: 0 0 auto;
 }
 
 .user-icon-button {


### PR DESCRIPTION
## Summary
- compute mobile map attribution clearance from measured overlay heights instead of hardcoded per-tab offsets
- feed measured bottom occupancy into CSS via app-shell custom property for robust Y-axis placement
- restore visible LOCAL/STAGING environment badge in the sidebar user header row

## Verification
- npm run build
- npm test