### PR TITLE
fix: tighten readonly controls and deep-link notice behavior (#24)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -115,6 +115,7 @@ export function AppShell() {
   const [offlineBannerDismissed, setOfflineBannerDismissed] = useState(false);
   const [showLibraryFromRequest, setShowLibraryFromRequest] = useState(false);
   const deepLinkAppliedRef = useRef(false);
+  const deepLinkLoadFailedRef = useRef(false);
   const cloudInitSeenRef = useRef(false);
   const cloudInitSettledRef = useRef(false);
   const appShellRef = useRef<HTMLElement | null>(null);
@@ -215,6 +216,7 @@ export function AppShell() {
 
   useEffect(() => {
     if (!deepLinkAppliedRef.current) return;
+    if (deepLinkParse.ok && deepLinkLoadFailedRef.current) return;
 
     const reserved = ["api", "cdn-cgi", "assets", "meshmap"];
     const head = (window.location.pathname ?? "/").split("/").filter(Boolean)[0]?.toLowerCase() ?? "";
@@ -240,7 +242,7 @@ export function AppShell() {
     if (currentPath !== targetPath) {
       window.history.replaceState(null, "", targetPath);
     }
-  }, [currentShareLink, activeSimulation, selectedSiteIds, sites]);
+  }, [currentShareLink, activeSimulation, selectedSiteIds, sites, deepLinkParse.ok]);
 
   useEffect(() => {
     const root = document.documentElement;
@@ -563,6 +565,7 @@ export function AppShell() {
       return;
     }
     if (!deepLinkParse.ok) {
+      deepLinkLoadFailedRef.current = deepLinkParse.reason !== "missing_sim";
       if (deepLinkParse.reason !== "missing_sim") {
         publishAppNotice({
           id: "invalid-deep-link",
@@ -581,6 +584,7 @@ export function AppShell() {
     }
 
     void (async () => {
+      deepLinkLoadFailedRef.current = false;
       const payload = deepLinkParse.payload;
       const safeDecode = (value: string): string => {
         try {
@@ -661,6 +665,7 @@ export function AppShell() {
           resolvedSimulationId = publicBundle.simulationId ?? resolvedSimulationId;
           exists = Boolean(resolvedSimulationId);
         } catch {
+          deepLinkLoadFailedRef.current = true;
           publishAppNotice({
             id: "shared-simulation-unavailable",
             message: "This shared simulation is unavailable.",
@@ -705,6 +710,7 @@ export function AppShell() {
               }
             }
             if (!exists) {
+              deepLinkLoadFailedRef.current = true;
               deepLinkAppliedRef.current = true;
               return;
             }
@@ -726,6 +732,7 @@ export function AppShell() {
                 resolvedSimulationId = publicBundle.simulationId ?? resolvedSimulationId;
                 exists = Boolean(resolvedSimulationId);
               } catch {
+                deepLinkLoadFailedRef.current = true;
                 publishAppNotice({
                   id: "shared-simulation-missing",
                   message: "This shared simulation no longer exists.",
@@ -736,6 +743,7 @@ export function AppShell() {
                 return;
               }
             } else {
+              deepLinkLoadFailedRef.current = true;
               publishAppNotice({
                 id: "shared-simulation-missing",
                 message: "This shared simulation no longer exists.",
@@ -761,6 +769,7 @@ export function AppShell() {
             simulationSlug: payload.simulationSlug,
           });
           if (status.status === "forbidden") {
+            deepLinkLoadFailedRef.current = true;
             publishAppNotice({
               id: "shared-simulation-forbidden",
               message: "You do not have access to this shared simulation.",
@@ -771,6 +780,7 @@ export function AppShell() {
             return;
           }
           if (status.status === "missing") {
+            deepLinkLoadFailedRef.current = true;
             publishAppNotice({
               id: "shared-simulation-missing",
               message: "This shared simulation no longer exists.",
@@ -793,10 +803,12 @@ export function AppShell() {
           persistent: true,
         });
         deepLinkAppliedRef.current = true;
+        deepLinkLoadFailedRef.current = true;
         return;
       }
 
       if (!resolvedSimulationId) {
+        deepLinkLoadFailedRef.current = true;
         publishAppNotice({
           id: "shared-simulation-unavailable",
           message: "This shared simulation is unavailable.",
@@ -807,6 +819,7 @@ export function AppShell() {
         return;
       }
       loadSimulationPreset(resolvedSimulationId);
+      deepLinkLoadFailedRef.current = false;
       const latest = useAppStore.getState();
       const decodedLinkSlugs = payload.selectedLinkSlugs?.map(safeDecode);
       const decodedSiteSlugs = payload.selectedSiteSlugs?.map(safeDecode);
@@ -1180,7 +1193,7 @@ export function AppShell() {
       style={shellStyle}
     >
       {!isMobileViewport && !isMapExpanded && !isProfileExpanded && (accessState === "granted" || accessState === "readonly") ? (
-        <Sidebar hideLibraryBrowsing={isAnonymousGuestReadonly} onOpenHelp={openOnboardingTutorial} />
+        <Sidebar hideLibraryBrowsing={isAnonymousGuestReadonly} onOpenHelp={openOnboardingTutorial} readOnly={!canPersistWorkspace} />
       ) : null}
       <section className={`workspace-panel ${isMapExpanded ? "is-map-expanded" : ""} ${isProfileExpanded ? "is-profile-expanded" : ""}`}>
         {!isOnline && !offlineBannerDismissed ? (
@@ -1357,7 +1370,7 @@ export function AppShell() {
         {isMobileViewport && !isMapExpanded && mobileActivePanel === "sidebar" ? (
           <div className="mobile-workspace-panel mobile-workspace-panel-sidebar" role="tabpanel" aria-label="Sidebar panel">
             {(accessState === "granted" || accessState === "readonly") ? (
-              <Sidebar hideLibraryBrowsing={isAnonymousGuestReadonly} onOpenHelp={openOnboardingTutorial} />
+              <Sidebar hideLibraryBrowsing={isAnonymousGuestReadonly} onOpenHelp={openOnboardingTutorial} readOnly={!canPersistWorkspace} />
             ) : null}
           </div>
         ) : null}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -256,9 +256,10 @@ const formatMqttSourceMeta = (value: unknown): string[] => {
 type SidebarProps = {
   onOpenHelp?: () => void;
   hideLibraryBrowsing?: boolean;
+  readOnly?: boolean;
 };
 
-export function Sidebar({ onOpenHelp, hideLibraryBrowsing = false }: SidebarProps) {
+export function Sidebar({ onOpenHelp, hideLibraryBrowsing = false, readOnly = false }: SidebarProps) {
   const { theme, colorTheme, variant } = useThemeVariant();
   const runtimeEnvironment = getCurrentRuntimeEnvironment();
   const envBadgeLabel = runtimeEnvironment === "local" ? "LOCAL" : runtimeEnvironment === "staging" ? "STAGING" : "";
@@ -1823,21 +1824,23 @@ export function Sidebar({ onOpenHelp, hideLibraryBrowsing = false }: SidebarProp
               </button>
             </>
           ) : null}
-          <button
-            className="inline-action danger"
-            disabled={sites.length <= 1}
-            onClick={() =>
-              requestDeleteConfirm(
-                "Remove Site",
-                `Remove ${selectedSite.name} from the current simulation?`,
-                () => deleteSite(selectedSite.id),
-                "Remove",
-              )
-            }
-            type="button"
-          >
-            Remove
-          </button>
+          {!readOnly ? (
+            <button
+              className="inline-action danger"
+              disabled={sites.length <= 1}
+              onClick={() =>
+                requestDeleteConfirm(
+                  "Remove Site",
+                  `Remove ${selectedSite.name} from the current simulation?`,
+                  () => deleteSite(selectedSite.id),
+                  "Remove",
+                )
+              }
+              type="button"
+            >
+              Remove
+            </button>
+          ) : null}
         </div>
       </section>
 
@@ -2035,26 +2038,30 @@ export function Sidebar({ onOpenHelp, hideLibraryBrowsing = false }: SidebarProp
           ))}
         </div>
         <div className="chip-group">
-          <button className="inline-action" disabled={sites.length < 2} onClick={openAddLinkModal} type="button">
-            New
-          </button>
-          <button className="inline-action" onClick={openEditLinkModal} type="button">
-            Edit
-          </button>
-          <button
-            className="inline-action danger"
-            disabled={!links.length}
-            onClick={() =>
-              requestDeleteConfirm(
-                "Delete Link",
-                `Delete selected link "${displayLinkName(selectedLink.id, selectedLink.name)}"?`,
-                () => deleteLink(selectedLink.id),
-              )
-            }
-            type="button"
-          >
-            Remove
-          </button>
+          {!readOnly ? (
+            <>
+              <button className="inline-action" disabled={sites.length < 2} onClick={openAddLinkModal} type="button">
+                New
+              </button>
+              <button className="inline-action" onClick={openEditLinkModal} type="button">
+                Edit
+              </button>
+              <button
+                className="inline-action danger"
+                disabled={!links.length}
+                onClick={() =>
+                  requestDeleteConfirm(
+                    "Delete Link",
+                    `Delete selected link "${displayLinkName(selectedLink.id, selectedLink.name)}"?`,
+                    () => deleteLink(selectedLink.id),
+                  )
+                }
+                type="button"
+              >
+                Remove
+              </button>
+            </>
+          ) : null}
         </div>
       </section>
 

--- a/src/index.css
+++ b/src/index.css
@@ -798,7 +798,7 @@ input {
 
 .map-inline-notice {
   position: absolute;
-  top: calc(18px + 36px + var(--workspace-panel-gap));
+  top: calc(18px + 36px + (var(--workspace-panel-gap) * 2));
   left: 50%;
   transform: translateX(-50%);
   width: max-content;
@@ -822,11 +822,11 @@ input {
 }
 
 .map-inline-notice-warning {
-  border-color: color-mix(in srgb, #f2b44b 68%, var(--border));
+  border-color: color-mix(in srgb, var(--accent) 52%, var(--border));
 }
 
 .map-inline-notice-error {
-  border-color: color-mix(in srgb, #d85a5a 70%, var(--border));
+  border-color: color-mix(in srgb, var(--text) 34%, var(--border));
 }
 
 .map-inline-notice .inline-action {
@@ -2031,7 +2031,7 @@ input {
   }
 
   .map-inline-notice {
-    top: calc(var(--mobile-controls-top) + 42px + var(--workspace-panel-gap));
+    top: calc(var(--mobile-controls-top) + 42px + (var(--workspace-panel-gap) * 2));
     max-width: calc(100% - 24px);
   }
 


### PR DESCRIPTION
## Summary
- hide mutating side-panel controls in readonly mode for Links (`New/Edit/Remove`) and Sites (`Remove`)
- stop bad deep-link auto-rewrite behavior by blocking pathname replacement after failed deep-link resolution
- theme map-inline notice border colors via theme tokens and increase vertical spacing below map controls to match panel rhythm

## Verification
- npm run test -- --run src/lib/deepLink.test.ts
- npm run test -- --run functions/api/v1/calculate.test.ts
- npm run test -- --run src/store/appStore.test.ts
- npm test
- npm run build