### PR TITLE
Refine map controls placement and panel treatment (#220)

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1925,128 +1925,7 @@ export function MapView({
   if (siteDraftStatus) inspectorLines.push(siteDraftStatus);
   return (
     <div className={hasMinimumTopology ? "map-panel" : "map-panel map-panel-empty"}>
-      <div className="map-controls map-controls-unified">
-        <div className="map-controls-group map-controls-group-provider">
-          <label className="map-provider-field">
-            <span>Map Provider</span>
-            <select
-              className="locale-select"
-              onChange={(event) => {
-                const nextProvider = event.target.value as typeof basemapProvider;
-                const nextProviderConfig =
-                  providerCapabilities.find((entry) => entry.provider === nextProvider) ?? providerCapabilities[0];
-                setBasemapProvider(nextProvider);
-                setBasemapStylePreset(
-                  nextProviderConfig.presets.find((preset) => preset.id === "normal-themed")?.id ??
-                    nextProviderConfig.presets.find((preset) => preset.id === "normal")?.id ??
-                    nextProviderConfig.presets[0]?.id ??
-                    "normal",
-                );
-                setUseFallbackMapStyle(false);
-                setMapProviderWarning(null);
-              }}
-              value={basemapProvider}
-            >
-              <optgroup label="Global">
-                {globalProviders.map((provider) => (
-                  <option disabled={!provider.available} key={provider.provider} value={provider.provider}>
-                    {provider.label}
-                    {!provider.available ? " (unavailable)" : ""}
-                  </option>
-                ))}
-              </optgroup>
-              <optgroup label="Regional">
-                {regionalProviders.map((provider) => (
-                  <option disabled={!provider.available} key={provider.provider} value={provider.provider}>
-                    {provider.label}
-                    {!provider.available ? " (unavailable)" : ""}
-                  </option>
-                ))}
-              </optgroup>
-            </select>
-          </label>
-          <label className="map-provider-field">
-            <span>Map Style</span>
-            <select
-              className="locale-select"
-              disabled={resolvedPresetOptions.length <= 1}
-              onChange={(event) => {
-                setBasemapStylePreset(event.target.value);
-                setUseFallbackMapStyle(false);
-                setMapProviderWarning(null);
-              }}
-              value={styleSelectValue}
-            >
-              {resolvedPresetOptions.map((preset) => (
-                <option key={preset.id} value={preset.id}>
-                  {preset.label}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label className="map-provider-field">
-            <span>Terrain</span>
-            <select
-              className="locale-select"
-              onChange={(event) => setShowTerrainOverlay(event.target.value === "on")}
-              value={showTerrainOverlay ? "on" : "off"}
-            >
-              <option value="on">Copernicus</option>
-              <option value="off">Off</option>
-            </select>
-          </label>
-          <label className="map-provider-field">
-            <span>Simulation Overlay</span>
-            <select
-              className="locale-select"
-              onChange={(event) => {
-                const mode = event.target.value as "none" | "heatmap" | "contours" | "passfail" | "relay";
-                if (mode === "heatmap") {
-                  setCoverageVizMode("heatmap");
-                  return;
-                }
-                if (mode === "contours") {
-                  setCoverageVizMode("contours");
-                  return;
-                }
-                setCoverageVizMode(mode);
-              }}
-              value={simulationOverlaySelectValue}
-            >
-              <option value="none">Hidden</option>
-              {allowedOverlayModes.includes("heatmap") ? <option value="heatmap">Heatmap</option> : null}
-              {allowedOverlayModes.includes("contours") ? <option value="contours">Contours</option> : null}
-              {allowedOverlayModes.includes("passfail") ? <option value="passfail">Pass/Fail</option> : null}
-              {allowedOverlayModes.includes("relay") ? <option value="relay">Relay</option> : null}
-            </select>
-          </label>
-          <label className="map-provider-field">
-            <span>Visible Sites</span>
-            <select
-              className="locale-select"
-              onChange={(event) => {
-                const mode = event.target.value as "simulation" | "library" | "mqtt";
-                if (mode === "simulation") {
-                  setShowDiscoverySites(false);
-                  setShowDiscoveryMqtt(false);
-                  return;
-                }
-                if (mode === "library") {
-                  setShowDiscoverySites(true);
-                  setShowDiscoveryMqtt(false);
-                  return;
-                }
-                setShowDiscoverySites(false);
-                setShowDiscoveryMqtt(true);
-              }}
-              value={siteVisibilityMode}
-            >
-              <option value="simulation">Only Simulation</option>
-              <option value="library">Simulation + Library</option>
-              <option value="mqtt">Simulation + MQTT</option>
-            </select>
-          </label>
-        </div>
+      <div className="map-controls map-controls-unified map-controls-icon-only">
         <div className="map-controls-group map-controls-group-utility map-controls-utility-pill">
           {showMultiSelectToggle ? (
             <button
@@ -2251,11 +2130,132 @@ export function MapView({
             onToggle={(event) => setShowOverlayGuide(event.currentTarget.open)}
             open={showOverlayGuide}
           >
-            <summary>Overlay Guide</summary>
+            <summary>Map</summary>
+            <div className="map-inspector-map-settings">
+              <label className="map-inspector-map-setting">
+                <span>Map Provider</span>
+                <select
+                  className="locale-select"
+                  onChange={(event) => {
+                    const nextProvider = event.target.value as typeof basemapProvider;
+                    const nextProviderConfig =
+                      providerCapabilities.find((entry) => entry.provider === nextProvider) ?? providerCapabilities[0];
+                    setBasemapProvider(nextProvider);
+                    setBasemapStylePreset(
+                      nextProviderConfig.presets.find((preset) => preset.id === "normal-themed")?.id ??
+                        nextProviderConfig.presets.find((preset) => preset.id === "normal")?.id ??
+                        nextProviderConfig.presets[0]?.id ??
+                        "normal",
+                    );
+                    setUseFallbackMapStyle(false);
+                    setMapProviderWarning(null);
+                  }}
+                  value={basemapProvider}
+                >
+                  <optgroup label="Global">
+                    {globalProviders.map((provider) => (
+                      <option disabled={!provider.available} key={provider.provider} value={provider.provider}>
+                        {provider.label}
+                        {!provider.available ? " (unavailable)" : ""}
+                      </option>
+                    ))}
+                  </optgroup>
+                  <optgroup label="Regional">
+                    {regionalProviders.map((provider) => (
+                      <option disabled={!provider.available} key={provider.provider} value={provider.provider}>
+                        {provider.label}
+                        {!provider.available ? " (unavailable)" : ""}
+                      </option>
+                    ))}
+                  </optgroup>
+                </select>
+              </label>
+              <label className="map-inspector-map-setting">
+                <span>Map Style</span>
+                <select
+                  className="locale-select"
+                  disabled={resolvedPresetOptions.length <= 1}
+                  onChange={(event) => {
+                    setBasemapStylePreset(event.target.value);
+                    setUseFallbackMapStyle(false);
+                    setMapProviderWarning(null);
+                  }}
+                  value={styleSelectValue}
+                >
+                  {resolvedPresetOptions.map((preset) => (
+                    <option key={preset.id} value={preset.id}>
+                      {preset.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="map-inspector-map-setting">
+                <span>Terrain</span>
+                <select
+                  className="locale-select"
+                  onChange={(event) => setShowTerrainOverlay(event.target.value === "on")}
+                  value={showTerrainOverlay ? "on" : "off"}
+                >
+                  <option value="on">Copernicus</option>
+                  <option value="off">Off</option>
+                </select>
+              </label>
+              <label className="map-inspector-map-setting">
+                <span>Simulation Overlay</span>
+                <select
+                  className="locale-select"
+                  onChange={(event) => {
+                    const mode = event.target.value as "none" | "heatmap" | "contours" | "passfail" | "relay";
+                    if (mode === "heatmap") {
+                      setCoverageVizMode("heatmap");
+                      return;
+                    }
+                    if (mode === "contours") {
+                      setCoverageVizMode("contours");
+                      return;
+                    }
+                    setCoverageVizMode(mode);
+                  }}
+                  value={simulationOverlaySelectValue}
+                >
+                  <option value="none">Hidden</option>
+                  {allowedOverlayModes.includes("heatmap") ? <option value="heatmap">Heatmap</option> : null}
+                  {allowedOverlayModes.includes("contours") ? <option value="contours">Contours</option> : null}
+                  {allowedOverlayModes.includes("passfail") ? <option value="passfail">Pass/Fail</option> : null}
+                  {allowedOverlayModes.includes("relay") ? <option value="relay">Relay</option> : null}
+                </select>
+              </label>
+              <label className="map-inspector-map-setting">
+                <span>Visible Sites</span>
+                <select
+                  className="locale-select"
+                  onChange={(event) => {
+                    const mode = event.target.value as "simulation" | "library" | "mqtt";
+                    if (mode === "simulation") {
+                      setShowDiscoverySites(false);
+                      setShowDiscoveryMqtt(false);
+                      return;
+                    }
+                    if (mode === "library") {
+                      setShowDiscoverySites(true);
+                      setShowDiscoveryMqtt(false);
+                      return;
+                    }
+                    setShowDiscoverySites(false);
+                    setShowDiscoveryMqtt(true);
+                  }}
+                  value={siteVisibilityMode}
+                >
+                  <option value="simulation">Only Simulation</option>
+                  <option value="library">Simulation + Library</option>
+                  <option value="mqtt">Simulation + MQTT</option>
+                </select>
+              </label>
+            </div>
             <p>
               Mode: <strong>{overlayGuideTitle}</strong>
             </p>
-            {coverageVizMode === "none" ? <p>Overlay is hidden. Click Heat, Pass/Fail, or Relay to show it again.</p> : null}
+            {coverageVizMode === "none" ? <p>Overlay is hidden. Use Simulation Overlay to show it again.</p> : null}
             {coverageVizMode === "heatmap" ? (
               <>
                 <p>

--- a/src/index.css
+++ b/src/index.css
@@ -15,6 +15,8 @@
   --los: Highlight;
   --shadow: 0 16px 42px color-mix(in srgb, CanvasText 14%, transparent);
   --focus-outline: color-mix(in srgb, var(--accent) 62%, Canvas 18%);
+  --glass-panel-opacity: 75%;
+  --glass-panel-blur: 12px;
 }
 
 * {
@@ -146,10 +148,16 @@ input {
 }
 
 .sidebar-panel {
-  background: linear-gradient(160deg, var(--surface), var(--surface-2));
+  background: linear-gradient(
+    160deg,
+    color-mix(in srgb, var(--surface) var(--glass-panel-opacity), transparent),
+    color-mix(in srgb, var(--surface-2) var(--glass-panel-opacity), transparent)
+  );
   border: 1px solid var(--border);
   border-radius: 18px;
   box-shadow: var(--shadow);
+  -webkit-backdrop-filter: blur(var(--glass-panel-blur));
+  backdrop-filter: blur(var(--glass-panel-blur));
   padding: 18px;
   position: relative;
   z-index: 40;
@@ -216,7 +224,7 @@ input {
 }
 
 .panel-section {
-  background: color-mix(in srgb, var(--surface-2) 92%, transparent);
+  background: var(--surface);
   border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
   border-radius: 12px;
   padding: 12px;
@@ -507,7 +515,7 @@ input {
 .compact-details {
   border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
   border-radius: 10px;
-  background: color-mix(in srgb, var(--surface-2) 90%, transparent);
+  background: var(--surface);
   padding: 8px 10px;
   display: grid;
   gap: 8px;
@@ -782,6 +790,12 @@ input {
   z-index: 60;
 }
 
+.map-controls-icon-only {
+  justify-content: center;
+  overflow: visible;
+  padding-top: 6px;
+}
+
 .map-controls-group-provider {
   align-items: flex-start;
   flex-wrap: nowrap;
@@ -835,7 +849,9 @@ input {
 .map-controls-utility-pill {
   border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
   border-radius: 999px;
-  background: color-mix(in srgb, var(--surface-2) 94%, transparent);
+  background: color-mix(in srgb, var(--surface-2) var(--glass-panel-opacity), transparent);
+  -webkit-backdrop-filter: blur(var(--glass-panel-blur));
+  backdrop-filter: blur(var(--glass-panel-blur));
   box-shadow: var(--shadow-elev-3);
   margin: 2px;
   padding: 4px;
@@ -887,7 +903,13 @@ input {
   overflow: auto;
   border: 1px solid var(--border);
   border-radius: 18px;
-  background: linear-gradient(160deg, var(--surface), var(--surface-2));
+  background: linear-gradient(
+    160deg,
+    color-mix(in srgb, var(--surface) var(--glass-panel-opacity), transparent),
+    color-mix(in srgb, var(--surface-2) var(--glass-panel-opacity), transparent)
+  );
+  -webkit-backdrop-filter: blur(var(--glass-panel-blur));
+  backdrop-filter: blur(var(--glass-panel-blur));
   box-shadow: var(--shadow);
   padding: 18px;
   display: grid;
@@ -998,6 +1020,34 @@ input {
 
 .map-inspector-details {
   margin-top: 8px;
+}
+
+.map-inspector-map-settings {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 10px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 84%, transparent);
+}
+
+.map-inspector-map-setting {
+  display: grid;
+  gap: 4px;
+}
+
+.map-inspector-map-setting > span {
+  color: var(--muted);
+  font-size: 0.7rem;
+  font-weight: 600;
+  line-height: 1.05;
+}
+
+.map-inspector-map-setting .locale-select {
+  width: 100%;
+  min-width: 0;
+  height: 30px;
+  font-size: 0.74rem;
+  padding: 2px 8px;
 }
 
 .map-progress {
@@ -1340,6 +1390,7 @@ input {
 }
 
 .chart-panel {
+  background: linear-gradient(160deg, var(--surface), var(--surface-2));
   padding: 8px 0 6px;
   display: flex;
   flex-direction: column;
@@ -1352,6 +1403,10 @@ input {
 
 .workspace-panel.is-profile-expanded .chart-panel {
   grid-row: 1;
+}
+
+.workspace-panel.is-profile-expanded .map-inspector {
+  display: none;
 }
 
 .chart-panel-empty {
@@ -1696,17 +1751,19 @@ input {
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 8px;
-    padding: 0;
-    border: 0;
-    border-radius: 0;
-    background: transparent;
-    box-shadow: none;
+    padding: 8px;
+    border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
+    border-radius: 12px;
+    background: color-mix(in srgb, var(--surface-2) var(--glass-panel-opacity), transparent);
+    -webkit-backdrop-filter: blur(var(--glass-panel-blur));
+    backdrop-filter: blur(var(--glass-panel-blur));
+    box-shadow: var(--shadow-elev-2);
   }
 
   .mobile-workspace-tab {
     border: 1px solid var(--border);
     border-radius: 10px;
-    background: color-mix(in srgb, var(--surface-2) 90%, transparent);
+    background: var(--surface);
     color: var(--text);
     height: 34px;
     font-size: 0.74rem;


### PR DESCRIPTION
## Summary
- move map settings into the right inspector expandable and rename it to Map
- keep the map utility icon pill on-map, center it, and fix its clipped shadow
- apply panel glass treatment updates, keep Path Profile opaque, and hide right inspector when profile is expanded

## Verification
- npm test
- npm run build