### PR TITLE
fix: reset mobile map layout and top-anchor attribution (#171)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -101,7 +101,7 @@ export function AppShell() {
   const [showMobileWarning, setShowMobileWarning] = useState(false);
   const [isMobileViewport, setIsMobileViewport] = useState(false);
   const [mobileActivePanel, setMobileActivePanel] = useState<MobileWorkspacePanel>("profile");
-  const [mobileBottomOccupied, setMobileBottomOccupied] = useState(0);
+  const [mobileControlsOccupied, setMobileControlsOccupied] = useState(0);
   const [localDevStatus, setLocalDevStatus] = useState<string | null>(null);
   const [offlineBannerDismissed, setOfflineBannerDismissed] = useState(false);
   const deepLinkAppliedRef = useRef(false);
@@ -414,7 +414,7 @@ export function AppShell() {
 
   useEffect(() => {
     if (!isMobileViewport) {
-      setMobileBottomOccupied(0);
+      setMobileControlsOccupied(0);
       return;
     }
 
@@ -432,11 +432,8 @@ export function AppShell() {
     };
 
     const recompute = () => {
-      const tabsHeight = measureHeight(".mobile-workspace-tabs");
-      const panelHeight = measureHeight(".mobile-workspace-panel");
-      const inspectorHeight = measureHeight(".map-inspector");
-      const nextValue = tabsHeight + Math.max(panelHeight, inspectorHeight);
-      setMobileBottomOccupied((current) => (current === nextValue ? current : nextValue));
+      const controlsHeight = measureHeight(".map-controls");
+      setMobileControlsOccupied((current) => (current === controlsHeight ? current : controlsHeight));
     };
 
     const schedule = () => {
@@ -450,7 +447,7 @@ export function AppShell() {
 
     const observer = new ResizeObserver(schedule);
     observer.observe(shell);
-    shell.querySelectorAll<HTMLElement>(".mobile-workspace-tabs, .mobile-workspace-panel, .map-inspector").forEach((element) => {
+    shell.querySelectorAll<HTMLElement>(".map-controls").forEach((element) => {
       observer.observe(element);
     });
     window.addEventListener("resize", schedule);
@@ -900,9 +897,9 @@ export function AppShell() {
   const shellStyle = useMemo<CSSProperties | undefined>(() => {
     if (!isMobileViewport) return undefined;
     return {
-      ["--mobile-bottom-occupied" as string]: `${mobileBottomOccupied}px`,
+      ["--mobile-controls-occupied" as string]: `${mobileControlsOccupied}px`,
     };
-  }, [isMobileViewport, mobileBottomOccupied]);
+  }, [isMobileViewport, mobileControlsOccupied]);
 
   if (accessState === "checking") {
     return (

--- a/src/index.css
+++ b/src/index.css
@@ -1549,12 +1549,13 @@ input {
   }
 
   .app-shell.is-mobile-shell {
+    --mobile-controls-top: calc(12px + env(safe-area-inset-top));
+    --mobile-controls-occupied: 0px;
     --mobile-tabbar-offset: calc(12px + env(safe-area-inset-bottom));
     --mobile-tabbar-height: 38px;
     --mobile-panel-height: 36vh;
-    --mobile-bottom-occupied: var(--mobile-tabbar-height);
-    --mobile-attribution-gap: 16px;
-    --mobile-attribution-bottom: calc(var(--mobile-tabbar-offset) + var(--mobile-bottom-occupied) + var(--mobile-attribution-gap));
+    --mobile-attribution-gap: 8px;
+    --mobile-attribution-top: calc(var(--mobile-controls-top) + var(--mobile-controls-occupied) + var(--mobile-attribution-gap));
   }
 
   .app-shell.is-mobile-shell .mobile-workspace-tabs {
@@ -1735,8 +1736,6 @@ input {
     right: 0;
     bottom: 0;
     left: 0;
-    width: 100vw;
-    height: 100lvh;
     margin: 0;
     border: 0;
     border-radius: 0;
@@ -1744,6 +1743,7 @@ input {
   }
 
   .map-controls {
+    top: var(--mobile-controls-top);
     flex-direction: column;
     align-items: stretch;
     left: 12px;
@@ -1797,10 +1797,11 @@ input {
 
   .app-shell.is-mobile-shell .map-panel .maplibregl-ctrl-bottom-right,
   .app-shell.is-mobile-shell .map-panel .maplibregl-ctrl-bottom-left {
-    left: 8px;
+    top: var(--mobile-attribution-top) !important;
+    bottom: auto !important;
+    left: 12px;
     right: auto;
-    bottom: var(--mobile-attribution-bottom) !important;
-    z-index: 96 !important;
+    z-index: 56 !important;
   }
 
   .app-shell.is-mobile-shell .map-panel .maplibregl-ctrl-attrib {


### PR DESCRIPTION
## Summary
- simplify mobile map panel back to fixed full-bleed inset layout (remove explicit viewport height sizing)
- anchor mobile attribution near top-left, below measured map controls, to avoid bottom overlay collisions
- retain bottom panel parity and remove dependence on tab/panel bottom offset heuristics

## Verification
- npm run build
- npm test