### PR TITLE
fix: raise geocode rate limit and disable search button while in-flight (#105)

### DIFF
--- a/functions/api/geocode.ts
+++ b/functions/api/geocode.ts
@@ -29,7 +29,7 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
       return withCors(request, json({ error: "Search query must be at least 3 characters." }, { status: 400 }));
     }
 
-    const limitPerMinute = parsePerMinuteLimit(env.GEOCODE_RATE_LIMIT_PER_MINUTE, 20);
+    const limitPerMinute = parsePerMinuteLimit(env.GEOCODE_RATE_LIMIT_PER_MINUTE, 60);
     const address = getClientAddress(request);
     const limiter = takeRateLimitToken({ key: `geocode:${address}`, limit: limitPerMinute });
     if (!limiter.allowed) {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -452,6 +452,7 @@ export function Sidebar({
   const [librarySearchStatus, setLibrarySearchStatus] = useState("");
   const [librarySearchResults, setLibrarySearchResults] = useState<GeocodeResult[]>([]);
   const [librarySearchPickBusyId, setLibrarySearchPickBusyId] = useState<string | null>(null);
+  const [librarySearchBusy, setLibrarySearchBusy] = useState(false);
   const [showMeshtasticBrowser, setShowMeshtasticBrowser] = useState(false);
   const [meshmapNodes, setMeshmapNodes] = useState<MeshmapNode[]>([]);
   const [meshmapSourceUrl, setMeshmapSourceUrl] = useState(readPreferredMeshmapSourceUrl);
@@ -1315,6 +1316,7 @@ export function Sidebar({
       setLibrarySearchStatus("Enter at least 3 characters to search.");
       return;
     }
+    setLibrarySearchBusy(true);
     setLibrarySearchStatus("Searching...");
     try {
       const results = await searchLocations(librarySearchQuery);
@@ -1323,6 +1325,8 @@ export function Sidebar({
     } catch (error) {
       const message = getUiErrorMessage(error);
       setLibrarySearchStatus(`Search failed: ${message}`);
+    } finally {
+      setLibrarySearchBusy(false);
     }
   };
   const selectLibrarySearchResult = async (result: GeocodeResult) => {
@@ -3408,8 +3412,8 @@ export function Sidebar({
                     value={librarySearchQuery}
                   />
                 </label>
-                <button className="inline-action" onClick={() => void runLibrarySearch()} type="button">
-                  Search
+                <button className="inline-action" disabled={librarySearchBusy} onClick={() => void runLibrarySearch()} type="button">
+                  {librarySearchBusy ? "Searching…" : "Search"}
                 </button>
                 {librarySearchStatus ? <p className="field-help">{librarySearchStatus}</p> : null}
                 {librarySearchResults.length ? (


### PR DESCRIPTION
## Summary
- Default geocode rate limit raised from 20 → 60 req/min per IP (our own server-side limit, not Nominatim)
- Search button now disables and shows "Searching…" while a request is in-flight, preventing rapid repeat clicks that burn through the limit

Closes #105