### PR TITLE
chore: remove duplicate useEffect and CSS blocks

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -672,51 +672,6 @@ export function Sidebar({
     }
   }, [hideLibraryBrowsing, showSiteLibraryRequest, setShowSiteLibraryRequest]);
   useEffect(() => {
-    if (showNewSimulationRequest) {
-      setNewSimulationName("");
-      setNewSimulationDescription("");
-      setNewSimulationNameError("");
-      setShowNewSimulationModal(true);
-      setShowNewSimulationRequest(false);
-    }
-  }, [showNewSimulationRequest, setShowNewSimulationRequest]);
-  useEffect(() => {
-    if (showSiteLibraryRequest) {
-      setShowSiteLibraryManager(true);
-      setShowSiteLibraryRequest(false);
-    }
-  }, [showSiteLibraryRequest, setShowSiteLibraryRequest]);
-  useEffect(() => {
-    if (showNewSimulationRequest) {
-      setNewSimulationName("");
-      setNewSimulationDescription("");
-      setNewSimulationNameError("");
-      setShowNewSimulationModal(true);
-      setShowNewSimulationRequest(false);
-    }
-  }, [showNewSimulationRequest, setShowNewSimulationRequest]);
-  useEffect(() => {
-    if (showSiteLibraryRequest) {
-      setShowSiteLibraryManager(true);
-      setShowSiteLibraryRequest(false);
-    }
-  }, [showSiteLibraryRequest, setShowSiteLibraryRequest]);
-  useEffect(() => {
-    if (showNewSimulationRequest) {
-      setNewSimulationName("");
-      setNewSimulationDescription("");
-      setNewSimulationNameError("");
-      setShowNewSimulationModal(true);
-      setShowNewSimulationRequest(false);
-    }
-  }, [showNewSimulationRequest, setShowNewSimulationRequest]);
-  useEffect(() => {
-    if (showSiteLibraryRequest) {
-      setShowSiteLibraryManager(true);
-      setShowSiteLibraryRequest(false);
-    }
-  }, [showSiteLibraryRequest, setShowSiteLibraryRequest]);
-  useEffect(() => {
     persistLibraryFilterState(SITE_LIBRARY_FILTERS_KEY, siteLibraryFilters);
   }, [siteLibraryFilters]);
   useEffect(() => {

--- a/src/index.css
+++ b/src/index.css
@@ -2322,57 +2322,6 @@ input {
   height: 18px;
 }
 
-.inline-action-icon {
-  min-width: 34px;
-  width: 34px;
-  height: 34px;
-  padding: 0;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border: 0;
-  background: transparent;
-}
-
-.inline-action-icon svg {
-  width: 18px;
-  height: 18px;
-}
-
-.inline-action-icon {
-  min-width: 34px;
-  width: 34px;
-  height: 34px;
-  padding: 0;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border: 0;
-  background: transparent;
-}
-
-.inline-action-icon svg {
-  width: 18px;
-  height: 18px;
-}
-
-.inline-action-icon {
-  min-width: 34px;
-  width: 34px;
-  height: 34px;
-  padding: 0;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border: 0;
-  background: transparent;
-}
-
-.inline-action-icon svg {
-  width: 18px;
-  height: 18px;
-}
-
 .user-admin-panel {
   display: grid;
   gap: 8px;


### PR DESCRIPTION
Removes 3 duplicate pairs of useEffect blocks in Sidebar.tsx and 3 duplicate .inline-action-icon CSS rules in index.css, introduced by the repeated squash-reconcile merges.