### PR TITLE
feat: add anonymous signup CTA in sidebar account strip (#322)

### DIFF
--- a/src/components/UserAdminPanel.tsx
+++ b/src/components/UserAdminPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState, type ChangeEvent } from "react";
-import { CircleQuestionMark, CircleX } from "lucide-react";
+import { CircleQuestionMark, CircleX, UserRoundPlus } from "lucide-react";
 import {
   bulkReassignOwnership,
   fetchAdminAuditEvents,
@@ -670,6 +670,11 @@ export function UserAdminPanel({ onOpenHelp }: UserAdminPanelProps) {
     window.location.href = "/cdn-cgi/access/logout";
   }, [isLocalRuntime]);
 
+  const handleSignUp = useCallback(() => {
+    const returnTo = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+    window.location.href = `/api/auth-start?returnTo=${encodeURIComponent(returnTo || "/")}`;
+  }, []);
+
   const [syncModalOpen, setSyncModalOpen] = useState(false);
 
   useEffect(() => {
@@ -734,29 +739,40 @@ export function UserAdminPanel({ onOpenHelp }: UserAdminPanelProps) {
   return (
     <>
       <div className="user-chip-row">
-        <button aria-label="Open user settings" className="user-chip" onClick={() => setOpen(true)} type="button">
-          <ProfileAvatar avatarUrl={me?.avatarUrl ?? ""} name={me?.username ?? "User"} />
-          {canModerate && unreadNotifications.length > 0 ? (
-            <span className="notification-badge">{unreadNotifications.length}</span>
-          ) : null}
-        </button>
+        {me ? (
+          <button aria-label="Open user settings" className="user-chip" onClick={() => setOpen(true)} type="button">
+            <ProfileAvatar avatarUrl={me.avatarUrl ?? ""} name={me.username ?? "User"} />
+            {canModerate && unreadNotifications.length > 0 ? (
+              <span className="notification-badge">{unreadNotifications.length}</span>
+            ) : null}
+          </button>
+        ) : (
+          <button aria-label="Sign up" className="user-chip user-chip-signup" onClick={handleSignUp} type="button">
+            <UserRoundPlus aria-hidden="true" strokeWidth={1.8} />
+            <span>Sign up</span>
+          </button>
+        )}
         <div className="user-chip-actions">
-          <button
-            aria-label={syncIndicator.label}
-            className={`user-icon-button sync-indicator-button ${syncIndicator.className}`}
-            onClick={handleSyncIndicatorClick}
-            title={syncIndicator.title}
-            type="button"
-          >
-            <SyncStatusIcon
-              className={syncIndicator.state === "syncing" ? "sync-icon-pulsing" : undefined}
-              state={syncIndicator.state}
-              title={syncIndicator.label}
-            />
-          </button>
-          <button aria-label="Open user settings" className="user-icon-button" onClick={() => setOpen(true)} type="button">
-            <SettingsIcon title="Settings" />
-          </button>
+          {me ? (
+            <>
+              <button
+                aria-label={syncIndicator.label}
+                className={`user-icon-button sync-indicator-button ${syncIndicator.className}`}
+                onClick={handleSyncIndicatorClick}
+                title={syncIndicator.title}
+                type="button"
+              >
+                <SyncStatusIcon
+                  className={syncIndicator.state === "syncing" ? "sync-icon-pulsing" : undefined}
+                  state={syncIndicator.state}
+                  title={syncIndicator.label}
+                />
+              </button>
+              <button aria-label="Open user settings" className="user-icon-button" onClick={() => setOpen(true)} type="button">
+                <SettingsIcon title="Settings" />
+              </button>
+            </>
+          ) : null}
           {onOpenHelp ? (
             <button aria-label="Open onboarding" className="user-icon-button" onClick={onOpenHelp} type="button">
               <CircleQuestionMark aria-hidden="true" strokeWidth={1.8} />

--- a/src/index.css
+++ b/src/index.css
@@ -2224,6 +2224,29 @@ input {
   flex: 0 0 auto;
 }
 
+.user-chip-row .user-chip.user-chip-signup {
+  width: auto;
+  min-width: 0;
+  height: 34px;
+  padding: 0 12px;
+  gap: 8px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--panel) 86%, var(--bg));
+  font-size: 0.84rem;
+  font-weight: 700;
+}
+
+.user-chip-row .user-chip.user-chip-signup:hover {
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+}
+
+.user-chip-row .user-chip.user-chip-signup svg {
+  width: 16px;
+  height: 16px;
+}
+
 .user-icon-button {
   border: 0;
   background: transparent;


### PR DESCRIPTION
## Summary
- keep the account strip visible for anonymous users in the sidebar
- replace avatar slot with a `UserRoundPlus` + `Sign up` button in anonymous mode
- hide sync/settings icon actions for anonymous mode while keeping signed-in behavior unchanged
- route signup CTA through `/api/auth-start?returnTo=...` so users return to the current page after auth

## Verification
- npm run build