### PR TITLE
fix: stabilize mobile full-bleed map and top attribution anchoring (#171)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -444,10 +444,12 @@ export function AppShell() {
     };
 
     schedule();
+    const followUpTimerA = window.setTimeout(schedule, 120);
+    const followUpTimerB = window.setTimeout(schedule, 280);
 
     const observer = new ResizeObserver(schedule);
     observer.observe(shell);
-    shell.querySelectorAll<HTMLElement>(".map-controls").forEach((element) => {
+    shell.querySelectorAll<HTMLElement>(".map-controls, .map-controls *").forEach((element) => {
       observer.observe(element);
     });
     window.addEventListener("resize", schedule);
@@ -457,6 +459,8 @@ export function AppShell() {
       if (frameId) {
         window.cancelAnimationFrame(frameId);
       }
+      window.clearTimeout(followUpTimerA);
+      window.clearTimeout(followUpTimerB);
       observer.disconnect();
       window.removeEventListener("resize", schedule);
       window.removeEventListener("orientationchange", schedule);

--- a/src/index.css
+++ b/src/index.css
@@ -1550,7 +1550,7 @@ input {
 
   .app-shell.is-mobile-shell {
     --mobile-controls-top: calc(12px + env(safe-area-inset-top));
-    --mobile-controls-occupied: 0px;
+    --mobile-controls-occupied: 128px;
     --mobile-tabbar-offset: calc(12px + env(safe-area-inset-bottom));
     --mobile-tabbar-height: 38px;
     --mobile-panel-height: 36vh;
@@ -1736,6 +1736,8 @@ input {
     right: 0;
     bottom: 0;
     left: 0;
+    width: 100vw;
+    height: 100lvh;
     margin: 0;
     border: 0;
     border-radius: 0;


### PR DESCRIPTION
## Summary
- restore explicit mobile map viewport sizing for full-bleed behavior
- keep attribution top-anchored below controls and improve initial measurement stability
- observe map control subtree and run follow-up measurements to avoid late jumps

## Verification
- npm run build
- npm test