### PR TITLE
fix: finish icon chrome cleanup and expandable/filter cues

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import clsx from "clsx";
-import { CircleChevronDown, CircleChevronRight, CircleX } from "lucide-react";
+import { CircleX, Funnel } from "lucide-react";
 import Map, {
   Layer,
   Marker,
@@ -3093,7 +3093,7 @@ export function Sidebar({ onOpenHelp }: SidebarProps) {
                 >
                   Ownership {selectionLabel(siteLibraryFilters.roleFilters, ALL_ROLE_FILTERS)}
                   <span className="library-filter-trigger-chevron" aria-hidden="true">
-                    {openSiteFilterGroup === "role" ? <CircleChevronDown strokeWidth={1.8} /> : <CircleChevronRight strokeWidth={1.8} />}
+                    <Funnel strokeWidth={1.8} />
                   </span>
                 </button>
                 {openSiteFilterGroup === "role" ? (
@@ -3143,7 +3143,7 @@ export function Sidebar({ onOpenHelp }: SidebarProps) {
                 >
                   Access level {selectionLabel(siteLibraryFilters.visibilityFilters, ALL_VISIBILITY_FILTERS)}
                   <span className="library-filter-trigger-chevron" aria-hidden="true">
-                    {openSiteFilterGroup === "visibility" ? <CircleChevronDown strokeWidth={1.8} /> : <CircleChevronRight strokeWidth={1.8} />}
+                    <Funnel strokeWidth={1.8} />
                   </span>
                 </button>
                 {openSiteFilterGroup === "visibility" ? (
@@ -3195,7 +3195,7 @@ export function Sidebar({ onOpenHelp }: SidebarProps) {
                 >
                   Source {selectionLabel(siteLibraryFilters.sourceFilters, ALL_SITE_SOURCE_FILTERS)}
                   <span className="library-filter-trigger-chevron" aria-hidden="true">
-                    {openSiteFilterGroup === "source" ? <CircleChevronDown strokeWidth={1.8} /> : <CircleChevronRight strokeWidth={1.8} />}
+                    <Funnel strokeWidth={1.8} />
                   </span>
                 </button>
                 {openSiteFilterGroup === "source" ? (

--- a/src/components/SimulationLibraryPanel.tsx
+++ b/src/components/SimulationLibraryPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import clsx from "clsx";
-import { CircleChevronDown, CircleChevronRight, CircleX } from "lucide-react";
+import { CircleX, Funnel } from "lucide-react";
 import {
   DEFAULT_LIBRARY_FILTER_STATE,
   filterAndSortLibraryItems,
@@ -303,7 +303,7 @@ export default function SimulationLibraryPanel({
           >
             Ownership {selectionLabel(filters.roleFilters, ALL_ROLE_FILTERS)}
             <span className="library-filter-trigger-chevron" aria-hidden="true">
-              {openFilterGroup === "role" ? <CircleChevronDown strokeWidth={1.8} /> : <CircleChevronRight strokeWidth={1.8} />}
+              <Funnel strokeWidth={1.8} />
             </span>
           </button>
           {openFilterGroup === "role" ? (
@@ -350,7 +350,7 @@ export default function SimulationLibraryPanel({
           >
             Access level {selectionLabel(filters.visibilityFilters, ALL_VISIBILITY_FILTERS)}
             <span className="library-filter-trigger-chevron" aria-hidden="true">
-              {openFilterGroup === "visibility" ? <CircleChevronDown strokeWidth={1.8} /> : <CircleChevronRight strokeWidth={1.8} />}
+              <Funnel strokeWidth={1.8} />
             </span>
           </button>
           {openFilterGroup === "visibility" ? (

--- a/src/index.css
+++ b/src/index.css
@@ -526,13 +526,27 @@ input {
 }
 
 .compact-details > summary::before {
-  content: "▸";
+  content: "";
+  display: inline-block;
+  width: 18px;
+  height: 18px;
+  background-color: currentColor;
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'/%3E%3Cpath d='m10 8 4 4-4 4'/%3E%3C/svg%3E");
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  -webkit-mask-size: 18px 18px;
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'/%3E%3Cpath d='m10 8 4 4-4 4'/%3E%3C/svg%3E");
+  mask-repeat: no-repeat;
+  mask-position: center;
+  mask-size: 18px 18px;
   margin-right: 8px;
   color: var(--accent);
+  vertical-align: middle;
 }
 
 .compact-details[open] > summary::before {
-  content: "▾";
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'/%3E%3Cpath d='m8 10 4 4 4-4'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'/%3E%3Cpath d='m8 10 4 4 4-4'/%3E%3C/svg%3E");
 }
 
 .metrics {
@@ -1167,15 +1181,25 @@ input {
 .map-control-btn-icon {
   min-width: 34px;
   width: 34px;
+  height: 34px;
   padding: 0;
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
 }
 
 .map-control-btn-icon svg {
   width: 18px;
   height: 18px;
+}
+
+.map-control-btn-icon:hover,
+.map-control-btn-icon:focus-visible {
+  border: 0;
+  background: transparent;
 }
 
 .map-control-btn:hover {
@@ -1399,10 +1423,13 @@ input {
 .chart-endpoint-icon {
   min-width: 34px;
   width: 34px;
+  height: 34px;
   padding: 0;
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  border: 0;
+  background: transparent;
 }
 
 .chart-endpoint-icon svg {
@@ -1922,6 +1949,8 @@ input {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  border: 0;
+  background: transparent;
 }
 
 .inline-action-icon svg {


### PR DESCRIPTION
## Summary
- remove remaining icon chrome so icon-only controls (including close and map/profile icon actions) render without bordered button boxes
- switch library filter trigger icons from chevrons to Funnel
- replace compact details expand/collapse caret glyphs with circle-chevron right/down indicators

## Verification
- npm test
- npm run build