### PR TITLE
Restore iOS partial-fix baseline behavior (#220)

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1099,11 +1099,14 @@ export function MapView({
     const handleViewportChange = () => {
       mapRef.current?.resize();
     };
+    const viewport = window.visualViewport;
     window.addEventListener("resize", handleViewportChange);
     window.addEventListener("orientationchange", handleViewportChange);
+    viewport?.addEventListener("resize", handleViewportChange);
     return () => {
       window.removeEventListener("resize", handleViewportChange);
       window.removeEventListener("orientationchange", handleViewportChange);
+      viewport?.removeEventListener("resize", handleViewportChange);
     };
   }, []);
   const hasNonAutoLinks = useMemo(


### PR DESCRIPTION
## Summary
- restore the `visualViewport`-based map resize behavior that was present in commit `3eed567`
- keep only `visualViewport` resize handling (no scroll listener) to reduce Safari URL bar animation churn

## Verification
- npm test
- npm run build