### PR TITLE
fix: adjust desktop panel width to 20vw with max 400px (#240)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -99,8 +99,8 @@ input {
 
 .app-shell {
   display: grid;
-  grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
-  --sidebar-overlay-width: clamp(280px, 30vw, 360px);
+  --sidebar-overlay-width: clamp(280px, 20vw, 400px);
+  grid-template-columns: minmax(0, var(--sidebar-overlay-width)) minmax(0, 1fr);
   --workspace-panel-gap: 18px;
   gap: 18px;
   padding: 18px;


### PR DESCRIPTION
## Summary
- set desktop sidebar/inspector width token to clamp(280px, 20vw, 400px)
- drive app shell sidebar column from the shared width token

## Verification
- npm test
- npm run build