### PR TITLE
fix: use default carto normal style for provider fallback (#167)

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -14,7 +14,7 @@ import { STANDARD_SITE_RADIO } from "../lib/linkRadio";
 import { sampleSrtmElevation } from "../lib/srtm";
 import { getUiErrorMessage } from "../lib/uiError";
 import { useThemeVariant } from "../hooks/useThemeVariant";
-import { getBasemapProviderCapabilities, resolveBasemapSelection } from "../lib/basemaps";
+import { getBasemapProviderCapabilities, getCartoFallbackStyle, resolveBasemapSelection } from "../lib/basemaps";
 import {
   PROFILE_DRAFT_SITE_REQUEST_EVENT,
   type ProfileDraftSiteRequestDetail,
@@ -82,31 +82,6 @@ const terrainRasterPaint = {
   "raster-contrast": 0.16,
   "raster-saturation": -0.06,
 };
-
-const fallbackStyle = {
-  version: 8,
-  sources: {
-    osm: {
-      type: "raster",
-      tiles: [
-        "https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
-        "https://b.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
-      ],
-      tileSize: 256,
-      attribution:
-        '<a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noreferrer">© OpenStreetMap contributors</a> <a href="https://carto.com/attributions" target="_blank" rel="noreferrer">© CARTO</a>',
-    },
-  },
-  layers: [
-    {
-      id: "osm-base",
-      type: "raster",
-      source: "osm",
-      minzoom: 0,
-      maxzoom: 19,
-    },
-  ],
-} as const;
 
 const supportsWebgl = (): boolean => {
   try {
@@ -1852,6 +1827,7 @@ export function MapView({
     () => resolveBasemapSelection(basemapProvider, basemapStylePreset, theme, colorTheme),
     [basemapProvider, basemapStylePreset, theme, colorTheme],
   );
+  const fallbackMapStyle = useMemo(() => getCartoFallbackStyle(theme, colorTheme), [theme, colorTheme]);
   const requestedProviderConfig =
     providerCapabilities.find((entry) => entry.provider === basemapProvider) ?? providerCapabilities[0];
   const activeProviderConfig =
@@ -2415,7 +2391,7 @@ export function MapView({
           latitude: activeViewState.latitude,
           zoom: activeViewState.zoom,
         }}
-        mapStyle={useFallbackMapStyle ? (fallbackStyle as unknown as string) : resolvedBasemap.style}
+        mapStyle={useFallbackMapStyle ? fallbackMapStyle : resolvedBasemap.style}
         onError={() => {
           if (!useFallbackMapStyle && resolvedBasemap.provider !== "kartverket") {
             setUseFallbackMapStyle(true);

--- a/src/lib/basemaps.test.ts
+++ b/src/lib/basemaps.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { getCartoFallbackStyle, resolveBasemapSelection } from "./basemaps";
+
+describe("basemap fallback style", () => {
+  it("uses CARTO default Normal themed style when provider fails", () => {
+    const expected = resolveBasemapSelection("carto", "normal-themed", "light", "blue").style;
+    const fallback = getCartoFallbackStyle("light", "blue");
+    expect(fallback).toEqual(expected);
+  });
+
+  it("adapts fallback style to dark theme", () => {
+    const darkFallback = getCartoFallbackStyle("dark", "blue");
+    const darkStyle = darkFallback as { sources?: { cartoRaster?: { tiles?: string[] } } };
+    const tiles = darkStyle.sources?.cartoRaster?.tiles ?? [];
+    expect(tiles.some((tile) => tile.includes("dark_all"))).toBe(true);
+  });
+});

--- a/src/lib/basemaps.ts
+++ b/src/lib/basemaps.ts
@@ -315,6 +315,11 @@ export const resolveBasemapSelection = (
   };
 };
 
+export const getCartoFallbackStyle = (
+  theme: BasemapTheme,
+  colorTheme: UiColorTheme = "blue",
+): string | StyleSpecification => styleForPreset("carto", "normal-themed", theme, colorTheme);
+
 export const defaultPresetIdForTheme = (provider: BasemapProvider, theme: BasemapTheme): string => {
   const providerConfig = providerCapabilities.find((entry) => entry.provider === provider);
   if (!providerConfig) return "normal";


### PR DESCRIPTION
## Summary
- switch map provider error fallback to use CARTO default Normal themed style instead of legacy light raster fallback
- add `getCartoFallbackStyle()` in basemap resolver to centralize fallback style selection
- add tests for fallback style parity and dark-theme tile behavior

## Verification
- npm run test -- --run src/lib/basemaps.test.ts
- npm run test -- --run src/lib/deepLink.test.ts
- npm run test -- --run functions/api/v1/calculate.test.ts
- npm run test -- --run src/store/appStore.test.ts
- npm test
- npm run build