### PR TITLE
fix(#309): fix attribution z-index and mobile profile tab toggle

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1384,8 +1384,16 @@ export function AppShell() {
               aria-selected={mobileActivePanel === "profile"}
               className={`mobile-workspace-tab ${mobileActivePanel === "profile" ? "is-active" : ""}`}
               onClick={() => {
-                setIsMapExpanded(false);
-                setMobileActivePanel("profile");
+                if (isProfileExpanded) {
+                  setIsProfileExpanded(false);
+                  setIsMapExpanded(false);
+                  setMobileActivePanel("profile");
+                } else if (!isMapExpanded && mobileActivePanel === "profile") {
+                  setIsMapExpanded(true);
+                } else {
+                  setIsMapExpanded(false);
+                  setMobileActivePanel("profile");
+                }
               }}
               role="tab"
               type="button"

--- a/src/index.css
+++ b/src/index.css
@@ -968,6 +968,10 @@ input {
   bottom: calc(var(--mobile-tabbar-offset) + var(--mobile-tabbar-height) + 12px);
 }
 
+.app-shell.is-profile-expanded .floating-attribution-pill {
+  z-index: 30;
+}
+
 .map-control-note {
   position: absolute;
   top: 66px;
@@ -2102,6 +2106,10 @@ input {
 
   .app-shell.is-mobile-shell .map-panel .maplibregl-ctrl-attrib {
     z-index: 97;
+  }
+
+  .app-shell.is-mobile-shell.is-profile-expanded .map-panel .maplibregl-ctrl-attrib {
+    z-index: 40;
   }
 
   .workspace-panel:not(.is-profile-expanded) .map-inspector {


### PR DESCRIPTION
## Summary
- Lower `floating-attribution-pill` z-index when `is-profile-expanded` is active — fixes attribution rendering on top of fullscreen path profile on desktop and mobile
- Restore mobile profile tab re-tap state machine: fullscreen → normal → map fullscreen, matching the sidebar/inspector tab behavior that was removed in PR #310

## Test plan
- [ ] Desktop: enter profile fullscreen, confirm map attribution is hidden behind the panel
- [ ] Mobile: tap profile tab while in fullscreen → exits fullscreen; tap again → map fullscreen
- [ ] Mobile: confirm sidebar and inspector tab re-tap behavior unchanged
- [ ] Mobile: confirm attribution not visible over expanded profile

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)