### PR TITLE
fix: surface 429/cache-fallback warnings in meshmap UI

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1184,7 +1184,12 @@ export function MapView({
       .then((result) => {
         if (canceled) return;
         setMqttNodes(result.nodes);
-        setMqttLoadStatus(null);
+        if (result.fromCache && result.networkError) {
+          const ageMin = Math.max(1, Math.round((result.cacheAgeMs ?? 0) / 60_000));
+          setMqttLoadStatus(`Live fetch failed — showing ${result.nodes.length} cached node(s) from ${ageMin} min ago.`);
+        } else {
+          setMqttLoadStatus(null);
+        }
       })
       .catch((error) => {
         if (canceled) return;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1399,7 +1399,9 @@ export function Sidebar({ onOpenHelp }: SidebarProps) {
       if (result.fromCache) {
         const ageMin = Math.max(1, Math.round((result.cacheAgeMs ?? 0) / 60_000));
         setMeshmapStatus(
-          `Loaded ${formatNumber(result.nodes.length)} node(s) from cached snapshot (${ageMin} min old).`,
+          result.networkError
+            ? `Live fetch failed — showing ${formatNumber(result.nodes.length)} cached node(s) from ${ageMin} min ago.`
+            : `Loaded ${formatNumber(result.nodes.length)} node(s) from cached snapshot (${ageMin} min old).`,
         );
       } else {
         setMeshmapStatus(`Loaded ${formatNumber(result.nodes.length)} node(s) from live feed.`);

--- a/src/lib/meshtasticMqtt.ts
+++ b/src/lib/meshtasticMqtt.ts
@@ -40,6 +40,7 @@ export type MeshmapFetchResult = {
   sourceUrl: string;
   fromCache: boolean;
   cacheAgeMs?: number;
+  networkError?: boolean;
 };
 
 const DEFAULT_MESHMAP_FEED_URL = "/meshmap/nodes.json";
@@ -185,6 +186,7 @@ export const fetchMeshmapNodes = async (options: MeshmapFetchOptions = {}): Prom
         sourceUrl: cached.sourceUrl,
         fromCache: true,
         cacheAgeMs: Date.now() - cached.savedAt,
+        networkError: true,
       };
     }
     const message = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
When fetchMeshmapNodes falls back to localStorage cache after a network error (429, etc), the UI now shows a warning with retry button instead of silently showing stale data.

Closes #294