### PR TITLE
fix: prevent zero-width path profile in fullscreen desktop mode (#309)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1027,6 +1027,8 @@ export function AppShell() {
     <main
       ref={appShellRef}
       className={`app-shell ${isMapExpanded ? "is-map-expanded" : ""} ${
+        isProfileExpanded ? "is-profile-expanded" : ""
+      } ${
         accessState === "readonly" ? "is-readonly-shell" : ""
       } ${
         isMobileViewport ? "is-mobile-shell" : ""

--- a/src/index.css
+++ b/src/index.css
@@ -114,7 +114,8 @@ input {
   animation: fade-in 260ms ease;
 }
 
-.app-shell.is-map-expanded {
+.app-shell.is-map-expanded,
+.app-shell.is-profile-expanded {
   grid-template-columns: minmax(0, 1fr);
 }
 


### PR DESCRIPTION
## Problem
On desktop, path profile fullscreen could hide the sidebar but still reserve the sidebar grid column in app shell. On narrower windows this collapsed the profile panel to effectively 0px width.

## Fix
- Add `is-profile-expanded` class to `AppShell`
- Apply single-column app-shell layout for `.app-shell.is-profile-expanded`, same as map fullscreen

## Result
Path profile fullscreen now gets full available width instead of collapsing.

## Verification
- [x] `npm test`
- [x] `npm run build`