### PR TITLE
Fix iOS map full-bleed canvas clipping (#220)

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1103,10 +1103,12 @@ export function MapView({
     window.addEventListener("resize", handleViewportChange);
     window.addEventListener("orientationchange", handleViewportChange);
     viewport?.addEventListener("resize", handleViewportChange);
+    viewport?.addEventListener("scroll", handleViewportChange);
     return () => {
       window.removeEventListener("resize", handleViewportChange);
       window.removeEventListener("orientationchange", handleViewportChange);
       viewport?.removeEventListener("resize", handleViewportChange);
+      viewport?.removeEventListener("scroll", handleViewportChange);
     };
   }, []);
   const hasNonAutoLinks = useMemo(

--- a/src/index.css
+++ b/src/index.css
@@ -1942,6 +1942,15 @@ input {
     box-shadow: none;
   }
 
+  .app-shell.is-mobile-shell .map-panel .maplibregl-map,
+  .app-shell.is-mobile-shell .map-panel .maplibregl-canvas-container,
+  .app-shell.is-mobile-shell .map-panel .maplibregl-canvas {
+    position: absolute;
+    inset: 0;
+    width: 100% !important;
+    height: 100% !important;
+  }
+
   .map-controls {
     top: var(--mobile-controls-top);
     flex-direction: column;


### PR DESCRIPTION
## Summary
- restore the  map resize listener baseline ( resize + scroll)
- pin the internal MapLibre viewport/canvas stack to full mobile map shell bounds so Safari toolbar transitions do not leave a clipped rectangle
- keep existing mobile panel spacing offsets unchanged

## Verification
- npm test
- npm run build