### PR TITLE
fix: apply guest deep links without cloud-init wait (#24)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -3,6 +3,7 @@ import { CircleX } from "lucide-react";
 import { fetchDeepLinkStatus, fetchMe, setLocalDevRole } from "../lib/cloudUser";
 import { fetchCloudLibrary, fetchPublicSimulationLibrary, pushCloudLibrary } from "../lib/cloudLibrary";
 import { buildDeepLinkPathname, buildDeepLinkUrl, canonicalizeDeepLinkKey, parseDeepLinkFromLocation, slugifyName } from "../lib/deepLink";
+import { canRunDeepLinkApply } from "../lib/deepLinkApplyGate";
 import { emptyWorkspaceState } from "../lib/emptyWorkspaceState";
 import { getCurrentRuntimeEnvironment } from "../lib/environment";
 import { getUiErrorMessage } from "../lib/uiError";
@@ -503,8 +504,16 @@ export function AppShell() {
   }, [isInitializing]);
 
   useEffect(() => {
-    if ((accessState !== "granted" && accessState !== "readonly") || deepLinkAppliedRef.current || isInitializing) return;
-    if (!cloudInitSettledRef.current) return;
+    if (
+      !canRunDeepLinkApply({
+        accessState,
+        deepLinkAlreadyApplied: deepLinkAppliedRef.current,
+        isInitializing,
+        cloudInitSettled: cloudInitSettledRef.current,
+      })
+    ) {
+      return;
+    }
     if (!deepLinkParse.ok) {
       if (deepLinkParse.reason !== "missing_sim") {
         setDeepLinkNotice(

--- a/src/lib/deepLinkApplyGate.test.ts
+++ b/src/lib/deepLinkApplyGate.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { canRunDeepLinkApply } from "./deepLinkApplyGate";
+
+describe("canRunDeepLinkApply", () => {
+  it("allows readonly guest deep links without cloud init settle", () => {
+    expect(
+      canRunDeepLinkApply({
+        accessState: "readonly",
+        deepLinkAlreadyApplied: false,
+        isInitializing: false,
+        cloudInitSettled: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("requires cloud init settled for granted users", () => {
+    expect(
+      canRunDeepLinkApply({
+        accessState: "granted",
+        deepLinkAlreadyApplied: false,
+        isInitializing: false,
+        cloudInitSettled: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("blocks while checking, pending, or locked", () => {
+    expect(
+      canRunDeepLinkApply({
+        accessState: "checking",
+        deepLinkAlreadyApplied: false,
+        isInitializing: false,
+        cloudInitSettled: true,
+      }),
+    ).toBe(false);
+    expect(
+      canRunDeepLinkApply({
+        accessState: "pending",
+        deepLinkAlreadyApplied: false,
+        isInitializing: false,
+        cloudInitSettled: true,
+      }),
+    ).toBe(false);
+    expect(
+      canRunDeepLinkApply({
+        accessState: "locked",
+        deepLinkAlreadyApplied: false,
+        isInitializing: false,
+        cloudInitSettled: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/lib/deepLinkApplyGate.ts
+++ b/src/lib/deepLinkApplyGate.ts
@@ -1,0 +1,16 @@
+export type DeepLinkApplyAccessState = "checking" | "granted" | "readonly" | "pending" | "locked";
+
+export const canRunDeepLinkApply = (input: {
+  accessState: DeepLinkApplyAccessState;
+  deepLinkAlreadyApplied: boolean;
+  isInitializing: boolean;
+  cloudInitSettled: boolean;
+}): boolean => {
+  if ((input.accessState !== "granted" && input.accessState !== "readonly") || input.deepLinkAlreadyApplied || input.isInitializing) {
+    return false;
+  }
+  if (input.accessState === "granted" && !input.cloudInitSettled) {
+    return false;
+  }
+  return true;
+};


### PR DESCRIPTION
## Summary
- fix guest readonly deep-link application flow so shared links can apply even when cloud sync initialization never enters a settle cycle
- keep granted-user behavior unchanged by continuing to wait for cloud-init settle before deep-link import logic
- add a focused deep-link apply gate helper with tests to prevent regressions for guest and granted states

## Verification
- npm run test -- --run src/lib/deepLinkApplyGate.test.ts
- npm run test -- --run src/lib/deepLink.test.ts
- npm run test -- --run functions/api/v1/calculate.test.ts
- npm run test -- --run src/store/appStore.test.ts
- npm test
- npm run build