### PR TITLE
fix: show auth-loading state and relabel anonymous CTA (#322)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1216,7 +1216,12 @@ export function AppShell() {
       style={shellStyle}
     >
       {!isMobileViewport && !isMapExpanded && !isProfileExpanded && (accessState === "granted" || accessState === "readonly" || isAnonymousBootstrapShell) ? (
-        <Sidebar hideLibraryBrowsing={isReadOnlyShell} onOpenHelp={openOnboardingTutorial} readOnly={!canPersistWorkspace} />
+        <Sidebar
+          authBootstrapPending={accessState === "checking"}
+          hideLibraryBrowsing={isReadOnlyShell}
+          onOpenHelp={openOnboardingTutorial}
+          readOnly={!canPersistWorkspace}
+        />
       ) : null}
       <section className={`workspace-panel ${isMapExpanded ? "is-map-expanded" : ""} ${isProfileExpanded ? "is-profile-expanded" : ""}`}>
         {accessState === "checking" ? (
@@ -1406,7 +1411,12 @@ export function AppShell() {
         {isMobileViewport && !isMapExpanded && mobileActivePanel === "sidebar" ? (
           <div className="mobile-workspace-panel mobile-workspace-panel-sidebar" role="tabpanel" aria-label="Sidebar panel">
             {(accessState === "granted" || accessState === "readonly" || isAnonymousBootstrapShell) ? (
-              <Sidebar hideLibraryBrowsing={isReadOnlyShell} onOpenHelp={openOnboardingTutorial} readOnly={!canPersistWorkspace} />
+              <Sidebar
+                authBootstrapPending={accessState === "checking"}
+                hideLibraryBrowsing={isReadOnlyShell}
+                onOpenHelp={openOnboardingTutorial}
+                readOnly={!canPersistWorkspace}
+              />
             ) : null}
           </div>
         ) : null}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -257,9 +257,10 @@ type SidebarProps = {
   onOpenHelp?: () => void;
   hideLibraryBrowsing?: boolean;
   readOnly?: boolean;
+  authBootstrapPending?: boolean;
 };
 
-export function Sidebar({ onOpenHelp, hideLibraryBrowsing = false, readOnly = false }: SidebarProps) {
+export function Sidebar({ onOpenHelp, hideLibraryBrowsing = false, readOnly = false, authBootstrapPending = false }: SidebarProps) {
   const { theme, colorTheme, variant } = useThemeVariant();
   const runtimeEnvironment = getCurrentRuntimeEnvironment();
   const envBadgeLabel = runtimeEnvironment === "local" ? "LOCAL" : runtimeEnvironment === "staging" ? "STAGING" : "";
@@ -1737,7 +1738,7 @@ export function Sidebar({ onOpenHelp, hideLibraryBrowsing = false, readOnly = fa
 
   return (
     <aside className="sidebar-panel">
-      <UserAdminPanel onOpenHelp={onOpenHelp} />
+      <UserAdminPanel authBootstrapPending={authBootstrapPending} onOpenHelp={onOpenHelp} />
       <header>
         <div className="sidebar-title-row">
           <h1>{t(locale, "appTitle")}</h1>

--- a/src/components/UserAdminPanel.tsx
+++ b/src/components/UserAdminPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState, type ChangeEvent } from "react";
-import { CircleQuestionMark, CircleX, UserRoundPlus } from "lucide-react";
+import { CircleQuestionMark, CircleUserRound, CircleX } from "lucide-react";
 import {
   bulkReassignOwnership,
   fetchAdminAuditEvents,
@@ -132,9 +132,10 @@ const resizeAvatarFileToDataUrl = async (file: File): Promise<{ originalDataUrl:
 
 type UserAdminPanelProps = {
   onOpenHelp?: () => void;
+  authBootstrapPending?: boolean;
 };
 
-export function UserAdminPanel({ onOpenHelp }: UserAdminPanelProps) {
+export function UserAdminPanel({ onOpenHelp, authBootstrapPending = false }: UserAdminPanelProps) {
   const runtimeEnvironment = getCurrentRuntimeEnvironment();
   const isLocalRuntime = runtimeEnvironment === "local";
   const uiThemePreference = useAppStore((state) => state.uiThemePreference);
@@ -746,10 +747,16 @@ export function UserAdminPanel({ onOpenHelp }: UserAdminPanelProps) {
               <span className="notification-badge">{unreadNotifications.length}</span>
             ) : null}
           </button>
+        ) : authBootstrapPending ? (
+          <div aria-label="Loading account" className="user-chip user-chip-loading" role="status" title="Checking account access">
+            <div className="map-progress-track">
+              <div className="map-progress-fill map-progress-fill-indeterminate" />
+            </div>
+          </div>
         ) : (
-          <button aria-label="Sign up" className="user-chip user-chip-signup" onClick={handleSignUp} type="button">
-            <UserRoundPlus aria-hidden="true" strokeWidth={1.8} />
-            <span>Sign up</span>
+          <button aria-label="Sign in or sign up" className="user-chip user-chip-signup" onClick={handleSignUp} type="button">
+            <CircleUserRound aria-hidden="true" strokeWidth={1.8} />
+            <span>Sign in / Sign up</span>
           </button>
         )}
         <div className="user-chip-actions">

--- a/src/index.css
+++ b/src/index.css
@@ -2235,6 +2235,7 @@ input {
   background: color-mix(in srgb, var(--panel) 86%, var(--bg));
   font-size: 0.84rem;
   font-weight: 700;
+  white-space: nowrap;
 }
 
 .user-chip-row .user-chip.user-chip-signup:hover {
@@ -2245,6 +2246,20 @@ input {
 .user-chip-row .user-chip.user-chip-signup svg {
   width: 16px;
   height: 16px;
+}
+
+.user-chip-row .user-chip.user-chip-loading {
+  width: 132px;
+  min-width: 132px;
+  height: 34px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--panel) 86%, var(--bg));
+}
+
+.user-chip-row .user-chip.user-chip-loading .map-progress-track {
+  height: 6px;
 }
 
 .user-icon-button {


### PR DESCRIPTION
## Summary
- rename anonymous CTA to `Sign in / Sign up` and switch icon to `CircleUserRound`
- add auth-bootstrap pending prop from AppShell -> Sidebar -> UserAdminPanel
- while auth check is in progress, show an indeterminate loading bar in the user-bar slot instead of showing the CTA

## Verification
- npm test
- npm run build