### PR TITLE
fix: align env badge in sidebar title row and compact user chip (#240)

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -335,6 +335,7 @@ type SidebarProps = {
 export function Sidebar({ onOpenHelp }: SidebarProps) {
   const { theme, colorTheme, variant } = useThemeVariant();
   const runtimeEnvironment = getCurrentRuntimeEnvironment();
+  const envBadgeLabel = runtimeEnvironment === "local" ? "LOCAL" : runtimeEnvironment === "staging" ? "STAGING" : "";
   const buildChannel = runtimeEnvironment === "production" ? "stable" : runtimeEnvironment === "staging" ? "beta" : "alpha";
   const buildLabel = buildLabelForChannel(buildChannel);
   const links = useAppStore((state) => state.links);
@@ -1961,7 +1962,10 @@ export function Sidebar({ onOpenHelp }: SidebarProps) {
     <aside className="sidebar-panel">
       <UserAdminPanel onOpenHelp={onOpenHelp} />
       <header>
-        <h1>{t(locale, "appTitle")}</h1>
+        <div className="sidebar-title-row">
+          <h1>{t(locale, "appTitle")}</h1>
+          {envBadgeLabel ? <span className="sidebar-env-badge">{envBadgeLabel}</span> : null}
+        </div>
         <p>{t(locale, "workspaceSubtitle")}</p>
       </header>
       <section className="panel-section section-scenario">

--- a/src/components/UserAdminPanel.tsx
+++ b/src/components/UserAdminPanel.tsx
@@ -134,7 +134,6 @@ type UserAdminPanelProps = {
 
 export function UserAdminPanel({ onOpenHelp }: UserAdminPanelProps) {
   const runtimeEnvironment = getCurrentRuntimeEnvironment();
-  const envBadgeLabel = runtimeEnvironment === "local" ? "LOCAL" : runtimeEnvironment === "staging" ? "STAGING" : "";
   const isLocalRuntime = runtimeEnvironment === "local";
   const uiThemePreference = useAppStore((state) => state.uiThemePreference);
   const setUiThemePreference = useAppStore((state) => state.setUiThemePreference);
@@ -732,14 +731,12 @@ export function UserAdminPanel({ onOpenHelp }: UserAdminPanelProps) {
   return (
     <>
       <div className="user-chip-row">
-        <button className="user-chip" onClick={() => setOpen(true)} type="button">
+        <button aria-label="Open user settings" className="user-chip" onClick={() => setOpen(true)} type="button">
           <ProfileAvatar avatarUrl={me?.avatarUrl ?? ""} name={me?.username ?? "User"} />
-          <span className="user-chip-text">{me?.username ?? "Loading user..."}</span>
           {canModerate && unreadNotifications.length > 0 ? (
             <span className="notification-badge">{unreadNotifications.length}</span>
           ) : null}
         </button>
-        {envBadgeLabel ? <span className="user-env-badge">{envBadgeLabel}</span> : null}
         <button
           aria-label={syncIndicator.label}
           className={`user-icon-button sync-indicator-button ${syncIndicator.className}`}

--- a/src/index.css
+++ b/src/index.css
@@ -186,6 +186,25 @@ input {
   gap: 4px;
 }
 
+.sidebar-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.sidebar-env-badge {
+  border: 1px solid color-mix(in srgb, var(--accent) 38%, var(--border));
+  background: color-mix(in srgb, var(--accent-soft) 44%, var(--surface));
+  border-radius: 9px;
+  padding: 3px 7px;
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: var(--text);
+  flex: 0 0 auto;
+}
+
 .sidebar-panel h1 {
   font-size: 1.28rem;
   letter-spacing: 0.02em;
@@ -1896,20 +1915,13 @@ input {
 }
 
 .user-chip-row .user-chip {
-  flex: 1 1 auto;
-  min-width: 0;
-  width: auto;
-}
-
-.user-env-badge {
-  border: 1px solid color-mix(in srgb, var(--accent) 38%, var(--border));
-  background: color-mix(in srgb, var(--accent-soft) 44%, var(--surface));
-  border-radius: 9px;
-  padding: 3px 7px;
-  font-size: 0.66rem;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  color: var(--text);
+  width: 38px;
+  height: 38px;
+  min-width: 38px;
+  padding: 0;
+  justify-content: center;
+  gap: 0;
+  position: relative;
   flex: 0 0 auto;
 }
 
@@ -1953,7 +1965,10 @@ input {
 }
 
 .user-chip .notification-badge {
-  margin-left: 8px;
+  margin-left: 0;
+  position: absolute;
+  top: -4px;
+  right: -4px;
 }
 
 .sync-indicator-button {


### PR DESCRIPTION
## Summary
- move LOCAL/STAGING badge to the LinkSim title row and right-align it
- remove username text from top sidebar user chip and keep avatar-only profile entry
- keep sync/settings/help controls in the same top row with compact avatar chip sizing

## Verification
- npm test
- npm run build