### PR TITLE
fix: restore sign-in flow for access-check load failures (#24)

### DIFF
--- a/src/lib/appShellGuards.test.ts
+++ b/src/lib/appShellGuards.test.ts
@@ -36,6 +36,10 @@ describe("isAuthSignInRequiredMessage", () => {
     expect(isAuthSignInRequiredMessage("Unauthorized")).toBe(true);
     expect(isAuthSignInRequiredMessage("401 Unauthorized")).toBe(true);
     expect(isAuthSignInRequiredMessage("Authentication required")).toBe(true);
+    expect(isAuthSignInRequiredMessage("Load failed")).toBe(true);
+    expect(isAuthSignInRequiredMessage("Failed to fetch")).toBe(true);
+    expect(isAuthSignInRequiredMessage("Sign in · Cloudflare Access")).toBe(true);
+    expect(isAuthSignInRequiredMessage("You are signed out. Sign in to continue.")).toBe(true);
   });
 
   it("ignores unrelated errors", () => {

--- a/src/lib/appShellGuards.ts
+++ b/src/lib/appShellGuards.ts
@@ -14,8 +14,14 @@ export const isAuthSignInRequiredMessage = (message: string | null | undefined):
   const normalized = String(message ?? "").trim().toLowerCase();
   if (!normalized) return false;
   return (
+    normalized.includes("signed out") ||
+    normalized.includes("sign in to continue") ||
     normalized.includes("unauthorized") ||
     normalized.includes("forbidden") ||
+    normalized.includes("load failed") ||
+    normalized.includes("failed to fetch") ||
+    normalized.includes("cloudflare access") ||
+    normalized.includes("unexpected token <") ||
     normalized.includes("authentication required") ||
     normalized.includes("not authenticated")
   );


### PR DESCRIPTION
## Summary
- classify access-check failures like `Load failed`, `Failed to fetch`, and Cloudflare Access login-intercept signatures as sign-in-required
- ensure locked-state messaging continues to render the Sign In action after diagnostic text is rewritten to user-facing copy
- add regression coverage for these auth-failure message variants

## Verification
- npm run test -- --run src/lib/appShellGuards.test.ts
- npm test
- npm run build