### PR TITLE
fix: meshmap proxy caching bug + unify MQTT loading with progress bar (#294)

### DIFF
--- a/functions/meshmap/[[path]].ts
+++ b/functions/meshmap/[[path]].ts
@@ -41,7 +41,11 @@ export const onRequest: PagesFunction<Env> = async ({ request, env }) => {
   });
 
   const responseHeaders = new Headers(response.headers);
-  responseHeaders.set("Cache-Control", "public, max-age=1800");
+  if (response.ok) {
+    responseHeaders.set("Cache-Control", "public, max-age=1800");
+  } else {
+    responseHeaders.set("Cache-Control", "no-store");
+  }
   return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Egg, Fullscreen, Loader2, Maximize2, Minimize2, Rabbit, RefreshCw, Share, SquareStack, ZoomIn, ZoomOut } from "lucide-react";
+import { Egg, Fullscreen, Maximize2, Minimize2, Rabbit, RefreshCw, Share, SquareStack, ZoomIn, ZoomOut } from "lucide-react";
 import Map, {
   Layer,
   type MapRef,
@@ -1913,12 +1913,11 @@ export function MapView({
       `Shared/public library sites visible: ${sharedOrPublicLibrarySites.length}. Click a marker to inspect, then choose Add to simulation.`,
     );
   }
-  if (showDiscoveryMqtt) {
+  if (showDiscoveryMqtt && !mqttLoadStatus) {
     inspectorLines.push(
-      mqttLoadStatus ??
-        (mqttTooDenseInView
-          ? `MQTT nodes in view: ${mqttNodesInView.length}. Zoom in to show markers (limit ${mqttInViewLimit}).`
-          : `MQTT nodes in view: ${mqttNodesInView.length}. Click a marker to open an Add Site draft.`),
+      mqttTooDenseInView
+        ? `MQTT nodes in view: ${mqttNodesInView.length}. Zoom in to show markers (limit ${mqttInViewLimit}).`
+        : `MQTT nodes in view: ${mqttNodesInView.length}. Click a marker to open an Add Site draft.`,
     );
   }
   if (endpointPickTarget && endpointPickError) inspectorLines.push(endpointPickError);
@@ -2071,12 +2070,13 @@ export function MapView({
           ) : null}
           {showDiscoveryMqtt && mqttLoadStatus ? (
             <div className="map-inspector-section">
-              <span className="map-inline-actions">
-                {mqttLoadStatus === "Loading MQTT nodes..." ? (
-                  <span className="map-spinner">
-                    <Loader2 aria-hidden="true" size={14} strokeWidth={2} />
-                  </span>
-                ) : mqttLoadStatus.includes("failed") ? (
+              <p className="map-inspector-line">{mqttLoadStatus}</p>
+              {mqttLoadStatus === "Loading MQTT nodes..." ? (
+                <div className="map-progress-track">
+                  <div className="map-progress-fill map-progress-fill-indeterminate" />
+                </div>
+              ) : mqttLoadStatus.includes("failed") ? (
+                <span className="map-inline-actions">
                   <button
                     aria-label="Retry MQTT load"
                     className="map-control-btn"
@@ -2089,8 +2089,8 @@ export function MapView({
                     <RefreshCw aria-hidden="true" size={12} strokeWidth={2} />
                     <span>Retry</span>
                   </button>
-                ) : null}
-              </span>
+                </span>
+              ) : null}
             </div>
           ) : null}
           {mqttDuplicatePrompt ? (

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import clsx from "clsx";
-import { CircleX, Funnel, Loader2, RefreshCw } from "lucide-react";
+import { CircleX, Funnel, RefreshCw } from "lucide-react";
 import Map, {
   Layer,
   Marker,
@@ -3444,11 +3444,6 @@ export function Sidebar({ onOpenHelp }: SidebarProps) {
                   </label>
                   <div className="chip-group">
                     <button className="inline-action" disabled={meshmapLoading} onClick={() => void loadMeshmapFeed()} type="button">
-                      {meshmapLoading ? (
-                        <span className="map-spinner">
-                          <Loader2 aria-hidden="true" size={14} strokeWidth={2} />
-                        </span>
-                      ) : null}
                       {meshmapLoading ? "Loading..." : "Load Feed"}
                     </button>
                     <button
@@ -3459,6 +3454,11 @@ export function Sidebar({ onOpenHelp }: SidebarProps) {
                       {showMeshtasticBrowser ? "Hide Browser" : "Show Browser"}
                     </button>
                   </div>
+                  {meshmapLoading ? (
+                    <div className="map-progress-track" style={{ marginTop: 8 }}>
+                      <div className="map-progress-fill map-progress-fill-indeterminate" />
+                    </div>
+                  ) : null}
                   {meshmapCachedSummary ? (
                     <p className="field-help">
                       Cached snapshot: {formatNumber(meshmapCachedSummary.nodeCount)} node(s) from{" "}

--- a/src/index.css
+++ b/src/index.css
@@ -2306,19 +2306,6 @@ input {
   }
 }
 
-@keyframes map-spin {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
-}
-
-.map-spinner {
-  display: inline-flex;
-  align-items: center;
-  animation: map-spin 0.8s linear infinite;
-  margin-right: 4px;
-  vertical-align: middle;
-}
-
 .profile-avatar {
   width: 30px;
   height: 30px;


### PR DESCRIPTION
## Changes
- Only set Cache-Control on successful 2xx proxy responses; no-store on errors (prevents caching 429s)
- Replace MQTT spinner with indeterminate progress bar matching terrain loading pattern
- Remove unused map-spinner CSS class and Loader2 imports

Closes #294