### PR TITLE
fix: default fresh basemap preset to Normal themed (#167)

### DIFF
--- a/src/store/appStore.basemapDefaults.test.ts
+++ b/src/store/appStore.basemapDefaults.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const storage = vi.hoisted(() => {
+  const data = new Map<string, string>();
+  const mock = {
+    getItem: (key: string) => data.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      data.set(key, String(value));
+    },
+    removeItem: (key: string) => {
+      data.delete(key);
+    },
+    clear: () => {
+      data.clear();
+    },
+    key: (index: number) => Array.from(data.keys())[index] ?? null,
+    get length() {
+      return data.size;
+    },
+  };
+  vi.stubGlobal("localStorage", mock);
+  vi.stubGlobal("window", {
+    localStorage: mock,
+    setTimeout,
+    clearTimeout,
+  });
+  return { data, mock };
+});
+
+vi.mock("../lib/coverage", () => ({
+  buildCoverage: vi.fn(() => []),
+}));
+
+vi.mock("../lib/elevationService", () => ({
+  fetchElevations: vi.fn(async () => [123]),
+}));
+
+describe("appStore basemap defaults", () => {
+  beforeEach(() => {
+    storage.mock.clear();
+    vi.resetModules();
+  });
+
+  it("defaults to carto normal-themed when local storage is empty", async () => {
+    const { useAppStore } = await import("./appStore");
+    const state = useAppStore.getState();
+    expect(state.basemapProvider).toBe("carto");
+    expect(state.basemapStylePreset).toBe("normal-themed");
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1050,7 +1050,7 @@ const bufferedBoundsForSites = (sites: Site[], radiusKm: number): TerrainFetchBo
 
 const initialBasemapProvider = normalizeBasemapProvider(readStorage<string>(BASEMAP_PROVIDER_KEY, "carto"));
 const initialBasemapStylePreset = normalizeBasemapStylePreset(
-  readStorage<string>(BASEMAP_STYLE_PRESET_KEY, "normal"),
+  readStorage<string>(BASEMAP_STYLE_PRESET_KEY, "normal-themed"),
 );
 
 export const useAppStore = create<AppState>((set, get) => ({


### PR DESCRIPTION
## Summary
- set fresh startup fallback for `basemapStylePreset` to `normal-themed` so CARTO defaults to Normal themed after localStorage reset
- add regression test for empty-storage startup defaults in `src/store/appStore.basemapDefaults.test.ts`

## Verification
- npm run test -- --run src/store/appStore.basemapDefaults.test.ts
- npm run test -- --run src/store/appStore.test.ts
- npm run test -- --run src/lib/deepLink.test.ts
- npm run test -- --run functions/api/v1/calculate.test.ts
- npm run build