### PR TITLE
fix: Open Library button not working on mobile when sidebar panel is inactive

### DIFF
--- a/functions/_lib/buildInfo.ts
+++ b/functions/_lib/buildInfo.ts
@@ -1,5 +1,5 @@
 export const APP_VERSION = "0.12.1";
-export const APP_COMMIT = "29870b2d";
+export const APP_COMMIT = "7a8d7958";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -14,12 +14,14 @@ import { LinkProfileChart } from "./LinkProfileChart";
 import { MapView } from "./MapView";
 import { ModalOverlay } from "./ModalOverlay";
 import OnboardingTutorialModal from "./OnboardingTutorialModal";
+import SimulationLibraryPanel from "./SimulationLibraryPanel";
 import WelcomeModal from "./WelcomeModal";
 import { Sidebar } from "./Sidebar";
 import { UserAdminPanel } from "./UserAdminPanel";
 
 initializeMigrations();
 
+const LAST_SIMULATION_REF_KEY = "rmw-last-simulation-ref-v1";
 const ONBOARDING_SEEN_KEY_PREFIX = "linksim:onboarding-seen:v1:";
 const MOBILE_WARNING_DISMISS_KEY = "linksim:mobile-warning-dismissed:v1";
 const LOCAL_FORCE_READONLY_KEY = "linksim:local-force-readonly:v1";
@@ -83,6 +85,7 @@ export function AppShell() {
   const isOnline = useAppStore((state) => state.isOnline);
   const setIsOnline = useAppStore((state) => state.setIsOnline);
   const isInitializing = useAppStore((state) => state.isInitializing);
+  const showSimulationLibraryRequest = useAppStore((state) => state.showSimulationLibraryRequest);
   const setShowSimulationLibraryRequest = useAppStore((state) => state.setShowSimulationLibraryRequest);
   const setShowNewSimulationRequest = useAppStore((state) => state.setShowNewSimulationRequest);
   const setShowSiteLibraryRequest = useAppStore((state) => state.setShowSiteLibraryRequest);
@@ -105,6 +108,7 @@ export function AppShell() {
   const [mobileControlsOccupied, setMobileControlsOccupied] = useState(0);
   const [localDevStatus, setLocalDevStatus] = useState<string | null>(null);
   const [offlineBannerDismissed, setOfflineBannerDismissed] = useState(false);
+  const [showLibraryFromRequest, setShowLibraryFromRequest] = useState(false);
   const deepLinkAppliedRef = useRef(false);
   const cloudInitSeenRef = useRef(false);
   const cloudInitSettledRef = useRef(false);
@@ -841,6 +845,12 @@ export function AppShell() {
     setShowSimulationLibraryRequest(true);
   }, [libraryAutoOpened, workspaceState, showWelcomeModal, accessState, activeUserId, setShowSimulationLibraryRequest]);
 
+  useEffect(() => {
+    if (!showSimulationLibraryRequest) return;
+    setShowSimulationLibraryRequest(false);
+    setShowLibraryFromRequest(true);
+  }, [showSimulationLibraryRequest, setShowSimulationLibraryRequest]);
+
   const copyCurrentLink = useCallback(async () => {
     if (!activeSimulation) {
       setShareStatus("Open a saved simulation first. Unsaved workspace state cannot be shared as a deep link.");
@@ -1199,6 +1209,24 @@ export function AppShell() {
       ) : null}
       <WelcomeModal onClose={closeWelcome} onCreateNewSimulation={createNewFromWelcome} onOpenLibrary={openLibraryFromWelcome} onOpenOnboarding={openWelcomeFromWelcome} open={showWelcomeModal} />
       <OnboardingTutorialModal onClose={() => setShowOnboardingTutorial(false)} onOpenLibrary={() => setShowSimulationLibraryRequest(true)} onOpenSiteLibrary={() => setShowSiteLibraryRequest(true)} open={showOnboardingTutorial} />
+      {showLibraryFromRequest ? (
+        <ModalOverlay
+          aria-label="Simulation Library"
+          onClose={() => setShowLibraryFromRequest(false)}
+        >
+          <SimulationLibraryPanel
+            onClose={() => setShowLibraryFromRequest(false)}
+            onLoadSimulation={(presetId) => {
+              loadSimulationPreset(presetId);
+              try {
+                localStorage.setItem(LAST_SIMULATION_REF_KEY, `saved:${presetId}`);
+              } catch {
+                // ignore storage errors
+              }
+            }}
+          />
+        </ModalOverlay>
+      ) : null}
       {showMobileWarning ? (
         <ModalOverlay aria-label="Mobile support notice" onClose={() => setShowMobileWarning(false)} tier="raised">
           <div className="library-manager-card mobile-warning-modal-card">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -321,8 +321,6 @@ export function Sidebar({ onOpenHelp }: SidebarProps) {
   const getSelectedSite = useAppStore((state) => state.getSelectedSite);
   const getSelectedNetwork = useAppStore((state) => state.getSelectedNetwork);
   const model = useAppStore((state) => state.propagationModel);
-  const showSimulationLibraryRequest = useAppStore((state) => state.showSimulationLibraryRequest);
-  const setShowSimulationLibraryRequest = useAppStore((state) => state.setShowSimulationLibraryRequest);
   const showNewSimulationRequest = useAppStore((state) => state.showNewSimulationRequest);
   const setShowNewSimulationRequest = useAppStore((state) => state.setShowNewSimulationRequest);
   const showSiteLibraryRequest = useAppStore((state) => state.showSiteLibraryRequest);
@@ -602,12 +600,6 @@ export function Sidebar({ onOpenHelp }: SidebarProps) {
       .slice()
       .sort((a, b) => parseTs(b.createdAt) - parseTs(a.createdAt))[0]?.id ?? siteLibrary[0].id;
   }, [siteLibrary]);
-  useEffect(() => {
-    if (showSimulationLibraryRequest) {
-      setShowSimulationLibraryManager(true);
-      setShowSimulationLibraryRequest(false);
-    }
-  }, [showSimulationLibraryRequest, setShowSimulationLibraryRequest]);
   useEffect(() => {
     if (showNewSimulationRequest) {
       setNewSimulationName("");

--- a/src/lib/buildInfo.ts
+++ b/src/lib/buildInfo.ts
@@ -1,5 +1,5 @@
 export const APP_VERSION = "0.12.1";
-export const APP_COMMIT = "29870b2d";
+export const APP_COMMIT = "7a8d7958";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {


### PR DESCRIPTION
## Problem
On mobile, clicking "Open Library" (or the auto-open on first visit) animated but never opened the Simulation Library modal.

## Root Cause
The `SimulationLibraryPanel` modal and its request-handling `useEffect` lived inside the `Sidebar` component. On mobile, `Sidebar` is only mounted when `mobileActivePanel === "sidebar"` (default is `"profile"`), so the effect that converts `showSimulationLibraryRequest` → opening the modal never fired.

## Fix
- Added a `useEffect` in `AppShell` that intercepts `showSimulationLibraryRequest` and opens the modal directly — AppShell is always mounted regardless of mobile panel state
- Removed the now-redundant effect and unused store selectors from `Sidebar`
- The Sidebar's own direct button (`setShowSimulationLibraryManager(true)`) still works on desktop

## Verification
- [ ] `npm test` passes (189/189)
- [ ] `npm run build` succeeds
- [ ] Manual test on staging: mobile viewport with no simulation → click "Open Library" → modal opens
- [ ] Manual test on staging: desktop "Open Library" button still works