### PR TITLE
fix(#181): auto-load terrain tile in site editor when coordinates set

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -308,6 +308,8 @@ export function Sidebar({ onOpenHelp, hideLibraryBrowsing = false, readOnly = fa
   const updateLink = useAppStore((state) => state.updateLink);
   const insertSiteFromLibrary = useAppStore((state) => state.insertSiteFromLibrary);
   const updateMapViewport = useAppStore((state) => state.updateMapViewport);
+  const isEditorTerrainFetching = useAppStore((state) => state.isEditorTerrainFetching);
+  const loadTerrainForCoordinate = useAppStore((state) => state.loadTerrainForCoordinate);
   const insertSitesFromLibrary = useAppStore((state) => state.insertSitesFromLibrary);
   const updateSiteLibraryEntry = useAppStore((state) => state.updateSiteLibraryEntry);
   const deleteSiteLibraryEntries = useAppStore((state) => state.deleteSiteLibraryEntries);
@@ -537,6 +539,20 @@ export function Sidebar({ onOpenHelp, hideLibraryBrowsing = false, readOnly = fa
       zoom: 12,
     }));
   }, [newLibraryLat, newLibraryLon]);
+  // Debounced terrain prefetch for Add Site form
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      loadTerrainForCoordinate(newLibraryLat, newLibraryLon);
+    }, 500);
+    return () => clearTimeout(timer);
+  }, [newLibraryLat, newLibraryLon, loadTerrainForCoordinate]);
+  // Debounced terrain prefetch for Edit Site form
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      loadTerrainForCoordinate(resourceLatDraft, resourceLonDraft);
+    }, 500);
+    return () => clearTimeout(timer);
+  }, [resourceLatDraft, resourceLonDraft, loadTerrainForCoordinate]);
   const [resourceGroundDraft, setResourceGroundDraft] = useState(0);
   const [resourceAntennaDraft, setResourceAntennaDraft] = useState(2);
   const [resourceTxPowerDraft, setResourceTxPowerDraft] = useState(STANDARD_SITE_RADIO.txPowerDbm);
@@ -1265,6 +1281,18 @@ export function Sidebar({ onOpenHelp, hideLibraryBrowsing = false, readOnly = fa
     if (!Number.isFinite(elevation)) return null;
     return Math.round(elevation);
   };
+  // Auto-fill Add Site elevation when terrain loads (only if user hasn't set a value)
+  useEffect(() => {
+    if (newLibraryGroundM !== 0) return;
+    const elevation = fetchGroundFromLoadedTerrain(newLibraryLat, newLibraryLon);
+    if (elevation !== null) setNewLibraryGroundM(elevation);
+  }, [srtmTiles]); // eslint-disable-line react-hooks/exhaustive-deps
+  // Auto-fill Edit Site elevation when terrain loads (only if user hasn't set a value)
+  useEffect(() => {
+    if (resourceGroundDraft !== 0) return;
+    const elevation = fetchGroundFromLoadedTerrain(resourceLatDraft, resourceLonDraft);
+    if (elevation !== null) setResourceGroundDraft(elevation);
+  }, [srtmTiles]); // eslint-disable-line react-hooks/exhaustive-deps
   const fetchNewLibraryGroundFromTerrain = () => {
     const elevation = fetchGroundFromLoadedTerrain(newLibraryLat, newLibraryLon);
     if (elevation === null) {
@@ -2528,6 +2556,7 @@ export function Sidebar({ onOpenHelp, hideLibraryBrowsing = false, readOnly = fa
                       />
                       <button
                         className="inline-action field-inline-btn"
+                        disabled={isEditorTerrainFetching}
                         onClick={() => {
                           const elevation = fetchGroundFromLoadedTerrain(resourceLatDraft, resourceLonDraft);
                           if (elevation === null) {
@@ -2542,7 +2571,7 @@ export function Sidebar({ onOpenHelp, hideLibraryBrowsing = false, readOnly = fa
                         }}
                         type="button"
                       >
-                        Fetch
+                        {isEditorTerrainFetching ? "Loading…" : "Fetch"}
                       </button>
                     </div>
                   </label>
@@ -3292,8 +3321,8 @@ export function Sidebar({ onOpenHelp, hideLibraryBrowsing = false, readOnly = fa
                       type="number"
                       value={newLibraryGroundM}
                     />
-                    <button className="inline-action field-inline-btn" onClick={fetchNewLibraryGroundFromTerrain} type="button">
-                      Fetch
+                    <button className="inline-action field-inline-btn" disabled={isEditorTerrainFetching} onClick={fetchNewLibraryGroundFromTerrain} type="button">
+                      {isEditorTerrainFetching ? "Loading…" : "Fetch"}
                     </button>
                   </div>
                 </label>

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -311,6 +311,7 @@ type AppState = {
   networks: Network[];
   srtmTiles: SrtmTile[];
   isTerrainFetching: boolean;
+  isEditorTerrainFetching: boolean;
   isTerrainRecommending: boolean;
   selectedLinkId: string;
   profileCursorIndex: number;
@@ -509,6 +510,7 @@ type AppState = {
   fetchTerrainForCurrentArea: () => Promise<void>;
   recommendAndFetchTerrainForCurrentArea: () => Promise<void>;
   loadTerrainForCurrentArea: () => Promise<void>;
+  loadTerrainForCoordinate: (lat: number, lon: number) => Promise<void>;
   clearTerrainCache: () => Promise<void>;
   getSelectedLink: () => Link;
   getSelectedSite: () => Site;
@@ -1105,6 +1107,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   networks: [],
   srtmTiles: [],
   isTerrainFetching: false,
+  isEditorTerrainFetching: false,
   isTerrainRecommending: false,
   selectedLinkId: "",
   profileCursorIndex: 0,
@@ -3305,6 +3308,29 @@ export const useAppStore = create<AppState>((set, get) => ({
     }
   },
   recommendAndFetchTerrainForCurrentArea: () => get().loadTerrainForCurrentArea(),
+  loadTerrainForCoordinate: async (lat: number, lon: number) => {
+    const { isEditorTerrainFetching, srtmTiles, terrainDataset } = get();
+    if (isEditorTerrainFetching) return;
+    if (sampleSrtmElevation(srtmTiles, lat, lon) !== null) return;
+    set({ isEditorTerrainFetching: true });
+    try {
+      const minLat = Math.floor(lat);
+      const minLon = Math.floor(lon);
+      const result = await loadCopernicusTilesForAreaPhased(
+        minLat,
+        minLat + 1,
+        minLon,
+        minLon + 1,
+        terrainDataset ?? "copernicus90",
+      );
+      const incoming = [...result.priority.tiles, ...result.remaining.tiles];
+      if (incoming.length > 0) {
+        set((s) => ({ srtmTiles: mergeSrtmTiles(s.srtmTiles, incoming) }));
+      }
+    } finally {
+      set({ isEditorTerrainFetching: false });
+    }
+  },
   loadTerrainForCurrentArea: async () => {
     if (get().isTerrainFetching) return;
     const { sites } = get();


### PR DESCRIPTION
## Summary
- Adds `loadTerrainForCoordinate(lat, lon)` store action — loads only the single 1°×1° tile at the coordinate, using a dedicated `isEditorTerrainFetching` flag that doesn't conflict with the main terrain load button
- Pre-checks `sampleSrtmElevation` before any network call; skips if tile already in memory
- Both Add Site and Edit Site forms now debounce (500ms) a terrain load whenever lat/lon changes
- Fetch button shows "Loading…" and is disabled while tile loads
- Auto-fills elevation when terrain becomes available if ground is still at default (0)

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)