### PR TITLE
fix(#309): raise workspace-panel z-index in profile fullscreen

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -688,6 +688,7 @@ input {
 .workspace-panel.is-profile-expanded {
   grid-template-rows: minmax(0, 1fr);
   padding-right: 0;
+  z-index: 101;
 }
 
 .workspace-header {
@@ -966,10 +967,6 @@ input {
 
 .app-shell.is-mobile-shell .floating-attribution-pill {
   bottom: calc(var(--mobile-tabbar-offset) + var(--mobile-tabbar-height) + 12px);
-}
-
-.app-shell.is-profile-expanded .floating-attribution-pill {
-  z-index: 30;
 }
 
 .map-control-note {


### PR DESCRIPTION
## Root cause
`workspace-panel` creates a stacking context at `z-index: 30` in the root. The `floating-attribution-pill` is `position: fixed; z-index: 100` in the root context. Lowering the pill to `z-index: 30` made them equal, but since the pill is later in the DOM it still painted on top.

## Fix
Raise `workspace-panel` to `z-index: 101` when `is-profile-expanded`, putting the entire workspace stacking context above the attribution pill.

Also removes the ineffective `.app-shell.is-profile-expanded .floating-attribution-pill { z-index: 30 }` rule added in the previous pass.

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)