### PR TITLE
chore: enforce milestone checklist for staging-to-main releases

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,7 +26,8 @@
 
 ## Release checklist (required when base is `main`)
 
-- [ ] Source branch is `release/vX.Y.Z` (or `hotfix/*` for approved incidents).
+- [ ] Source branch is `staging` (or `hotfix/*` for approved incidents).
 - [ ] Staging verification was done on the exact same commit.
 - [ ] SemVer bump is correct and intentional.
 - [ ] `vX.Y.Z` tag points to the commit being promoted.
+- [ ] Milestone release checklist completed: `docs/milestone-release-checklist.md`.

--- a/.github/workflows/pr-branch-policy.yml
+++ b/.github/workflows/pr-branch-policy.yml
@@ -50,6 +50,20 @@ jobs:
           fi
           echo "PR head is behind origin/$BASE_REF. Rebase/merge base branch before merge."
           exit 1
+      - name: Require milestone checklist attestation for staging-main release
+        if: github.base_ref == 'main' && github.head_ref == 'staging'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || "";
+            const requiredPattern = /\[[xX]\]\s*Milestone release checklist completed:\s*docs\/milestone-release-checklist\.md/;
+            if (requiredPattern.test(body)) {
+              core.info("Milestone release checklist attestation found in PR body.");
+              return;
+            }
+            core.setFailed(
+              "Missing required PR body attestation for staging->main release: '- [x] Milestone release checklist completed: docs/milestone-release-checklist.md'",
+            );
       - name: Set commit status on success
         if: success()
         uses: actions/github-script@v7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,11 +4,13 @@
 - Treat this file as the single handoff entrypoint.
 - Before any code changes, review open GitHub Issues for the repo and then read:
   1. `docs/release-flow.md`
+  2. `docs/milestone-release-checklist.md`
 - If instructions conflict, precedence is:
   1. explicit user instruction in current thread
   2. this `AGENTS.md`
   3. GitHub Issues / GitHub Projects state for the repo
   4. `docs/release-flow.md`
+  5. `docs/milestone-release-checklist.md`
 
 - Always update the relevant GitHub Issue(s) before and after implementation batches.
 - Default environment workflow:

--- a/docs/milestone-release-checklist.md
+++ b/docs/milestone-release-checklist.md
@@ -1,0 +1,24 @@
+# Milestone Release Checklist
+
+Use this checklist before opening a normal production promotion PR (`staging` -> `main`).
+
+## Scope and freeze
+- [ ] Milestone scope is frozen for release.
+- [ ] No new feature PRs are merged into `staging` after sign-off.
+- [ ] All in-scope issues are labeled `in-staging` or `released`.
+
+## Verification
+- [ ] `npm test` passes on the release candidate.
+- [ ] `npm run build` passes on the release candidate.
+- [ ] Staging verification was completed on `https://staging.linksim.link`.
+- [ ] Verified production promotion will use the exact same staging commit SHA.
+
+## Version and notes
+- [ ] SemVer bump is present and intentional.
+- [ ] `CHANGELOG.md` has a human-readable entry for this release.
+- [ ] Release tag `vX.Y.Z` points to the production commit.
+
+## PR attestation (required)
+Include this checked line in the PR body for `staging` -> `main`:
+
+`- [x] Milestone release checklist completed: docs/milestone-release-checklist.md`

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -3,6 +3,10 @@
 ## Default rule
 - Unless explicitly stated otherwise, work in the local test environment.
 
+## Required reading before implementation/release work
+- `docs/release-flow.md`
+- `docs/milestone-release-checklist.md`
+
 ## Branch model (integration + release)
 - `issue/<id>-<slug>`: single issue implementation branch.
 - `staging`: integration branch for accepted issue work.
@@ -95,6 +99,10 @@
   - `npm test` passes
   - `npm run build` passes
   - `CHANGELOG.md` includes a human-readable entry for the release
+  - `docs/milestone-release-checklist.md` is completed
+- PR body requirement for normal promotion (`staging` -> `main`):
+  - include the checked line:
+    - `- [x] Milestone release checklist completed: docs/milestone-release-checklist.md`
 
 ## Issue state machine
 - Use these labels to keep issue status explicit:


### PR DESCRIPTION
## What changed

- added `docs/milestone-release-checklist.md` as the canonical milestone promotion checklist
- updated startup rules so agents must read both `docs/release-flow.md` and `docs/milestone-release-checklist.md`
- updated release docs and PR template to require explicit checklist attestation for normal production promotions
- enforced checklist attestation in CI for `staging` -> `main` PRs via PR Branch Policy workflow

## Why this change

This makes milestone promotion rules executable and auditable, reducing the chance that agents skip release gates.