### PR TITLE
Repair iOS diagnostic probe and add map wrapper override (#220)

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1105,7 +1105,9 @@ export function MapView({
     panelHeight: number | null;
     mapHeight: number | null;
     canvasHeight: number | null;
+    mapLoaded: boolean;
   } | null>(null);
+  const [mapIsLoaded, setMapIsLoaded] = useState(false);
 
   useEffect(() => {
     const triggerInitialResize = () => {
@@ -1146,7 +1148,7 @@ export function MapView({
     }
     const collectViewportDebug = () => {
       const panel = mapPanelRef.current;
-      const map = mapRef.current?.getMap();
+      const map = mapIsLoaded && mapRef.current ? mapRef.current.getMap() : null;
       const mapContainer = map?.getContainer() ?? null;
       const mapCanvas = map?.getCanvas() ?? null;
       const visualViewport = window.visualViewport;
@@ -1157,6 +1159,7 @@ export function MapView({
         panelHeight: panel ? Math.round(panel.getBoundingClientRect().height) : null,
         mapHeight: mapContainer ? Math.round(mapContainer.getBoundingClientRect().height) : null,
         canvasHeight: mapCanvas ? Math.round(mapCanvas.getBoundingClientRect().height) : null,
+        mapLoaded: mapIsLoaded,
       });
     };
     collectViewportDebug();
@@ -1171,7 +1174,7 @@ export function MapView({
       visualViewport?.removeEventListener("resize", collectViewportDebug);
       visualViewport?.removeEventListener("scroll", collectViewportDebug);
     };
-  }, [isStagingEnvironment]);
+  }, [isStagingEnvironment, mapIsLoaded]);
   const hasNonAutoLinks = useMemo(
     () => links.some((link) => (link.name ?? "").trim().toLowerCase() !== "auto link"),
     [links],
@@ -1999,6 +2002,7 @@ export function MapView({
           <span>{`panel ${viewportDebug.panelHeight ?? "-"}`}</span>
           <span>{`map ${viewportDebug.mapHeight ?? "-"}`}</span>
           <span>{`canvas ${viewportDebug.canvasHeight ?? "-"}`}</span>
+          <span>{`loaded ${viewportDebug.mapLoaded ? "Y" : "N"}`}</span>
         </div>
       ) : null}
       <div className="map-controls map-controls-unified map-controls-icon-only">
@@ -2561,6 +2565,7 @@ export function MapView({
           });
         }}
         onMoveEnd={onMoveEnd}
+        onLoad={() => setMapIsLoaded(true)}
       >
         {showTerrainOverlay && simulationTerrainOverlay ? (
           <Source

--- a/src/index.css
+++ b/src/index.css
@@ -1971,6 +1971,13 @@ input {
     height: 100% !important;
   }
 
+  .app-shell.is-mobile-shell .map-panel .maplibregl-wrapper {
+    position: absolute !important;
+    inset: 0 !important;
+    width: 100% !important;
+    height: 100% !important;
+  }
+
   .map-controls {
     top: var(--mobile-controls-top);
     flex-direction: column;


### PR DESCRIPTION
## Summary
- Add onLoad callback to Map component to track when MapLibre is ready for diagnostics 
- Fix diagnostic probe to only collect map/canvas data when mapIsLoaded=true
- Add CSS override for .maplibregl-wrapper to force full-bleed bounds on mobile
- Add mapLoaded status to debug chip display

## Verification
- npm test
- npm run build