### PR TITLE
feat(#346): load Oslo demo workspace for anonymous bare-URL visitors

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -86,6 +86,7 @@ export function AppShell() {
   const siteLibrary = useAppStore((state) => state.siteLibrary);
   const sites = useAppStore((state) => state.sites);
   const selectedSiteIds = useAppStore((state) => state.selectedSiteIds);
+  const loadDemoScenario = useAppStore((state) => state.loadDemoScenario);
   const initializeCloudSync = useAppStore((state) => state.initializeCloudSync);
   const performCloudSyncPush = useAppStore((state) => state.performCloudSyncPush);
   const setCurrentUser = useAppStore((state) => state.setCurrentUser);
@@ -101,6 +102,9 @@ export function AppShell() {
   const [isProfileExpanded, setIsProfileExpanded] = useState(false);
   const [accessState, setAccessState] = useState<"checking" | "granted" | "readonly" | "pending" | "locked">("checking");
   const [accessDiagnosticMessage, setAccessDiagnosticMessage] = useState<string | null>(null);
+  // Derived early so effects below can reference them without temporal dead zone.
+  const lockedNeedsSignIn = isAuthSignInRequiredMessage(accessDiagnosticMessage);
+  const isAnonymousGuestReadonly = accessState === "readonly" && !currentUser;
   const [activeUserId, setActiveUserId] = useState("");
   const [showWelcomeModal, setShowWelcomeModal] = useState(false);
   const [showOnboardingTutorial, setShowOnboardingTutorial] = useState(false);
@@ -139,7 +143,6 @@ export function AppShell() {
     () => simulationPresets.find((preset) => preset.id === selectedScenarioId) ?? null,
     [simulationPresets, selectedScenarioId],
   );
-  const isAnonymousGuestReadonly = accessState === "readonly" && !currentUser;
   const publishAppNotice = useCallback((notice: AppNotice) => {
     setAppNotice((current) => {
       if (current && current.id === notice.id && current.message === notice.message) {
@@ -434,6 +437,17 @@ export function AppShell() {
       void runMigrations().then(() => initializeCloudSync());
     }
   }, [accessState, initializeCloudSync]);
+
+  // Auto-load the Oslo demo workspace for anonymous visitors with no deeplink.
+  useEffect(() => {
+    const isAnonNoDeepLink =
+      !deepLinkParse.ok &&
+      (isAnonymousGuestReadonly || (accessState === "locked" && lockedNeedsSignIn));
+    if (isAnonNoDeepLink && sites.length === 0) {
+      loadDemoScenario();
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [accessState, isAnonymousGuestReadonly, lockedNeedsSignIn, deepLinkParse.ok]);
 
   const signOutOrReadonly = useCallback(() => {
     if (isLocalRuntime) {
@@ -1097,7 +1111,6 @@ export function AppShell() {
       ["--mobile-controls-occupied" as string]: `${mobileControlsOccupied}px`,
     };
   }, [isMobileViewport, mobileControlsOccupied]);
-  const lockedNeedsSignIn = isAuthSignInRequiredMessage(accessDiagnosticMessage);
   const isAnonymousBootstrapShell = accessState === "checking" || (accessState === "locked" && lockedNeedsSignIn);
   const isReadOnlyShell = isAnonymousGuestReadonly || isAnonymousBootstrapShell;
 
@@ -1229,9 +1242,17 @@ export function AppShell() {
             <span className="field-help">Checking access in the background. Anonymous mode is available while this resolves.</span>
           </div>
         ) : null}
-        {accessState === "locked" && lockedNeedsSignIn ? (
+        {accessState === "locked" && lockedNeedsSignIn && !deepLinkParse.ok ? (
           <div className="workspace-header-actions">
-            <span className="field-help">You are signed out. Continue in anonymous mode or sign in to unlock your account workspace.</span>
+            <span className="field-help">Exploring in demo mode.</span>
+            <button className="inline-action" onClick={signIn} type="button">
+              Sign in to save your own simulations
+            </button>
+          </div>
+        ) : null}
+        {accessState === "locked" && lockedNeedsSignIn && deepLinkParse.ok ? (
+          <div className="workspace-header-actions">
+            <span className="field-help">Viewing as guest.</span>
             <button className="inline-action" onClick={signIn} type="button">
               Sign In
             </button>
@@ -1256,19 +1277,17 @@ export function AppShell() {
             </div>
           </div>
         ) : null}
-        {workspaceState === "no-simulation" ? (
+        {workspaceState === "no-simulation" && !isReadOnlyShell ? (
           <div className="empty-workspace-overlay">
             <div className="empty-workspace-message">
               <p>Open an existing simulation or create a new one to continue.</p>
-              {!isReadOnlyShell ? (
-                <button
-                  className="inline-action"
-                  onClick={() => setShowSimulationLibraryRequest(true)}
-                  type="button"
-                >
-                  Open Library
-                </button>
-              ) : null}
+              <button
+                className="inline-action"
+                onClick={() => setShowSimulationLibraryRequest(true)}
+                type="button"
+              >
+                Open Library
+              </button>
             </div>
           </div>
         ) : null}

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -920,6 +920,8 @@ const buildTerrainShadeOverlay = (
 
 const computeFitViewport = (
   sites: { position: { lat: number; lon: number } }[],
+  containerWidth = 800,
+  containerHeight = 600,
 ): { lat: number; lon: number; zoom: number } => {
   if (!sites.length) return { lat: 59.9, lon: 10.7, zoom: 8 };
   if (sites.length === 1) {
@@ -935,12 +937,15 @@ const computeFitViewport = (
 
   const centerLat = (minLat + maxLat) / 2;
   const centerLon = (minLon + maxLon) / 2;
+  // Apply Mercator cos(lat) correction: at high latitudes 1° of latitude spans
+  // more pixels than at the equator.
+  const cosLat = Math.cos((centerLat * Math.PI) / 180);
 
   const latSpan = Math.max(0.004, (maxLat - minLat) * 1.4);
   const lonSpan = Math.max(0.004, (maxLon - minLon) * 1.4);
 
-  const zoomLat = Math.log2(170 / latSpan);
-  const zoomLon = Math.log2(360 / lonSpan);
+  const zoomLat = Math.log2((360 * cosLat) / latSpan * (containerHeight / 256));
+  const zoomLon = Math.log2((360 / lonSpan) * (containerWidth / 256));
   const zoom = clamp(Math.min(zoomLat, zoomLon), 3, 15);
 
   return { lat: centerLat, lon: centerLon, zoom };
@@ -1548,7 +1553,10 @@ export function MapView({
 
   const fitToNodes = () => {
     setFitControlActive(true);
-    const next = computeFitViewport(sites);
+    const container = mapRef.current?.getContainer();
+    const w = container?.clientWidth ?? 800;
+    const h = container?.clientHeight ?? 600;
+    const next = computeFitViewport(sites, w, h);
     setInteractionViewState(null);
     updateMapViewport({
       center: { lat: next.lat, lon: next.lon },

--- a/src/lib/scenarios.ts
+++ b/src/lib/scenarios.ts
@@ -103,3 +103,91 @@ export const getScenarioById = (id: string): BuiltinScenario | undefined =>
   BUILTIN_SCENARIOS.find((scenario) => scenario.id === id);
 
 export const defaultScenario = BUILTIN_SCENARIOS[0];
+
+/**
+ * Demo workspace shown to anonymous visitors on bare URL.
+ * Not included in BUILTIN_SCENARIOS — invisible in normal scenario UI.
+ */
+export const DEMO_SCENARIO: BuiltinScenario = {
+  id: "demo",
+  name: "Oslo Demo",
+  sites: [
+    {
+      id: "demo-site-tryvanns",
+      name: "Tryvannstårnet",
+      position: { lat: 59.9883, lon: 10.6678 },
+      groundElevationM: 529,
+      antennaHeightM: 118,
+      txPowerDbm: 22,
+      txGainDbi: 5,
+      rxGainDbi: 5,
+      cableLossDb: 1,
+    },
+    {
+      id: "demo-site-haukasen",
+      name: "Haukåsen",
+      position: { lat: 59.904, lon: 10.8972 },
+      groundElevationM: 357,
+      antennaHeightM: 20,
+      txPowerDbm: 22,
+      txGainDbi: 2,
+      rxGainDbi: 2,
+      cableLossDb: 1,
+    },
+    {
+      id: "demo-site-kikut",
+      name: "Kikut",
+      position: { lat: 60.0844, lon: 10.6442 },
+      groundElevationM: 614,
+      antennaHeightM: 2,
+      txPowerDbm: 22,
+      txGainDbi: 2,
+      rxGainDbi: 2,
+      cableLossDb: 1,
+    },
+    {
+      id: "demo-site-kolsas",
+      name: "Kolsåstoppen",
+      position: { lat: 59.9291, lon: 10.519 },
+      groundElevationM: 379,
+      antennaHeightM: 2,
+      txPowerDbm: 22,
+      txGainDbi: 2,
+      rxGainDbi: 2,
+      cableLossDb: 1,
+    },
+  ],
+  links: [
+    {
+      id: "demo-lnk-kikut-kolsas",
+      fromSiteId: "demo-site-kikut",
+      toSiteId: "demo-site-kolsas",
+      frequencyMHz: 869.618,
+    },
+  ],
+  systems: mkSystems(),
+  networks: [
+    {
+      id: "demo-net-1",
+      name: "Demo Channel",
+      frequencyMHz: 869.618,
+      bandwidthKhz: 62,
+      spreadFactor: 8,
+      codingRate: 5,
+      frequencyOverrideMHz: 869.618,
+      regionCode: "EU_868",
+      memberships: [
+        { siteId: "demo-site-tryvanns", systemId: "sys-base" },
+        { siteId: "demo-site-haukasen", systemId: "sys-mobile" },
+        { siteId: "demo-site-kikut", systemId: "sys-mobile" },
+        { siteId: "demo-site-kolsas", systemId: "sys-mobile" },
+      ],
+    },
+  ],
+  // viewport is intentionally minimal — loadDemoScenario() computes it from site bounds
+  viewport: { center: { lat: 59.99, lon: 10.65 }, zoom: 9 },
+  defaultSiteId: "demo-site-kikut",
+  defaultLinkId: "demo-lnk-kikut-kolsas",
+  defaultNetworkId: "demo-net-1",
+  defaultFrequencyPresetId: "oslo-local-869618",
+};

--- a/src/lib/simulationArea.ts
+++ b/src/lib/simulationArea.ts
@@ -50,12 +50,16 @@ export const boundsToViewport = (
   pixelWidth = 800,
   pixelHeight = 600,
 ): MapViewport => {
-  const zoomLat = Math.log2((360 / bounds.latSpanDeg) * (pixelHeight / 256));
+  const latCenter = (bounds.minLat + bounds.maxLat) / 2;
+  // Apply Mercator cos(lat) correction: at high latitudes 1° of latitude spans
+  // more pixels than at the equator, so we must scale down the lat zoom accordingly.
+  const cosLat = Math.cos((latCenter * Math.PI) / 180);
+  const zoomLat = Math.log2((360 / bounds.latSpanDeg) * (pixelHeight / 256) * cosLat);
   const zoomLon = Math.log2((360 / bounds.lonSpanDeg) * (pixelWidth / 256));
   const zoom = Math.max(1, Math.floor(Math.min(zoomLat, zoomLon, 20)));
   return {
     center: {
-      lat: (bounds.minLat + bounds.maxLat) / 2,
+      lat: latCenter,
       lon: (bounds.minLon + bounds.maxLon) / 2,
     },
     zoom,

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -18,7 +18,7 @@ import {
   withClimateDefaults,
 } from "../lib/propagationEnvironment";
 import { analyzeLink, buildProfile } from "../lib/propagation";
-import { BUILTIN_SCENARIOS, defaultScenario, getScenarioById } from "../lib/scenarios";
+import { BUILTIN_SCENARIOS, defaultScenario, DEMO_SCENARIO, getScenarioById } from "../lib/scenarios";
 import { boundsToViewport, simulationAreaBoundsForSites } from "../lib/simulationArea";
 import { tilesForBounds } from "../lib/terrainTiles";
 import { mergeSrtmTiles } from "../lib/terrainMerge";
@@ -388,6 +388,7 @@ type AppState = {
   setBasemapProvider: (value: BasemapProvider) => void;
   setBasemapStylePreset: (value: string) => void;
   selectScenario: (id: string) => void;
+  loadDemoScenario: () => void;
   setSelectedLinkId: (id: string) => void;
   setTemporaryDirectionReversed: (value: boolean) => void;
   toggleTemporaryDirectionReversed: () => void;
@@ -1672,6 +1673,45 @@ export const useAppStore = create<AppState>((set, get) => ({
       siteLibrary: libraryBacked.siteLibrary,
     });
     writeStorage(LAST_SESSION_KEY, { selectedScenarioId: scenario.id, savedAtIso: new Date().toISOString() });
+    useCoverageStore.getState().recomputeCoverage();
+  },
+  loadDemoScenario: () => {
+    const scenario = DEMO_SCENARIO;
+    const libraryBacked = ensureSitesBackedByLibrary(scenario.sites, get().siteLibrary);
+    if (libraryBacked.addedCount > 0) {
+      writeStorage(SITE_LIBRARY_KEY, libraryBacked.siteLibrary);
+    }
+    const bounds = simulationAreaBoundsForSites(scenario.sites);
+    const viewport = bounds ? boundsToViewport(bounds) : scenario.viewport;
+    set({
+      // selectedScenarioId intentionally not set — demo stays invisible in scenario UI
+      sites: libraryBacked.sites,
+      links: scenario.links,
+      systems: scenario.systems,
+      networks: scenario.networks,
+      selectedSiteId: scenario.defaultSiteId,
+      selectedSiteIds: scenario.defaultSiteId ? [scenario.defaultSiteId] : [],
+      selectedLinkId: scenario.defaultLinkId,
+      profileCursorIndex: 0,
+      temporaryDirectionReversed: false,
+      selectedNetworkId: scenario.defaultNetworkId,
+      selectedFrequencyPresetId: scenario.defaultFrequencyPresetId,
+      propagationModel: "ITM",
+      rxSensitivityTargetDbm: -120,
+      environmentLossDb: 0,
+      propagationEnvironment: defaultPropagationEnvironment(),
+      autoPropagationEnvironment: true,
+      propagationEnvironmentReason: "Auto defaults active.",
+      terrainFetchStatus: "",
+      terrainRecommendation: "",
+      isHighResTerrainLoaded: false,
+      terrainLoadingStartedAtMs: 0,
+      terrainLoadEpoch: 0,
+      siteDragPreview: {},
+      endpointPickTarget: null,
+      mapViewport: viewport,
+      siteLibrary: libraryBacked.siteLibrary,
+    });
     useCoverageStore.getState().recomputeCoverage();
   },
   setSelectedLinkId: (id) =>


### PR DESCRIPTION
## Summary
- Adds a `DEMO_SCENARIO` (outside `BUILTIN_SCENARIOS`) with 4 real Oslo sites: Tryvannstårnet, Haukåsen, Kikut, Kolsåstoppen
- Auto-loads on bare URL + no deeplink + anonymous access via new `loadDemoScenario()` store action
- Replaces generic "You are signed out" banner with clean demo-mode copy; deeplink guest gets its own concise banner
- Hides the "no-simulation" empty overlay for read-only shell (demo loads synchronously)
- Fixes `boundsToViewport()` — applies Mercator cos(lat) correction to zoomLat (wrong zoom at high latitudes)
- Fixes `computeFitViewport()` — same cos(lat) correction + uses actual map container dimensions (closes #223 Fit button)

## Test plan
- [ ] Open bare URL anonymously (or local force-readonly) — confirm demo loads with 4 Oslo sites, Kikut→Kolsåstoppen selected, map fitted to area
- [ ] Confirm banner reads "Exploring in demo mode" with "Sign in to save your own simulations" button
- [ ] Open a deeplink as anonymous — confirm separate "Viewing as guest / Sign In" banner
- [ ] Click Fit button with sites loaded — confirm map fits sites correctly at lat ~60°N
- [ ] Authenticated user: no demo auto-load, normal workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)