### PR TITLE
fix: keep path profile fullscreen independent from map fullscreen (#309)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1017,6 +1017,12 @@ export function AppShell() {
     );
   }
 
+  const toggleProfileExpanded = useCallback(() => {
+    setIsMapExpanded(false);
+    setMobileActivePanel("profile");
+    setIsProfileExpanded((prev) => !prev);
+  }, []);
+
   return (
     <main
       ref={appShellRef}
@@ -1163,11 +1169,6 @@ export function AppShell() {
               aria-selected={mobileActivePanel === "profile"}
               className={`mobile-workspace-tab ${mobileActivePanel === "profile" ? "is-active" : ""}`}
               onClick={() => {
-                if (!isMapExpanded && mobileActivePanel === "profile") {
-                  setIsMapExpanded(true);
-                  setIsProfileExpanded(false);
-                  return;
-                }
                 setIsMapExpanded(false);
                 setMobileActivePanel("profile");
               }}
@@ -1181,14 +1182,14 @@ export function AppShell() {
         {!isMobileViewport && !isMapExpanded ? (
           <LinkProfileChart
             isExpanded={isProfileExpanded}
-            onToggleExpanded={() => setIsProfileExpanded((prev) => !prev)}
+            onToggleExpanded={toggleProfileExpanded}
           />
         ) : null}
         {isMobileViewport && !isMapExpanded && mobileActivePanel === "profile" ? (
           <div className="mobile-workspace-panel" role="tabpanel" aria-label="Path profile panel">
             <LinkProfileChart
               isExpanded={isProfileExpanded}
-              onToggleExpanded={() => setIsProfileExpanded((prev) => !prev)}
+              onToggleExpanded={toggleProfileExpanded}
             />
           </div>
         ) : null}


### PR DESCRIPTION
## Problem
On staging, tapping Full screen in the Path Profile panel can trigger map fullscreen behavior (hide panels), which is incorrect.

## Fix
- Added a dedicated `toggleProfileExpanded` handler in `AppShell` and wired both desktop/mobile `LinkProfileChart` instances to it
- The profile fullscreen handler now explicitly keeps map fullscreen off and the active mobile panel on `profile`
- Removed the mobile `Path Profile` tab re-tap shortcut that promoted directly to map fullscreen

## Why this works
Path-profile fullscreen and map fullscreen now use independent state transitions and no longer share a path through the mobile profile-tab toggle.

## Verification
- [x] `npm test`
- [x] `npm run build`