### PR TITLE
fix(#346): clean up demo landing UI and fix viewport fit

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1234,6 +1234,9 @@ export function AppShell() {
           hideLibraryBrowsing={isReadOnlyShell}
           onOpenHelp={openOnboardingTutorial}
           readOnly={!canPersistWorkspace}
+          simulationDisplayLabel={
+            isReadOnlyShell && !deepLinkParse.ok && sites.length > 0 ? "Oslo Demo" : undefined
+          }
         />
       ) : null}
       <section className={`workspace-panel ${isMapExpanded ? "is-map-expanded" : ""} ${isProfileExpanded ? "is-profile-expanded" : ""}`}>
@@ -1242,17 +1245,21 @@ export function AppShell() {
             <span className="field-help">Checking access in the background. Anonymous mode is available while this resolves.</span>
           </div>
         ) : null}
-        {accessState === "locked" && lockedNeedsSignIn && !deepLinkParse.ok ? (
+        {accessState === "locked" && lockedNeedsSignIn ? (
           <div className="workspace-header-actions">
-            <span className="field-help">Exploring in demo mode.</span>
+            <span className="field-help">
+              {deepLinkParse.ok ? "Viewing as guest." : "Demo workspace — sign in to save your own simulations."}
+            </span>
             <button className="inline-action" onClick={signIn} type="button">
-              Sign in to save your own simulations
+              Sign In
             </button>
           </div>
         ) : null}
-        {accessState === "locked" && lockedNeedsSignIn && deepLinkParse.ok ? (
+        {isAnonymousGuestReadonly ? (
           <div className="workspace-header-actions">
-            <span className="field-help">Viewing as guest.</span>
+            <span className="field-help">
+              {deepLinkParse.ok ? "Viewing as guest." : "Demo workspace — sign in to save your own simulations."}
+            </span>
             <button className="inline-action" onClick={signIn} type="button">
               Sign In
             </button>

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -918,37 +918,31 @@ const buildTerrainShadeOverlay = (
   };
 };
 
-const computeFitViewport = (
-  sites: { position: { lat: number; lon: number } }[],
-  containerWidth = 800,
-  containerHeight = 600,
-): { lat: number; lon: number; zoom: number } => {
-  if (!sites.length) return { lat: 59.9, lon: 10.7, zoom: 8 };
-  if (sites.length === 1) {
-    return { lat: sites[0].position.lat, lon: sites[0].position.lon, zoom: 13 };
-  }
+/** ~20 km geographic margin added around sites before fitting. */
+const FIT_PAD_DEG = 0.18;
+/**
+ * Pixel insets reserved for UI chrome inside the map container.
+ * Right accounts for the map controls pill; others are minimal breathing room.
+ */
+const FIT_CHROME_PADDING = { top: 30, right: 70, bottom: 30, left: 20 } as const;
 
+/**
+ * Compute the LngLatBounds to pass to maplibre fitBounds for a set of sites,
+ * expanding by ~20 km in all directions.
+ */
+const computeSiteFitBounds = (
+  sites: { position: { lat: number; lon: number } }[],
+): [[number, number], [number, number]] | null => {
+  if (!sites.length) return null;
   const lats = sites.map((s) => s.position.lat);
   const lons = sites.map((s) => s.position.lon);
-  const minLat = Math.min(...lats);
-  const maxLat = Math.max(...lats);
-  const minLon = Math.min(...lons);
-  const maxLon = Math.max(...lons);
-
-  const centerLat = (minLat + maxLat) / 2;
-  const centerLon = (minLon + maxLon) / 2;
-  // Apply Mercator cos(lat) correction: at high latitudes 1° of latitude spans
-  // more pixels than at the equator.
-  const cosLat = Math.cos((centerLat * Math.PI) / 180);
-
-  const latSpan = Math.max(0.004, (maxLat - minLat) * 1.4);
-  const lonSpan = Math.max(0.004, (maxLon - minLon) * 1.4);
-
-  const zoomLat = Math.log2((360 * cosLat) / latSpan * (containerHeight / 256));
-  const zoomLon = Math.log2((360 / lonSpan) * (containerWidth / 256));
-  const zoom = clamp(Math.min(zoomLat, zoomLon), 3, 15);
-
-  return { lat: centerLat, lon: centerLon, zoom };
+  const centerLat = (Math.min(...lats) + Math.max(...lats)) / 2;
+  // Scale lon padding by 1/cos(lat) so the geographic margin is uniform in km.
+  const lonPad = FIT_PAD_DEG / Math.max(0.1, Math.cos((centerLat * Math.PI) / 180));
+  return [
+    [Math.min(...lons) - lonPad, Math.min(...lats) - FIT_PAD_DEG],
+    [Math.max(...lons) + lonPad, Math.max(...lats) + FIT_PAD_DEG],
+  ];
 };
 
 type MapViewProps = {
@@ -1085,7 +1079,9 @@ export function MapView({
   const [showSimulationSummary, setShowSimulationSummary] = useState(false);
   const [isMultiSelectMode, setIsMultiSelectMode] = useState(false);
   const [showOverlayGuide, setShowOverlayGuide] = useState(true);
+  const fitSitesEpoch = useAppStore((state) => state.fitSitesEpoch);
   const [fitControlActive, setFitControlActive] = useState(false);
+  const [isMapLoaded, setIsMapLoaded] = useState(false);
   const [endpointPickError, setEndpointPickError] = useState<string | null>(null);
   const [pendingNewSiteDraft, setPendingNewSiteDraft] = useState<PendingNewSiteDraft | null>(null);
   const [armAddSiteOnNextEmptyMapClick, setArmAddSiteOnNextEmptyMapClick] = useState(false);
@@ -1122,6 +1118,22 @@ export function MapView({
       window.removeEventListener("orientationchange", handleViewportChange);
     };
   }, []);
+
+  // When a scenario or simulation loads (fitSitesEpoch increments), fit the map to
+  // all sites with a ~20 km geographic margin and insets for UI chrome.
+  useEffect(() => {
+    if (!fitSitesEpoch || !isMapLoaded || !mapRef.current) return;
+    const bounds = computeSiteFitBounds(sites);
+    if (!bounds) return;
+    mapRef.current.fitBounds(bounds, {
+      padding: FIT_CHROME_PADDING,
+      animate: false,
+      maxZoom: 14,
+    });
+    setInteractionViewState(null);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fitSitesEpoch, isMapLoaded]);
+
   const hasNonAutoLinks = useMemo(
     () => links.some((link) => (link.name ?? "").trim().toLowerCase() !== "auto link"),
     [links],
@@ -1552,15 +1564,15 @@ export function MapView({
   };
 
   const fitToNodes = () => {
+    if (!mapRef.current) return;
+    const bounds = computeSiteFitBounds(sites);
+    if (!bounds) return;
     setFitControlActive(true);
-    const container = mapRef.current?.getContainer();
-    const w = container?.clientWidth ?? 800;
-    const h = container?.clientHeight ?? 600;
-    const next = computeFitViewport(sites, w, h);
     setInteractionViewState(null);
-    updateMapViewport({
-      center: { lat: next.lat, lon: next.lon },
-      zoom: next.zoom,
+    mapRef.current.fitBounds(bounds, {
+      padding: FIT_CHROME_PADDING,
+      animate: true,
+      maxZoom: 14,
     });
   };
 
@@ -2530,6 +2542,7 @@ export function MapView({
           zoom: activeViewState.zoom,
         }}
         mapStyle={useFallbackMapStyle ? fallbackMapStyle : resolvedBasemap.style}
+        onLoad={() => setIsMapLoaded(true)}
         onError={() => {
           if (!useFallbackMapStyle && resolvedBasemap.provider !== "kartverket") {
             setUseFallbackMapStyle(true);

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -258,9 +258,11 @@ type SidebarProps = {
   hideLibraryBrowsing?: boolean;
   readOnly?: boolean;
   authBootstrapPending?: boolean;
+  /** Override the computed simulation name shown in the Simulation section header. */
+  simulationDisplayLabel?: string;
 };
 
-export function Sidebar({ onOpenHelp, hideLibraryBrowsing = false, readOnly = false, authBootstrapPending = false }: SidebarProps) {
+export function Sidebar({ onOpenHelp, hideLibraryBrowsing = false, readOnly = false, authBootstrapPending = false, simulationDisplayLabel }: SidebarProps) {
   const { theme, colorTheme, variant } = useThemeVariant();
   const runtimeEnvironment = getCurrentRuntimeEnvironment();
   const envBadgeLabel = runtimeEnvironment === "local" ? "LOCAL" : runtimeEnvironment === "staging" ? "STAGING" : "";
@@ -1787,7 +1789,7 @@ export function Sidebar({ onOpenHelp, hideLibraryBrowsing = false, readOnly = fa
       </header>
       <section className="panel-section section-scenario">
         <div className="section-heading">
-          <h2>Simulation: {activeSimulationLabel}</h2>
+          <h2>Simulation: {simulationDisplayLabel ?? activeSimulationLabel}</h2>
           <InfoTip text="Open a simulation from the library or create a new one. A simulation is a workspace where you can add sites and tweak settings. They can be private or shared." />
         </div>
         <div className="chip-group simulation-buttons">
@@ -1822,7 +1824,7 @@ export function Sidebar({ onOpenHelp, hideLibraryBrowsing = false, readOnly = fa
               ) : null}
             </>
           ) : (
-            <span className="field-help">Shared-link guest mode: library browsing is hidden.</span>
+            <span className="field-help">Sign in to browse the simulation library.</span>
           )}
         </div>
         {simulationSaveStatus ? <p className="field-help">{simulationSaveStatus}</p> : null}

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -310,6 +310,7 @@ type AppState = {
   systems: RadioSystem[];
   networks: Network[];
   srtmTiles: SrtmTile[];
+  fitSitesEpoch: number;
   isTerrainFetching: boolean;
   isEditorTerrainFetching: boolean;
   isTerrainRecommending: boolean;
@@ -389,6 +390,7 @@ type AppState = {
   setBasemapStylePreset: (value: string) => void;
   selectScenario: (id: string) => void;
   loadDemoScenario: () => void;
+  requestFitToSites: () => void;
   setSelectedLinkId: (id: string) => void;
   setTemporaryDirectionReversed: (value: boolean) => void;
   toggleTemporaryDirectionReversed: () => void;
@@ -1107,6 +1109,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   systems: [],
   networks: [],
   srtmTiles: [],
+  fitSitesEpoch: 0,
   isTerrainFetching: false,
   isEditorTerrainFetching: false,
   isTerrainRecommending: false,
@@ -1671,6 +1674,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       endpointPickTarget: null,
       mapViewport: scenario.viewport,
       siteLibrary: libraryBacked.siteLibrary,
+      fitSitesEpoch: get().fitSitesEpoch + 1,
     });
     writeStorage(LAST_SESSION_KEY, { selectedScenarioId: scenario.id, savedAtIso: new Date().toISOString() });
     useCoverageStore.getState().recomputeCoverage();
@@ -1681,16 +1685,21 @@ export const useAppStore = create<AppState>((set, get) => ({
     if (libraryBacked.addedCount > 0) {
       writeStorage(SITE_LIBRARY_KEY, libraryBacked.siteLibrary);
     }
-    const bounds = simulationAreaBoundsForSites(scenario.sites);
-    const viewport = bounds ? boundsToViewport(bounds) : scenario.viewport;
+    // Resolve link selection: both endpoints must be selected for path profile to show.
+    const defaultLink = scenario.links.find((l) => l.id === scenario.defaultLinkId);
+    const selectedSiteIds = defaultLink
+      ? normalizeSelectedSiteIds([defaultLink.fromSiteId, defaultLink.toSiteId], libraryBacked.sites)
+      : scenario.defaultSiteId
+        ? [scenario.defaultSiteId]
+        : [];
     set({
       // selectedScenarioId intentionally not set — demo stays invisible in scenario UI
       sites: libraryBacked.sites,
       links: scenario.links,
       systems: scenario.systems,
       networks: scenario.networks,
-      selectedSiteId: scenario.defaultSiteId,
-      selectedSiteIds: scenario.defaultSiteId ? [scenario.defaultSiteId] : [],
+      selectedSiteId: selectedSiteIds[0] ?? scenario.defaultSiteId,
+      selectedSiteIds,
       selectedLinkId: scenario.defaultLinkId,
       profileCursorIndex: 0,
       temporaryDirectionReversed: false,
@@ -1709,11 +1718,14 @@ export const useAppStore = create<AppState>((set, get) => ({
       terrainLoadEpoch: 0,
       siteDragPreview: {},
       endpointPickTarget: null,
-      mapViewport: viewport,
+      // mapViewport: undefined — fitSitesEpoch triggers proper fit via MapView
+      fitSitesEpoch: get().fitSitesEpoch + 1,
       siteLibrary: libraryBacked.siteLibrary,
+      mapOverlayMode: defaultOverlayModeForSelectionCount(selectedSiteIds.length),
     });
     useCoverageStore.getState().recomputeCoverage();
   },
+  requestFitToSites: () => set((state) => ({ fitSitesEpoch: state.fitSitesEpoch + 1 })),
   setSelectedLinkId: (id) =>
     set((state) => {
       const selectedLink = state.links.find((link) => link.id === id) ?? null;
@@ -2657,6 +2669,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         siteDragPreview: {},
         mapOverlayMode: defaultOverlayModeForSelectionCount(0),
         terrainFetchStatus: `Loaded simulation preset: ${preset.name}`,
+        fitSitesEpoch: get().fitSitesEpoch + 1,
       });
       writeStorage(LAST_SESSION_KEY, { selectedScenarioId: preset.id, savedAtIso: loadedAtIso });
       useCoverageStore.getState().recomputeCoverage();
@@ -2719,6 +2732,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       terrainFetchStatus: `Loaded simulation preset: ${preset.name}`,
       siteLibrary: libraryBacked.siteLibrary,
       mapOverlayMode: defaultOverlayModeForSelectionCount(selectedSiteId ? 1 : 0),
+      fitSitesEpoch: get().fitSitesEpoch + 1,
     });
     if (libraryBacked.addedCount > 0) {
       writeStorage(SITE_LIBRARY_KEY, libraryBacked.siteLibrary);


### PR DESCRIPTION
## Summary
- Merges double banner into a single `workspace-header-actions` bar with existing `field-help` + `inline-action Sign In` pattern
- Removes long custom button text; keeps "Sign In" consistent with rest of app
- Sidebar: adds `simulationDisplayLabel` prop; shows "Oslo Demo" for anonymous demo (replaces "no simulation selected")
- Sidebar: replaces "Shared-link guest mode: library browsing is hidden." with neutral "Sign in to browse the simulation library."
- Fixes `loadDemoScenario`: both link endpoints are now in `selectedSiteIds` so path profile and LOS overlay activate on load
- Adds `fitSitesEpoch` to store; incremented by `loadDemoScenario`, `selectScenario`, `loadSimulationPreset`
- MapView: reacts to `fitSitesEpoch` via `mapRef.current.fitBounds()` — correct Mercator, pixel padding for chrome
- Fit button also uses `fitBounds` with `animate: true`
- Geographic margin: ~20 km (0.18° lat, lon scaled by cos(lat))
- Chrome pixel padding: `{ top: 30, right: 70, bottom: 30, left: 20 }` — right accounts for controls pill

## Test plan
- [ ] Open bare URL anonymously — demo loads with Kikut→Kolsåstoppen selected, path profile visible immediately
- [ ] Single "Demo workspace — sign in to save your own simulations. [Sign In]" banner visible, no double messages
- [ ] Sidebar heading reads "Simulation: Oslo Demo" not "no simulation selected"
- [ ] Sidebar shows "Sign in to browse the simulation library." not "Shared-link guest mode..."
- [ ] Fit button fits all 4 Oslo sites with ~20 km margin, not clipped behind controls pill
- [ ] Open a simulation from Library — map fits to its sites correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)