### PR TITLE
feat: support anonymous shared deep-link guest mode (#24)

### DIFF
--- a/docs/access-policy-templates.md
+++ b/docs/access-policy-templates.md
@@ -22,6 +22,22 @@ Provide a safe baseline for LinkSim without over-complicated guardrails.
 - Exclude:
   - Explicitly blocked users/groups (if used)
 
+## Guest Deep-Link Mode (for issue #24 behavior)
+
+Use this profile when anonymous users must be able to open shared Simulation deep links without an Access login prompt.
+
+### Access boundary
+- Keep the app shell route publicly reachable so deep links can load without Access challenge.
+- Keep authenticated APIs protected with Access (`/api/me`, `/api/library`, `/api/users*`, admin/mod endpoints).
+- Keep `/api/public-simulation` reachable without Access challenge.
+
+### App authorization model
+- Keep `REGISTRATION_MODE=approval_required`.
+- Treat Access as identity proof for signed-in users.
+- Treat LinkSim visibility/role checks as the data authorization source.
+- Anonymous deep-link users must only load the shared/public Simulation bundle resolved by deep link.
+- Guest mode must not expose library browsing/discovery of unrelated objects.
+
 ### LinkSim app-level approval
 - Keep `REGISTRATION_MODE=approval_required`.
 - Cloudflare Access answers “who can sign in”.
@@ -40,12 +56,14 @@ Provide a safe baseline for LinkSim without over-complicated guardrails.
 - `AUTH_OBSERVABILITY=true` (recommended)
 
 ## Validation checklist
-1. Unauthenticated user gets Access challenge.
-2. Authenticated non-approved user lands in pending flow.
-3. Admin can open:
+1. In baseline mode: unauthenticated user gets Access challenge.
+2. In guest deep-link mode: unauthenticated user can open a shared deep link without challenge.
+3. In guest deep-link mode: unauthenticated user cannot access authenticated APIs (`/api/me`, `/api/library`, admin routes).
+4. Authenticated non-approved user lands in pending flow.
+5. Admin can open:
    - `/api/auth-diagnostics`
    - `/api/schema-diagnostics`
-4. App denies privileged endpoints for non-admin users.
+6. App denies privileged endpoints for non-admin users.
 
 ## Common misconfigurations
 - Missing `ACCESS_AUD` or `ACCESS_TEAM_DOMAIN`.

--- a/docs/cloudflare-auth-setup.md
+++ b/docs/cloudflare-auth-setup.md
@@ -80,12 +80,14 @@ Deploy from this repo. Pages Functions under `functions/api/*` deploy automatica
 
 ## 8) Verify
 
-- Access protects app URL (unauth users blocked/challenged)
+- Baseline mode: Access protects app URL (unauth users blocked/challenged)
+- Guest deep-link mode (optional): app shell route can load without challenge, but authenticated APIs remain protected
 - Sign in via GitHub (or OTP fallback)
 - Open User Settings and confirm user status
 - For admins: check `/api/schema-diagnostics` and `/api/auth-diagnostics`
 - Trigger `Sync From Cloud`
 - Create/edit site/simulation and confirm cloud sync status updates
+- In guest deep-link mode, verify `/api/public-simulation` is reachable without Access challenge
 
 ## Local Development
 

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -131,6 +131,7 @@ export function AppShell() {
     () => simulationPresets.find((preset) => preset.id === selectedScenarioId) ?? null,
     [simulationPresets, selectedScenarioId],
   );
+  const isAnonymousGuestReadonly = accessState === "readonly" && !currentUser;
   const canPersistWorkspace =
     accessState === "granted" && (!activeSimulation || canEditResource(activeSimulation));
   const workspaceState = emptyWorkspaceState(sites.length, Boolean(activeSimulation));
@@ -359,7 +360,7 @@ export function AppShell() {
           window.location.href = "/cdn-cgi/access/logout";
           return;
         }
-        if (deepLinkParse.ok && (message.includes("401") || message.includes("Unauthorized"))) {
+        if (deepLinkParse.ok) {
           setAccessState("readonly");
           setDeepLinkNotice("Read-only shared view.");
           return;
@@ -1038,7 +1039,7 @@ export function AppShell() {
       style={shellStyle}
     >
       {!isMobileViewport && !isMapExpanded && !isProfileExpanded && (accessState === "granted" || accessState === "readonly") ? (
-        <Sidebar onOpenHelp={openOnboardingTutorial} />
+        <Sidebar hideLibraryBrowsing={isAnonymousGuestReadonly} onOpenHelp={openOnboardingTutorial} />
       ) : null}
       <section className={`workspace-panel ${isMapExpanded ? "is-map-expanded" : ""} ${isProfileExpanded ? "is-profile-expanded" : ""}`}>
         {!isOnline && !offlineBannerDismissed ? (
@@ -1060,18 +1061,26 @@ export function AppShell() {
             </div>
           </div>
         ) : null}
-        {accessState === "readonly" ? <p className="field-help">Read-only shared view.</p> : null}
+        {accessState === "readonly" ? (
+          <p className="field-help">
+            {isAnonymousGuestReadonly
+              ? "Read-only guest view. Library browsing is hidden in shared-link mode."
+              : "Read-only shared view."}
+          </p>
+        ) : null}
         {workspaceState === "no-simulation" ? (
           <div className="empty-workspace-overlay">
             <div className="empty-workspace-message">
               <p>Open an existing simulation or create a new one to continue.</p>
-              <button
-                className="inline-action"
-                onClick={() => setShowSimulationLibraryRequest(true)}
-                type="button"
-              >
-                Open Library
-              </button>
+              {!isAnonymousGuestReadonly ? (
+                <button
+                  className="inline-action"
+                  onClick={() => setShowSimulationLibraryRequest(true)}
+                  type="button"
+                >
+                  Open Library
+                </button>
+              ) : null}
             </div>
           </div>
         ) : null}
@@ -1197,7 +1206,9 @@ export function AppShell() {
         ) : null}
         {isMobileViewport && !isMapExpanded && mobileActivePanel === "sidebar" ? (
           <div className="mobile-workspace-panel mobile-workspace-panel-sidebar" role="tabpanel" aria-label="Sidebar panel">
-            {(accessState === "granted" || accessState === "readonly") ? <Sidebar onOpenHelp={openOnboardingTutorial} /> : null}
+            {(accessState === "granted" || accessState === "readonly") ? (
+              <Sidebar hideLibraryBrowsing={isAnonymousGuestReadonly} onOpenHelp={openOnboardingTutorial} />
+            ) : null}
           </div>
         ) : null}
       </section>
@@ -1215,7 +1226,7 @@ export function AppShell() {
       ) : null}
       <WelcomeModal onClose={closeWelcome} onCreateNewSimulation={createNewFromWelcome} onOpenLibrary={openLibraryFromWelcome} onOpenOnboarding={openWelcomeFromWelcome} open={showWelcomeModal} />
       <OnboardingTutorialModal onClose={() => setShowOnboardingTutorial(false)} onOpenLibrary={() => setShowSimulationLibraryRequest(true)} onOpenSiteLibrary={() => setShowSiteLibraryRequest(true)} open={showOnboardingTutorial} />
-      {showLibraryFromRequest ? (
+      {showLibraryFromRequest && !isAnonymousGuestReadonly ? (
         <ModalOverlay
           aria-label="Simulation Library"
           onClose={() => setShowLibraryFromRequest(false)}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -255,9 +255,10 @@ const formatMqttSourceMeta = (value: unknown): string[] => {
 
 type SidebarProps = {
   onOpenHelp?: () => void;
+  hideLibraryBrowsing?: boolean;
 };
 
-export function Sidebar({ onOpenHelp }: SidebarProps) {
+export function Sidebar({ onOpenHelp, hideLibraryBrowsing = false }: SidebarProps) {
   const { theme, colorTheme, variant } = useThemeVariant();
   const runtimeEnvironment = getCurrentRuntimeEnvironment();
   const envBadgeLabel = runtimeEnvironment === "local" ? "LOCAL" : runtimeEnvironment === "staging" ? "STAGING" : "";
@@ -602,19 +603,27 @@ export function Sidebar({ onOpenHelp }: SidebarProps) {
   }, [siteLibrary]);
   useEffect(() => {
     if (showNewSimulationRequest) {
+      if (hideLibraryBrowsing) {
+        setShowNewSimulationRequest(false);
+        return;
+      }
       setNewSimulationName("");
       setNewSimulationDescription("");
       setNewSimulationNameError("");
       setShowNewSimulationModal(true);
       setShowNewSimulationRequest(false);
     }
-  }, [showNewSimulationRequest, setShowNewSimulationRequest]);
+  }, [hideLibraryBrowsing, showNewSimulationRequest, setShowNewSimulationRequest]);
   useEffect(() => {
     if (showSiteLibraryRequest) {
+      if (hideLibraryBrowsing) {
+        setShowSiteLibraryRequest(false);
+        return;
+      }
       setShowSiteLibraryManager(true);
       setShowSiteLibraryRequest(false);
     }
-  }, [showSiteLibraryRequest, setShowSiteLibraryRequest]);
+  }, [hideLibraryBrowsing, showSiteLibraryRequest, setShowSiteLibraryRequest]);
   useEffect(() => {
     persistLibraryFilterState(SITE_LIBRARY_FILTERS_KEY, siteLibraryFilters);
   }, [siteLibraryFilters]);
@@ -1731,33 +1740,39 @@ export function Sidebar({ onOpenHelp }: SidebarProps) {
           <InfoTip text="Open a simulation from the library or create a new one. A simulation is a workspace where you can add sites and tweak settings. They can be private or shared." />
         </div>
         <div className="chip-group simulation-buttons">
-          <button
-            className="inline-action"
-            onClick={() => setShowSimulationLibraryManager(true)}
-            type="button"
-          >
-            Library
-          </button>
-          <button
-            className="inline-action"
-            onClick={() => {
-              setNewSimulationName("");
-              setNewSimulationDescription("");
-              setNewSimulationNameError("");
-              setShowNewSimulationModal(true);
-            }}
-            type="button"
-          >
-            New
-          </button>
-          <button className="inline-action" onClick={saveSimulationAsNew} type="button">
-            Duplicate
-          </button>
-          {selectedSimulationRef.startsWith("saved:") ? (
-            <button className="inline-action" onClick={openActiveSimulationDetails} type="button">
-              Edit
-            </button>
-          ) : null}
+          {!hideLibraryBrowsing ? (
+            <>
+              <button
+                className="inline-action"
+                onClick={() => setShowSimulationLibraryManager(true)}
+                type="button"
+              >
+                Library
+              </button>
+              <button
+                className="inline-action"
+                onClick={() => {
+                  setNewSimulationName("");
+                  setNewSimulationDescription("");
+                  setNewSimulationNameError("");
+                  setShowNewSimulationModal(true);
+                }}
+                type="button"
+              >
+                New
+              </button>
+              <button className="inline-action" onClick={saveSimulationAsNew} type="button">
+                Duplicate
+              </button>
+              {selectedSimulationRef.startsWith("saved:") ? (
+                <button className="inline-action" onClick={openActiveSimulationDetails} type="button">
+                  Edit
+                </button>
+              ) : null}
+            </>
+          ) : (
+            <span className="field-help">Shared-link guest mode: library browsing is hidden.</span>
+          )}
         </div>
         {simulationSaveStatus ? <p className="field-help">{simulationSaveStatus}</p> : null}
       </section>
@@ -1784,17 +1799,21 @@ export function Sidebar({ onOpenHelp }: SidebarProps) {
           ))}
         </div>
         <div className="chip-group">
-          <button className="inline-action" onClick={() => setShowSiteLibraryManager(true)} type="button">
-            Library
-          </button>
-          {newestSiteLibraryEntryId ? (
-            <button className="inline-action" onClick={() => insertSiteFromLibrary(newestSiteLibraryEntryId)} type="button">
-              Insert newest
-            </button>
+          {!hideLibraryBrowsing ? (
+            <>
+              <button className="inline-action" onClick={() => setShowSiteLibraryManager(true)} type="button">
+                Library
+              </button>
+              {newestSiteLibraryEntryId ? (
+                <button className="inline-action" onClick={() => insertSiteFromLibrary(newestSiteLibraryEntryId)} type="button">
+                  Insert newest
+                </button>
+              ) : null}
+              <button className="inline-action" onClick={openLibraryForSelectedSite} type="button">
+                Edit
+              </button>
+            </>
           ) : null}
-          <button className="inline-action" onClick={openLibraryForSelectedSite} type="button">
-            Edit
-          </button>
           <button
             className="inline-action danger"
             disabled={sites.length <= 1}
@@ -2809,7 +2828,7 @@ export function Sidebar({ onOpenHelp }: SidebarProps) {
           </div>
         </ModalOverlay>
       ) : null}
-      {showNewSimulationModal ? (
+      {showNewSimulationModal && !hideLibraryBrowsing ? (
         <ModalOverlay
           aria-label="New Simulation"
           onClose={() => {
@@ -2880,7 +2899,7 @@ export function Sidebar({ onOpenHelp }: SidebarProps) {
         </ModalOverlay>
       ) : null}
 
-      {showSimulationLibraryManager ? (
+      {showSimulationLibraryManager && !hideLibraryBrowsing ? (
         <ModalOverlay
           aria-label="Simulation Library"
           onClose={() => setShowSimulationLibraryManager(false)}
@@ -2929,7 +2948,7 @@ export function Sidebar({ onOpenHelp }: SidebarProps) {
           </div>
         </ModalOverlay>
       ) : null}
-      {showSiteLibraryManager ? (
+      {showSiteLibraryManager && !hideLibraryBrowsing ? (
         <ModalOverlay
           aria-label="Site Library"
           onClose={() => {


### PR DESCRIPTION
## Summary
- add anonymous guest-readonly handling for deep-link entry so shared links can render without requiring an authenticated profile
- hide simulation/site library browsing surfaces in guest deep-link mode to prevent browsing unrelated objects
- document Cloudflare Access guest deep-link policy split and validation steps for protected APIs vs `/api/public-simulation`

## Verification
- npm test
- npm run build
- npm run test -- --run src/lib/deepLink.test.ts
- npm run test -- --run functions/api/v1/calculate.test.ts
- npm run test -- --run src/store/appStore.test.ts