### PR TITLE
hotfix: restore production sign-in recovery from locked state (#24)

### DIFF
--- a/functions/api/auth-start.test.ts
+++ b/functions/api/auth-start.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { onRequestGet } from "./auth-start";
+
+const mkCtx = (request: Request) => ({ request } as Parameters<typeof onRequestGet>[0]);
+
+describe("api/auth-start", () => {
+  it("redirects to same-origin returnTo path", async () => {
+    const req = new Request("https://example.test/api/auth-start?returnTo=%2Ffoo%3Fbar%3D1%23baz");
+    const res = await onRequestGet(mkCtx(req));
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("https://example.test/foo?bar=1#baz");
+  });
+
+  it("falls back to root for invalid returnTo", async () => {
+    const req = new Request("https://example.test/api/auth-start?returnTo=https%3A%2F%2Fevil.test%2Fpwnd");
+    const res = await onRequestGet(mkCtx(req));
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("https://example.test/");
+  });
+});

--- a/functions/api/auth-start.ts
+++ b/functions/api/auth-start.ts
@@ -1,0 +1,18 @@
+const sanitizeReturnTo = (raw: string | null, origin: string): string => {
+  if (typeof raw !== "string") return "/";
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith("/") || trimmed.startsWith("//")) return "/";
+  try {
+    const resolved = new URL(trimmed, origin);
+    if (resolved.origin !== origin) return "/";
+    return `${resolved.pathname}${resolved.search}${resolved.hash}`;
+  } catch {
+    return "/";
+  }
+};
+
+export const onRequestGet = async ({ request }: { request: Request }) => {
+  const url = new URL(request.url);
+  const returnTo = sanitizeReturnTo(url.searchParams.get("returnTo"), url.origin);
+  return Response.redirect(`${url.origin}${returnTo}`, 302);
+};

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -385,6 +385,11 @@ export function AppShell() {
     window.location.href = "/cdn-cgi/access/logout";
   }, [deepLinkParse.ok, isLocalRuntime]);
 
+  const signIn = useCallback(() => {
+    const returnTo = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+    window.location.href = `/api/auth-start?returnTo=${encodeURIComponent(returnTo || "/")}`;
+  }, []);
+
   const switchLocalRole = useCallback(
     async (role: "admin" | "moderator" | "user" | "pending") => {
       try {
@@ -971,6 +976,9 @@ export function AppShell() {
             If your user was removed by an admin, ask for re-approval. Then sign out and sign in again.
           </p>
           <div className="chip-group">
+            <button className="inline-action" onClick={signIn} type="button">
+              Sign In
+            </button>
             <button className="inline-action" onClick={signOutOrReadonly} type="button">
               Sign Out
             </button>


### PR DESCRIPTION
## Summary
- add a protected auth entry endpoint at `/api/auth-start` to trigger Cloudflare Access login safely
- route locked-state Sign In action through `/api/auth-start?returnTo=...` instead of `/cdn-cgi/access/login`
- keep users on their original path after auth with same-origin returnTo sanitization
- add API tests for safe redirect behavior

## Verification
- npm run test -- --run functions/api/auth-start.test.ts
- npm test
- npm run build:bundle