### PR TITLE
chore: bring in hotfix additions from main

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -687,6 +687,21 @@ export function Sidebar({
     }
   }, [showSiteLibraryRequest, setShowSiteLibraryRequest]);
   useEffect(() => {
+    if (showNewSimulationRequest) {
+      setNewSimulationName("");
+      setNewSimulationDescription("");
+      setNewSimulationNameError("");
+      setShowNewSimulationModal(true);
+      setShowNewSimulationRequest(false);
+    }
+  }, [showNewSimulationRequest, setShowNewSimulationRequest]);
+  useEffect(() => {
+    if (showSiteLibraryRequest) {
+      setShowSiteLibraryManager(true);
+      setShowSiteLibraryRequest(false);
+    }
+  }, [showSiteLibraryRequest, setShowSiteLibraryRequest]);
+  useEffect(() => {
     persistLibraryFilterState(SITE_LIBRARY_FILTERS_KEY, siteLibraryFilters);
   }, [siteLibraryFilters]);
   useEffect(() => {

--- a/src/index.css
+++ b/src/index.css
@@ -2339,6 +2339,23 @@ input {
   height: 18px;
 }
 
+.inline-action-icon {
+  min-width: 34px;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  background: transparent;
+}
+
+.inline-action-icon svg {
+  width: 18px;
+  height: 18px;
+}
+
 .user-admin-panel {
   display: grid;
   gap: 8px;


### PR DESCRIPTION
Adds the two code additions present in main (0.12.2) but missing from staging after the squash reconcile: duplicate useEffect cleanup in Sidebar.tsx and .inline-action-icon CSS rule. Required for a clean staging→main merge.