### PR TITLE
fix: show indeterminate terrain prep state before progress starts (#24)

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1486,15 +1486,23 @@ export function MapView({
   }, [isTerrainFetching, terrainLoadingStartedAtMs]);
   const keepWorkingSuffix =
     elapsedTerrainLoadingMs > 60_000 ? " — loading will continue in the background, even if you leave the app" : "";
+  const hasTerrainDownloadProgress =
+    terrainProgressTilesLoaded > 0 || terrainProgressBytesLoaded > 0 || terrainProgressBytesEstimated > 0;
   const formatMb = (bytes: number) => `${(Math.max(0, bytes) / (1024 * 1024)).toFixed(1)} MB`;
   const terrainProgressLabel =
-    isTerrainFetching && terrainProgressTilesTotal > 0
+    isTerrainFetching && hasTerrainDownloadProgress && terrainProgressTilesTotal > 0
       ? `Loading terrain ${terrainProgressPercent}% — ${formatMb(terrainProgressBytesLoaded)} of ~${formatMb(
           terrainProgressBytesEstimated || terrainProgressBytesLoaded,
         )} (${terrainProgressTilesLoaded}/${terrainProgressTilesTotal} tiles)`
       : null;
+  const terrainPreparingLabel =
+    isTerrainFetching && !hasTerrainDownloadProgress
+      ? terrainProgressTilesTotal > 0
+        ? `Preparing terrain download... (${terrainProgressTilesLoaded}/${terrainProgressTilesTotal} tiles queued)`
+        : "Preparing terrain download..."
+      : null;
   const backgroundBusyLabel = (isTerrainFetching
-    ? terrainProgressLabel || terrainFetchStatus || "Loading terrain data..."
+    ? terrainProgressLabel || terrainPreparingLabel || terrainFetchStatus || "Loading terrain data..."
     : isTerrainRecommending
       ? terrainFetchStatus || "Checking terrain dataset coverage..."
       : "") + keepWorkingSuffix;
@@ -2007,7 +2015,7 @@ export function MapView({
               <div className="map-progress-track">
                 {isSimulationRecomputing ? (
                   <div className="map-progress-fill" style={{ width: `${simulationProgress}%` }} />
-                ) : isTerrainFetching && terrainProgressTilesTotal > 0 ? (
+                ) : isTerrainFetching && hasTerrainDownloadProgress && terrainProgressTilesTotal > 0 ? (
                   <div className="map-progress-fill" style={{ width: `${terrainProgressPercent}%` }} />
                 ) : (
                   <div className="map-progress-fill map-progress-fill-indeterminate" />


### PR DESCRIPTION
## Summary
- keep the new determinate terrain progress bar for active download phase, but restore the old bouncing indicator during initial terrain preparation
- show phase-aware copy while waiting for the first tile progress event (`Preparing terrain download...`) instead of a misleading 0 MB determinate label
- preserve existing percent/MB/tile progress display once tile transfer progress begins

## Verification
- npm run test -- --run src/lib/deepLink.test.ts
- npm run test -- --run functions/api/v1/calculate.test.ts
- npm run test -- --run src/store/appStore.test.ts
- npm test
- npm run build