### PR TITLE
chore: add .claude/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ debug-logs/
 # Python
 __pycache__/
 *.pyc
+
+# Claude Code
+.claude/


### PR DESCRIPTION
Prevents Claude Code worktrees and plans directory from showing as dirty files during deploy preflight.