### PR TITLE
Fix iOS map shell edge pinning regression (#220)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1742,9 +1742,7 @@ input {
     html,
     body,
     #root,
-    .app-shell.is-mobile-shell,
-    .app-shell.is-mobile-shell .workspace-panel,
-    .app-shell.is-mobile-shell .map-panel {
+    .app-shell.is-mobile-shell {
       height: -webkit-fill-available;
       min-height: -webkit-fill-available;
     }
@@ -1927,15 +1925,7 @@ input {
 
   .app-shell.is-mobile-shell .map-panel {
     position: fixed;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    width: 100vw;
-    height: 100vh;
-    min-height: 100vh;
-    height: 100lvh;
-    min-height: 100lvh;
+    inset: 0;
     margin: 0;
     border: 0;
     border-radius: 0;


### PR DESCRIPTION
## Summary
- simplify mobile map shell sizing to fixed edge pinning (`inset: 0`) without explicit width/height viewport units
- narrow WebKit `-webkit-fill-available` fallback scope to root and mobile app shell only, avoiding map-container constraints

## Verification
- npm test
- npm run build