### PR TITLE
feat: unify Lucide icon controls across UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "fflate": "^0.8.2",
         "geotiff": "^3.0.5",
         "jose": "^6.2.1",
+        "lucide-react": "^1.7.0",
         "maplibre-gl": "^5.20.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -4865,6 +4866,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.7.0.tgz",
+      "integrity": "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "fflate": "^0.8.2",
     "geotiff": "^3.0.5",
     "jose": "^6.2.1",
+    "lucide-react": "^1.7.0",
     "maplibre-gl": "^5.20.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,4 +1,5 @@
 import { type CSSProperties, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { CircleX } from "lucide-react";
 import { fetchDeepLinkStatus, fetchMe, setLocalDevRole } from "../lib/cloudUser";
 import { fetchCloudLibrary, fetchPublicSimulationLibrary, pushCloudLibrary } from "../lib/cloudLibrary";
 import { buildDeepLinkPathname, buildDeepLinkUrl, canonicalizeDeepLinkKey, parseDeepLinkFromLocation, slugifyName } from "../lib/deepLink";
@@ -1201,13 +1202,15 @@ export function AppShell() {
             <div className="library-manager-header">
               <h2>Mobile Support Notice</h2>
               <button
-                className="inline-action"
+                aria-label="Close"
+                className="inline-action inline-action-icon"
                 onClick={() => {
                   setShowMobileWarning(false);
                 }}
+                title="Close"
                 type="button"
               >
-                Close
+                <CircleX aria-hidden="true" strokeWidth={1.8} />
               </button>
             </div>
             <p className="field-help">
@@ -1238,8 +1241,8 @@ export function AppShell() {
           <div className="library-manager-card">
             <div className="library-manager-header">
               <h2>Share Simulation</h2>
-              <button className="inline-action" onClick={() => setShowShareModal(false)} type="button">
-                Close
+              <button aria-label="Close" className="inline-action inline-action-icon" onClick={() => setShowShareModal(false)} title="Close" type="button">
+                <CircleX aria-hidden="true" strokeWidth={1.8} />
               </button>
             </div>
             {!activeSimulation ? (

--- a/src/components/InfoTip.tsx
+++ b/src/components/InfoTip.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { Info } from "lucide-react";
 
 export function InfoTip({ text }: { text: string }) {
   const tipId = useId();
@@ -47,7 +48,7 @@ export function InfoTip({ text }: { text: string }) {
         ref={triggerRef}
         type="button"
       >
-        i
+        <Info aria-hidden="true" strokeWidth={1.9} />
       </button>
       {open && typeof document !== "undefined"
         ? createPortal(

--- a/src/components/LinkProfileChart.tsx
+++ b/src/components/LinkProfileChart.tsx
@@ -1,5 +1,6 @@
 import { extent, max } from "d3-array";
 import { scaleLinear } from "d3-scale";
+import { ArrowLeftRight, Maximize2, Minimize2 } from "lucide-react";
 import type { MouseEvent } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -796,21 +797,21 @@ export function LinkProfileChart({ isExpanded, onToggleExpanded }: LinkProfileCh
       <div className="chart-footer-row">
         <button
           aria-label="Reverse path direction for this view"
-          className={`chart-endpoint-swap ${temporaryDirectionReversed ? "is-active" : ""}`}
+          className={`chart-endpoint-swap chart-endpoint-icon ${temporaryDirectionReversed ? "is-active" : ""}`}
           onClick={toggleTemporaryDirectionReversed}
           title="Temporarily reverse path direction"
           type="button"
         >
-          Flip Direction
+          <ArrowLeftRight aria-hidden="true" strokeWidth={1.8} />
         </button>
         <button
           aria-label={isExpanded ? "Exit full screen" : "Full screen"}
-          className={`chart-endpoint-swap ${isExpanded ? "is-active" : ""}`}
+          className={`chart-endpoint-swap chart-endpoint-icon ${isExpanded ? "is-active" : ""}`}
           onClick={onToggleExpanded}
           title={isExpanded ? "Exit full screen" : "Full screen"}
           type="button"
         >
-          {isExpanded ? "Exit Full screen" : "Full screen"}
+          {isExpanded ? <Minimize2 aria-hidden="true" strokeWidth={1.8} /> : <Maximize2 aria-hidden="true" strokeWidth={1.8} />}
         </button>
         <div className="chart-hover-state">
           {cursorPoint && footerCursorState ? (

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { Maximize2, Minimize2, SearchSlash, Share, ZoomIn, ZoomOut } from "lucide-react";
 import Map, {
   Layer,
   type MapRef,
@@ -2034,9 +2035,15 @@ export function MapView({
             </select>
           </label>
         </div>
-        <div className="map-controls-group map-controls-group-utility">
-          <button className="map-control-btn" onClick={onToggleMapExpanded} type="button">
-            {isMapExpanded ? "Show Panels" : "Hide Panels"}
+        <div className="map-controls-group map-controls-group-utility map-controls-utility-pill">
+          <button
+            aria-label={isMapExpanded ? "Show panels" : "Hide panels"}
+            className="map-control-btn map-control-btn-icon"
+            onClick={onToggleMapExpanded}
+            title={isMapExpanded ? "Show panels" : "Hide panels"}
+            type="button"
+          >
+            {isMapExpanded ? <Maximize2 aria-hidden="true" strokeWidth={1.8} /> : <Minimize2 aria-hidden="true" strokeWidth={1.8} />}
           </button>
           {showMultiSelectToggle ? (
             <button
@@ -2047,18 +2054,18 @@ export function MapView({
               {isMultiSelectMode ? "Multi-select On" : "Multi-select Off"}
             </button>
           ) : null}
-          <button className="map-control-btn" onClick={fitToNodes} type="button">
-            Fit
+          <button aria-label="Fit map to sites" className="map-control-btn map-control-btn-icon" onClick={fitToNodes} title="Fit" type="button">
+            <SearchSlash aria-hidden="true" strokeWidth={1.8} />
           </button>
-          <button className="map-control-btn" onClick={() => zoomBy(1)} type="button">
-            +
+          <button aria-label="Zoom in" className="map-control-btn map-control-btn-icon" onClick={() => zoomBy(1)} title="Zoom in" type="button">
+            <ZoomIn aria-hidden="true" strokeWidth={1.8} />
           </button>
-          <button className="map-control-btn" onClick={() => zoomBy(-1)} type="button">
-            -
+          <button aria-label="Zoom out" className="map-control-btn map-control-btn-icon" onClick={() => zoomBy(-1)} title="Zoom out" type="button">
+            <ZoomOut aria-hidden="true" strokeWidth={1.8} />
           </button>
           {onShare ? (
-            <button className="map-control-btn" onClick={onShare} type="button">
-              Share
+            <button aria-label="Share" className="map-control-btn map-control-btn-icon" onClick={onShare} title="Share" type="button">
+              <Share aria-hidden="true" strokeWidth={1.8} />
             </button>
           ) : null}
         </div>

--- a/src/components/OnboardingTutorialModal.tsx
+++ b/src/components/OnboardingTutorialModal.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { CircleX } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import onboardingMarkdown from "../../docs/onboarding.md?raw";
@@ -43,8 +44,8 @@ export default function OnboardingTutorialModal({
         <div className="library-manager-header">
           <h2>Getting Started</h2>
           <div className="chip-group">
-            <button className="inline-action" onClick={onClose} type="button">
-              Close
+            <button aria-label="Close" className="inline-action inline-action-icon" onClick={onClose} title="Close" type="button">
+              <CircleX aria-hidden="true" strokeWidth={1.8} />
             </button>
           </div>
         </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import clsx from "clsx";
+import { CircleChevronDown, CircleChevronRight, CircleX } from "lucide-react";
 import Map, {
   Layer,
   Marker,
@@ -2135,8 +2136,8 @@ export function Sidebar({ onOpenHelp }: SidebarProps) {
           <div className="library-manager-card user-profile-popup">
             <div className="library-manager-header">
               <h2>{linkModal.mode === "add" ? "Add Link" : "Edit Link"}</h2>
-              <button className="inline-action" onClick={() => setLinkModal(null)} type="button">
-                Close
+              <button aria-label="Close" className="inline-action inline-action-icon" onClick={() => setLinkModal(null)} title="Close" type="button">
+                <CircleX aria-hidden="true" strokeWidth={1.8} />
               </button>
             </div>
             <label className="field-grid">
@@ -2348,8 +2349,8 @@ export function Sidebar({ onOpenHelp }: SidebarProps) {
           <div className="library-manager-card user-profile-popup">
             <div className="library-manager-header">
               <h2>User Profile</h2>
-              <button className="inline-action" onClick={() => setProfilePopupUser(null)} type="button">
-                Close
+              <button aria-label="Close" className="inline-action inline-action-icon" onClick={() => setProfilePopupUser(null)} title="Close" type="button">
+                <CircleX aria-hidden="true" strokeWidth={1.8} />
               </button>
             </div>
             <p className="field-help">
@@ -2431,8 +2432,8 @@ export function Sidebar({ onOpenHelp }: SidebarProps) {
           <div className="library-manager-card">
             <div className="library-manager-header">
               <h2>Change Log · {changeLogPopup.label}</h2>
-              <button className="inline-action" onClick={() => setChangeLogPopup(null)} type="button">
-                Close
+              <button aria-label="Close" className="inline-action inline-action-icon" onClick={() => setChangeLogPopup(null)} title="Close" type="button">
+                <CircleX aria-hidden="true" strokeWidth={1.8} />
               </button>
             </div>
             {changeLogPopup.busy ? <p className="field-help">Loading changes...</p> : null}
@@ -2504,8 +2505,8 @@ export function Sidebar({ onOpenHelp }: SidebarProps) {
           <div className="library-manager-card user-profile-popup resource-details-card">
             <div className="library-manager-header">
               <h2>Edit · {resourceDetailsPopup.label}</h2>
-              <button className="inline-action" onClick={() => setResourceDetailsPopup(null)} type="button">
-                Close
+              <button aria-label="Close" className="inline-action inline-action-icon" onClick={() => setResourceDetailsPopup(null)} title="Close" type="button">
+                <CircleX aria-hidden="true" strokeWidth={1.8} />
               </button>
             </div>
             <p className="field-help">Type: {resourceDetailsPopup.kind === "site" ? "Site" : "Simulation"}</p>
@@ -2934,16 +2935,18 @@ export function Sidebar({ onOpenHelp }: SidebarProps) {
           <div className="library-manager-card user-profile-popup">
             <div className="library-manager-header">
               <h2>New Simulation</h2>
-              <button
-                className="inline-action"
-                onClick={() => {
-                  setShowNewSimulationModal(false);
-                  setNewSimulationNameError("");
-                }}
-                type="button"
-              >
-                Close
-              </button>
+                <button
+                  aria-label="Close"
+                  className="inline-action inline-action-icon"
+                  onClick={() => {
+                    setShowNewSimulationModal(false);
+                    setNewSimulationNameError("");
+                  }}
+                  title="Close"
+                  type="button"
+                >
+                  <CircleX aria-hidden="true" strokeWidth={1.8} />
+                </button>
             </div>
             <label className="field-grid">
               <span>Name</span>
@@ -3016,8 +3019,8 @@ export function Sidebar({ onOpenHelp }: SidebarProps) {
           <div className="library-manager-card user-profile-popup">
             <div className="library-manager-header">
               <h2>Visibility Change Confirmation</h2>
-              <button className="inline-action" onClick={() => setPendingSimulationVisibilityPrompt(null)} type="button">
-                Close
+              <button aria-label="Close" className="inline-action inline-action-icon" onClick={() => setPendingSimulationVisibilityPrompt(null)} title="Close" type="button">
+                <CircleX aria-hidden="true" strokeWidth={1.8} />
               </button>
             </div>
             <p className="field-help">
@@ -3053,15 +3056,17 @@ export function Sidebar({ onOpenHelp }: SidebarProps) {
             <div className="library-manager-header">
               <h2>Site Library</h2>
               <button
-                className="inline-action"
+                aria-label="Close"
+                className="inline-action inline-action-icon"
                 onClick={() => {
                   setShowSiteLibraryManager(false);
                   setPendingDraftAutoInsert(false);
                   closeSiteFilterEditors();
                 }}
+                title="Close"
                 type="button"
               >
-                Close
+                <CircleX aria-hidden="true" strokeWidth={1.8} />
               </button>
             </div>
             <p className="field-help">
@@ -3087,7 +3092,9 @@ export function Sidebar({ onOpenHelp }: SidebarProps) {
                   type="button"
                 >
                   Ownership {selectionLabel(siteLibraryFilters.roleFilters, ALL_ROLE_FILTERS)}
-                  <span className="library-filter-trigger-chevron">{openSiteFilterGroup === "role" ? "^" : "v"}</span>
+                  <span className="library-filter-trigger-chevron" aria-hidden="true">
+                    {openSiteFilterGroup === "role" ? <CircleChevronDown strokeWidth={1.8} /> : <CircleChevronRight strokeWidth={1.8} />}
+                  </span>
                 </button>
                 {openSiteFilterGroup === "role" ? (
                   <div className="library-filter-popover">
@@ -3135,8 +3142,8 @@ export function Sidebar({ onOpenHelp }: SidebarProps) {
                   type="button"
                 >
                   Access level {selectionLabel(siteLibraryFilters.visibilityFilters, ALL_VISIBILITY_FILTERS)}
-                  <span className="library-filter-trigger-chevron">
-                    {openSiteFilterGroup === "visibility" ? "^" : "v"}
+                  <span className="library-filter-trigger-chevron" aria-hidden="true">
+                    {openSiteFilterGroup === "visibility" ? <CircleChevronDown strokeWidth={1.8} /> : <CircleChevronRight strokeWidth={1.8} />}
                   </span>
                 </button>
                 {openSiteFilterGroup === "visibility" ? (
@@ -3187,7 +3194,9 @@ export function Sidebar({ onOpenHelp }: SidebarProps) {
                   type="button"
                 >
                   Source {selectionLabel(siteLibraryFilters.sourceFilters, ALL_SITE_SOURCE_FILTERS)}
-                  <span className="library-filter-trigger-chevron">{openSiteFilterGroup === "source" ? "^" : "v"}</span>
+                  <span className="library-filter-trigger-chevron" aria-hidden="true">
+                    {openSiteFilterGroup === "source" ? <CircleChevronDown strokeWidth={1.8} /> : <CircleChevronRight strokeWidth={1.8} />}
+                  </span>
                 </button>
                 {openSiteFilterGroup === "source" ? (
                   <div className="library-filter-popover">
@@ -3721,8 +3730,8 @@ export function Sidebar({ onOpenHelp }: SidebarProps) {
           <div className="library-manager-card user-profile-popup">
             <div className="library-manager-header">
               <h2>{deleteConfirm.title}</h2>
-              <button className="inline-action" onClick={() => setDeleteConfirm(null)} type="button">
-                Close
+              <button aria-label="Close" className="inline-action inline-action-icon" onClick={() => setDeleteConfirm(null)} title="Close" type="button">
+                <CircleX aria-hidden="true" strokeWidth={1.8} />
               </button>
             </div>
             <p className="field-help">{deleteConfirm.message}</p>

--- a/src/components/SimulationLibraryPanel.tsx
+++ b/src/components/SimulationLibraryPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import clsx from "clsx";
+import { CircleChevronDown, CircleChevronRight, CircleX } from "lucide-react";
 import {
   DEFAULT_LIBRARY_FILTER_STATE,
   filterAndSortLibraryItems,
@@ -274,8 +275,8 @@ export default function SimulationLibraryPanel({
     <div className="library-manager-card">
       <div className="library-manager-header">
         <h2>Simulation Library</h2>
-        <button className="inline-action" onClick={onClose} type="button">
-          Close
+        <button aria-label="Close" className="inline-action inline-action-icon" onClick={onClose} title="Close" type="button">
+          <CircleX aria-hidden="true" strokeWidth={1.8} />
         </button>
       </div>
       <p className="field-help">
@@ -301,8 +302,8 @@ export default function SimulationLibraryPanel({
             type="button"
           >
             Ownership {selectionLabel(filters.roleFilters, ALL_ROLE_FILTERS)}
-            <span className="library-filter-trigger-chevron">
-              {openFilterGroup === "role" ? "^" : "v"}
+            <span className="library-filter-trigger-chevron" aria-hidden="true">
+              {openFilterGroup === "role" ? <CircleChevronDown strokeWidth={1.8} /> : <CircleChevronRight strokeWidth={1.8} />}
             </span>
           </button>
           {openFilterGroup === "role" ? (
@@ -348,8 +349,8 @@ export default function SimulationLibraryPanel({
             type="button"
           >
             Access level {selectionLabel(filters.visibilityFilters, ALL_VISIBILITY_FILTERS)}
-            <span className="library-filter-trigger-chevron">
-              {openFilterGroup === "visibility" ? "^" : "v"}
+            <span className="library-filter-trigger-chevron" aria-hidden="true">
+              {openFilterGroup === "visibility" ? <CircleChevronDown strokeWidth={1.8} /> : <CircleChevronRight strokeWidth={1.8} />}
             </span>
           </button>
           {openFilterGroup === "visibility" ? (
@@ -508,14 +509,16 @@ export default function SimulationLibraryPanel({
             <div className="library-manager-header">
               <h2>New Simulation</h2>
               <button
-                className="inline-action"
+                aria-label="Close"
+                className="inline-action inline-action-icon"
                 onClick={() => {
                   setShowNewSimulationModal(false);
                   setNewSimulationNameError("");
                 }}
+                title="Close"
                 type="button"
               >
-                Close
+                <CircleX aria-hidden="true" strokeWidth={1.8} />
               </button>
             </div>
             <label className="field-grid">

--- a/src/components/UserAdminPanel.tsx
+++ b/src/components/UserAdminPanel.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState, type ChangeEvent } from "react";
+import { CircleQuestionMark, CircleX } from "lucide-react";
 import {
   bulkReassignOwnership,
   fetchAdminAuditEvents,
@@ -746,7 +747,7 @@ export function UserAdminPanel({ onOpenHelp }: UserAdminPanelProps) {
             type="button"
           >
             <SyncStatusIcon
-              className={syncIndicator.state === "syncing" ? "sync-icon-spinning" : undefined}
+              className={syncIndicator.state === "syncing" ? "sync-icon-pulsing" : undefined}
               state={syncIndicator.state}
               title={syncIndicator.label}
             />
@@ -756,7 +757,7 @@ export function UserAdminPanel({ onOpenHelp }: UserAdminPanelProps) {
           </button>
           {onOpenHelp ? (
             <button aria-label="Open onboarding" className="user-icon-button" onClick={onOpenHelp} type="button">
-              ?
+              <CircleQuestionMark aria-hidden="true" strokeWidth={1.8} />
             </button>
           ) : null}
         </div>
@@ -767,8 +768,8 @@ export function UserAdminPanel({ onOpenHelp }: UserAdminPanelProps) {
           <div className="library-manager-card sync-modal">
             <div className="library-manager-header">
               <h2>Cloud Sync</h2>
-              <button className="inline-action" onClick={() => setSyncModalOpen(false)} type="button">
-                Close
+              <button aria-label="Close" className="inline-action inline-action-icon" onClick={() => setSyncModalOpen(false)} title="Close" type="button">
+                <CircleX aria-hidden="true" strokeWidth={1.8} />
               </button>
             </div>
             <div className="sync-modal-content">
@@ -799,7 +800,7 @@ export function UserAdminPanel({ onOpenHelp }: UserAdminPanelProps) {
                   </>
                 ) : syncStatus === "syncing" ? (
                   <>
-                    <span className="sync-indicator-large sync-syncing"><SyncStatusIcon className="sync-icon-spinning" state="syncing" title="Syncing" /></span>
+                    <span className="sync-indicator-large sync-syncing"><SyncStatusIcon className="sync-icon-pulsing" state="syncing" title="Syncing" /></span>
                     <div>
                       <p className="field-help">Syncing to cloud...</p>
                       {!lastSyncedAt && <p className="field-help">Initial sync in progress...</p>}
@@ -865,8 +866,8 @@ export function UserAdminPanel({ onOpenHelp }: UserAdminPanelProps) {
                 <button className="inline-action" onClick={handleSignOut} type="button">
                   Sign Out
                 </button>
-                <button className="inline-action" onClick={() => setOpen(false)} type="button">
-                  Close
+                <button aria-label="Close" className="inline-action inline-action-icon" onClick={() => setOpen(false)} title="Close" type="button">
+                  <CircleX aria-hidden="true" strokeWidth={1.8} />
                 </button>
               </div>
             </div>
@@ -1255,8 +1256,8 @@ export function UserAdminPanel({ onOpenHelp }: UserAdminPanelProps) {
                 <div className="library-manager-card user-profile-popup">
                   <div className="library-manager-header">
                     <h2>User Profile</h2>
-                    <button className="inline-action" onClick={closeManagedUser} type="button">
-                      Close
+                    <button aria-label="Close" className="inline-action inline-action-icon" onClick={closeManagedUser} title="Close" type="button">
+                      <CircleX aria-hidden="true" strokeWidth={1.8} />
                     </button>
                   </div>
                   <div className="user-list-row">

--- a/src/components/icons/AppIcons.tsx
+++ b/src/components/icons/AppIcons.tsx
@@ -1,3 +1,5 @@
+import { Cloud, CloudAlert, CloudCheck, CloudOff, CloudSync, Settings } from "lucide-react";
+
 type SyncStatusIconProps = {
   state: "local" | "offline" | "pending" | "syncing" | "synced" | "error";
   className?: string;
@@ -5,57 +7,34 @@ type SyncStatusIconProps = {
 };
 
 export function SyncStatusIcon({ state, className, title }: SyncStatusIconProps) {
-  if (state === "error" || state === "offline") {
-    return (
-      <svg aria-label={title} className={className} role="img" viewBox="0 0 20 20">
-        <title>{title}</title>
-        <path d="M10 2.5l8 14H2l8-14z" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.8" />
-        <path d="M10 7v4.8" fill="none" stroke="currentColor" strokeLinecap="round" strokeWidth="1.9" />
-        <circle cx="10" cy="14.5" r="1" fill="currentColor" />
-      </svg>
-    );
+  const iconProps = {
+    "aria-label": title,
+    className,
+    role: "img" as const,
+    strokeWidth: 1.8,
+  };
+
+  if (state === "offline") {
+    return <CloudOff {...iconProps} />;
   }
 
   if (state === "pending") {
-    return (
-      <svg aria-label={title} className={className} role="img" viewBox="0 0 20 20">
-        <title>{title}</title>
-        <circle cx="10" cy="10" r="7" fill="none" stroke="currentColor" strokeWidth="1.8" />
-        <path d="M10 10V4" fill="none" stroke="currentColor" strokeLinecap="round" strokeWidth="1.9" />
-        <path d="M10 10l4.2 2.4" fill="none" stroke="currentColor" strokeLinecap="round" strokeWidth="1.9" />
-      </svg>
-    );
+    return <Cloud {...iconProps} />;
   }
 
   if (state === "syncing") {
-    return (
-      <svg aria-label={title} className={className} role="img" viewBox="0 0 20 20">
-        <title>{title}</title>
-        <path d="M4 10a6 6 0 0 1 10.2-4.2" fill="none" stroke="currentColor" strokeLinecap="round" strokeWidth="1.8" />
-        <path d="M14.4 3.6h2.6v2.6" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.8" />
-        <path d="M16 10a6 6 0 0 1-10.2 4.2" fill="none" stroke="currentColor" strokeLinecap="round" strokeWidth="1.8" />
-        <path d="M5.6 16.4H3v-2.6" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.8" />
-      </svg>
-    );
+    return <CloudSync {...iconProps} />;
   }
 
   if (state === "local") {
-    return (
-      <svg aria-label={title} className={className} role="img" viewBox="0 0 20 20">
-        <title>{title}</title>
-        <path d="M3 9.2L10 3l7 6.2v7H3v-7z" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.8" />
-        <path d="M8 16.2v-4h4v4" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.8" />
-      </svg>
-    );
+    return <CloudOff {...iconProps} />;
   }
 
-  return (
-    <svg aria-label={title} className={className} role="img" viewBox="0 0 20 20">
-      <title>{title}</title>
-      <circle cx="10" cy="10" r="7" fill="none" stroke="currentColor" strokeWidth="1.8" />
-      <path d="M6.6 10.1l2.3 2.3 4.5-4.6" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.9" />
-    </svg>
-  );
+  if (state === "error") {
+    return <CloudAlert {...iconProps} />;
+  }
+
+  return <CloudCheck {...iconProps} />;
 }
 
 type SettingsIconProps = {
@@ -64,11 +43,5 @@ type SettingsIconProps = {
 };
 
 export function SettingsIcon({ className, title }: SettingsIconProps) {
-  return (
-    <svg aria-label={title} className={className} role="img" viewBox="0 0 20 20">
-      <title>{title}</title>
-      <path d="M10 4.2l1.2.3.8-1.4 2 1.2-.5 1.5.9.9 1.5-.5 1.2 2-.4.8-.4.8 1.3.9v2.4l-1.3.9.4.8.4.8-1.2 2-1.5-.5-.9.9.5 1.5-2 1.2-.8-1.4L10 15.8l-1.2.3-.8 1.4-2-1.2.5-1.5-.9-.9-1.5.5-1.2-2 .4-.8.4-.8-1.3-.9V9l1.3-.9-.4-.8-.4-.8 1.2-2 1.5.5.9-.9-.5-1.5 2-1.2.8 1.4L10 4.2z" fill="none" stroke="currentColor" strokeLinejoin="round" strokeWidth="1.5" />
-      <circle cx="10" cy="10" r="2.4" fill="none" stroke="currentColor" strokeWidth="1.5" />
-    </svg>
-  );
+  return <Settings aria-label={title} className={className} role="img" strokeWidth={1.8} />;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -265,18 +265,22 @@ input {
 }
 
 .info-tip {
-  position: relative;
   width: 18px;
   height: 18px;
-  display: inline-grid;
-  place-items: center;
-  border-radius: 50%;
-  border: 1px solid color-mix(in srgb, var(--accent) 55%, var(--border));
-  background: color-mix(in srgb, var(--accent-soft) 65%, transparent);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  background: transparent;
   color: var(--text);
-  font-size: 0.72rem;
-  font-weight: 700;
+  padding: 0;
   cursor: help;
+}
+
+.info-tip svg {
+  width: 18px;
+  height: 18px;
+  display: block;
 }
 
 .info-tip-box {
@@ -812,6 +816,16 @@ input {
   flex: 0 0 auto;
 }
 
+.map-controls-utility-pill {
+  border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--surface-2) 94%, transparent);
+  box-shadow: var(--shadow-elev-3);
+  padding: 4px;
+  gap: 4px;
+  align-items: center;
+}
+
 .map-control-note {
   position: absolute;
   top: 66px;
@@ -1150,6 +1164,20 @@ input {
   box-shadow: var(--shadow-elev-3);
 }
 
+.map-control-btn-icon {
+  min-width: 34px;
+  width: 34px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.map-control-btn-icon svg {
+  width: 18px;
+  height: 18px;
+}
+
 .map-control-btn:hover {
   border-color: var(--accent);
 }
@@ -1366,6 +1394,20 @@ input {
 .chart-endpoint-swap.is-active {
   border-color: var(--accent);
   background: var(--accent-soft);
+}
+
+.chart-endpoint-icon {
+  min-width: 34px;
+  width: 34px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.chart-endpoint-icon svg {
+  width: 18px;
+  height: 18px;
 }
 
 .chart-hover-state {
@@ -1872,6 +1914,21 @@ input {
   color: var(--danger-on, #fff);
 }
 
+.inline-action-icon {
+  min-width: 34px;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.inline-action-icon svg {
+  width: 18px;
+  height: 18px;
+}
+
 .user-admin-panel {
   display: grid;
   gap: 8px;
@@ -2059,9 +2116,9 @@ input {
   display: inline-flex;
 }
 
-.sync-icon-spinning {
+.sync-icon-pulsing {
   transform-origin: center;
-  animation: sync-spin 0.8s linear infinite;
+  animation: sync-pulse 1.2s ease-in-out infinite;
 }
 
 .sync-error-details {
@@ -2112,12 +2169,15 @@ input {
   min-inline-size: 0;
 }
 
-@keyframes sync-spin {
-  from {
-    transform: rotate(0deg);
+@keyframes sync-pulse {
+  0%,
+  100% {
+    opacity: 0.78;
+    transform: scale(0.94);
   }
-  to {
-    transform: rotate(360deg);
+  50% {
+    opacity: 1;
+    transform: scale(1);
   }
 }
 
@@ -2649,9 +2709,15 @@ input {
 }
 
 .library-filter-trigger-chevron {
-  font-size: 0.7rem;
-  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   color: var(--muted);
+}
+
+.library-filter-trigger-chevron svg {
+  width: 18px;
+  height: 18px;
 }
 
 .library-filter-popover {


### PR DESCRIPTION
## Summary
- replace custom sync/settings icons with Lucide mapping (`CloudCheck`, `CloudSync`, `Cloud`, `CloudAlert`, `CloudOff`, `Settings`) and keep syncing as pulse animation
- migrate onboarding/help, info-tip, filter chevrons, chart actions, map utility controls, and close actions to consistent Lucide icon buttons (`CircleQuestionMark`, `Info`, `CircleChevronRight/Down`, `ArrowLeftRight`, `Maximize2/Minimize2`, `SearchSlash`, `ZoomIn/ZoomOut`, `Share`, `CircleX`)
- group map utility controls into a shared rounded pill for legibility over map backgrounds and standardize icon sizing to 18px

## Verification
- `npm test`
- `npm run build`