### PR TITLE
feat: add determinate terrain loading progress in map UI (#24)

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1017,6 +1017,11 @@ export function MapView({
   const srtmTiles = useAppStore((state) => state.srtmTiles);
   const terrainFetchStatus = useAppStore((state) => state.terrainFetchStatus);
   const terrainLoadingStartedAtMs = useAppStore((state) => state.terrainLoadingStartedAtMs);
+  const terrainProgressPercent = useAppStore((state) => state.terrainProgressPercent);
+  const terrainProgressTilesLoaded = useAppStore((state) => state.terrainProgressTilesLoaded);
+  const terrainProgressTilesTotal = useAppStore((state) => state.terrainProgressTilesTotal);
+  const terrainProgressBytesLoaded = useAppStore((state) => state.terrainProgressBytesLoaded);
+  const terrainProgressBytesEstimated = useAppStore((state) => state.terrainProgressBytesEstimated);
   const selectedCoverageMode = useAppStore((state) => state.selectedCoverageMode);
   const propagationModel = useAppStore((state) => state.propagationModel);
   const selectedNetworkId = useAppStore((state) => state.selectedNetworkId);
@@ -1481,8 +1486,15 @@ export function MapView({
   }, [isTerrainFetching, terrainLoadingStartedAtMs]);
   const keepWorkingSuffix =
     elapsedTerrainLoadingMs > 60_000 ? " — loading will continue in the background, even if you leave the app" : "";
+  const formatMb = (bytes: number) => `${(Math.max(0, bytes) / (1024 * 1024)).toFixed(1)} MB`;
+  const terrainProgressLabel =
+    isTerrainFetching && terrainProgressTilesTotal > 0
+      ? `Loading terrain ${terrainProgressPercent}% — ${formatMb(terrainProgressBytesLoaded)} of ~${formatMb(
+          terrainProgressBytesEstimated || terrainProgressBytesLoaded,
+        )} (${terrainProgressTilesLoaded}/${terrainProgressTilesTotal} tiles)`
+      : null;
   const backgroundBusyLabel = (isTerrainFetching
-    ? terrainFetchStatus || "Loading terrain data..."
+    ? terrainProgressLabel || terrainFetchStatus || "Loading terrain data..."
     : isTerrainRecommending
       ? terrainFetchStatus || "Checking terrain dataset coverage..."
       : "") + keepWorkingSuffix;
@@ -1995,6 +2007,8 @@ export function MapView({
               <div className="map-progress-track">
                 {isSimulationRecomputing ? (
                   <div className="map-progress-fill" style={{ width: `${simulationProgress}%` }} />
+                ) : isTerrainFetching && terrainProgressTilesTotal > 0 ? (
+                  <div className="map-progress-fill" style={{ width: `${terrainProgressPercent}%` }} />
                 ) : (
                   <div className="map-progress-fill map-progress-fill-indeterminate" />
                 )}

--- a/src/lib/copernicusTerrainClient.ts
+++ b/src/lib/copernicusTerrainClient.ts
@@ -13,6 +13,14 @@ export type CopernicusLoadResult = {
   fallbackTiles: string[];
 };
 
+export type CopernicusTileProgress = {
+  dataset: CopernicusDataset;
+  tileKey: string;
+  bytes: number;
+  completedTiles: number;
+  totalTiles: number;
+};
+
 type CopernicusRecommendation = {
   dataset: CopernicusDataset;
   completeness: number;
@@ -346,18 +354,27 @@ const getCachedOrFetchTile = async (
   pathPrefix: "30m" | "90m",
   path: string,
   tileKey: string,
-): Promise<{ buffer: ArrayBuffer; fromCache: boolean }> => {
+): Promise<{ buffer: ArrayBuffer; fromCache: boolean; byteLength: number }> => {
   const dataset: CopernicusDataset = pathPrefix === "30m" ? "copernicus30" : "copernicus90";
   const cache = await caches.open(CACHE_NAME);
   const proxiedUrl = `/copernicus/${pathPrefix}/${path}`;
   const localIndex = readTileIndex(dataset);
   if (localIndex.has(tileKey)) {
     const cached = await cache.match(proxiedUrl);
-    if (cached) return { buffer: await cached.arrayBuffer(), fromCache: true };
+    if (cached) {
+      const buffer = await cached.arrayBuffer();
+      return { buffer, fromCache: true, byteLength: buffer.byteLength };
+    }
   }
   const response = await fetchWithRetry(proxiedUrl, TILE_RETRY_POLICY);
+  const contentLength = Number(response.headers.get("content-length") ?? "");
   await cache.put(proxiedUrl, response.clone());
-  return { buffer: await response.arrayBuffer(), fromCache: false };
+  const buffer = await response.arrayBuffer();
+  return {
+    buffer,
+    fromCache: false,
+    byteLength: Number.isFinite(contentLength) && contentLength > 0 ? contentLength : buffer.byteLength,
+  };
 };
 
 const loadTileBatch = async (
@@ -365,6 +382,7 @@ const loadTileBatch = async (
   dataset: CopernicusDataset,
   pathPrefix: "30m" | "90m",
   fallbackDataset?: "copernicus90",
+  onTileProgress?: (progress: CopernicusTileProgress) => void,
 ): Promise<{
   tiles: SrtmTile[];
   failedTiles: string[];
@@ -378,20 +396,36 @@ const loadTileBatch = async (
   const failedTiles = new Set<string>();
   const fallbackTiles: string[] = [];
   const parsedTiles: SrtmTile[] = [];
+  let completedTiles = 0;
+  const totalTiles = keys.length;
+
+  const reportProgress = (tileKey: string, bytes: number, progressDataset: CopernicusDataset) => {
+    completedTiles += 1;
+    onTileProgress?.({
+      dataset: progressDataset,
+      tileKey,
+      bytes,
+      completedTiles,
+      totalTiles,
+    });
+  };
 
   for (const key of keys) {
     const item = tileList[key];
     if (!item) {
       failedTiles.add(key);
+      reportProgress(key, 0, dataset);
       continue;
     }
     try {
-      const { buffer, fromCache } = await getCachedOrFetchTile(pathPrefix, item.path, key);
+      const { buffer, fromCache, byteLength } = await getCachedOrFetchTile(pathPrefix, item.path, key);
       if (fromCache) cacheHits.push(key);
       else fetchedTiles.push(key);
       parsedTiles.push(await parseCopernicusTile(key, dataset, item.path, buffer));
+      reportProgress(key, byteLength, dataset);
     } catch {
       failedTiles.add(key);
+      reportProgress(key, 0, dataset);
     }
   }
 
@@ -401,14 +435,16 @@ const loadTileBatch = async (
       const item = fallbackList[key];
       if (!item) continue;
       try {
-        const { buffer, fromCache } = await getCachedOrFetchTile(DATASET_PATH[fallbackDataset], item.path, key);
+        const { buffer, fromCache, byteLength } = await getCachedOrFetchTile(DATASET_PATH[fallbackDataset], item.path, key);
         if (fromCache) cacheHits.push(key);
         else fetchedTiles.push(key);
         parsedTiles.push(await parseCopernicusTile(key, fallbackDataset, item.path, buffer));
         fallbackTiles.push(key);
         failedTiles.delete(key);
+        reportProgress(key, byteLength, fallbackDataset);
       } catch {
         // keep failed
+        reportProgress(key, 0, fallbackDataset);
       }
     }
   }
@@ -496,7 +532,7 @@ export const loadCopernicusTilesForAreaPhased = async (
   maxLon: number,
   dataset: CopernicusDataset,
   priorityKeys?: Set<string>,
-  options?: { skipRemaining?: boolean },
+  options?: { skipRemaining?: boolean; onTileProgress?: (progress: CopernicusTileProgress) => void },
 ): Promise<CopernicusPhasedLoadResult> => {
   const candidateKeys = tilesForBounds(minLat, maxLat, minLon, maxLon);
   const pathPrefix = DATASET_PATH[dataset];
@@ -509,14 +545,32 @@ export const loadCopernicusTilesForAreaPhased = async (
     const priorityKeysList = candidateKeys.filter((k) => priorityKeys.has(k));
     const remainingKeys = candidateKeys.filter((k) => !priorityKeys.has(k));
 
-    priority = await loadTileBatch(priorityKeysList, dataset, pathPrefix, is30m ? "copernicus90" : undefined);
+    priority = await loadTileBatch(
+      priorityKeysList,
+      dataset,
+      pathPrefix,
+      is30m ? "copernicus90" : undefined,
+      options?.onTileProgress,
+    );
     if (options?.skipRemaining) {
       remaining = { tiles: [], failedTiles: [], fetchedTiles: [], cacheHits: [], fallbackTiles: [] };
     } else {
-      remaining = await loadTileBatch(remainingKeys, dataset, pathPrefix, is30m ? "copernicus90" : undefined);
+      remaining = await loadTileBatch(
+        remainingKeys,
+        dataset,
+        pathPrefix,
+        is30m ? "copernicus90" : undefined,
+        options?.onTileProgress,
+      );
     }
   } else {
-    priority = await loadTileBatch(candidateKeys, dataset, pathPrefix, is30m ? "copernicus90" : undefined);
+    priority = await loadTileBatch(
+      candidateKeys,
+      dataset,
+      pathPrefix,
+      is30m ? "copernicus90" : undefined,
+      options?.onTileProgress,
+    );
     remaining = { tiles: [], failedTiles: [], fetchedTiles: [], cacheHits: [], fallbackTiles: [] };
   }
 

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -30,6 +30,7 @@ import {
   recommendCopernicusDatasetForArea,
   type CopernicusDataset,
   type CopernicusLoadResult,
+  type CopernicusTileProgress,
 } from "../lib/copernicusTerrainClient";
 import {
   normalizeTerrainDataset,
@@ -339,6 +340,11 @@ type AppState = {
   isHighResTerrainLoaded: boolean;
   terrainLoadingStartedAtMs: number;
   terrainLoadEpoch: number;
+  terrainProgressPercent: number;
+  terrainProgressTilesLoaded: number;
+  terrainProgressTilesTotal: number;
+  terrainProgressBytesLoaded: number;
+  terrainProgressBytesEstimated: number;
   siteLibrary: SiteLibraryEntry[];
   simulationPresets: SimulationPreset[];
   siteDragPreview: Record<string, { position: { lat: number; lon: number }; groundElevationM: number }>;
@@ -1128,6 +1134,11 @@ export const useAppStore = create<AppState>((set, get) => ({
   isHighResTerrainLoaded: false,
   terrainLoadingStartedAtMs: 0,
   terrainLoadEpoch: 0,
+  terrainProgressPercent: 0,
+  terrainProgressTilesLoaded: 0,
+  terrainProgressTilesTotal: 0,
+  terrainProgressBytesLoaded: 0,
+  terrainProgressBytesEstimated: 0,
   siteLibrary: initialSiteLibrary,
   simulationPresets: initialSimulationPresets,
   siteDragPreview: {},
@@ -3022,7 +3033,14 @@ export const useAppStore = create<AppState>((set, get) => ({
       }));
     },
   ingestSrtmFiles: async (files) => {
-    set({ isTerrainFetching: true });
+    set({
+      isTerrainFetching: true,
+      terrainProgressPercent: 0,
+      terrainProgressTilesLoaded: 0,
+      terrainProgressTilesTotal: 0,
+      terrainProgressBytesLoaded: 0,
+      terrainProgressBytesEstimated: 0,
+    });
     try {
       const list = Array.from(files);
       const parsed = await Promise.all(
@@ -3041,11 +3059,12 @@ export const useAppStore = create<AppState>((set, get) => ({
       set((state) => ({
         srtmTiles: mergeSrtmTiles(state.srtmTiles, parsed),
         isTerrainFetching: false,
+        terrainProgressPercent: 0,
       }));
       clearTerrainLossCache();
       useCoverageStore.getState().recomputeCoverage();
     } finally {
-      set({ isTerrainFetching: false });
+      set({ isTerrainFetching: false, terrainProgressPercent: 0 });
     }
   },
   recommendTerrainDatasetForCurrentArea: async () => {
@@ -3115,7 +3134,53 @@ export const useAppStore = create<AppState>((set, get) => ({
       isTerrainFetching: true,
       isHighResTerrainLoaded: alreadyHasHighRes,
       terrainLoadingStartedAtMs: Date.now(),
+      terrainProgressPercent: 0,
+      terrainProgressTilesLoaded: 0,
+      terrainProgressTilesTotal: isSmallArea ? requiredTileKeys.size : requiredTileKeys.size,
+      terrainProgressBytesLoaded: 0,
+      terrainProgressBytesEstimated: 0,
     });
+
+    let terrainProgressTilesLoaded = 0;
+    let terrainProgressTilesTotal = isSmallArea ? requiredTileKeys.size : requiredTileKeys.size;
+    let terrainProgressBytesLoaded = 0;
+    let terrainProgressMeasuredTiles = 0;
+    const syncTerrainProgress = () => {
+      const estimatedBytes =
+        terrainProgressMeasuredTiles > 0
+          ? Math.round((terrainProgressBytesLoaded / terrainProgressMeasuredTiles) * Math.max(terrainProgressTilesTotal, 1))
+          : 0;
+      const percent =
+        terrainProgressTilesTotal > 0
+          ? Math.min(100, Math.round((terrainProgressTilesLoaded / terrainProgressTilesTotal) * 100))
+          : 0;
+      set({
+        terrainProgressPercent: percent,
+        terrainProgressTilesLoaded,
+        terrainProgressTilesTotal,
+        terrainProgressBytesLoaded,
+        terrainProgressBytesEstimated: estimatedBytes,
+      });
+    };
+    const extendTerrainProgressTotal = (byTiles: number) => {
+      if (byTiles <= 0) return;
+      terrainProgressTilesTotal += byTiles;
+      syncTerrainProgress();
+    };
+    const makeTileProgressHandler = () => {
+      const seen = new Set<string>();
+      return (progress: CopernicusTileProgress) => {
+        const key = progress.tileKey;
+        if (seen.has(key)) return;
+        seen.add(key);
+        terrainProgressTilesLoaded += 1;
+        if (progress.bytes > 0) {
+          terrainProgressBytesLoaded += progress.bytes;
+          terrainProgressMeasuredTiles += 1;
+        }
+        syncTerrainProgress();
+      };
+    };
 
     const loadPhased = async (
       dataset: CopernicusDataset,
@@ -3130,7 +3195,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         bounds.maxLon,
         dataset,
         priorityKeys,
-        { skipRemaining },
+        { skipRemaining, onTileProgress: makeTileProgressHandler() },
       );
 
     const applyTiles = (result: CopernicusLoadResult) => {
@@ -3164,7 +3229,15 @@ export const useAppStore = create<AppState>((set, get) => ({
 
     try {
       if (alreadyHasHighRes) {
-        set({ terrainFetchStatus: formatStatus({ tiles: [], fetchedTiles: [], cacheHits: [], fallbackTiles: [], failedTiles: [] }, TERRAIN_DATASET_FETCH_LABEL.copernicus30), isTerrainFetching: false, terrainLoadingStartedAtMs: 0 });
+        set({
+          terrainFetchStatus: formatStatus(
+            { tiles: [], fetchedTiles: [], cacheHits: [], fallbackTiles: [], failedTiles: [] },
+            TERRAIN_DATASET_FETCH_LABEL.copernicus30,
+          ),
+          isTerrainFetching: false,
+          terrainLoadingStartedAtMs: 0,
+          terrainProgressPercent: 100,
+        });
         return;
       }
 
@@ -3180,6 +3253,7 @@ export const useAppStore = create<AppState>((set, get) => ({
           isHighResTerrainLoaded: true,
           terrainLoadingStartedAtMs: 0,
           terrainLoadEpoch: 0,
+          terrainProgressPercent: 100,
         });
         return;
       }
@@ -3194,10 +3268,17 @@ export const useAppStore = create<AppState>((set, get) => ({
       const currentTileKeys = new Set(currentState.srtmTiles.filter((t) => t.sourceId === "copernicus30").map((t) => t.key));
       const hasHighResNow = [...requiredTileKeys].every((k) => currentTileKeys.has(k));
       if (hasHighResNow) {
-        set({ terrainFetchStatus: formatStatus(ninetyResult, TERRAIN_DATASET_FETCH_LABEL.copernicus90), isTerrainFetching: false, isHighResTerrainLoaded: true, terrainLoadingStartedAtMs: 0 });
+        set({
+          terrainFetchStatus: formatStatus(ninetyResult, TERRAIN_DATASET_FETCH_LABEL.copernicus90),
+          isTerrainFetching: false,
+          isHighResTerrainLoaded: true,
+          terrainLoadingStartedAtMs: 0,
+          terrainProgressPercent: 100,
+        });
         return;
       }
 
+      extendTerrainProgressTotal(requiredTileKeys.size);
       set({ terrainFetchStatus: "Loading terrain (30m, high-res refinement)...", isHighResTerrainLoaded: false });
       const thirtyPhased = await loadPhased("copernicus30", coreBounds, endpointKeys);
       applyTiles(thirtyPhased.priority);
@@ -3205,6 +3286,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       const thirtyResult = mergeLoadResults(thirtyPhased.priority, thirtyPhased.remaining);
 
       if (extendedOnlyKeys.size > 0) {
+        extendTerrainProgressTotal(extendedOnlyKeys.size);
         set({ terrainFetchStatus: "Loading terrain (30m, extended radial area)..." });
         const extendedPhased = await loadPhased("copernicus30", extendedBounds, extendedOnlyKeys, true);
         applyTiles(extendedPhased.priority);
@@ -3215,6 +3297,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         isHighResTerrainLoaded: true,
         terrainLoadingStartedAtMs: 0,
         terrainLoadEpoch: 0,
+        terrainProgressPercent: 100,
       });
     } catch (error) {
       const message = getUiErrorMessage(error);
@@ -3241,6 +3324,11 @@ export const useAppStore = create<AppState>((set, get) => ({
       terrainRecommendation: "Evaluating terrain dataset coverage...",
       terrainFetchStatus: "Loading terrain (90m)...",
       terrainLoadingStartedAtMs: Date.now(),
+      terrainProgressPercent: 0,
+      terrainProgressTilesLoaded: 0,
+      terrainProgressTilesTotal: 0,
+      terrainProgressBytesLoaded: 0,
+      terrainProgressBytesEstimated: 0,
     });
 
     try {
@@ -3267,6 +3355,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         isTerrainRecommending: false,
         isTerrainFetching: false,
         terrainLoadingStartedAtMs: 0,
+        terrainProgressPercent: 0,
       });
       return;
     }
@@ -3305,6 +3394,48 @@ export const useAppStore = create<AppState>((set, get) => ({
       isHighResTerrainLoaded: alreadyHasHighRes,
     });
 
+    let terrainProgressTilesLoaded = 0;
+    let terrainProgressTilesTotal = isSmallArea ? requiredTileKeys.size : requiredTileKeys.size;
+    let terrainProgressBytesLoaded = 0;
+    let terrainProgressMeasuredTiles = 0;
+    const syncTerrainProgress = () => {
+      const estimatedBytes =
+        terrainProgressMeasuredTiles > 0
+          ? Math.round((terrainProgressBytesLoaded / terrainProgressMeasuredTiles) * Math.max(terrainProgressTilesTotal, 1))
+          : 0;
+      const percent =
+        terrainProgressTilesTotal > 0
+          ? Math.min(100, Math.round((terrainProgressTilesLoaded / terrainProgressTilesTotal) * 100))
+          : 0;
+      set({
+        terrainProgressPercent: percent,
+        terrainProgressTilesLoaded,
+        terrainProgressTilesTotal,
+        terrainProgressBytesLoaded,
+        terrainProgressBytesEstimated: estimatedBytes,
+      });
+    };
+    syncTerrainProgress();
+    const extendTerrainProgressTotal = (byTiles: number) => {
+      if (byTiles <= 0) return;
+      terrainProgressTilesTotal += byTiles;
+      syncTerrainProgress();
+    };
+    const makeTileProgressHandler = () => {
+      const seen = new Set<string>();
+      return (progress: CopernicusTileProgress) => {
+        const key = progress.tileKey;
+        if (seen.has(key)) return;
+        seen.add(key);
+        terrainProgressTilesLoaded += 1;
+        if (progress.bytes > 0) {
+          terrainProgressBytesLoaded += progress.bytes;
+          terrainProgressMeasuredTiles += 1;
+        }
+        syncTerrainProgress();
+      };
+    };
+
     const loadPhased = async (
       dataset: CopernicusDataset,
       bounds: TerrainFetchBounds,
@@ -3318,7 +3449,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         bounds.maxLon,
         dataset,
         priorityKeys,
-        { skipRemaining },
+        { skipRemaining, onTileProgress: makeTileProgressHandler() },
       );
 
     const applyTiles = (result: CopernicusLoadResult) => {
@@ -3352,7 +3483,15 @@ export const useAppStore = create<AppState>((set, get) => ({
     try {
       if (alreadyHasHighRes) {
         if (get().terrainLoadEpoch !== epoch) return;
-        set({ terrainFetchStatus: formatStatus({ tiles: [], fetchedTiles: [], cacheHits: [], fallbackTiles: [], failedTiles: [] }, TERRAIN_DATASET_FETCH_LABEL.copernicus30), isTerrainFetching: false, terrainLoadingStartedAtMs: 0 });
+        set({
+          terrainFetchStatus: formatStatus(
+            { tiles: [], fetchedTiles: [], cacheHits: [], fallbackTiles: [], failedTiles: [] },
+            TERRAIN_DATASET_FETCH_LABEL.copernicus30,
+          ),
+          isTerrainFetching: false,
+          terrainLoadingStartedAtMs: 0,
+          terrainProgressPercent: 100,
+        });
         return;
       }
 
@@ -3368,6 +3507,7 @@ export const useAppStore = create<AppState>((set, get) => ({
           isTerrainFetching: false,
           isHighResTerrainLoaded: true,
           terrainLoadingStartedAtMs: 0,
+          terrainProgressPercent: 100,
         });
         return;
       }
@@ -3382,10 +3522,17 @@ export const useAppStore = create<AppState>((set, get) => ({
       const currentTileKeys = new Set(currentState.srtmTiles.filter((t) => t.sourceId === "copernicus30").map((t) => t.key));
       const hasHighResNow = [...requiredTileKeys].every((k) => currentTileKeys.has(k));
       if (hasHighResNow) {
-        set({ terrainFetchStatus: formatStatus(ninetyResult, TERRAIN_DATASET_FETCH_LABEL.copernicus90), isTerrainFetching: false, isHighResTerrainLoaded: true, terrainLoadingStartedAtMs: 0 });
+        set({
+          terrainFetchStatus: formatStatus(ninetyResult, TERRAIN_DATASET_FETCH_LABEL.copernicus90),
+          isTerrainFetching: false,
+          isHighResTerrainLoaded: true,
+          terrainLoadingStartedAtMs: 0,
+          terrainProgressPercent: 100,
+        });
         return;
       }
 
+      extendTerrainProgressTotal(requiredTileKeys.size);
       set({ terrainFetchStatus: "Loading terrain (30m, high-res refinement)...", isHighResTerrainLoaded: false });
       const thirtyPhased = await loadPhased("copernicus30", coreBounds, endpointKeys);
       if (get().terrainLoadEpoch !== epoch) return;
@@ -3394,6 +3541,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       const thirtyResult = mergeLoadResults(thirtyPhased.priority, thirtyPhased.remaining);
 
       if (extendedOnlyKeys.size > 0) {
+        extendTerrainProgressTotal(extendedOnlyKeys.size);
         set({ terrainFetchStatus: "Loading terrain (30m, extended radial area)..." });
         const extendedPhased = await loadPhased("copernicus30", extendedBounds, extendedOnlyKeys, true);
         if (get().terrainLoadEpoch !== epoch) return;
@@ -3404,14 +3552,19 @@ export const useAppStore = create<AppState>((set, get) => ({
         isTerrainFetching: false,
         isHighResTerrainLoaded: true,
         terrainLoadingStartedAtMs: 0,
+        terrainProgressPercent: 100,
       });
     } catch (error) {
       if (get().terrainLoadEpoch !== epoch) return;
-      set({ terrainFetchStatus: `Terrain fetch failed: ${getUiErrorMessage(error)}`, isTerrainFetching: false, terrainLoadingStartedAtMs: 0 });
+      set({
+        terrainFetchStatus: `Terrain fetch failed: ${getUiErrorMessage(error)}`,
+        isTerrainFetching: false,
+        terrainLoadingStartedAtMs: 0,
+      });
     }
   },
   clearTerrainCache: async () => {
-    set({ isTerrainFetching: true });
+    set({ isTerrainFetching: true, terrainProgressPercent: 0 });
     await clearCopernicusCache();
     clearTerrainLossCache();
     set((state) => ({
@@ -3420,6 +3573,11 @@ export const useAppStore = create<AppState>((set, get) => ({
       isHighResTerrainLoaded: false,
       terrainLoadingStartedAtMs: 0,
       terrainLoadEpoch: 0,
+      terrainProgressPercent: 0,
+      terrainProgressTilesLoaded: 0,
+      terrainProgressTilesTotal: 0,
+      terrainProgressBytesLoaded: 0,
+      terrainProgressBytesEstimated: 0,
       terrainFetchStatus: "Terrain source caches cleared.",
     }));
     useCoverageStore.getState().recomputeCoverage();


### PR DESCRIPTION
## Summary
- add determinate terrain loading progress in the map inspector with percent, tile count, and byte estimate labels
- plumb per-tile progress metadata from Copernicus tile loading (including `content-length` when available) into app store progress state
- keep existing terrain fetch sequence intact while improving user-facing loading expectations

## Verification
- npm run test -- --run src/lib/deepLink.test.ts
- npm run test -- --run functions/api/v1/calculate.test.ts
- npm run test -- --run src/store/appStore.test.ts
- npm test
- npm run build