### PR TITLE
fix: center mobile map utility pill

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1865,6 +1865,16 @@ input {
     justify-content: flex-start;
   }
 
+  .map-controls-group-utility {
+    align-self: center;
+    width: auto;
+    justify-content: center;
+  }
+
+  .map-controls-utility-pill {
+    max-width: calc(100% - 24px);
+  }
+
   .map-inspector {
     right: 12px;
     width: min(420px, calc(100% - 24px));


### PR DESCRIPTION
## Summary
- make map utility controls pill compact on mobile and center it within map controls
- keep pill width bounded to viewport while preserving icon spacing

## Verification
- npm test
- npm run build