### PR TITLE
Fix iOS full-bleed map fallback and viewport repaint (#220)

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1099,11 +1099,16 @@ export function MapView({
     const handleViewportChange = () => {
       mapRef.current?.resize();
     };
+    const viewport = window.visualViewport;
     window.addEventListener("resize", handleViewportChange);
     window.addEventListener("orientationchange", handleViewportChange);
+    viewport?.addEventListener("resize", handleViewportChange);
+    viewport?.addEventListener("scroll", handleViewportChange);
     return () => {
       window.removeEventListener("resize", handleViewportChange);
       window.removeEventListener("orientationchange", handleViewportChange);
+      viewport?.removeEventListener("resize", handleViewportChange);
+      viewport?.removeEventListener("scroll", handleViewportChange);
     };
   }, []);
   const hasNonAutoLinks = useMemo(

--- a/src/index.css
+++ b/src/index.css
@@ -1738,6 +1738,18 @@ input {
     min-height: 100lvh;
   }
 
+  @supports (-webkit-touch-callout: none) {
+    html,
+    body,
+    #root,
+    .app-shell.is-mobile-shell,
+    .app-shell.is-mobile-shell .workspace-panel,
+    .app-shell.is-mobile-shell .map-panel {
+      height: -webkit-fill-available;
+      min-height: -webkit-fill-available;
+    }
+  }
+
   .app-shell.is-mobile-shell .mobile-workspace-tabs {
     position: fixed;
     left: 12px;
@@ -1921,7 +1933,9 @@ input {
     left: 0;
     width: 100vw;
     height: 100vh;
+    min-height: 100vh;
     height: 100lvh;
+    min-height: 100lvh;
     margin: 0;
     border: 0;
     border-radius: 0;


### PR DESCRIPTION
## Summary
- add iOS WebKit fallback sizing (`-webkit-fill-available`) for mobile root/app/workspace/map shells to stabilize full-bleed behavior
- keep mobile panel gap spacing and profile-panel bottom alignment consistent with tab bar spacing
- trigger map resize on `window.visualViewport` resize/scroll events so Safari chrome changes repaint map bounds correctly

## Verification
- npm test
- npm run build