### PR TITLE
fix: skip auth-only sidebar fetches in guest mode (#24)

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -793,6 +793,10 @@ export function Sidebar({ onOpenHelp, hideLibraryBrowsing = false }: SidebarProp
     setSelectedLinkId(visibleLinks[0].id);
   }, [selectedLinkId, setSelectedLinkId, visibleLinks]);
   useEffect(() => {
+    if (hideLibraryBrowsing) {
+      setResourceCollaboratorDirectory([]);
+      return;
+    }
     let canceled = false;
     const loadDirectory = () => {
       if (canceled) return;
@@ -817,8 +821,13 @@ export function Sidebar({ onOpenHelp, hideLibraryBrowsing = false }: SidebarProp
       canceled = true;
       window.clearTimeout(timerId);
     };
-  }, []);
+  }, [hideLibraryBrowsing]);
   useEffect(() => {
+    if (hideLibraryBrowsing) {
+      setResourceCollaboratorDirectoryBusy(false);
+      setResourceCollaboratorDirectoryStatus("");
+      return;
+    }
     if (!resourceDetailsPopup) return;
     let canceled = false;
     setResourceCollaboratorDirectoryBusy(true);
@@ -840,7 +849,7 @@ export function Sidebar({ onOpenHelp, hideLibraryBrowsing = false }: SidebarProp
     return () => {
       canceled = true;
     };
-  }, [resourceDetailsPopup]);
+  }, [hideLibraryBrowsing, resourceDetailsPopup]);
   const meshmapNodesInView = useMemo(() => {
     const lonSpan = Math.max(0.12, 360 / Math.pow(2, meshmapView.zoom) * 2.2);
     const latSpan = Math.max(0.12, 170 / Math.pow(2, meshmapView.zoom) * 1.8);
@@ -1727,7 +1736,7 @@ export function Sidebar({ onOpenHelp, hideLibraryBrowsing = false }: SidebarProp
 
   return (
     <aside className="sidebar-panel">
-      <UserAdminPanel onOpenHelp={onOpenHelp} />
+      {!hideLibraryBrowsing ? <UserAdminPanel onOpenHelp={onOpenHelp} /> : null}
       <header>
         <div className="sidebar-title-row">
           <h1>{t(locale, "appTitle")}</h1>


### PR DESCRIPTION
## Summary
- stop mounting `UserAdminPanel` in guest deep-link sidebar mode to avoid auth-only startup requests
- skip collaborator directory prefetch and modal fetch logic while library browsing is hidden for anonymous guest sessions
- keep protected API boundaries unchanged; this is a guest UI/runtime guard hardening pass

## Verification
- npm run test -- --run src/lib/deepLink.test.ts
- npm run test -- --run functions/api/v1/calculate.test.ts
- npm run test -- --run src/store/appStore.test.ts
- npm test
- npm run build