### PR TITLE
fix: expand Easter theme window across Easter week (#256)

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -2129,8 +2129,8 @@ export function MapView({
               </p>
               <p className="map-inspector-line">
                 {isHolidayThemeForced
-                  ? "Easter theme is active this weekend."
-                  : "Your preferred theme is active for this Easter weekend."}
+                  ? "Easter theme is active this week."
+                  : "Your preferred theme is active for this Easter week."}
               </p>
               <span className="map-inline-actions">
                 {isHolidayThemeForced ? (

--- a/src/themes/holidayThemes.test.ts
+++ b/src/themes/holidayThemes.test.ts
@@ -16,9 +16,9 @@ describe("holidayThemes", () => {
     expect(isoDay(computeGregorianEasterSunday(2026))).toBe("2026-04-05");
   });
 
-  it("resolves Easter window from Friday to Monday inclusive", () => {
+  it("resolves Easter window from the prior Friday through Monday after Easter", () => {
     const easter2025 = resolveEasterWindow(2025);
-    expect(isoDay(easter2025.startUtc)).toBe("2025-04-18");
+    expect(isoDay(easter2025.startUtc)).toBe("2025-04-11");
     expect(isoDay(easter2025.endUtc)).toBe("2025-04-21");
   });
 
@@ -31,7 +31,12 @@ describe("holidayThemes", () => {
 
   it("stays inactive outside the Easter window", () => {
     expect(getActiveHolidayTheme(new Date("2026-04-09T12:00:00.000Z"))).toBeNull();
-    expect(getActiveHolidayTheme(new Date("2026-04-02T12:00:00.000Z"))).toBeNull();
+    expect(getActiveHolidayTheme(new Date("2026-03-26T12:00:00.000Z"))).toBeNull();
+  });
+
+  it("includes the full Easter week window boundaries", () => {
+    expect(getActiveHolidayTheme(new Date("2026-03-27T12:00:00.000Z"))?.key).toBe("easter");
+    expect(getActiveHolidayTheme(new Date("2026-04-06T12:00:00.000Z"))?.key).toBe("easter");
   });
 
   it("returns stable window ids for per-window preference handling", () => {

--- a/src/themes/holidayThemes.ts
+++ b/src/themes/holidayThemes.ts
@@ -46,7 +46,7 @@ export const computeGregorianEasterSunday = (year: number): Date => {
 export const resolveEasterWindow = (year: number): HolidayThemeWindow => {
   const easterSunday = computeGregorianEasterSunday(year);
   return {
-    startUtc: addUtcDays(easterSunday, -2),
+    startUtc: addUtcDays(easterSunday, -9),
     endUtc: addUtcDays(easterSunday, 1),
   };
 };


### PR DESCRIPTION
## Summary
- expand the Easter holiday window from prior Friday through Monday after Easter
- align holiday tests with the updated schedule (2026: Mar 27 through Apr 6)
- update inspector copy from weekend phrasing to Easter week phrasing

## Verification
- npm run test -- --run src/themes/holidayThemes.test.ts
- npm run test
- npm run build