### PR TITLE
fix(#346): map-inline-notice for demo banner; profile-aware fitBounds

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -438,14 +438,22 @@ export function AppShell() {
     }
   }, [accessState, initializeCloudSync]);
 
-  // Auto-load the Oslo demo workspace for anonymous visitors with no deeplink.
+  // Auto-load the Oslo demo workspace for anonymous visitors with no deeplink,
+  // and publish a persistent map notice (uses the existing map-inline-notice UI).
   useEffect(() => {
     const isAnonNoDeepLink =
       !deepLinkParse.ok &&
       (isAnonymousGuestReadonly || (accessState === "locked" && lockedNeedsSignIn));
-    if (isAnonNoDeepLink && sites.length === 0) {
+    if (!isAnonNoDeepLink) return;
+    if (sites.length === 0) {
       loadDemoScenario();
     }
+    publishAppNotice({
+      id: "demo-mode",
+      message: deepLinkParse.ok ? "Viewing as guest." : "Demo workspace — sign in to save your own simulations.",
+      tone: "info",
+      persistent: true,
+    });
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [accessState, isAnonymousGuestReadonly, lockedNeedsSignIn, deepLinkParse.ok]);
 
@@ -1245,26 +1253,6 @@ export function AppShell() {
             <span className="field-help">Checking access in the background. Anonymous mode is available while this resolves.</span>
           </div>
         ) : null}
-        {accessState === "locked" && lockedNeedsSignIn ? (
-          <div className="workspace-header-actions">
-            <span className="field-help">
-              {deepLinkParse.ok ? "Viewing as guest." : "Demo workspace — sign in to save your own simulations."}
-            </span>
-            <button className="inline-action" onClick={signIn} type="button">
-              Sign In
-            </button>
-          </div>
-        ) : null}
-        {isAnonymousGuestReadonly ? (
-          <div className="workspace-header-actions">
-            <span className="field-help">
-              {deepLinkParse.ok ? "Viewing as guest." : "Demo workspace — sign in to save your own simulations."}
-            </span>
-            <button className="inline-action" onClick={signIn} type="button">
-              Sign In
-            </button>
-          </div>
-        ) : null}
         {!isOnline && !offlineBannerDismissed ? (
           <div className="offline-banner" role="status">
             <span>Offline. Changes are saved locally and will sync when connection returns.</span>
@@ -1368,6 +1356,11 @@ export function AppShell() {
                   onDismiss: appNotice.persistent ? () => setAppNotice(null) : undefined,
                 }
               : undefined
+          }
+          fitBottomInset={
+            isMobileViewport || isMapExpanded || isProfileExpanded
+              ? 30
+              : Math.max(220, typeof window !== "undefined" ? window.innerHeight * 0.32 : 220) + 18 + 18
           }
         />
         {isMobileViewport ? (

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -958,6 +958,8 @@ type MapViewProps = {
     tone: "info" | "warning" | "error";
     onDismiss?: () => void;
   };
+  /** Pixel inset for the bottom edge when computing fitBounds, to avoid UI chrome. */
+  fitBottomInset?: number;
 };
 
 type PendingNewSiteDraft = {
@@ -992,6 +994,7 @@ export function MapView({
   onToggleMapExpanded,
   onShare,
   notice,
+  fitBottomInset = 30,
 }: MapViewProps) {
   const sites = useAppStore((state) => state.sites);
   const siteLibrary = useAppStore((state) => state.siteLibrary);
@@ -1126,13 +1129,13 @@ export function MapView({
     const bounds = computeSiteFitBounds(sites);
     if (!bounds) return;
     mapRef.current.fitBounds(bounds, {
-      padding: FIT_CHROME_PADDING,
+      padding: { ...FIT_CHROME_PADDING, bottom: fitBottomInset },
       animate: false,
       maxZoom: 14,
     });
     setInteractionViewState(null);
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fitSitesEpoch, isMapLoaded]);
+  }, [fitSitesEpoch, isMapLoaded, fitBottomInset]);
 
   const hasNonAutoLinks = useMemo(
     () => links.some((link) => (link.name ?? "").trim().toLowerCase() !== "auto link"),
@@ -1570,7 +1573,7 @@ export function MapView({
     setFitControlActive(true);
     setInteractionViewState(null);
     mapRef.current.fitBounds(bounds, {
-      padding: FIT_CHROME_PADDING,
+      padding: { ...FIT_CHROME_PADDING, bottom: fitBottomInset },
       animate: true,
       maxZoom: 14,
     });


### PR DESCRIPTION
## Summary
- Removes the custom `workspace-header-actions` demo/guest banners
- Publishes a persistent `appNotice` instead — renders via the existing `map-inline-notice` pill (centered, correct z-index, below map controls)
- No inline Sign In button in the notice; it can be dismissed
- Adds `fitBottomInset` prop to MapView (default 30px)
- AppShell passes `max(220, 32vh) + 36px` on desktop when profile panel is visible, matching the CSS `chart-panel` bottom offset rule
- Map-expanded / profile-expanded / mobile all use 30px (no panel obstruction)

## Test plan
- [ ] Open bare URL anonymously → see "Demo workspace — sign in..." as map-inline-notice pill (centered, below controls, no right-side overlap)
- [ ] Dismiss notice → clears cleanly
- [ ] Open simulation with profile panel visible → Fit button keeps all sites above the profile panel
- [ ] Auto-fit on simulation load respects profile panel height

🤖 Generated with [Claude Code](https://claude.com/claude-code)