### PR TITLE
fix: use fullscreen fit icon and unclip map control pill shadow

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Maximize2, Minimize2, Share, ZoomIn, ZoomOut } from "lucide-react";
+import { Fullscreen, Maximize2, Minimize2, Share, ZoomIn, ZoomOut } from "lucide-react";
 import Map, {
   Layer,
   type MapRef,
@@ -2064,7 +2064,7 @@ export function MapView({
             title="Fit"
             type="button"
           >
-            <Maximize2 aria-hidden="true" strokeWidth={1.8} />
+            <Fullscreen aria-hidden="true" strokeWidth={1.8} />
           </button>
           <button aria-label="Zoom in" className="map-control-btn map-control-btn-icon" onClick={() => zoomBy(1)} title="Zoom in" type="button">
             <ZoomIn aria-hidden="true" strokeWidth={1.8} />

--- a/src/index.css
+++ b/src/index.css
@@ -767,7 +767,9 @@ input {
   justify-content: space-between;
   align-items: flex-start;
   gap: 8px;
+  padding: 3px 0;
   overflow-x: auto;
+  overflow-y: visible;
   scrollbar-width: thin;
 }
 


### PR DESCRIPTION
## Summary
- switch map Fit control from `Maximize2` to Lucide `Fullscreen`
- prevent map utility pill shadow clipping by allowing vertical overflow and adding light vertical padding in map controls container

## Verification
- npm test
- npm run build