### PR TITLE
feat(#142): share with specific users via per-collaborator roles

### DIFF
--- a/functions/_lib/db.ts
+++ b/functions/_lib/db.ts
@@ -1954,7 +1954,7 @@ export const resolveSimulationIdBySlug = async (
 
 export const fetchPublicSimulationBundle = async (
   env: Env,
-  options: { simulationId?: string; simulationSlug?: string },
+  options: { simulationId?: string; simulationSlug?: string; actorId?: string | null },
 ): Promise<
   | { status: "missing" | "forbidden" }
   | {
@@ -1976,7 +1976,17 @@ export const fetchPublicSimulationBundle = async (
     .first<{ id: string; payload_json: string; visibility: DbVisibility }>();
   if (!simulationRow) return { status: "missing" };
   const visibility = visibilityFromDbVisibility(simulationRow.visibility);
-  if (visibility === "private") return { status: "forbidden" };
+
+  let actorSimulationRole: string | null = null;
+  if (visibility === "private") {
+    if (!options.actorId) return { status: "forbidden" };
+    const roleRow = await env.DB
+      .prepare("SELECT role FROM simulation_roles WHERE simulation_id = ? AND user_id = ? LIMIT 1")
+      .bind(resolvedId, options.actorId)
+      .first<{ role: string }>();
+    if (!roleRow) return { status: "forbidden" };
+    actorSimulationRole = roleRow.role;
+  }
 
   let simulation: CloudResourceRecord;
   try {
@@ -1986,7 +1996,7 @@ export const fetchPublicSimulationBundle = async (
   }
   simulation.id = simulationRow.id;
   simulation.visibility = visibility;
-  simulation.effectiveRole = "viewer";
+  simulation.effectiveRole = actorSimulationRole ?? "viewer";
 
   const referencedSiteIds = referencedLibrarySiteIdsFromSimulation(simulation);
   if (!referencedSiteIds.length) {
@@ -2005,7 +2015,9 @@ export const fetchPublicSimulationBundle = async (
     .all<{ id: string; payload_json: string; visibility: DbVisibility }>();
   const sites: CloudResourceRecord[] = [];
   for (const row of rows.results) {
-    if (visibilityFromDbVisibility(row.visibility) === "private") continue;
+    // When actor has an explicit simulation role (private access), include all referenced
+    // sites regardless of their individual visibility — simulation-level access covers its sites.
+    if (actorSimulationRole === null && visibilityFromDbVisibility(row.visibility) === "private") continue;
     try {
       const site = JSON.parse(row.payload_json) as CloudResourceRecord;
       site.id = row.id;

--- a/functions/api/public-simulation.test.ts
+++ b/functions/api/public-simulation.test.ts
@@ -1,11 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { fetchPublicSimulationBundleMock } = vi.hoisted(() => ({
+const { fetchPublicSimulationBundleMock, verifyAuthMock } = vi.hoisted(() => ({
   fetchPublicSimulationBundleMock: vi.fn(),
+  verifyAuthMock: vi.fn(),
 }));
 
 vi.mock("../_lib/db", () => ({
   fetchPublicSimulationBundle: fetchPublicSimulationBundleMock,
+}));
+
+vi.mock("../_lib/auth", () => ({
+  verifyAuth: verifyAuthMock,
 }));
 
 import { onRequestGet } from "./public-simulation";
@@ -15,6 +20,7 @@ const mkCtx = (request: Request) => ({ request, env } as unknown as Parameters<t
 
 beforeEach(() => {
   vi.clearAllMocks();
+  verifyAuthMock.mockResolvedValue(null);
   fetchPublicSimulationBundleMock.mockResolvedValue({
     status: "ok",
     simulationId: "sim-1",
@@ -34,5 +40,29 @@ describe("api/public-simulation", () => {
     const res = await onRequestGet(mkCtx(new Request("https://example.test/api/public-simulation?sim=sim-1")));
     expect(res.status).toBe(200);
     expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("passes actorId null when request is unauthenticated", async () => {
+    verifyAuthMock.mockResolvedValue(null);
+    await onRequestGet(mkCtx(new Request("https://example.test/api/public-simulation?sim=sim-1")));
+    expect(fetchPublicSimulationBundleMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ actorId: null }),
+    );
+  });
+
+  it("passes actorId from auth when request is authenticated", async () => {
+    verifyAuthMock.mockResolvedValue({ userId: "user-42" });
+    await onRequestGet(mkCtx(new Request("https://example.test/api/public-simulation?sim=sim-1")));
+    expect(fetchPublicSimulationBundleMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ actorId: "user-42" }),
+    );
+  });
+
+  it("returns 403 when bundle status is forbidden", async () => {
+    fetchPublicSimulationBundleMock.mockResolvedValue({ status: "forbidden" });
+    const res = await onRequestGet(mkCtx(new Request("https://example.test/api/public-simulation?sim=sim-1")));
+    expect(res.status).toBe(403);
   });
 });

--- a/functions/api/public-simulation.ts
+++ b/functions/api/public-simulation.ts
@@ -1,3 +1,4 @@
+import { verifyAuth } from "../_lib/auth";
 import { fetchPublicSimulationBundle } from "../_lib/db";
 import { errorResponse, handleOptions, json, withCors } from "../_lib/http";
 import type { Env } from "../_lib/types";
@@ -15,9 +16,13 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
       return withCors(request, json({ error: "Missing simulation id or slug" }, { status: 400, headers: NO_STORE_HEADERS }));
     }
 
+    const auth = await verifyAuth(request, env).catch(() => null);
+    const actorId = auth?.userId ?? null;
+
     const bundle = await fetchPublicSimulationBundle(env, {
       simulationId: simulationId || undefined,
       simulationSlug: simulationSlug || undefined,
+      actorId,
     });
 
     if (bundle.status !== "ok") {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -572,6 +572,7 @@ export function Sidebar({
   const [resourceRxGainDraft, setResourceRxGainDraft] = useState(STANDARD_SITE_RADIO.rxGainDbi);
   const [resourceCableLossDraft, setResourceCableLossDraft] = useState(STANDARD_SITE_RADIO.cableLossDb);
   const [resourceCollaboratorUserIds, setResourceCollaboratorUserIds] = useState<string[]>([]);
+  const [resourceCollaboratorRoles, setResourceCollaboratorRoles] = useState<Record<string, "viewer" | "editor">>({});
   const [resourceCollaboratorQuery, setResourceCollaboratorQuery] = useState("");
   const [resourceCollaboratorDirectory, setResourceCollaboratorDirectory] = useState<CollaboratorDirectoryUser[]>([]);
   const [resourceCollaboratorDirectoryBusy, setResourceCollaboratorDirectoryBusy] = useState(false);
@@ -1543,11 +1544,10 @@ export function Sidebar({
       setResourceRxGainDraft(site?.rxGainDbi ?? STANDARD_SITE_RADIO.rxGainDbi);
       setResourceCableLossDraft(site?.cableLossDb ?? STANDARD_SITE_RADIO.cableLossDb);
       setResourceAccessVisibility(normalizeAccessVisibility(site?.visibility));
-      setResourceCollaboratorUserIds(
-        (site?.sharedWith ?? [])
-          .filter((grant) => grant.role === "editor" || grant.role === "admin")
-          .filter((grant) => grant.userId !== site?.ownerUserId)
-          .map((grant) => grant.userId),
+      const siteGrants = (site?.sharedWith ?? []).filter((grant) => grant.userId !== site?.ownerUserId);
+      setResourceCollaboratorUserIds(siteGrants.map((grant) => grant.userId));
+      setResourceCollaboratorRoles(
+        Object.fromEntries(siteGrants.map((grant) => [grant.userId, grant.role === "editor" || grant.role === "admin" ? "editor" : "viewer"])),
       );
     } else {
       const simulation = simulationPresets.find((entry) => entry.id === resourceId);
@@ -1561,11 +1561,10 @@ export function Sidebar({
       setResourceRxGainDraft(STANDARD_SITE_RADIO.rxGainDbi);
       setResourceCableLossDraft(STANDARD_SITE_RADIO.cableLossDb);
       setResourceAccessVisibility(normalizeAccessVisibility(simulation?.visibility));
-      setResourceCollaboratorUserIds(
-        (simulation?.sharedWith ?? [])
-          .filter((grant) => grant.role === "editor" || grant.role === "admin")
-          .filter((grant) => grant.userId !== simulation?.ownerUserId)
-          .map((grant) => grant.userId),
+      const simGrants = (simulation?.sharedWith ?? []).filter((grant) => grant.userId !== simulation?.ownerUserId);
+      setResourceCollaboratorUserIds(simGrants.map((grant) => grant.userId));
+      setResourceCollaboratorRoles(
+        Object.fromEntries(simGrants.map((grant) => [grant.userId, grant.role === "editor" || grant.role === "admin" ? "editor" : "viewer"])),
       );
     }
     setResourceCollaboratorQuery("");
@@ -1610,6 +1609,7 @@ export function Sidebar({
       cableLossDb: number;
       visibility: "private" | "public" | "shared";
       collaboratorUserIds: string[];
+      collaboratorRoles: Record<string, "viewer" | "editor">;
     }>,
   ): boolean => {
     if (!resourceDetailsPopup) return false;
@@ -1629,6 +1629,7 @@ export function Sidebar({
     const nextRxGainDbi = overrides?.rxGainDbi ?? resourceRxGainDraft;
     const nextCableLossDb = overrides?.cableLossDb ?? resourceCableLossDraft;
     const nextCollaboratorUserIds = overrides?.collaboratorUserIds ?? resourceCollaboratorUserIds;
+    const nextCollaboratorRoles = overrides?.collaboratorRoles ?? resourceCollaboratorRoles;
     const normalizedVisibility = nextVisibility === "public" ? "shared" : nextVisibility;
     const normalizedName = nextName.trim();
     if (!normalizedName) {
@@ -1637,7 +1638,7 @@ export function Sidebar({
     }
     const sharedWith = nextCollaboratorUserIds
       .filter((userId) => userId !== currentResourceOwnerId)
-      .map((userId) => ({ userId, role: "editor" as const }));
+      .map((userId) => ({ userId, role: (nextCollaboratorRoles[userId] ?? "viewer") as "viewer" | "editor" }));
     const currentEntry =
       resourceDetailsPopup.kind === "site"
         ? siteLibrary.find((entry) => entry.id === resourceDetailsPopup.resourceId)
@@ -1718,7 +1719,7 @@ export function Sidebar({
     }
     const sharedWith = resourceCollaboratorUserIds
       .filter((userId) => userId !== currentResourceOwnerId)
-      .map((userId) => ({ userId, role: "editor" as const }));
+      .map((userId) => ({ userId, role: (resourceCollaboratorRoles[userId] ?? "viewer") as "viewer" | "editor" }));
     updateSimulationPresetEntry(pending.simulationId, {
       visibility: pending.targetVisibility,
       sharedWith,
@@ -1741,6 +1742,9 @@ export function Sidebar({
       ? resourceCollaboratorUserIds
       : [...resourceCollaboratorUserIds, userId];
     setResourceCollaboratorUserIds(nextCollaborators);
+    if (!resourceCollaboratorRoles[userId]) {
+      setResourceCollaboratorRoles((prev) => ({ ...prev, [userId]: "viewer" }));
+    }
     void persistResourceAccessSettings({ collaboratorUserIds: nextCollaborators });
     setResourceCollaboratorQuery("");
   };
@@ -1767,7 +1771,18 @@ export function Sidebar({
     }
     const nextCollaborators = resourceCollaboratorUserIds.filter((id) => id !== userId);
     setResourceCollaboratorUserIds(nextCollaborators);
+    setResourceCollaboratorRoles((prev) => {
+      const next = { ...prev };
+      delete next[userId];
+      return next;
+    });
     void persistResourceAccessSettings({ collaboratorUserIds: nextCollaborators });
+  };
+
+  const setCollaboratorRole = (userId: string, role: "viewer" | "editor") => {
+    const nextRoles = { ...resourceCollaboratorRoles, [userId]: role };
+    setResourceCollaboratorRoles(nextRoles);
+    void persistResourceAccessSettings({ collaboratorRoles: nextRoles });
   };
 
   const changeProfileRole = async (nextRole: "admin" | "moderator" | "user" | "pending") => {
@@ -2814,7 +2829,7 @@ export function Sidebar({
               <div className="field-grid user-bio-field collaborator-picker-grid">
                 <span>
                   Collaborators{" "}
-                  <InfoTip text="Collaborators grant edit rights. Editors can add collaborators but cannot remove existing collaborators. Owners/admins can remove." />
+                  <InfoTip text="Add specific users and assign them viewer or editor access. Viewers can view and run; editors can also modify and add collaborators. Owners/admins can remove collaborators." />
                 </span>
                 <div className="collaborator-picker">
                   <div className="chip-group collaborator-selected-list">
@@ -2822,6 +2837,14 @@ export function Sidebar({
                       selectedCollaboratorUsers.map((user) => (
                         <span className="site-quick-item" key={user.id}>
                           <UserBadge avatarUrl={user.avatarUrl} name={user.username} />
+                          <select
+                            aria-label={`Role for ${user.username}`}
+                            onChange={(e) => setCollaboratorRole(user.id, e.target.value as "viewer" | "editor")}
+                            value={resourceCollaboratorRoles[user.id] ?? "viewer"}
+                          >
+                            <option value="viewer">Viewer</option>
+                            <option value="editor">Editor</option>
+                          </select>
                           <button className="inline-action" onClick={() => removeCollaborator(user.id)} type="button">
                             Remove
                           </button>
@@ -2858,8 +2881,9 @@ export function Sidebar({
                 </div>
               </div>
               <p className="field-help">
-                Collaborators are granted edit rights. Regular editors can add collaborators but cannot remove existing
-                collaborators/owner. Owners/admins can remove collaborators.
+                Viewers can view and run the simulation. Editors can also modify it and add collaborators. Owners/admins
+                can remove collaborators. Private simulations remain private — only added collaborators gain access via
+                the share link when logged in.
               </p>
               {resourceAccessStatus ? <p className="field-help">{resourceAccessStatus}</p> : <p className="field-help">Saved automatically.</p>}
             </details>


### PR DESCRIPTION
## Summary
- Adds per-collaborator role selector (viewer/editor) to the share dialog — owners can now choose what access level each invited user receives
- Private simulations now work for auth-gated share links: if a user has an explicit role in `simulation_roles`, they can access the simulation via the share link while it remains private to everyone else
- Sites referenced by the simulation are included for authenticated collaborators even if those sites are individually private (simulation-level access implicitly covers its sites)
- Fixes hardcoded `"editor"` role when saving collaborator grants — previously all collaborators were saved as editors regardless of UI

## Changes
- `functions/_lib/db.ts`: `fetchPublicSimulationBundle()` now accepts optional `actorId`, checks `simulation_roles` for private simulations, and includes private referenced sites for collaborators
- `functions/api/public-simulation.ts`: optionally calls `verifyAuth()` and passes actorId to db layer
- `functions/api/public-simulation.test.ts`: new test cases for auth-gated access (TDD)
- `src/components/Sidebar.tsx`: new `resourceCollaboratorRoles` state, role selector UI, updated persist logic

## Test plan
- [ ] All 204 tests pass (`npm test`)
- [ ] Build succeeds (`npm run build`)
- [ ] Create a private simulation, add a test user as "viewer" → share link works when logged in as that user
- [ ] Share link returns 403 for unauthenticated requests on private simulations
- [ ] Share link returns 403 for authenticated users without a collaborator role
- [ ] Change collaborator role to "editor" → role updates in D1 `simulation_roles`
- [ ] Private sites referenced by the simulation are accessible to collaborators via the share link

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)