### PR TITLE
fix: remove right-side gutter in profile fullscreen mode (#309)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -698,6 +698,7 @@ input {
 
 .workspace-panel.is-profile-expanded {
   grid-template-rows: minmax(0, 1fr);
+  padding-right: 0;
 }
 
 .workspace-header {
@@ -801,7 +802,7 @@ input {
   scrollbar-width: thin;
 }
 
-.app-shell:not(.is-map-expanded) .map-controls {
+.app-shell:not(.is-map-expanded):not(.is-profile-expanded) .map-controls {
   left: calc(var(--sidebar-overlay-width) + 30px);
   right: calc(var(--sidebar-overlay-width) + 30px);
 }
@@ -952,7 +953,7 @@ input {
   max-width: 260px;
 }
 
-.app-shell:not(.is-map-expanded) .map-control-note {
+.app-shell:not(.is-map-expanded):not(.is-profile-expanded) .map-control-note {
   right: calc(var(--sidebar-overlay-width) + 30px);
 }
 


### PR DESCRIPTION
## Problem
Path profile fullscreen on desktop still left a right-side gutter where map background/attribution was visible.

## Fix
- Set `padding-right: 0` for `.workspace-panel.is-profile-expanded`
- Restrict sidebar-offset control positioning to only non-expanded shell states:
  - `.app-shell:not(.is-map-expanded):not(.is-profile-expanded) .map-controls`
  - `.app-shell:not(.is-map-expanded):not(.is-profile-expanded) .map-control-note`

## Verification
- [x] `npm test`
- [x] `npm run build`