### PR TITLE
fix: map icon states and fit affordance behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@
 - Never commit or push directly to `main`; always create/use a separate branch for changes and push that branch.
 - Use TDD methodology for changes and new features: write/update failing tests first, implement the minimal fix to pass, then refactor with tests green.
 - Keep terminology consistent: use `Simulation`, `Site`, `Library`, `Path`, and `Channel` terms across UI and docs.
+- Icon accessibility rule: every UI icon must include accessible text. For icon-only controls, require an explicit `aria-label` on the interactive element (and matching `title` where applicable). Decorative inline icons should be `aria-hidden="true"`.
 - Any modal/popover that can open on top of another dialog must use `tier="raised"` in `ModalOverlay`.
 - When catching UI errors, use `getUiErrorMessage()` from `src/lib/uiError.ts` for consistent messaging.
 - Do not leave issue status in an ambiguous state. Close issues only when code and verification are done.

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Maximize2, Minimize2, SearchSlash, Share, ZoomIn, ZoomOut } from "lucide-react";
+import { Maximize2, Minimize2, Share, ZoomIn, ZoomOut } from "lucide-react";
 import Map, {
   Layer,
   type MapRef,
@@ -1060,6 +1060,7 @@ export function MapView({
   const [showSimulationSummary, setShowSimulationSummary] = useState(false);
   const [isMultiSelectMode, setIsMultiSelectMode] = useState(false);
   const [showOverlayGuide, setShowOverlayGuide] = useState(true);
+  const [fitControlActive, setFitControlActive] = useState(false);
   const [endpointPickError, setEndpointPickError] = useState<string | null>(null);
   const [pendingNewSiteDraft, setPendingNewSiteDraft] = useState<PendingNewSiteDraft | null>(null);
   const [armAddSiteOnNextEmptyMapClick, setArmAddSiteOnNextEmptyMapClick] = useState(false);
@@ -1499,12 +1500,14 @@ export function MapView({
   };
 
   const zoomBy = (delta: number) => {
+    setFitControlActive(false);
     const nextZoom = clamp(activeViewState.zoom + delta, 2, providerMaxZoom);
     setInteractionViewState(null);
     updateMapViewport({ zoom: nextZoom });
   };
 
   const fitToNodes = () => {
+    setFitControlActive(true);
     const next = computeFitViewport(sites);
     setInteractionViewState(null);
     updateMapViewport({
@@ -2038,12 +2041,12 @@ export function MapView({
         <div className="map-controls-group map-controls-group-utility map-controls-utility-pill">
           <button
             aria-label={isMapExpanded ? "Show panels" : "Hide panels"}
-            className="map-control-btn map-control-btn-icon"
+            className={`map-control-btn map-control-btn-icon ${isMapExpanded ? "is-selected" : ""}`}
             onClick={onToggleMapExpanded}
             title={isMapExpanded ? "Show panels" : "Hide panels"}
             type="button"
           >
-            {isMapExpanded ? <Maximize2 aria-hidden="true" strokeWidth={1.8} /> : <Minimize2 aria-hidden="true" strokeWidth={1.8} />}
+            {isMapExpanded ? <Minimize2 aria-hidden="true" strokeWidth={1.8} /> : <Maximize2 aria-hidden="true" strokeWidth={1.8} />}
           </button>
           {showMultiSelectToggle ? (
             <button
@@ -2054,8 +2057,14 @@ export function MapView({
               {isMultiSelectMode ? "Multi-select On" : "Multi-select Off"}
             </button>
           ) : null}
-          <button aria-label="Fit map to sites" className="map-control-btn map-control-btn-icon" onClick={fitToNodes} title="Fit" type="button">
-            <SearchSlash aria-hidden="true" strokeWidth={1.8} />
+          <button
+            aria-label="Fit map to sites"
+            className={`map-control-btn map-control-btn-icon ${fitControlActive ? "is-selected" : ""}`}
+            onClick={fitToNodes}
+            title="Fit"
+            type="button"
+          >
+            <Maximize2 aria-hidden="true" strokeWidth={1.8} />
           </button>
           <button aria-label="Zoom in" className="map-control-btn map-control-btn-icon" onClick={() => zoomBy(1)} title="Zoom in" type="button">
             <ZoomIn aria-hidden="true" strokeWidth={1.8} />
@@ -2428,13 +2437,16 @@ export function MapView({
         onTouchStart={() => {
           mapRef.current?.getMap().stop();
         }}
-        onMove={(event) =>
+        onMove={(event) => {
+          if (event.originalEvent) {
+            setFitControlActive(false);
+          }
           setInteractionViewState({
             longitude: event.viewState.longitude,
             latitude: event.viewState.latitude,
             zoom: Math.min(event.viewState.zoom, providerMaxZoom),
-          })
-        }
+          });
+        }}
         onMoveEnd={onMoveEnd}
       >
         {showTerrainOverlay && simulationTerrainOverlay ? (

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3093,7 +3093,7 @@ export function Sidebar({ onOpenHelp }: SidebarProps) {
                 >
                   Ownership {selectionLabel(siteLibraryFilters.roleFilters, ALL_ROLE_FILTERS)}
                   <span className="library-filter-trigger-chevron" aria-hidden="true">
-                    <Funnel strokeWidth={1.8} />
+                    <Funnel aria-hidden="true" strokeWidth={1.8} />
                   </span>
                 </button>
                 {openSiteFilterGroup === "role" ? (
@@ -3143,7 +3143,7 @@ export function Sidebar({ onOpenHelp }: SidebarProps) {
                 >
                   Access level {selectionLabel(siteLibraryFilters.visibilityFilters, ALL_VISIBILITY_FILTERS)}
                   <span className="library-filter-trigger-chevron" aria-hidden="true">
-                    <Funnel strokeWidth={1.8} />
+                    <Funnel aria-hidden="true" strokeWidth={1.8} />
                   </span>
                 </button>
                 {openSiteFilterGroup === "visibility" ? (
@@ -3195,7 +3195,7 @@ export function Sidebar({ onOpenHelp }: SidebarProps) {
                 >
                   Source {selectionLabel(siteLibraryFilters.sourceFilters, ALL_SITE_SOURCE_FILTERS)}
                   <span className="library-filter-trigger-chevron" aria-hidden="true">
-                    <Funnel strokeWidth={1.8} />
+                    <Funnel aria-hidden="true" strokeWidth={1.8} />
                   </span>
                 </button>
                 {openSiteFilterGroup === "source" ? (

--- a/src/components/SimulationLibraryPanel.tsx
+++ b/src/components/SimulationLibraryPanel.tsx
@@ -303,7 +303,7 @@ export default function SimulationLibraryPanel({
           >
             Ownership {selectionLabel(filters.roleFilters, ALL_ROLE_FILTERS)}
             <span className="library-filter-trigger-chevron" aria-hidden="true">
-              <Funnel strokeWidth={1.8} />
+              <Funnel aria-hidden="true" strokeWidth={1.8} />
             </span>
           </button>
           {openFilterGroup === "role" ? (
@@ -350,7 +350,7 @@ export default function SimulationLibraryPanel({
           >
             Access level {selectionLabel(filters.visibilityFilters, ALL_VISIBILITY_FILTERS)}
             <span className="library-filter-trigger-chevron" aria-hidden="true">
-              <Funnel strokeWidth={1.8} />
+              <Funnel aria-hidden="true" strokeWidth={1.8} />
             </span>
           </button>
           {openFilterGroup === "visibility" ? (

--- a/src/index.css
+++ b/src/index.css
@@ -1202,6 +1202,11 @@ input {
   background: transparent;
 }
 
+.map-control-btn-icon.is-selected {
+  background: var(--accent-soft);
+  color: color-mix(in srgb, var(--accent) 82%, var(--text));
+}
+
 .map-control-btn:hover {
   border-color: var(--accent);
 }


### PR DESCRIPTION
## Summary
- correct map fullscreen toggle icon direction and keep it highlighted while map is expanded
- switch Fit to fullscreen icon and keep it highlighted after click until a user pan/zoom interaction occurs
- complete icon accessibility pass for added icons (decorative icons marked aria-hidden) and add explicit icon accessibility rule to AGENTS.md

## Verification
- npm test
- npm run build