### PR TITLE
fix: reduce guest deep-link auth noise and preflight errors (#24)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -318,6 +318,14 @@ export function AppShell() {
           setDeepLinkNotice("Local read-only mode.");
           return;
         }
+        if (deepLinkParse.ok && !isLocalRuntime) {
+          if (cancelled || timedOut) return;
+          window.clearTimeout(timeoutId);
+          setAccessDiagnosticMessage(null);
+          setAccessState("readonly");
+          setDeepLinkNotice("Read-only shared view.");
+          return;
+        }
         const profile = await fetchMe();
         if (cancelled || timedOut) return;
         window.clearTimeout(timeoutId);
@@ -350,12 +358,21 @@ export function AppShell() {
         if (cancelled || timedOut) return;
         window.clearTimeout(timeoutId);
         const message = getUiErrorMessage(error);
-        console.error("[AppShell] Access check failed", {
-          message,
-          isLocalRuntime,
-          deepLinkMode: deepLinkParse.ok,
-          online: typeof navigator === "undefined" ? true : navigator.onLine,
-        });
+        if (deepLinkParse.ok) {
+          console.info("[AppShell] Guest deep-link bootstrap using read-only fallback", {
+            message,
+            isLocalRuntime,
+            deepLinkMode: deepLinkParse.ok,
+            online: typeof navigator === "undefined" ? true : navigator.onLine,
+          });
+        } else {
+          console.error("[AppShell] Access check failed", {
+            message,
+            isLocalRuntime,
+            deepLinkMode: deepLinkParse.ok,
+            online: typeof navigator === "undefined" ? true : navigator.onLine,
+          });
+        }
         setAccessDiagnosticMessage(`Access check failed: ${message}`);
         if (message.includes("Session revoked by admin")) {
           window.location.href = "/cdn-cgi/access/logout";
@@ -593,6 +610,28 @@ export function AppShell() {
         }
       }
 
+      if (!exists && accessState === "readonly") {
+        try {
+          const publicBundle = await fetchPublicSimulationLibrary({
+            simulationId: resolvedSimulationId || undefined,
+            simulationSlug: payload.simulationSlug,
+          });
+          importLibraryData(
+            {
+              siteLibrary: publicBundle.siteLibrary as Parameters<typeof importLibraryData>[0]["siteLibrary"],
+              simulationPresets: publicBundle.simulationPresets as Parameters<typeof importLibraryData>[0]["simulationPresets"],
+            },
+            "merge",
+          );
+          resolvedSimulationId = publicBundle.simulationId ?? resolvedSimulationId;
+          exists = Boolean(resolvedSimulationId);
+        } catch {
+          setDeepLinkNotice("This shared simulation is unavailable.");
+          deepLinkAppliedRef.current = true;
+          return;
+        }
+      }
+
       if (!exists) {
         try {
           const status = await fetchDeepLinkStatus({
@@ -657,28 +696,6 @@ export function AppShell() {
           }
         } catch {
           // Ignore and use generic message.
-        }
-      }
-
-      if (!exists && accessState === "readonly") {
-        try {
-          const publicBundle = await fetchPublicSimulationLibrary({
-            simulationId: resolvedSimulationId || undefined,
-            simulationSlug: payload.simulationSlug,
-          });
-          importLibraryData(
-            {
-              siteLibrary: publicBundle.siteLibrary as Parameters<typeof importLibraryData>[0]["siteLibrary"],
-              simulationPresets: publicBundle.simulationPresets as Parameters<typeof importLibraryData>[0]["simulationPresets"],
-            },
-            "merge",
-          );
-          resolvedSimulationId = publicBundle.simulationId ?? resolvedSimulationId;
-          exists = Boolean(resolvedSimulationId);
-        } catch {
-          setDeepLinkNotice("This shared simulation is unavailable.");
-          deepLinkAppliedRef.current = true;
-          return;
         }
       }
 

--- a/src/lib/cloudUser.test.ts
+++ b/src/lib/cloudUser.test.ts
@@ -6,6 +6,7 @@ import {
   fetchResourceChanges,
   fetchAdminAuditEvents,
   updateUserRole,
+  updateMyProfile,
 } from "./cloudUser";
 
 beforeEach(() => {
@@ -29,6 +30,23 @@ describe("cloudUser client", () => {
 
     const result = await fetchMe();
     expect(result.id).toBe("u1");
+    const [, init] = vi.mocked(globalThis.fetch).mock.calls[0] ?? [];
+    const headers = new Headers((init as RequestInit | undefined)?.headers ?? {});
+    expect(headers.has("content-type")).toBe(false);
+  });
+
+  it("sends JSON content-type when request has body", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ user: { id: "u1", username: "U", bio: "", avatarUrl: "", isAdmin: false, isApproved: true, createdAt: "x", updatedAt: "x" } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    await updateMyProfile({ bio: "hello" });
+    const [, init] = vi.mocked(globalThis.fetch).mock.calls[0] ?? [];
+    const headers = new Headers((init as RequestInit | undefined)?.headers ?? {});
+    expect(headers.get("content-type")).toBe("application/json");
   });
 
   it("normalizes non-array users and changes payloads", async () => {

--- a/src/lib/cloudUser.ts
+++ b/src/lib/cloudUser.ts
@@ -124,12 +124,14 @@ export type DeepLinkStatus = "ok" | "forbidden" | "missing";
 export type DeepLinkStatusResult = { status: DeepLinkStatus; simulationId?: string };
 
 const apiCall = async <T>(path: string, init?: RequestInit): Promise<T> => {
+  const headers = new Headers(init?.headers ?? {});
+  const hasBody = init?.body !== undefined && init.body !== null;
+  if (hasBody && !headers.has("content-type")) {
+    headers.set("content-type", "application/json");
+  }
   const response = await fetch(path, {
     ...init,
-    headers: {
-      "content-type": "application/json",
-      ...(init?.headers ?? {}),
-    },
+    headers,
   });
   if (!response.ok) {
     const raw = await response.text();


### PR DESCRIPTION
## Summary
- avoid protected `/api/me` bootstrap during anonymous deep-link startup by switching non-local deep-link entry directly into readonly guest mode
- prioritize public simulation bundle lookup before any deep-link status checks in readonly mode to avoid hitting protected status endpoints
- update API client header behavior so GET requests do not force JSON preflight while preserving JSON content type for body requests

## Verification
- npm run test -- --run src/lib/cloudUser.test.ts
- npm run test -- --run src/lib/deepLink.test.ts
- npm run test -- --run functions/api/v1/calculate.test.ts
- npm run test -- --run src/store/appStore.test.ts
- npm test
- npm run build