### PR TITLE
fix: dual-sidebar desktop layout and minimal header controls (#240)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1075,7 +1075,7 @@ export function AppShell() {
         </div>
         <MapView
           isMapExpanded={isMapExpanded}
-          showInspector={!isMobileViewport || (!isMapExpanded && mobileActivePanel === "inspector")}
+          showInspector={!isMapExpanded && (!isMobileViewport || mobileActivePanel === "inspector")}
           showMultiSelectToggle={isMobileViewport}
           canPersist={canPersistWorkspace}
           onShare={

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1966,7 +1966,6 @@ export function Sidebar({ onOpenHelp }: SidebarProps) {
           <h1>{t(locale, "appTitle")}</h1>
           {envBadgeLabel ? <span className="sidebar-env-badge">{envBadgeLabel}</span> : null}
         </div>
-        <p>{t(locale, "workspaceSubtitle")}</p>
       </header>
       <section className="panel-section section-scenario">
         <div className="section-heading">

--- a/src/index.css
+++ b/src/index.css
@@ -558,6 +558,7 @@ input {
   display: grid;
   grid-template-rows: minmax(0, 1fr) minmax(220px, 32vh);
   gap: var(--workspace-panel-gap);
+  padding-right: calc(var(--sidebar-overlay-width) + 18px);
   min-height: 0;
   z-index: 30;
   pointer-events: none;
@@ -613,6 +614,7 @@ input {
 
 .workspace-panel.is-map-expanded {
   grid-template-rows: minmax(0, 1fr);
+  padding-right: 0;
 }
 
 .empty-workspace-overlay {
@@ -753,6 +755,7 @@ input {
 
 .app-shell:not(.is-map-expanded) .map-controls {
   left: calc(var(--sidebar-overlay-width) + 30px);
+  right: calc(var(--sidebar-overlay-width) + 30px);
 }
 
 .map-controls-unified {
@@ -823,6 +826,10 @@ input {
   max-width: 260px;
 }
 
+.app-shell:not(.is-map-expanded) .map-control-note {
+  right: calc(var(--sidebar-overlay-width) + 30px);
+}
+
 .map-inline-actions {
   margin-top: 8px;
   display: flex;
@@ -840,26 +847,21 @@ input {
 
 .map-inspector {
   position: absolute;
-  top: 66px;
+  top: 18px;
+  bottom: 18px;
   right: 18px;
   z-index: 60;
   width: min(var(--sidebar-overlay-width), calc(100% - 36px));
-  max-height: calc(100dvh - 84px);
-  bottom: auto;
+  max-height: none;
   overflow: auto;
   border: 1px solid var(--border);
   border-radius: 18px;
   background: linear-gradient(160deg, var(--surface), var(--surface-2));
   box-shadow: var(--shadow);
-  padding: 12px;
+  padding: 18px;
   display: grid;
   gap: 0;
   font-size: 0.76rem;
-}
-
-.workspace-panel:not(.is-map-expanded):not(.is-profile-expanded) .map-inspector {
-  bottom: auto;
-  max-height: calc(100dvh - 66px - 18px - (32vh + var(--workspace-panel-gap)));
 }
 
 .workspace-panel:not(.is-map-expanded):not(.is-profile-expanded) .map-panel .maplibregl-ctrl-bottom-right,
@@ -1717,6 +1719,7 @@ input {
     grid-template-columns: minmax(0, 1fr);
     grid-template-rows: minmax(0, 1fr);
     gap: 12px;
+    padding-right: 0;
     height: 100lvh;
     min-height: 100lvh;
     align-content: start;


### PR DESCRIPTION
## Summary
- make desktop inspector behave as full-height right sidebar and keep center area between sidebars
- remove sidebar subtitle line (Simulation Workspace)
- right-align top header icons and keep avatar/icon-only control styling

## Verification
- npm test
- npm run build