### PR TITLE
chore: back-merge main into staging after v0.12.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project are documented here in a human-readable format.
 
+## [0.12.0] - 2026-03-28
+
+### Added
+- Mobile: tabbed interface splits map/profile view and sidebar for better small-screen layout.
+- Desktop: right-side inspector panel for simulation results alongside the sidebar.
+- Easter holiday theme framework with automatic seasonal activation and window management.
+- Holiday theme system is reusable for future seasonal overrides.
+
+### Changed
+- Unified UI iconography with the Lucide icon set across all controls, map buttons, and sidebar.
+- Map UI controls consolidated into the sidebar; removed floating overlays on mobile.
+- iOS: map renders full-bleed behind safe areas with proper viewport anchoring.
+- Sidebar header simplified to icon-only row; environment badge moved to title area.
+- Basemap fallback now uses Carto Normal style instead of incorrect default layer.
+
+### Fixed
+- Fullscreen toggle for map and path profile now operate independently.
+- Mobile attribution placement is stable across panel open/close states.
+- iOS map canvas sizing is consistent across orientation changes and viewport updates.
+- Coverage store extracted from main Zustand store to reduce re-render overhead.
+
 ## [0.11.0] - 2026-03-26
 
 ### Added

--- a/functions/_lib/buildInfo.ts
+++ b/functions/_lib/buildInfo.ts
@@ -1,5 +1,5 @@
-export const APP_VERSION = "0.11.0";
-export const APP_COMMIT = "87f75a57";
+export const APP_VERSION = "0.12.0";
+export const APP_COMMIT = "0ad66970";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "linksim",
   "private": true,
-  "version": "0.11.0",
+  "version": "0.12.0",
   "license": "GPL-3.0-only",
   "type": "module",
   "scripts": {

--- a/src/lib/buildInfo.ts
+++ b/src/lib/buildInfo.ts
@@ -1,5 +1,5 @@
-export const APP_VERSION = "0.11.0";
-export const APP_COMMIT = "87f75a57";
+export const APP_VERSION = "0.12.0";
+export const APP_COMMIT = "0ad66970";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {


### PR DESCRIPTION
Restores version parity between main and staging after production release of v0.12.0.