### PR TITLE
fix: polish unified notice style and spacing under map controls (#24)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1179,7 +1179,7 @@ export function AppShell() {
             </div>
           </div>
         ) : null}
-        {workspaceState === "blank-simulation" ? (
+        {workspaceState === "blank-simulation" && !appNotice ? (
           <div className="workspace-header-actions">
             <span className="field-help">This Simulation is blank. Add sites from the map or Site Library to continue.</span>
           </div>

--- a/src/index.css
+++ b/src/index.css
@@ -807,30 +807,27 @@ input {
   right: calc(var(--sidebar-overlay-width) + 30px);
 }
 
-.app-shell:not(.is-map-expanded):not(.is-profile-expanded) .map-inline-notice {
-  left: calc(var(--sidebar-overlay-width) + 30px);
-  right: calc(var(--sidebar-overlay-width) + 30px);
-}
-
 .map-controls-unified {
   z-index: 60;
 }
 
 .map-inline-notice {
   position: absolute;
-  top: 72px;
-  left: 18px;
-  right: 18px;
+  top: calc(18px + 36px + var(--workspace-panel-gap));
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(92vw, 760px);
   z-index: 55;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: space-between;
   gap: 10px;
-  padding: 8px 10px;
-  border-radius: 12px;
-  border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
-  background: color-mix(in srgb, var(--surface-2) 94%, transparent);
-  box-shadow: var(--shadow-elev-2);
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
+  background: color-mix(in srgb, var(--surface-2) 90%, transparent);
+  font-size: 0.84rem;
+  box-shadow: var(--shadow-elev-3);
 }
 
 .map-inline-notice-warning {
@@ -843,6 +840,7 @@ input {
 
 .map-inline-notice .inline-action {
   white-space: nowrap;
+  padding: 4px 10px;
 }
 
 .map-controls-icon-only {
@@ -2042,9 +2040,8 @@ input {
   }
 
   .map-inline-notice {
-    top: calc(var(--mobile-controls-top) + 46px);
-    left: 12px;
-    right: 12px;
+    top: calc(var(--mobile-controls-top) + 42px + var(--workspace-panel-gap));
+    width: calc(100% - 24px);
   }
 
   .map-provider-field .locale-select {


### PR DESCRIPTION
## Summary
- restyle the unified map notice to match prior field-help chip visuals while keeping the improved placement below map controls
- increase spacing from map controls using panel-gap rhythm so notice spacing is consistent with other panel spacing
- suppress duplicate blank-simulation banner when an app notice is active to avoid mixed/competing messages

## Verification
- npm run test -- --run src/lib/deepLink.test.ts
- npm run test -- --run functions/api/v1/calculate.test.ts
- npm run test -- --run src/store/appStore.test.ts
- npm test
- npm run build