### PR TITLE
fix: mobile attribution fix updates (#240)

### DIFF
--- a/functions/_lib/buildInfo.ts
+++ b/functions/_lib/buildInfo.ts
@@ -1,5 +1,5 @@
 export const APP_VERSION = "0.12.1";
-export const APP_COMMIT = "47627f6a";
+export const APP_COMMIT = "29870b2d";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1188,20 +1188,11 @@ export function AppShell() {
           </div>
         ) : null}
       </section>
-      {!isMobileViewport && (isMapExpanded || isProfileExpanded) ? (
+      {isMapExpanded || isProfileExpanded ? (
         <div className="floating-attribution-pill">
           <MapIcon aria-hidden="true" size={11} strokeWidth={1.8} />
           <Copyright aria-hidden="true" size={9} strokeWidth={2.5} />
-          <span>{resolvedBasemap.attribution}</span>
-          <Copyright aria-hidden="true" size={9} strokeWidth={2.5} />
-          <span>MapLibre</span>
-        </div>
-      ) : null}
-      {isMobileViewport && isMapExpanded ? (
-        <div className="floating-attribution-text">
-          <MapIcon aria-hidden="true" size={11} strokeWidth={1.8} />
-          <Copyright aria-hidden="true" size={9} strokeWidth={2.5} />
-          <span>{resolvedBasemap.attribution}</span>
+          <span>{resolvedBasemap.attribution.replace(/©/g, "")}</span>
           <Copyright aria-hidden="true" size={9} strokeWidth={2.5} />
           <span>MapLibre</span>
         </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2165,7 +2165,7 @@ export function Sidebar({ onOpenHelp }: SidebarProps) {
         <div className="sidebar-footer-attribution">
           <MapIcon aria-hidden="true" size={11} strokeWidth={1.8} />
           <Copyright aria-hidden="true" size={9} strokeWidth={2.5} />
-          <span>{resolvedBasemap.attribution}</span>
+          <span>{resolvedBasemap.attribution.replace(/©/g, "")}</span>
           <Copyright aria-hidden="true" size={9} strokeWidth={2.5} />
           <span>MapLibre</span>
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1035,14 +1035,7 @@ input {
 }
 
 .map-panel .maplibregl-ctrl-attrib {
-  border: 1px solid color-mix(in srgb, var(--border) 86%, transparent);
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--surface-2) 94%, var(--surface));
-  color: var(--text);
-  box-shadow: var(--shadow-elev-2);
-  font-size: 0.7rem;
-  line-height: 1.2;
-  padding: 3px 8px;
+  display: none !important;
 }
 
 .map-panel .maplibregl-ctrl-attrib.maplibregl-compact {

--- a/src/lib/buildInfo.ts
+++ b/src/lib/buildInfo.ts
@@ -1,5 +1,5 @@
 export const APP_VERSION = "0.12.1";
-export const APP_COMMIT = "47627f6a";
+export const APP_COMMIT = "29870b2d";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {


### PR DESCRIPTION
## Summary
- Strip © symbols from attribution string and replace with Lucide copyright icons
- Hide old MapLibre attribution control with CSS `display: none`
- Use pill style for both desktop and mobile when sidebar is hidden