### PR TITLE
merge: bring attribution fix (#240) into staging alongside Open Library fix (#304)

### DIFF
--- a/functions/_lib/buildInfo.ts
+++ b/functions/_lib/buildInfo.ts
@@ -1,5 +1,5 @@
 export const APP_VERSION = "0.12.1";
-export const APP_COMMIT = "7a8d7958";
+export const APP_COMMIT = "974812d6";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,5 +1,5 @@
 import { type CSSProperties, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { CircleX, Copyright, Map as MapIcon } from "lucide-react";
+import { CircleX } from "lucide-react";
 import { fetchDeepLinkStatus, fetchMe, setLocalDevRole } from "../lib/cloudUser";
 import { fetchCloudLibrary, fetchPublicSimulationLibrary, pushCloudLibrary } from "../lib/cloudLibrary";
 import { buildDeepLinkPathname, buildDeepLinkUrl, canonicalizeDeepLinkKey, parseDeepLinkFromLocation, slugifyName } from "../lib/deepLink";
@@ -1200,11 +1200,14 @@ export function AppShell() {
       </section>
       {isMapExpanded || isProfileExpanded ? (
         <div className="floating-attribution-pill">
-          <MapIcon aria-hidden="true" size={11} strokeWidth={1.8} />
-          <Copyright aria-hidden="true" size={9} strokeWidth={2.5} />
-          <span>{resolvedBasemap.attribution.replace(/©/g, "")}</span>
-          <Copyright aria-hidden="true" size={9} strokeWidth={2.5} />
-          <span>MapLibre</span>
+          <span>&copy;</span>
+          <a href={resolvedBasemap.attributionUrl} rel="noreferrer" target="_blank">
+            {resolvedBasemap.attribution.replace(/©/g, "").trim()}
+          </a>
+          <span>&copy;</span>
+          <a href="https://github.com/maplibre/maplibre-gl-js" rel="noreferrer" target="_blank">
+            MapLibre
+          </a>
         </div>
       ) : null}
       <WelcomeModal onClose={closeWelcome} onCreateNewSimulation={createNewFromWelcome} onOpenLibrary={openLibraryFromWelcome} onOpenOnboarding={openWelcomeFromWelcome} open={showWelcomeModal} />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2184,6 +2184,16 @@ export function Sidebar({ onOpenHelp }: SidebarProps) {
           <span>MapLibre</span>
         </div>
         <div className="sidebar-footer-links">
+          <span>©</span>
+          <a href={resolvedBasemap.attributionUrl} rel="noreferrer" target="_blank">
+            {resolvedBasemap.attribution.replace(/©/g, "").trim()}
+          </a>
+          <span>©</span>
+          <a href="https://github.com/maplibre/maplibre-gl-js" rel="noreferrer" target="_blank">
+            MapLibre
+          </a>
+        </div>
+        <div className="sidebar-footer-links">
           <a href="https://github.com/wilhel1812/LinkSim/blob/main/docs/legal/TERMS.md" rel="noreferrer" target="_blank">
             <Handshake aria-hidden="true" size={13} strokeWidth={1.8} />
             Terms

--- a/src/index.css
+++ b/src/index.css
@@ -214,6 +214,8 @@ input {
   display: inline-flex;
   align-items: center;
   gap: 4px;
+  flex-wrap: wrap;
+  justify-content: center;
 }
 
 .sidebar-footer-links a {
@@ -914,15 +916,15 @@ input {
   backdrop-filter: blur(var(--glass-panel-blur));
   box-shadow: var(--shadow-elev-3);
   padding: 6px 12px;
-  pointer-events: none;
 }
 
 .floating-attribution-pill a {
-  color: var(--accent);
+  color: var(--muted);
   text-decoration: none;
 }
 
 .floating-attribution-pill a:hover {
+  color: var(--text);
   text-decoration: underline;
 }
 
@@ -949,6 +951,10 @@ input {
 
 .floating-attribution-text a:hover {
   text-decoration: underline;
+}
+
+.app-shell.is-mobile-shell .floating-attribution-pill {
+  bottom: calc(var(--mobile-tabbar-offset) + var(--mobile-tabbar-height) + 12px);
 }
 
 .map-control-note {

--- a/src/lib/basemaps.ts
+++ b/src/lib/basemaps.ts
@@ -13,6 +13,7 @@ export type BasemapProviderCapability = {
   label: string;
   group: "global" | "regional";
   attribution: string;
+  attributionUrl?: string;
   requiresKey: boolean;
   keyEnvVar?: string;
   available: boolean;
@@ -23,6 +24,7 @@ export type BasemapProviderCapability = {
 export type BasemapSelectionResolved = {
   style: string | StyleSpecification;
   attribution: string;
+  attributionUrl: string;
   provider: BasemapProvider;
   providerLabel: string;
   presetId: string;
@@ -219,6 +221,7 @@ const providerCapabilities: BasemapProviderCapability[] = [
     label: "CARTO",
     group: "global",
     attribution: CARTO_ATTRIBUTION,
+    attributionUrl: "https://carto.com/attributions",
     requiresKey: false,
     available: true,
     presets: cartoPresets,
@@ -228,6 +231,7 @@ const providerCapabilities: BasemapProviderCapability[] = [
     label: "MapTiler",
     group: "global",
     attribution: "© OpenStreetMap contributors © MapTiler",
+    attributionUrl: "https://www.openstreetmap.org/copyright",
     requiresKey: true,
     keyEnvVar: "VITE_MAPTILER_KEY",
     available: MAPTILER_KEY.length > 0,
@@ -239,6 +243,7 @@ const providerCapabilities: BasemapProviderCapability[] = [
     label: "Stadia",
     group: "global",
     attribution: "© Stadia Maps © OpenMapTiles © OpenStreetMap contributors © Stamen Design",
+    attributionUrl: "https://stadiamaps.com/",
     requiresKey: false,
     keyEnvVar: "VITE_STADIA_KEY",
     available: true,
@@ -249,6 +254,7 @@ const providerCapabilities: BasemapProviderCapability[] = [
     label: "Kartverket",
     group: "regional",
     attribution: "© Kartverket",
+    attributionUrl: "https://kartverket.no/",
     requiresKey: false,
     available: true,
     presets: kartverketPresets,
@@ -309,6 +315,7 @@ export const resolveBasemapSelection = (
   return {
     style: styleForPreset(provider.provider, preset.id, theme, colorTheme),
     attribution: provider.attribution,
+    attributionUrl: provider.attributionUrl ?? "https://www.openstreetmap.org/copyright",
     provider: provider.provider,
     providerLabel: provider.label,
     presetId: preset.id,

--- a/src/lib/buildInfo.ts
+++ b/src/lib/buildInfo.ts
@@ -1,5 +1,5 @@
 export const APP_VERSION = "0.12.1";
-export const APP_COMMIT = "7a8d7958";
+export const APP_COMMIT = "974812d6";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {


### PR DESCRIPTION
## Summary
Merges `issue/240-mobile-attribution-fix` into staging, resolving conflicts with the Open Library fix (#304).

Merged commits:
- fix: make attribution clickable, fix mobile pill position
- fix: remove Map icon, enable link clicks in pill, match sidebar link style
- fix: match link colors to sidebar footer links (muted, text on hover)
- fix: use same CSS class for all footer links to match styling
- fix: separate footer into three equal rows (attribution, links, version)
- fix: use text © instead of Lucide icons, add flex-wrap for multi-line support

Conflict resolution:
- **AppShell.tsx**: Kept attribution branch's text © + clickable links (removed unused Copyright/MapIcon imports)
- **index.css**: Kept attribution branch's muted link colors, hover states, mobile pill positioning
- **buildInfo.ts**: Updated commit hash

## Verification
- [ ] `npm test` passes (189/189)
- [ ] `npm run build` succeeds
- [ ] Footer attribution uses text ©, not Lucide icons
- [ ] Open Library button works on mobile