### PR TITLE
fix: remove duplicate map attribution from sidebar footer

### DIFF
--- a/functions/_lib/buildInfo.ts
+++ b/functions/_lib/buildInfo.ts
@@ -1,5 +1,5 @@
 export const APP_VERSION = "0.12.1";
-export const APP_COMMIT = "974812d6";
+export const APP_COMMIT = "62942b78";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import clsx from "clsx";
-import { CircleX, Copyright, Funnel, Handshake, HatGlasses, Map as MapIcon, RefreshCw } from "lucide-react";
+import { CircleX, Funnel, Handshake, HatGlasses, RefreshCw } from "lucide-react";
 import Map, {
   Layer,
   Marker,
@@ -2176,13 +2176,6 @@ export function Sidebar({ onOpenHelp }: SidebarProps) {
 
       <div className="sidebar-grow" />
       <footer className="sidebar-footer">
-        <div className="sidebar-footer-attribution">
-          <MapIcon aria-hidden="true" size={11} strokeWidth={1.8} />
-          <Copyright aria-hidden="true" size={9} strokeWidth={2.5} />
-          <span>{resolvedBasemap.attribution.replace(/©/g, "")}</span>
-          <Copyright aria-hidden="true" size={9} strokeWidth={2.5} />
-          <span>MapLibre</span>
-        </div>
         <div className="sidebar-footer-links">
           <span>©</span>
           <a href={resolvedBasemap.attributionUrl} rel="noreferrer" target="_blank">

--- a/src/index.css
+++ b/src/index.css
@@ -190,26 +190,6 @@ input {
   text-align: center;
 }
 
-.sidebar-footer-attribution {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 0.68rem;
-  color: var(--muted);
-  flex-wrap: wrap;
-  justify-content: center;
-  margin-bottom: 4px;
-}
-
-.sidebar-footer-attribution a {
-  color: var(--accent);
-  text-decoration: none;
-}
-
-.sidebar-footer-attribution a:hover {
-  text-decoration: underline;
-}
-
 .sidebar-footer-links {
   display: inline-flex;
   align-items: center;

--- a/src/lib/buildInfo.ts
+++ b/src/lib/buildInfo.ts
@@ -1,5 +1,5 @@
 export const APP_VERSION = "0.12.1";
-export const APP_COMMIT = "974812d6";
+export const APP_COMMIT = "62942b78";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {


### PR DESCRIPTION
Removes the old lucide-icon attribution that was left alongside the new text-© clickable attribution.