### PR TITLE
Clean map viewport experiments and reset mobile fullscreen behavior (#220)

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -25,7 +25,6 @@ import { useCoverageStore } from "../store/coverageStore";
 import { TERRAIN_DATASET_LABEL } from "../lib/terrainDataset";
 import type { Link, PropagationEnvironment, Site } from "../types/radio";
 import { fetchMeshmapNodes, type MeshmapNode } from "../lib/meshtasticMqtt";
-import { getCurrentRuntimeEnvironment } from "../lib/environment";
 import { SimulationResultsSection } from "./SimulationResultsSection";
 
 const mapLineLayer = (linkColor: string, selectedColor: string): LayerProps => ({
@@ -1095,101 +1094,18 @@ export function MapView({
     zoom: number;
   } | null>(null);
   const mapRef = useRef<MapRef | null>(null);
-  const mapPanelRef = useRef<HTMLDivElement | null>(null);
-  const runtimeEnvironment = getCurrentRuntimeEnvironment();
-  const isStagingEnvironment = runtimeEnvironment === "staging";
-  const [viewportDebug, setViewportDebug] = useState<{
-    innerHeight: number;
-    visualHeight: number | null;
-    visualOffsetTop: number | null;
-    panelHeight: number | null;
-    panelTop: number | null;
-    panelBottom: number | null;
-    mapHeight: number | null;
-    mapTop: number | null;
-    mapBottom: number | null;
-    canvasHeight: number | null;
-    canvasTop: number | null;
-    canvasBottom: number | null;
-    mapLoaded: boolean;
-  } | null>(null);
-  const [mapIsLoaded, setMapIsLoaded] = useState(false);
-
-  useEffect(() => {
-    const triggerInitialResize = () => {
-      mapRef.current?.resize();
-    };
-    triggerInitialResize();
-    const rafId = window.requestAnimationFrame(triggerInitialResize);
-    const timeoutFastId = window.setTimeout(triggerInitialResize, 260);
-    const timeoutSlowId = window.setTimeout(triggerInitialResize, 960);
-    return () => {
-      window.cancelAnimationFrame(rafId);
-      window.clearTimeout(timeoutFastId);
-      window.clearTimeout(timeoutSlowId);
-    };
-  }, []);
 
   useEffect(() => {
     const handleViewportChange = () => {
       mapRef.current?.resize();
     };
-    const viewport = window.visualViewport;
     window.addEventListener("resize", handleViewportChange);
     window.addEventListener("orientationchange", handleViewportChange);
-    viewport?.addEventListener("resize", handleViewportChange);
-    viewport?.addEventListener("scroll", handleViewportChange);
     return () => {
       window.removeEventListener("resize", handleViewportChange);
       window.removeEventListener("orientationchange", handleViewportChange);
-      viewport?.removeEventListener("resize", handleViewportChange);
-      viewport?.removeEventListener("scroll", handleViewportChange);
     };
   }, []);
-
-  useEffect(() => {
-    if (!isStagingEnvironment) {
-      setViewportDebug(null);
-      return;
-    }
-    const collectViewportDebug = () => {
-      const panel = mapPanelRef.current;
-      const map = mapIsLoaded && mapRef.current ? mapRef.current.getMap() : null;
-      const mapContainer = map?.getContainer() ?? null;
-      const mapCanvas = map?.getCanvas() ?? null;
-      const panelRect = panel?.getBoundingClientRect() ?? null;
-      const mapRect = mapContainer?.getBoundingClientRect() ?? null;
-      const canvasRect = mapCanvas?.getBoundingClientRect() ?? null;
-      const visualViewport = window.visualViewport;
-      setViewportDebug({
-        innerHeight: window.innerHeight,
-        visualHeight: visualViewport ? Math.round(visualViewport.height) : null,
-        visualOffsetTop: visualViewport ? Math.round(visualViewport.offsetTop) : null,
-        panelHeight: panelRect ? Math.round(panelRect.height) : null,
-        panelTop: panelRect ? Math.round(panelRect.top) : null,
-        panelBottom: panelRect ? Math.round(panelRect.bottom) : null,
-        mapHeight: mapRect ? Math.round(mapRect.height) : null,
-        mapTop: mapRect ? Math.round(mapRect.top) : null,
-        mapBottom: mapRect ? Math.round(mapRect.bottom) : null,
-        canvasHeight: canvasRect ? Math.round(canvasRect.height) : null,
-        canvasTop: canvasRect ? Math.round(canvasRect.top) : null,
-        canvasBottom: canvasRect ? Math.round(canvasRect.bottom) : null,
-        mapLoaded: mapIsLoaded,
-      });
-    };
-    collectViewportDebug();
-    const visualViewport = window.visualViewport;
-    window.addEventListener("resize", collectViewportDebug);
-    window.addEventListener("orientationchange", collectViewportDebug);
-    visualViewport?.addEventListener("resize", collectViewportDebug);
-    visualViewport?.addEventListener("scroll", collectViewportDebug);
-    return () => {
-      window.removeEventListener("resize", collectViewportDebug);
-      window.removeEventListener("orientationchange", collectViewportDebug);
-      visualViewport?.removeEventListener("resize", collectViewportDebug);
-      visualViewport?.removeEventListener("scroll", collectViewportDebug);
-    };
-  }, [isStagingEnvironment, mapIsLoaded]);
   const hasNonAutoLinks = useMemo(
     () => links.some((link) => (link.name ?? "").trim().toLowerCase() !== "auto link"),
     [links],
@@ -2008,24 +1924,7 @@ export function MapView({
   if (endpointPickTarget && endpointPickError) inspectorLines.push(endpointPickError);
   if (siteDraftStatus) inspectorLines.push(siteDraftStatus);
   return (
-    <div className={hasMinimumTopology ? "map-panel" : "map-panel map-panel-empty"} ref={mapPanelRef}>
-      {isStagingEnvironment && viewportDebug ? (
-        <div aria-live="polite" className="map-viewport-debug" role="status">
-          <span>{`inner ${viewportDebug.innerHeight}`}</span>
-          <span>{`vv ${viewportDebug.visualHeight ?? "-"}`}</span>
-          <span>{`vvTop ${viewportDebug.visualOffsetTop ?? "-"}`}</span>
-          <span>{`panel ${viewportDebug.panelHeight ?? "-"}`}</span>
-          <span>{`pT ${viewportDebug.panelTop ?? "-"}`}</span>
-          <span>{`pB ${viewportDebug.panelBottom ?? "-"}`}</span>
-          <span>{`map ${viewportDebug.mapHeight ?? "-"}`}</span>
-          <span>{`mT ${viewportDebug.mapTop ?? "-"}`}</span>
-          <span>{`mB ${viewportDebug.mapBottom ?? "-"}`}</span>
-          <span>{`canvas ${viewportDebug.canvasHeight ?? "-"}`}</span>
-          <span>{`cT ${viewportDebug.canvasTop ?? "-"}`}</span>
-          <span>{`cB ${viewportDebug.canvasBottom ?? "-"}`}</span>
-          <span>{`loaded ${viewportDebug.mapLoaded ? "Y" : "N"}`}</span>
-        </div>
-      ) : null}
+    <div className={hasMinimumTopology ? "map-panel" : "map-panel map-panel-empty"}>
       <div className="map-controls map-controls-unified map-controls-icon-only">
         <div className="map-controls-group map-controls-group-utility map-controls-utility-pill">
           {showMultiSelectToggle ? (
@@ -2586,7 +2485,6 @@ export function MapView({
           });
         }}
         onMoveEnd={onMoveEnd}
-        onLoad={() => setMapIsLoaded(true)}
       >
         {showTerrainOverlay && simulationTerrainOverlay ? (
           <Source

--- a/src/index.css
+++ b/src/index.css
@@ -81,7 +81,7 @@ body::before {
 }
 
 .env-staging body::after {
-  display: none;
+  border-color: var(--staging-frame);
 }
 
 .env-local body::after {
@@ -745,26 +745,6 @@ input {
 
 .map-panel-empty .maplibregl-map {
   filter: saturate(0.35) brightness(0.8);
-}
-
-.map-viewport-debug {
-  position: fixed;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  z-index: 2147483000;
-  display: inline-flex;
-  gap: 6px;
-  align-items: center;
-  padding: 6px 8px;
-  border: 1px solid color-mix(in srgb, var(--border) 84%, transparent);
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--surface) 96%, transparent);
-  color: var(--text);
-  font-size: 0.67rem;
-  line-height: 1;
-  pointer-events: none;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
 
 .map-empty-state {
@@ -1736,10 +1716,8 @@ input {
   html,
   body,
   #root {
-    height: 100vh;
-    min-height: 100vh;
-    height: 100lvh;
-    min-height: 100lvh;
+    height: 100dvh;
+    min-height: 100dvh;
     overflow: hidden;
   }
 
@@ -1752,21 +1730,8 @@ input {
     --mobile-panel-height: 36vh;
     --mobile-attribution-gap: 8px;
     --mobile-attribution-top: calc(var(--mobile-controls-top) + var(--mobile-controls-occupied) + var(--mobile-attribution-gap));
-    height: 100vh;
-    min-height: 100vh;
-    height: 100lvh;
-    min-height: 100lvh;
-  }
-
-  @supports (-webkit-touch-callout: none) {
-    html,
-    body,
-    #root,
-    .app-shell.is-mobile-shell,
-    .app-shell.is-mobile-shell .workspace-panel {
-      height: -webkit-fill-available;
-      min-height: -webkit-fill-available;
-    }
+    height: 100dvh;
+    min-height: 100dvh;
   }
 
   .app-shell.is-mobile-shell .mobile-workspace-tabs {
@@ -1946,35 +1911,14 @@ input {
 
   .app-shell.is-mobile-shell .map-panel {
     position: fixed;
-    top: 0;
-    right: 0;
-    bottom: auto;
-    left: 0;
+    inset: 0;
     width: 100vw;
-    height: 100vh;
-    height: 100lvh;
-    min-height: 100vh;
-    min-height: 100lvh;
+    height: 100dvh;
+    min-height: 100dvh;
     margin: 0;
     border: 0;
     border-radius: 0;
     box-shadow: none;
-  }
-
-  .app-shell.is-mobile-shell .map-panel .maplibregl-map,
-  .app-shell.is-mobile-shell .map-panel .maplibregl-canvas-container,
-  .app-shell.is-mobile-shell .map-panel .maplibregl-canvas {
-    position: absolute;
-    inset: 0;
-    width: 100% !important;
-    height: 100% !important;
-  }
-
-  .app-shell.is-mobile-shell .map-panel .maplibregl-wrapper {
-    position: absolute !important;
-    inset: 0 !important;
-    width: 100% !important;
-    height: 100% !important;
   }
 
   .map-controls {


### PR DESCRIPTION
## Summary
- remove temporary staging diagnostics and iOS viewport experiment code from MapView
- reset mobile map to normal fullscreen sizing (`fixed` + `inset: 0` + `100dvh`) and remove experimental map internals overrides
- keep WebKit-safe-area baseline in place (`viewport-fit=cover` and `env(safe-area-inset-*)` UI offsets)
- restore staging frame indicator border

## Verification
- npm test
- npm run build