### PR TITLE
fix: restore signed-in deep-link auth and unify share notices (#24)

### DIFF
--- a/functions/api/deep-link-status.test.ts
+++ b/functions/api/deep-link-status.test.ts
@@ -46,20 +46,20 @@ describe("api/deep-link-status", () => {
   it("returns missing when simulation id is missing", async () => {
     const res = await onRequestGet(mkCtx(new Request("https://example.test/api/deep-link-status")));
     expect(res.status).toBe(200);
-    await expect(res.json()).resolves.toEqual({ status: "missing" });
+    await expect(res.json()).resolves.toEqual({ status: "missing", authenticated: true });
   });
 
   it("returns access status for simulation id", async () => {
     resolveSimulationAccessForUserMock.mockResolvedValueOnce("forbidden");
     const res = await onRequestGet(mkCtx(new Request("https://example.test/api/deep-link-status?sim=sim-2")));
     expect(res.status).toBe(200);
-    await expect(res.json()).resolves.toEqual({ status: "forbidden", simulationId: "sim-2" });
+    await expect(res.json()).resolves.toEqual({ status: "forbidden", simulationId: "sim-2", authenticated: true });
   });
 
   it("resolves slug to simulation id", async () => {
     resolveSimulationIdBySlugMock.mockResolvedValueOnce("sim-abc");
     const res = await onRequestGet(mkCtx(new Request("https://example.test/api/deep-link-status?slug=my-sim")));
     expect(res.status).toBe(200);
-    await expect(res.json()).resolves.toEqual({ status: "ok", simulationId: "sim-abc" });
+    await expect(res.json()).resolves.toEqual({ status: "ok", simulationId: "sim-abc", authenticated: true });
   });
 });

--- a/functions/api/deep-link-status.ts
+++ b/functions/api/deep-link-status.ts
@@ -9,10 +9,12 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
   try {
     const auth = await verifyAuth(request, env);
     let actor = { id: "", isAdmin: false, isModerator: false };
+    let authenticated = false;
     if (auth) {
       await ensureUser(env, auth.userId, auth.tokenPayload);
       const me = await fetchUserProfile(env, auth.userId);
       if (me?.accountState !== "revoked") {
+        authenticated = true;
         actor = {
           id: me?.id ?? "",
           isAdmin: Boolean(me?.isAdmin),
@@ -28,7 +30,7 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
       simulationId = (await resolveSimulationIdBySlug(env, simulationSlug)) ?? "";
     }
     if (!simulationId) {
-      return withCors(request, json({ status: "missing" }));
+      return withCors(request, json({ status: "missing", authenticated }));
     }
 
     const status = await resolveSimulationAccessForUser(
@@ -41,7 +43,7 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
       simulationId,
     );
 
-    return withCors(request, json({ status, simulationId }));
+    return withCors(request, json({ status, simulationId, authenticated }));
   } catch (error) {
     return errorResponse(request, error, 500);
   }

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -106,8 +106,6 @@ export function AppShell() {
   const [libraryAutoOpened, setLibraryAutoOpened] = useState(false);
   const [showShareModal, setShowShareModal] = useState(false);
   const [shareBusy, setShareBusy] = useState(false);
-  const [shareStatus, setShareStatus] = useState<string | null>(null);
-  const [copyToast, setCopyToast] = useState<string | null>(null);
   const [appNotice, setAppNotice] = useState<AppNotice | null>(null);
   const [showMobileWarning, setShowMobileWarning] = useState(false);
   const [isMobileViewport, setIsMobileViewport] = useState(false);
@@ -147,6 +145,12 @@ export function AppShell() {
       return notice;
     });
   }, []);
+  const publishTransientNotice = useCallback(
+    (id: string, message: string, tone: AppNotice["tone"] = "info") => {
+      publishAppNotice({ id, message, tone, persistent: false });
+    },
+    [publishAppNotice],
+  );
   const canPersistWorkspace =
     accessState === "granted" && (!activeSimulation || canEditResource(activeSimulation));
   const workspaceState = emptyWorkspaceState(sites.length, Boolean(activeSimulation));
@@ -332,11 +336,17 @@ export function AppShell() {
           return;
         }
         if (deepLinkParse.ok && !isLocalRuntime) {
-          if (cancelled || timedOut) return;
-          window.clearTimeout(timeoutId);
-          setAccessDiagnosticMessage(null);
-          setAccessState("readonly");
-          return;
+          const deepLinkStatus = await fetchDeepLinkStatus({
+            simulationId: deepLinkParse.payload.simulationId,
+            simulationSlug: deepLinkParse.payload.simulationSlug,
+          });
+          if (!deepLinkStatus.authenticated) {
+            if (cancelled || timedOut) return;
+            window.clearTimeout(timeoutId);
+            setAccessDiagnosticMessage(null);
+            setAccessState("readonly");
+            return;
+          }
         }
         const profile = await fetchMe();
         if (cancelled || timedOut) return;
@@ -400,7 +410,7 @@ export function AppShell() {
       cancelled = true;
       window.clearTimeout(timeoutId);
     };
-  }, [deepLinkParse.ok, isLocalRuntime, isInitializing, setCurrentUser]);
+  }, [deepLinkParse, isLocalRuntime, isInitializing, setCurrentUser]);
 
   useEffect(() => {
     if (accessState === "granted") {
@@ -956,43 +966,58 @@ export function AppShell() {
 
   const copyCurrentLink = useCallback(async () => {
     if (!activeSimulation) {
-      setShareStatus("Open a saved simulation first. Unsaved workspace state cannot be shared as a deep link.");
+      publishAppNotice({
+        id: "share-open-simulation-first",
+        message: "Open a saved simulation first. Unsaved workspace state cannot be shared as a deep link.",
+        tone: "warning",
+        persistent: true,
+      });
       return;
     }
     if (!currentShareLink) {
-      setShareStatus("Unable to build share link for this simulation.");
+      publishAppNotice({
+        id: "share-link-build-failed",
+        message: "Unable to build share link for this simulation.",
+        tone: "error",
+        persistent: true,
+      });
       return;
     }
     await copyToClipboard(currentShareLink);
-    setShareStatus("Share link copied.");
-    setCopyToast("Copied to clipboard");
-  }, [activeSimulation, currentShareLink]);
-
-  useEffect(() => {
-    if (!copyToast) return;
-    const timer = window.setTimeout(() => setCopyToast(null), 1200);
-    return () => window.clearTimeout(timer);
-  }, [copyToast]);
+    publishTransientNotice("share-link-copied", "Share link copied.");
+  }, [activeSimulation, currentShareLink, publishAppNotice, publishTransientNotice]);
 
   const runUpgradeAndShare = useCallback(async () => {
     if (!activeSimulation || !currentUser) {
-      setShareStatus("No active saved simulation.");
+      publishAppNotice({
+        id: "share-no-active-simulation",
+        message: "No active saved simulation.",
+        tone: "warning",
+        persistent: true,
+      });
       return;
     }
     if (!canEditResource(activeSimulation)) {
-      setShareStatus("You do not have edit access to this simulation.");
+      publishAppNotice({
+        id: "share-no-edit-access-simulation",
+        message: "You do not have edit access to this simulation.",
+        tone: "warning",
+        persistent: true,
+      });
       return;
     }
     const blockedSites = referencedPrivateSites.filter((site) => !canEditResource(site));
     if (blockedSites.length) {
-      setShareStatus(
-        `Cannot upgrade ${blockedSites.length} private site(s) because you do not have edit access to them.`,
-      );
+      publishAppNotice({
+        id: "share-no-edit-access-sites",
+        message: `Cannot upgrade ${blockedSites.length} private site(s) because you do not have edit access to them.`,
+        tone: "warning",
+        persistent: true,
+      });
       return;
     }
 
     setShareBusy(true);
-    setShareStatus("Upgrading visibility and syncing to cloud...");
     try {
       for (const site of referencedPrivateSites) {
         updateSiteLibraryEntry(site.id, { visibility: "shared" });
@@ -1012,13 +1037,27 @@ export function AppShell() {
       });
 
       await copyCurrentLink();
-      setShareStatus("Simulation and referenced sites are now Shared. Link copied.");
+      publishTransientNotice("share-upgrade-complete", "Simulation and referenced sites are now Shared. Link copied.");
     } catch (error) {
-      setShareStatus(`Upgrade failed: ${getUiErrorMessage(error)}`);
+      publishAppNotice({
+        id: "share-upgrade-failed",
+        message: `Upgrade failed: ${getUiErrorMessage(error)}`,
+        tone: "error",
+        persistent: true,
+      });
     } finally {
       setShareBusy(false);
     }
-  }, [activeSimulation, copyCurrentLink, currentUser, referencedPrivateSites, updateSimulationPresetEntry, updateSiteLibraryEntry]);
+  }, [
+    activeSimulation,
+    copyCurrentLink,
+    currentUser,
+    publishAppNotice,
+    publishTransientNotice,
+    referencedPrivateSites,
+    updateSimulationPresetEntry,
+    updateSiteLibraryEntry,
+  ]);
 
   const shellStyle = useMemo<CSSProperties | undefined>(() => {
     if (!isMobileViewport) return undefined;
@@ -1201,7 +1240,6 @@ export function AppShell() {
               Return to Local User
             </button>
           ) : null}
-          {shareStatus ? <span className="field-help">{shareStatus}</span> : null}
         </div>
         <MapView
           isMapExpanded={isMapExpanded}
@@ -1211,11 +1249,14 @@ export function AppShell() {
           onShare={
             accessState === "granted"
               ? () => {
-                  setShareStatus(null);
+                  setAppNotice(null);
                   if (!activeSimulation) {
-                    setShareStatus(
-                      "Open a saved simulation first. Unsaved workspace state cannot be shared as a deep link.",
-                    );
+                    publishAppNotice({
+                      id: "share-open-simulation-first",
+                      message: "Open a saved simulation first. Unsaved workspace state cannot be shared as a deep link.",
+                      tone: "warning",
+                      persistent: true,
+                    });
                     return;
                   }
                   if (toVisibility(activeSimulation.visibility) === "private") {
@@ -1223,8 +1264,14 @@ export function AppShell() {
                     return;
                   }
                   void copyCurrentLink()
-                    .then(() => setShareStatus("Copied to clipboard."))
-                    .catch((error) => setShareStatus(getUiErrorMessage(error)));
+                    .catch((error) => {
+                      publishAppNotice({
+                        id: "share-copy-failed",
+                        message: getUiErrorMessage(error),
+                        tone: "error",
+                        persistent: true,
+                      });
+                    });
                 }
               : undefined
           }
@@ -1386,7 +1433,6 @@ export function AppShell() {
           </div>
         </ModalOverlay>
       ) : null}
-      {copyToast ? <div className="copy-toast">{copyToast}</div> : null}
       {showShareModal ? (
         <ModalOverlay aria-label="Share simulation" onClose={() => setShowShareModal(false)}>
           <div className="library-manager-card">
@@ -1429,7 +1475,6 @@ export function AppShell() {
                 ) : null}
               </>
             )}
-            {shareStatus ? <p className="field-help">{shareStatus}</p> : null}
           </div>
         </ModalOverlay>
       ) : null}

