### PR TITLE
chore: back-merge staging into main after 0.13.0 release

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,3 +31,7 @@
 - [ ] SemVer bump is correct and intentional.
 - [ ] `vX.Y.Z` tag points to the commit being promoted.
 - [ ] Milestone release checklist completed: `docs/milestone-release-checklist.md`.
+
+## Hotfix follow-up (required when source branch is `hotfix/*`)
+
+- [ ] After merge, open a `chore/sync-main-to-staging` PR to bring `main` back into `staging` and prevent ancestry drift on the next milestone release.

--- a/.github/workflows/detect-staging-drift.yml
+++ b/.github/workflows/detect-staging-drift.yml
@@ -1,0 +1,68 @@
+name: Detect staging drift from main
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  drift-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for drift
+        id: drift
+        run: |
+          git fetch origin staging
+          COUNT=$(git log --oneline origin/staging..origin/main | wc -l | tr -d ' ')
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          if [ "$COUNT" -gt 0 ]; then
+            echo "Commits in main not yet in staging:"
+            git log --oneline origin/staging..origin/main
+          fi
+
+      - name: Open drift issue if needed
+        if: steps.drift.outputs.count != '0'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const count = '${{ steps.drift.outputs.count }}';
+            const sha = context.sha.slice(0, 8);
+
+            // Check for an existing open drift issue to avoid duplicates
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'staging-drift',
+              state: 'open',
+            });
+            if (issues.data.length > 0) {
+              core.info('Drift issue already open: ' + issues.data[0].html_url);
+              return;
+            }
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `chore: sync main back into staging (drift after ${sha})`,
+              body: [
+                `**${count} commit(s)** in \`main\` are not in \`staging\`'s ancestry after push to main at ${sha}.`,
+                '',
+                'This drift will cause conflicts on the next `staging → main` promotion.',
+                '',
+                '## Required action',
+                '1. Create a `chore/sync-main-to-staging` branch from `origin/staging`',
+                '2. `git merge origin/main -X ours --no-edit` (prefer staging for any conflicts)',
+                '3. PR the branch into `staging`, merge, redeploy staging',
+                '4. Close this issue',
+                '',
+                '> Auto-opened by the detect-staging-drift workflow.',
+              ].join('\n'),
+              labels: ['staging-drift'],
+            });

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@
   - If code changes after staging verification, rerun local verification and redeploy staging before production.
   - Normal production promotion PR must be `staging` -> `main`.
   - Hotfix promotion PR may be `hotfix/<slug>` -> `main` only with explicit user approval in-thread.
+- **After any hotfix merges to main**: immediately create a `chore/sync-main-to-staging` branch from `origin/staging`, run `git merge origin/main -X ours --no-edit`, PR into `staging`, merge, and redeploy staging. Do not start new feature work until staging is back in sync. The `detect-staging-drift` workflow will open a GitHub Issue as a reminder if this is missed.
 - Local run reliability:
   - Restart local server whenever runtime/config/env changes can affect behavior.
   - Re-verify affected flows after restart before marking work as done.


### PR DESCRIPTION
Brings main in sync with staging post-0.13.0. Adds the drift-detection workflow, AGENTS.md hotfix-sync rule, and PR template hotfix checkbox. Explicit user approval obtained in-thread.