### PR TITLE
fix: meshmap MQTT data load UX — spinner, retry, proxy caching, remove dead fallback (#292)

### DIFF
--- a/functions/meshmap/[[path]].ts
+++ b/functions/meshmap/[[path]].ts
@@ -40,9 +40,11 @@ export const onRequest: PagesFunction<Env> = async ({ request, env }) => {
     },
   });
 
+  const responseHeaders = new Headers(response.headers);
+  responseHeaders.set("Cache-Control", "public, max-age=1800");
   return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,
-    headers: response.headers,
+    headers: responseHeaders,
   });
 };

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Egg, Fullscreen, Maximize2, Minimize2, Rabbit, Share, SquareStack, ZoomIn, ZoomOut } from "lucide-react";
+import { Egg, Fullscreen, Loader2, Maximize2, Minimize2, Rabbit, RefreshCw, Share, SquareStack, ZoomIn, ZoomOut } from "lucide-react";
 import Map, {
   Layer,
   type MapRef,
@@ -2067,6 +2067,30 @@ export function MapView({
                   {line}
                 </p>
               ))}
+            </div>
+          ) : null}
+          {showDiscoveryMqtt && mqttLoadStatus ? (
+            <div className="map-inspector-section">
+              <span className="map-inline-actions">
+                {mqttLoadStatus === "Loading MQTT nodes..." ? (
+                  <span className="map-spinner">
+                    <Loader2 aria-hidden="true" size={14} strokeWidth={2} />
+                  </span>
+                ) : mqttLoadStatus.includes("failed") ? (
+                  <button
+                    aria-label="Retry MQTT load"
+                    className="map-control-btn"
+                    onClick={() => {
+                      setMqttNodes([]);
+                      setMqttLoadStatus(null);
+                    }}
+                    type="button"
+                  >
+                    <RefreshCw aria-hidden="true" size={12} strokeWidth={2} />
+                    <span>Retry</span>
+                  </button>
+                ) : null}
+              </span>
             </div>
           ) : null}
           {mqttDuplicatePrompt ? (

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import clsx from "clsx";
-import { CircleX, Funnel } from "lucide-react";
+import { CircleX, Funnel, Loader2, RefreshCw } from "lucide-react";
 import Map, {
   Layer,
   Marker,
@@ -3444,6 +3444,11 @@ export function Sidebar({ onOpenHelp }: SidebarProps) {
                   </label>
                   <div className="chip-group">
                     <button className="inline-action" disabled={meshmapLoading} onClick={() => void loadMeshmapFeed()} type="button">
+                      {meshmapLoading ? (
+                        <span className="map-spinner">
+                          <Loader2 aria-hidden="true" size={14} strokeWidth={2} />
+                        </span>
+                      ) : null}
                       {meshmapLoading ? "Loading..." : "Load Feed"}
                     </button>
                     <button
@@ -3460,7 +3465,23 @@ export function Sidebar({ onOpenHelp }: SidebarProps) {
                       {formatDate(meshmapCachedSummary.savedAt)} ({meshmapCachedSummary.sourceUrl})
                     </p>
                   ) : null}
-                  {meshmapStatus ? <p className="field-help">{meshmapStatus}</p> : null}
+                  {meshmapStatus ? (
+                    <p className="field-help">
+                      {meshmapStatus}
+                      {meshmapStatus.includes("failed") ? (
+                        <button
+                          aria-label="Retry loading Meshtastic feed"
+                          className="inline-action"
+                          onClick={() => void loadMeshmapFeed()}
+                          style={{ marginLeft: 8 }}
+                          type="button"
+                        >
+                          <RefreshCw aria-hidden="true" size={12} strokeWidth={2} />
+                          <span>Retry</span>
+                        </button>
+                      ) : null}
+                    </p>
+                  ) : null}
                   {showMeshtasticBrowser ? (
                     <div className="meshmap-browser">
                       <div className="meshmap-browser-map">

--- a/src/index.css
+++ b/src/index.css
@@ -2306,6 +2306,19 @@ input {
   }
 }
 
+@keyframes map-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.map-spinner {
+  display: inline-flex;
+  align-items: center;
+  animation: map-spin 0.8s linear infinite;
+  margin-right: 4px;
+  vertical-align: middle;
+}
+
 .profile-avatar {
   width: 30px;
   height: 30px;

--- a/src/lib/meshtasticMqtt.ts
+++ b/src/lib/meshtasticMqtt.ts
@@ -43,7 +43,6 @@ export type MeshmapFetchResult = {
 };
 
 const DEFAULT_MESHMAP_FEED_URL = "/meshmap/nodes.json";
-const DIRECT_MESHMAP_FEED_URL = "https://meshmap.net/nodes.json";
 const MESHMAP_CACHE_KEY = "rmw-meshmap-cache-v1";
 const MESHMAP_SOURCE_URL_KEY = "rmw-meshmap-source-url-v1";
 
@@ -158,7 +157,6 @@ export const fetchMeshmapNodes = async (options: MeshmapFetchOptions = {}): Prom
   const sourceUrl = options.sourceUrl?.trim() || readPreferredMeshmapSourceUrl();
   const cacheTtlMs = options.cacheTtlMs ?? 12 * 60 * 60 * 1000;
   const cached = readCache();
-  const fallbackUrls = Array.from(new Set([DEFAULT_MESHMAP_FEED_URL, DIRECT_MESHMAP_FEED_URL]));
   try {
     const response = await fetch(sourceUrl, { cache: "no-store" });
     if (!response.ok) {
@@ -176,24 +174,6 @@ export const fetchMeshmapNodes = async (options: MeshmapFetchOptions = {}): Prom
       fromCache: false,
     };
   } catch (error) {
-    for (const fallbackUrl of fallbackUrls) {
-      if (fallbackUrl === sourceUrl) continue;
-      try {
-        const fallback = await fetch(fallbackUrl, { cache: "no-store" });
-        if (!fallback.ok) continue;
-        const payload = (await fallback.json()) as unknown;
-        const nodes = parseMeshmapLikeFeed(payload);
-        if (!nodes.length) continue;
-        writeCache(fallbackUrl, nodes);
-        return {
-          nodes,
-          sourceUrl: fallbackUrl,
-          fromCache: false,
-        };
-      } catch {
-        // Try next fallback URL.
-      }
-    }
     if (
       cached &&
       (cached.sourceUrl === sourceUrl || cached.sourceUrl === DEFAULT_MESHMAP_FEED_URL) &&


### PR DESCRIPTION
## Changes

1. **Remove dead direct fallback** (`src/lib/meshtasticMqtt.ts`) — Removed `DIRECT_MESHMAP_FEED_URL` and the fallback loop that tried `https://meshmap.net/nodes.json` directly (always fails with CORS from browsers)

2. **Proxy-level caching** (`functions/meshmap/[[path]].ts`) — Added `Cache-Control: public, max-age=1800` (30 min) to proxy responses. Cloudflare CDN caches meshmap.net responses at the edge, reducing upstream 429s.

3. **Loading spinner** (`src/components/MapView.tsx`, `src/components/Sidebar.tsx`) — Shows `<Loader2>` spinner with rotation animation while MQTT nodes are loading

4. **Retry button on failure** (`src/components/MapView.tsx`, `src/components/Sidebar.tsx`) — When MQTT load fails, shows a Retry button that re-triggers the fetch

## Verification
- ✅ `npm test` — 189/189 pass
- ✅ `npm run build` — clean
- ✅ No new lint errors

Closes #292