### PR TITLE
Raise staging viewport debug chip above mobile overlays (#220)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -749,9 +749,10 @@ input {
 
 .map-viewport-debug {
   position: fixed;
-  left: 10px;
-  bottom: calc(10px + env(safe-area-inset-bottom));
-  z-index: 120;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 2147483000;
   display: inline-flex;
   gap: 6px;
   align-items: center;


### PR DESCRIPTION
## Summary
- move the staging-only viewport diagnostics chip to the center of the screen
- set an extremely high z-index so it stays visible above mobile tab bar and overlays during iOS debugging

## Verification
- npm test
- npm run build