### PR TITLE
fix: keep anonymous user bar visible in sidebar (#322)

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1737,7 +1737,7 @@ export function Sidebar({ onOpenHelp, hideLibraryBrowsing = false, readOnly = fa
 
   return (
     <aside className="sidebar-panel">
-      {!hideLibraryBrowsing ? <UserAdminPanel onOpenHelp={onOpenHelp} /> : null}
+      <UserAdminPanel onOpenHelp={onOpenHelp} />
       <header>
         <div className="sidebar-title-row">
           <h1>{t(locale, "appTitle")}</h1>


### PR DESCRIPTION
## Summary
- keep `UserAdminPanel` visible in the sidebar even when `hideLibraryBrowsing` is true
- preserve `hideLibraryBrowsing` behavior for simulation/site library actions only
- restores anonymous top user bar visibility so signup CTA appears in private sessions

## Verification
- npm test
- npm run build