### PR TITLE
chore: sync unpushed staging fullscreen toggle fixes

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1002,7 +1002,7 @@ export function AppShell() {
   return (
     <main
       ref={appShellRef}
-      className={`app-shell ${isMapExpanded || isProfileExpanded ? "is-map-expanded" : ""} ${
+      className={`app-shell ${isMapExpanded ? "is-map-expanded" : ""} ${
         accessState === "readonly" ? "is-readonly-shell" : ""
       } ${
         isMobileViewport ? "is-mobile-shell" : ""


### PR DESCRIPTION
## Summary
- Syncs 4 local-only commits that are already deployed and verified on https://staging.linksim.link
- These fix path profile fullscreen toggle decoupling and app shell CSS class corrections
- Required as prerequisite for v0.12.0 release

## Commits
- `fix path profile fullscreen toggle to only toggle profile, not map`
- `fix: map and path profile fullscreen toggles work independently`
- `fix: decouple map and path profile fullscreen toggles`
- `fix: correct app shell CSS class for profile vs map expansion`