### PR TITLE
Fix iOS map background color and viewport transform (#220)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1976,6 +1976,13 @@ input {
     inset: 0 !important;
     width: 100% !important;
     height: 100% !important;
+    background-color: var(--bg) !important;
+  }
+
+  .app-shell.is-mobile-shell .map-panel .maplibregl-viewport {
+    position: absolute !important;
+    inset: 0 !important;
+    transform: none !important;
   }
 
   .map-controls {


### PR DESCRIPTION
## Summary
- Add background-color to maplibregl-wrapper using CSS variable --bg to cover default MapLibre yellow tile background that shows through when tiles haven't fully loaded
- Reset maplibregl-viewport transform to none on mobile to prevent rendering gaps at edges

## Verification
- npm test
- npm run build