### PR TITLE
chore: use local wrangler binary in deploy script instead of npx

### DIFF
--- a/scripts/deploy-pages-safe.mjs
+++ b/scripts/deploy-pages-safe.mjs
@@ -3,6 +3,7 @@ import path from "node:path";
 import { spawn } from "node:child_process";
 
 const root = process.cwd();
+const wrangler = path.join(root, "node_modules", ".bin", "wrangler");
 const wranglerProd = path.join(root, "wrangler.toml");
 const wranglerStaging = path.join(root, "wrangler.staging.toml");
 const wranglerBackup = path.join(root, "wrangler.toml.__deploy_backup__");
@@ -172,8 +173,8 @@ const parseWranglerJsonPayload = (stdout) => {
 async function verifyRemoteSchema(targetName, databaseName) {
   if (targetName !== "staging" && targetName !== "prod-main") return;
   const { stdout } = await run(
-    "npx",
-    ["wrangler", "d1", "execute", databaseName, "--remote", "--command", "PRAGMA table_info(resource_changes);"],
+    wrangler,
+    ["d1", "execute", databaseName, "--remote", "--command", "PRAGMA table_info(resource_changes);"],
     { capture: true },
   );
   const parsed = parseWranglerJsonPayload(stdout);
@@ -274,8 +275,8 @@ async function withWranglerConfig(configPath, fn) {
 async function verifyDeployment(projectName, commit) {
   for (let attempt = 1; attempt <= 6; attempt += 1) {
     const { stdout } = await run(
-      "npx",
-      ["wrangler", "pages", "deployment", "list", "--project-name", projectName],
+      wrangler,
+      ["pages", "deployment", "list", "--project-name", projectName],
       { capture: true },
     );
     const lines = stdout.split("\n");
@@ -306,8 +307,7 @@ async function main() {
   await writeReleaseManifest(targetName, target.projectName, deployBranch, commit);
 
   await withWranglerConfig(target.configPath, async () => {
-    await run("npx", [
-      "wrangler",
+    await run(wrangler, [
       "pages",
       "deploy",
       "dist",


### PR DESCRIPTION
Replaces all `npx wrangler` calls in `scripts/deploy-pages-safe.mjs` with the project-local `node_modules/.bin/wrangler`. Removes the dependency on `npx` being in PATH, which was causing deploy failures in non-login shell environments (e.g. agentic tools, editors).