### PR TITLE
fix: use protected auth-start entrypoint for sign-in recovery (#24)

### DIFF
--- a/functions/api/auth-start.test.ts
+++ b/functions/api/auth-start.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { onRequestGet } from "./auth-start";
+
+const mkCtx = (request: Request) => ({ request } as Parameters<typeof onRequestGet>[0]);
+
+describe("api/auth-start", () => {
+  it("redirects to same-origin returnTo path", async () => {
+    const req = new Request("https://example.test/api/auth-start?returnTo=%2Ffoo%3Fbar%3D1%23baz");
+    const res = await onRequestGet(mkCtx(req));
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("https://example.test/foo?bar=1#baz");
+  });
+
+  it("falls back to root for invalid returnTo", async () => {
+    const req = new Request("https://example.test/api/auth-start?returnTo=https%3A%2F%2Fevil.test%2Fpwnd");
+    const res = await onRequestGet(mkCtx(req));
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("https://example.test/");
+  });
+});

--- a/functions/api/auth-start.ts
+++ b/functions/api/auth-start.ts
@@ -1,0 +1,18 @@
+const sanitizeReturnTo = (raw: string | null, origin: string): string => {
+  if (typeof raw !== "string") return "/";
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith("/") || trimmed.startsWith("//")) return "/";
+  try {
+    const resolved = new URL(trimmed, origin);
+    if (resolved.origin !== origin) return "/";
+    return `${resolved.pathname}${resolved.search}${resolved.hash}`;
+  } catch {
+    return "/";
+  }
+};
+
+export const onRequestGet = async ({ request }: { request: Request }) => {
+  const url = new URL(request.url);
+  const returnTo = sanitizeReturnTo(url.searchParams.get("returnTo"), url.origin);
+  return Response.redirect(`${url.origin}${returnTo}`, 302);
+};

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -453,7 +453,8 @@ export function AppShell() {
   }, [deepLinkParse.ok, isLocalRuntime]);
 
   const signIn = useCallback(() => {
-    window.location.href = "/cdn-cgi/access/login";
+    const returnTo = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+    window.location.href = `/api/auth-start?returnTo=${encodeURIComponent(returnTo || "/")}`;
   }, []);
 
   const switchLocalRole = useCallback(


### PR DESCRIPTION
## Summary
- replace direct `/cdn-cgi/access/login` usage with a same-origin protected entrypoint at `/api/auth-start`
- preserve current path/query/hash via `returnTo` so sign-in returns users to where they started
- sanitize `returnTo` to same-origin relative paths only (fallback to `/`) to prevent open redirects
- add API tests for valid and invalid redirect targets

## Verification
- npm run test -- --run functions/api/auth-start.test.ts src/lib/appShellGuards.test.ts
- npm test
- npm run build