### PR TITLE
chore: enforce staging->main milestone release workflow

### DIFF
--- a/.github/workflows/pr-branch-policy.yml
+++ b/.github/workflows/pr-branch-policy.yml
@@ -27,12 +27,29 @@ jobs:
             exit 1
           fi
           if [ "$BASE_REF" = "main" ]; then
-            if [[ "$HEAD_REF" =~ ^release/v[0-9]+\.[0-9]+\.[0-9]+$ ]] || [[ "$HEAD_REF" =~ ^hotfix/[a-z0-9-]+$ ]]; then
+            if [ "$HEAD_REF" = "staging" ] || [[ "$HEAD_REF" =~ ^hotfix/[a-z0-9-]+$ ]]; then
               exit 0
             fi
-            echo "PR to main must come from release/vX.Y.Z or hotfix/<slug>."
+            echo "PR to main must come from staging (normal release) or hotfix/<slug> (approved incident only)."
             exit 1
           fi
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - name: Enforce PR head is up-to-date with base
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          git fetch origin "$BASE_REF"
+          if git merge-base --is-ancestor "origin/$BASE_REF" HEAD; then
+            echo "PR head includes latest origin/$BASE_REF"
+            exit 0
+          fi
+          echo "PR head is behind origin/$BASE_REF. Rebase/merge base branch before merge."
+          exit 1
       - name: Set commit status on success
         if: success()
         uses: actions/github-script@v7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@
 - Branch workflow:
   - Use per-issue branches: `issue/<id>-<slug>`.
   - Merge issue branches into `staging` first.
-  - Promote to production through `release/vX.Y.Z` branch/PR into `main`.
+  - For normal releases, promote to production only via a direct PR from `staging` into `main` (no release branch).
   - Use `hotfix/<slug>` only for explicitly approved incidents.
   - This staging-integration model is the default unless the user explicitly overrides it.
 - Prefer stabilization work (consistency, hardening, tests, UX cleanup) over net-new features unless explicitly requested.
@@ -62,7 +62,8 @@
 - Promotion gate:
   - Promote the exact same verified commit from local -> staging -> production.
   - If code changes after staging verification, rerun local verification and redeploy staging before production.
-  - Production promotion branch must be `release/vX.Y.Z` (or approved `hotfix/<slug>`).
+  - Normal production promotion PR must be `staging` -> `main`.
+  - Hotfix promotion PR may be `hotfix/<slug>` -> `main` only with explicit user approval in-thread.
 - Local run reliability:
   - Restart local server whenever runtime/config/env changes can affect behavior.
   - Re-verify affected flows after restart before marking work as done.
@@ -91,6 +92,10 @@
   - Start each issue branch from `origin/staging`.
   - Branch name format: `issue/<id>-<slug>`.
   - Keep PR scope to one issue; avoid mixed API/UI/deeplink batches in the same PR.
+  - Agent safety rails:
+    - Do not create normal-release `release/*` branches.
+    - Do not open PRs to `main` from `issue/*` or `chore/*` branches.
+    - If local branch is behind its PR base branch, rebase/refresh before merging.
 - Drift check before coding (required):
   - Run and report: `git log --oneline origin/staging -5`
   - Run and report: `git log --oneline origin/main -5`
@@ -111,8 +116,10 @@
   - After deploy, always confirm completion with `wrangler pages deployment list --project-name linksim-staging --environment production` and report the commit SHA/build label.
 - Milestone promotion model:
   - Complete and verify all milestone issues on `staging` first.
-  - Promote to production in one batch from a `release/vX.Y.Z` branch cut from `staging`.
+  - Promote to production in one batch with a direct PR from `staging` to `main`.
   - Use the exact verified staging commit for production; no code changes between staging sign-off and production deploy.
+  - Freeze milestone scope at sign-off: no new feature work lands on `staging` until production deploy completes.
+  - After production deploy, continue new issue work from the updated `origin/staging` baseline.
 
 ## Branch Protection Rollout Safety
 - When introducing a new required status check, roll it out in two phases to avoid PR deadlocks:

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -6,7 +6,6 @@
 ## Branch model (integration + release)
 - `issue/<id>-<slug>`: single issue implementation branch.
 - `staging`: integration branch for accepted issue work.
-- `release/vX.Y.Z`: release-candidate branch cut from `staging`.
 - `main`: production branch only.
 - `hotfix/<slug>`: production incident branch (only when explicitly approved).
 
@@ -26,11 +25,10 @@
 
 3. Production
 - Promote only after explicit user approval.
-- Cut `release/vX.Y.Z` from the verified `staging` commit.
-- Open PR `release/vX.Y.Z` -> `main`.
+- Open PR `staging` -> `main`.
 - Deploy the exact verified staging commit to production (no extra code changes in between).
 - Use explicit guarded command only: `npm run deploy:prod:main`.
-- After production deploy, back-merge `main` -> `staging` to keep parity.
+- After production deploy, continue all new work from updated `origin/staging`.
 
 ## Guardrails
 - No direct production hotfixes unless explicitly requested by the user.
@@ -52,7 +50,7 @@
   - `hotfix/<slug>`
   - `chore/<slug>`
 - PRs into `main` must come from:
-  - `release/vX.Y.Z`
+  - `staging` (default and only normal release path)
   - `hotfix/<slug>` (approved production incidents only)
 - Merge strategy: squash merge only.
 - Auto-delete merged branches enabled.
@@ -80,8 +78,23 @@
   3. Commit and push.
   4. Open PR to `staging` and merge once approved.
   5. Deploy `staging` using `npm run deploy:staging` and verify at https://staging.linksim.link.
-  6. Promote via `release/vX.Y.Z` PR to `main` only with explicit approval.
+  6. Promote via `staging` -> `main` PR only with explicit approval.
 - No hidden scope changes during promotion; if code changes after staging verification, restart the loop.
+
+## Milestone release rules
+- Milestone delivery happens in trains:
+  1. complete milestone issues on `staging`
+  2. verify milestone behavior on https://staging.linksim.link
+  3. freeze milestone scope at release sign-off (no new feature merges into `staging`)
+  4. promote with a single `staging` -> `main` PR
+  5. deploy production from the merged `main` commit
+- Promotion must use the same verified staging commit SHA.
+- If any code changes after staging sign-off, restart staging verification before production.
+- Before opening the promotion PR, require:
+  - all in-scope milestone issues are `in-staging` or `released`
+  - `npm test` passes
+  - `npm run build` passes
+  - `CHANGELOG.md` includes a human-readable entry for the release
 
 ## Issue state machine
 - Use these labels to keep issue status explicit:
@@ -97,6 +110,11 @@
   - `prod-main`
 - `prod-main` job runs in the `production` GitHub environment (configure required reviewers in repo settings).
 - `staging` runs in the `staging` environment.
+
+## Drift prevention rules
+- Issue branches must be created from latest `origin/staging`.
+- PRs into `staging` or `main` must be up-to-date with the base branch before merge.
+- Never promote from `issue/*` or `chore/*` directly into `main`.
 
 ## Deploy Targets Reference
 | Target | URL | Description |


### PR DESCRIPTION
## Summary

- Update `AGENTS.md` and `docs/release-flow.md` to make `staging -> main` the only normal release path
- Keep `hotfix/<slug> -> main` as explicit incident-only exception
- Add milestone-train release rules: complete on staging, verify, freeze scope, then single promotion PR
- Harden PR branch policy workflow to:
  - allow `main` PRs only from `staging` or `hotfix/*`
  - enforce PR head is up-to-date with base before merge

## Why

This prevents branch drift and out-of-sync release branches, and makes milestone releases predictable and safe.