### PR TITLE
fix: hide inspector in profile fullscreen mode (#309)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1102,7 +1102,7 @@ export function AppShell() {
         </div>
         <MapView
           isMapExpanded={isMapExpanded}
-          showInspector={!isMapExpanded && (!isMobileViewport || mobileActivePanel === "inspector")}
+          showInspector={!isMapExpanded && !isProfileExpanded && (!isMobileViewport || mobileActivePanel === "inspector")}
           showMultiSelectToggle={isMobileViewport}
           canPersist={canPersistWorkspace}
           onShare={


### PR DESCRIPTION
## Problem
Desktop path-profile fullscreen still left the right-side inspector visible.

## Fix
`showInspector` now requires `!isProfileExpanded` in `AppShell`, so inspector rendering is explicitly disabled while path profile fullscreen is active.

## Verification
- [x] `npm test`
- [x] `npm run build`