### PR TITLE
fix: share holiday theme state across all consumers via Zustand (#256)

### DIFF
--- a/src/components/UserAdminPanel.tsx
+++ b/src/components/UserAdminPanel.tsx
@@ -27,6 +27,7 @@ import { getCurrentRuntimeEnvironment } from "../lib/environment";
 import { getUiErrorMessage } from "../lib/uiError";
 import { formatDate } from "../lib/locale";
 import { useAppStore } from "../store/appStore";
+import { useThemeVariant } from "../hooks/useThemeVariant";
 import type { UiColorTheme } from "../themes/types";
 import { InfoTip } from "./InfoTip";
 import { ModalOverlay } from "./ModalOverlay";
@@ -148,6 +149,7 @@ export function UserAdminPanel({ onOpenHelp }: UserAdminPanelProps) {
   const syncErrorMessage = useAppStore((state) => state.syncErrorMessage);
   const performManualCloudSync = useAppStore((state) => state.performManualCloudSync);
   const setCurrentUser = useAppStore((state) => state.setCurrentUser);
+  const { activeHolidayTheme } = useThemeVariant();
   const [open, setOpen] = useState(false);
   const [me, setMe] = useState<CloudUser | null>(null);
   const [users, setUsers] = useState<CloudUser[]>([]);
@@ -947,6 +949,9 @@ export function UserAdminPanel({ onOpenHelp }: UserAdminPanelProps) {
                     <option value="pink">Pink</option>
                     <option value="red">Red</option>
                     <option value="green">Green</option>
+                    {activeHolidayTheme ? (
+                      <option value="yellow">{activeHolidayTheme.title.replace(" Theme", "")}</option>
+                    ) : null}
                   </select>
                 </div>
                 <div className="field-grid user-field-grid">

--- a/src/hooks/useThemeVariant.ts
+++ b/src/hooks/useThemeVariant.ts
@@ -1,76 +1,24 @@
-import { useCallback, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { getThemeVariant } from "../themes";
 import { resolveEffectiveColorTheme } from "../themes/holidayThemes";
 import { useUiTheme } from "./useUiTheme";
-
-const HOLIDAY_THEME_REVERT_KEY = "linksim-holiday-theme-revert-v1";
-const HOLIDAY_THEME_NOTICE_DISMISS_KEY = "linksim-holiday-theme-notice-dismiss-v1";
-
-type HolidayWindowState = {
-  reverted: string[];
-  dismissed: string[];
-};
-
-const readHolidayWindowState = (): HolidayWindowState => {
-  const fallback: HolidayWindowState = { reverted: [], dismissed: [] };
-  if (typeof window === "undefined") return fallback;
-  try {
-    const reverted = JSON.parse(window.localStorage.getItem(HOLIDAY_THEME_REVERT_KEY) ?? "[]");
-    const dismissed = JSON.parse(window.localStorage.getItem(HOLIDAY_THEME_NOTICE_DISMISS_KEY) ?? "[]");
-    return {
-      reverted: Array.isArray(reverted) ? reverted.filter((value): value is string => typeof value === "string") : [],
-      dismissed: Array.isArray(dismissed) ? dismissed.filter((value): value is string => typeof value === "string") : [],
-    };
-  } catch {
-    return fallback;
-  }
-};
-
-const appendUniqueWindowId = (ids: string[], nextId: string): string[] => (ids.includes(nextId) ? ids : [...ids, nextId]);
-
-const writeHolidayWindowState = (state: HolidayWindowState) => {
-  if (typeof window === "undefined") return;
-  window.localStorage.setItem(HOLIDAY_THEME_REVERT_KEY, JSON.stringify(state.reverted));
-  window.localStorage.setItem(HOLIDAY_THEME_NOTICE_DISMISS_KEY, JSON.stringify(state.dismissed));
-};
+import { useAppStore } from "../store/appStore";
 
 export const useThemeVariant = () => {
   const ui = useUiTheme();
-  const [holidayWindowState, setHolidayWindowState] = useState<HolidayWindowState>(() => readHolidayWindowState());
+  const holidayWindowState = useAppStore((s) => s.holidayWindowState);
+  const revertHolidayThemeForWindow = useAppStore((s) => s.revertHolidayThemeForWindow);
+  const dismissHolidayThemeNotice = useAppStore((s) => s.dismissHolidayThemeNotice);
+
   const { colorTheme, activeHolidayTheme, isHolidayThemeForced } = useMemo(
     () => resolveEffectiveColorTheme(ui.colorTheme, new Date(), holidayWindowState.reverted),
     [ui.colorTheme, holidayWindowState.reverted],
   );
   const holidayWindowId = activeHolidayTheme?.windowId ?? null;
-
   const isHolidayThemeNoticeDismissed = holidayWindowId
     ? holidayWindowState.dismissed.includes(holidayWindowId)
     : false;
   const variant = useMemo(() => getThemeVariant(colorTheme, ui.theme), [colorTheme, ui.theme]);
-
-  const dismissHolidayThemeNotice = useCallback(() => {
-    if (!holidayWindowId) return;
-    setHolidayWindowState((current) => {
-      const next: HolidayWindowState = {
-        reverted: current.reverted,
-        dismissed: appendUniqueWindowId(current.dismissed, holidayWindowId),
-      };
-      writeHolidayWindowState(next);
-      return next;
-    });
-  }, [holidayWindowId]);
-
-  const revertHolidayThemeForWindow = useCallback(() => {
-    if (!holidayWindowId) return;
-    setHolidayWindowState((current) => {
-      const next: HolidayWindowState = {
-        reverted: appendUniqueWindowId(current.reverted, holidayWindowId),
-        dismissed: appendUniqueWindowId(current.dismissed, holidayWindowId),
-      };
-      writeHolidayWindowState(next);
-      return next;
-    });
-  }, [holidayWindowId]);
 
   return {
     ...ui,

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -40,6 +40,7 @@ import {
 import { atmosphericBendingNUnitsToKFactor } from "../lib/terrainLoss";
 import type { LocaleCode } from "../i18n/locales";
 import type { UiColorTheme } from "../themes/types";
+import { getActiveHolidayTheme } from "../themes/holidayThemes";
 import type { CloudUser } from "../lib/cloudUser";
 import type {
   CoverageMode,
@@ -54,6 +55,11 @@ import type {
   Site,
   SrtmTile,
 } from "../types/radio";
+
+type HolidayThemeWindowState = {
+  reverted: string[];
+  dismissed: string[];
+};
 
 const SYNC_DEBOUNCE_MS = 2500;
 const LAST_SIMULATION_REF_KEY = "rmw-last-simulation-ref-v1";
@@ -317,6 +323,7 @@ type AppState = {
   locale: LocaleCode;
   uiThemePreference: "system" | "light" | "dark";
   uiColorTheme: UiColorTheme;
+  holidayWindowState: HolidayThemeWindowState;
   basemapProvider: BasemapProvider;
   basemapStylePreset: string;
   selectedScenarioId: string;
@@ -369,6 +376,8 @@ type AppState = {
   setIsInitializing: (value: boolean) => void;
   setUiThemePreference: (value: "system" | "light" | "dark") => void;
   setUiColorTheme: (value: UiColorTheme) => void;
+  revertHolidayThemeForWindow: () => void;
+  dismissHolidayThemeNotice: () => void;
   setBasemapProvider: (value: BasemapProvider) => void;
   setBasemapStylePreset: (value: string) => void;
   selectScenario: (id: string) => void;
@@ -994,6 +1003,34 @@ const normalizeUiColorTheme = (value: unknown): UiColorTheme =>
     ? value
     : "blue";
 const initialUiColorTheme = normalizeUiColorTheme(readStorage<string>(UI_COLOR_THEME_KEY, "blue"));
+const HOLIDAY_THEME_REVERT_KEY = "linksim-holiday-theme-revert-v1";
+const HOLIDAY_THEME_NOTICE_DISMISS_KEY = "linksim-holiday-theme-notice-dismiss-v1";
+
+const readHolidayWindowState = (): HolidayThemeWindowState => {
+  const fallback: HolidayThemeWindowState = { reverted: [], dismissed: [] };
+  if (typeof window === "undefined") return fallback;
+  try {
+    const reverted = JSON.parse(window.localStorage.getItem(HOLIDAY_THEME_REVERT_KEY) ?? "[]");
+    const dismissed = JSON.parse(window.localStorage.getItem(HOLIDAY_THEME_NOTICE_DISMISS_KEY) ?? "[]");
+    return {
+      reverted: Array.isArray(reverted) ? reverted.filter((v): v is string => typeof v === "string") : [],
+      dismissed: Array.isArray(dismissed) ? dismissed.filter((v): v is string => typeof v === "string") : [],
+    };
+  } catch {
+    return fallback;
+  }
+};
+
+const writeHolidayWindowState = (state: HolidayThemeWindowState) => {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(HOLIDAY_THEME_REVERT_KEY, JSON.stringify(state.reverted));
+  window.localStorage.setItem(HOLIDAY_THEME_NOTICE_DISMISS_KEY, JSON.stringify(state.dismissed));
+};
+
+const appendUniqueWindowId = (ids: string[], nextId: string): string[] =>
+  ids.includes(nextId) ? ids : [...ids, nextId];
+
+const initialHolidayWindowState = readHolidayWindowState();
 const normalizeBasemapProvider = (value: unknown): BasemapProvider =>
   value === "carto" || value === "maptiler" || value === "stadia" || value === "kartverket" ? value : "carto";
 const normalizeBasemapStylePreset = (value: unknown): string =>
@@ -1075,6 +1112,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   locale: "eng",
   uiThemePreference: initialUiThemePreference,
   uiColorTheme: initialUiColorTheme,
+  holidayWindowState: initialHolidayWindowState,
   basemapProvider: initialBasemapProvider,
   basemapStylePreset: initialBasemapStylePreset,
   selectedScenarioId: getInitialScenarioId(),
@@ -1547,6 +1585,30 @@ export const useAppStore = create<AppState>((set, get) => ({
     const normalized = normalizeUiColorTheme(value);
     writeStorage(UI_COLOR_THEME_KEY, normalized);
     set({ uiColorTheme: normalized });
+  },
+  revertHolidayThemeForWindow: () => {
+    const current = get().holidayWindowState;
+    const active = getActiveHolidayTheme(new Date());
+    if (!active) return;
+    const windowId = active.windowId;
+    const next: HolidayThemeWindowState = {
+      reverted: appendUniqueWindowId(current.reverted, windowId),
+      dismissed: appendUniqueWindowId(current.dismissed, windowId),
+    };
+    writeHolidayWindowState(next);
+    set({ holidayWindowState: next });
+  },
+  dismissHolidayThemeNotice: () => {
+    const current = get().holidayWindowState;
+    const active = getActiveHolidayTheme(new Date());
+    if (!active) return;
+    const windowId = active.windowId;
+    const next: HolidayThemeWindowState = {
+      reverted: current.reverted,
+      dismissed: appendUniqueWindowId(current.dismissed, windowId),
+    };
+    writeHolidayWindowState(next);
+    set({ holidayWindowState: next });
   },
   setBasemapProvider: (value) => {
     const normalized = normalizeBasemapProvider(value);


### PR DESCRIPTION
## Summary

- Lift `holidayWindowState` from `useThemeVariant` local `useState` into the Zustand store (`appStore.ts`) so all 3 consumers (AppShell, MapView, Sidebar) share the same reactive state
- Simplify `useThemeVariant.ts` — removed all local state management, now reads from Zustand
- Added conditional yellow Easter option to the color theme dropdown in UserAdminPanel

## Fixes

- **Bug 1:** Clicking "Revert Theme" now immediately reverts CSS variables (no refresh needed)
- **Bug 2:** Yellow Easter option appears in settings dropdown during the active Easter window

## Verification

- [x] `npm test` — 189 tests pass
- [x] `npm run build` — clean
- [ ] Verify on staging: revert theme works immediately
- [ ] Verify on staging: yellow option visible in dropdown