--- a/src/index.css
+++ b/src/index.css
@@ -643,21 +643,6 @@ input {
   text-overflow: ellipsis;
 }
 
-.copy-toast {
-  position: fixed;
-  left: 50%;
-  top: 52%;
-  transform: translate(-50%, -50%);
-  z-index: 12000;
-  padding: 10px 16px;
-  border-radius: 10px;
-  border: 1px solid var(--accent);
-  background: color-mix(in srgb, var(--surface-2) 92%, transparent);
-  box-shadow: var(--shadow-elev-2);
-  color: var(--text);
-  font-weight: 700;
-}
-
 .workspace-panel.is-map-expanded {
   grid-template-rows: minmax(0, 1fr);
   padding-right: 0;
@@ -816,7 +801,8 @@ input {
   top: calc(18px + 36px + var(--workspace-panel-gap));
   left: 50%;
   transform: translateX(-50%);
-  width: min(92vw, 760px);
+  width: max-content;
+  max-width: min(calc(100% - 36px), calc(100% - (var(--sidebar-overlay-width) * 2) - 60px));
   z-index: 55;
   display: inline-flex;
   align-items: center;
@@ -828,6 +814,11 @@ input {
   background: color-mix(in srgb, var(--surface-2) 90%, transparent);
   font-size: 0.84rem;
   box-shadow: var(--shadow-elev-3);
+}
+
+.workspace-panel.is-map-expanded .map-inline-notice,
+.workspace-panel.is-profile-expanded .map-inline-notice {
+  max-width: calc(100% - 36px);
 }
 
 .map-inline-notice-warning {
@@ -2041,7 +2032,7 @@ input {
 
   .map-inline-notice {
     top: calc(var(--mobile-controls-top) + 42px + var(--workspace-panel-gap));
-    width: calc(100% - 24px);
+    max-width: calc(100% - 24px);
   }
 
   .map-provider-field .locale-select {

--- a/src/lib/cloudUser.ts
+++ b/src/lib/cloudUser.ts
@@ -121,7 +121,7 @@ export type CollaboratorDirectoryUser = {
 };
 
 export type DeepLinkStatus = "ok" | "forbidden" | "missing";
-export type DeepLinkStatusResult = { status: DeepLinkStatus; simulationId?: string };
+export type DeepLinkStatusResult = { status: DeepLinkStatus; simulationId?: string; authenticated?: boolean };
 
 const apiCall = async <T>(path: string, init?: RequestInit): Promise<T> => {
   const headers = new Headers(init?.headers ?? {});
@@ -353,7 +353,7 @@ export const fetchDeepLinkStatus = async (input: {
   const params = new URLSearchParams();
   if (input.simulationId?.trim()) params.set("sim", input.simulationId.trim());
   if (input.simulationSlug?.trim()) params.set("slug", input.simulationSlug.trim());
-  const data = await apiCall<{ status?: unknown; simulationId?: unknown }>(
+  const data = await apiCall<{ status?: unknown; simulationId?: unknown; authenticated?: unknown }>(
     `/api/deep-link-status?${params.toString()}`,
     { method: "GET" },
   );
@@ -363,6 +363,7 @@ export const fetchDeepLinkStatus = async (input: {
   return {
     status: normalized,
     simulationId: typeof data.simulationId === "string" && data.simulationId.trim() ? data.simulationId : undefined,
+    authenticated: data.authenticated === true,
   };
 };
 


### PR DESCRIPTION
## Summary
- fix deep-link startup auth gating so signed-in users are no longer forced into guest readonly mode on deep-link entry
- expose authenticated hint on deep-link status endpoint and consume it client-side to decide guest fallback without reintroducing anonymous `/api/me` access noise
- move share/copy feedback (`shareStatus` + legacy centered copy toast) into the unified map notice surface and keep notice width content-sized with map-area max width constraints

## Verification
- npm run test -- --run functions/api/deep-link-status.test.ts
- npm run test -- --run src/lib/deepLink.test.ts
- npm run test -- --run functions/api/v1/calculate.test.ts
- npm run test -- --run src/store/appStore.test.ts
- npm test
- npm run build