### PR TITLE
fix: avoid hook-order crash in profile fullscreen toggle (#309)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1017,11 +1017,11 @@ export function AppShell() {
     );
   }
 
-  const toggleProfileExpanded = useCallback(() => {
+  const toggleProfileExpanded = () => {
     setIsMapExpanded(false);
     setMobileActivePanel("profile");
     setIsProfileExpanded((prev) => !prev);
-  }, []);
+  };
 
   return (
     <main


### PR DESCRIPTION
## Problem
Staging crash after #310 deploy with React minified error #310.

## Root cause
`useCallback` for `toggleProfileExpanded` was introduced after conditional early returns in `AppShell`, violating hook ordering rules.

## Fix
- Replaced that `useCallback` with a plain function (no hook)
- Keeps the profile fullscreen behavior from #310 without introducing new hooks in conditional paths

## Verification
- [x] `npm test`
- [x] `npm run build`