### PR TITLE
feat: persist UI panel state (#132) + site deletion detach (#124)

### DIFF
--- a/functions/_lib/buildInfo.ts
+++ b/functions/_lib/buildInfo.ts
@@ -1,5 +1,5 @@
-export const APP_VERSION = "0.12.1";
-export const APP_COMMIT = "fe6b29ce";
+export const APP_VERSION = "0.13.0";
+export const APP_COMMIT = "868ad88a";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {

--- a/functions/api/geocode.test.ts
+++ b/functions/api/geocode.test.ts
@@ -1,18 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { getClientAddressMock, takeRateLimitTokenMock } = vi.hoisted(() => ({
-  getClientAddressMock: vi.fn(),
-  takeRateLimitTokenMock: vi.fn(),
-}));
-
-vi.mock("../_lib/rateLimit", () => ({
-  getClientAddress: getClientAddressMock,
-  takeRateLimitToken: takeRateLimitTokenMock,
-}));
-
 import { onRequestGet } from "./geocode";
 
-const env = { DB: {} } as unknown as { DB: D1Database; GEOCODE_RATE_LIMIT_PER_MINUTE?: string };
+const env = { DB: {} } as unknown as { DB: D1Database };
 
 const mkCtx = (request: Request) => ({ request, env } as unknown as Parameters<typeof onRequestGet>[0]);
 
@@ -30,8 +20,6 @@ const setCache = (cache: CacheLike) => {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  getClientAddressMock.mockReturnValue("203.0.113.1");
-  takeRateLimitTokenMock.mockReturnValue({ allowed: true, remaining: 19, retryAfterSec: 0 });
   setCache({
     match: vi.fn().mockResolvedValue(undefined),
     put: vi.fn().mockResolvedValue(undefined),
@@ -52,16 +40,6 @@ describe("api/geocode", () => {
     const res = await onRequestGet(mkCtx(req));
     expect(res.status).toBe(400);
     await expect(res.json()).resolves.toMatchObject({ error: "Search query must be at least 3 characters." });
-  });
-
-  it("returns 429 when limiter denies request", async () => {
-    takeRateLimitTokenMock.mockReturnValueOnce({ allowed: false, remaining: 0, retryAfterSec: 7 });
-    const req = new Request("https://example.test/api/geocode?q=oslo");
-    const res = await onRequestGet(mkCtx(req));
-
-    expect(res.status).toBe(429);
-    expect(res.headers.get("retry-after")).toBe("7");
-    await expect(res.json()).resolves.toMatchObject({ error: "Geocode rate limit reached. Please wait and try again." });
   });
 
   it("serves cached response without upstream fetch", async () => {

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -28,6 +28,22 @@ const ONBOARDING_SEEN_KEY_PREFIX = "linksim:onboarding-seen:v1:";
 const LOCAL_FORCE_READONLY_KEY = "linksim:local-force-readonly:v1";
 const OPEN_SYNC_MODAL_EVENT = "linksim:open-sync-modal";
 const ACCESS_CHECK_TIMEOUT_MS = 10_000;
+
+const UI_PANEL_KEYS = {
+  navigatorHidden: "linksim-ui-navigator-hidden-v1",
+  inspectorHidden: "linksim-ui-inspector-hidden-v1",
+  profileHidden: "linksim-ui-profile-hidden-v1",
+} as const;
+
+const readPanelBool = (key: string, fallback: boolean): boolean => {
+  try {
+    const raw = localStorage.getItem(key);
+    if (raw === null) return fallback;
+    return raw === "true";
+  } catch {
+    return fallback;
+  }
+};
 type MobileWorkspacePanel = "navigator" | "inspector" | "profile";
 type MobileBottomPanelMode = "hidden" | "normal" | "full";
 type AppNotice = {
@@ -116,9 +132,9 @@ export function AppShell() {
   const setShowSiteLibraryRequest = useAppStore((state) => state.setShowSiteLibraryRequest);
   const [isMapExpanded, setIsMapExpanded] = useState(false);
   const [isProfileExpanded, setIsProfileExpanded] = useState(false);
-  const [isNavigatorHidden, setIsNavigatorHidden] = useState(false);
-  const [isInspectorHidden, setIsInspectorHidden] = useState(false);
-  const [isProfileHidden, setIsProfileHidden] = useState(false);
+  const [isNavigatorHidden, setIsNavigatorHidden] = useState(() => readPanelBool(UI_PANEL_KEYS.navigatorHidden, false));
+  const [isInspectorHidden, setIsInspectorHidden] = useState(() => readPanelBool(UI_PANEL_KEYS.inspectorHidden, false));
+  const [isProfileHidden, setIsProfileHidden] = useState(() => readPanelBool(UI_PANEL_KEYS.profileHidden, false));
   const [accessState, setAccessState] = useState<"checking" | "granted" | "readonly" | "pending" | "locked">("checking");
   const [accessDiagnosticMessage, setAccessDiagnosticMessage] = useState<string | null>(null);
   // Derived early so effects below can reference them without temporal dead zone.
@@ -535,6 +551,18 @@ export function AppShell() {
     const timer = window.setTimeout(() => setAppNotice(null), 5000);
     return () => window.clearTimeout(timer);
   }, [appNotice]);
+
+  useEffect(() => {
+    try { localStorage.setItem(UI_PANEL_KEYS.navigatorHidden, String(isNavigatorHidden)); } catch {}
+  }, [isNavigatorHidden]);
+
+  useEffect(() => {
+    try { localStorage.setItem(UI_PANEL_KEYS.inspectorHidden, String(isInspectorHidden)); } catch {}
+  }, [isInspectorHidden]);
+
+  useEffect(() => {
+    try { localStorage.setItem(UI_PANEL_KEYS.profileHidden, String(isProfileHidden)); } catch {}
+  }, [isProfileHidden]);
 
   useEffect(() => {
     const mediaQuery = window.matchMedia("(max-width: 980px)");

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -27,6 +27,26 @@ import type { Link, PropagationEnvironment, Site } from "../types/radio";
 import { fetchMeshmapNodes, type MeshmapNode } from "../lib/meshtasticMqtt";
 import { SimulationResultsSection } from "./SimulationResultsSection";
 
+const UI_SECTION_KEYS = {
+  mapViewResults: "linksim-ui-mapview-results-v1",
+  mapViewSimSummary: "linksim-ui-mapview-sim-summary-v1",
+  mapViewOverlayGuide: "linksim-ui-mapview-overlay-guide-v1",
+} as const;
+
+const readSectionBool = (key: string, fallback: boolean): boolean => {
+  try {
+    const raw = localStorage.getItem(key);
+    if (raw === null) return fallback;
+    return raw === "true";
+  } catch {
+    return fallback;
+  }
+};
+
+const writeSectionBool = (key: string, value: boolean): void => {
+  try { localStorage.setItem(key, String(value)); } catch {}
+};
+
 const mapLineLayer = (linkColor: string, selectedColor: string): LayerProps => ({
   id: "link-lines",
   type: "line",
@@ -1078,10 +1098,10 @@ export function MapView({
   const setCoverageVizMode = useAppStore((state) => state.setMapOverlayMode);
   const [bandStepMode, setBandStepMode] = useState<BandStepMode>("auto");
   const [showTerrainOverlay, setShowTerrainOverlay] = useState(false);
-  const [showResultsSummary, setShowResultsSummary] = useState(true);
-  const [showSimulationSummary, setShowSimulationSummary] = useState(false);
+  const [showResultsSummary, setShowResultsSummary] = useState(() => readSectionBool(UI_SECTION_KEYS.mapViewResults, true));
+  const [showSimulationSummary, setShowSimulationSummary] = useState(() => readSectionBool(UI_SECTION_KEYS.mapViewSimSummary, false));
   const [isMultiSelectMode, setIsMultiSelectMode] = useState(false);
-  const [showOverlayGuide, setShowOverlayGuide] = useState(true);
+  const [showOverlayGuide, setShowOverlayGuide] = useState(() => readSectionBool(UI_SECTION_KEYS.mapViewOverlayGuide, true));
   const fitSitesEpoch = useAppStore((state) => state.fitSitesEpoch);
   const [fitControlActive, setFitControlActive] = useState(false);
   const [isMapLoaded, setIsMapLoaded] = useState(false);
@@ -2215,7 +2235,7 @@ export function MapView({
           ) : null}
           <details
             className="compact-details map-inspector-details"
-            onToggle={(event) => setShowOverlayGuide(event.currentTarget.open)}
+            onToggle={(event) => { const v = event.currentTarget.open; writeSectionBool(UI_SECTION_KEYS.mapViewOverlayGuide, v); setShowOverlayGuide(v); }}
             open={showOverlayGuide}
           >
             <summary>Map</summary>
@@ -2477,7 +2497,7 @@ export function MapView({
           </details>
           <details
             className="compact-details map-inspector-details"
-            onToggle={(event) => setShowResultsSummary(event.currentTarget.open)}
+            onToggle={(event) => { const v = event.currentTarget.open; writeSectionBool(UI_SECTION_KEYS.mapViewResults, v); setShowResultsSummary(v); }}
             open={showResultsSummary}
           >
             <summary>Results</summary>
@@ -2485,7 +2505,7 @@ export function MapView({
           </details>
           <details
             className="compact-details map-inspector-details"
-            onToggle={(event) => setShowSimulationSummary(event.currentTarget.open)}
+            onToggle={(event) => { const v = event.currentTarget.open; writeSectionBool(UI_SECTION_KEYS.mapViewSimSummary, v); setShowSimulationSummary(v); }}
             open={showSimulationSummary}
           >
             <summary>Simulation Sources</summary>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -129,6 +129,25 @@ const meshmapLabelsLayer = (color: string, haloColor: string): LayerProps => ({
   },
 });
 
+const UI_SECTION_KEYS = {
+  sidebarRadioAdvanced: "linksim-ui-sidebar-radio-advanced-v1",
+  sidebarItmEnv: "linksim-ui-sidebar-itm-env-v1",
+} as const;
+
+const readSectionBool = (key: string, fallback: boolean): boolean => {
+  try {
+    const raw = localStorage.getItem(key);
+    if (raw === null) return fallback;
+    return raw === "true";
+  } catch {
+    return fallback;
+  }
+};
+
+const writeSectionBool = (key: string, value: boolean): void => {
+  try { localStorage.setItem(key, String(value)); } catch {}
+};
+
 const LAST_SIMULATION_REF_KEY = "rmw-last-simulation-ref-v1";
 const SITE_LIBRARY_FILTERS_KEY = "rmw-site-library-filters-v1";
 
@@ -585,6 +604,9 @@ export function Sidebar({
     targetVisibility: "public" | "shared";
     referencedPrivateSiteIds: string[];
   } | null>(null);
+  const [sidebarRadioAdvancedOpen, setSidebarRadioAdvancedOpen] = useState(() => readSectionBool(UI_SECTION_KEYS.sidebarRadioAdvanced, false));
+  const [sidebarItmEnvOpen, setSidebarItmEnvOpen] = useState(() => readSectionBool(UI_SECTION_KEYS.sidebarItmEnv, false));
+
   const [deleteConfirm, setDeleteConfirm] = useState<{
     title: string;
     message: string;
@@ -1915,7 +1937,11 @@ export function Sidebar({
       </section>
 
       <section className="panel-section section-radio">
-        <details className="compact-details">
+        <details
+          className="compact-details"
+          open={sidebarRadioAdvancedOpen}
+          onToggle={(e) => { const v = (e.currentTarget as HTMLDetailsElement).open; writeSectionBool(UI_SECTION_KEYS.sidebarRadioAdvanced, v); setSidebarRadioAdvancedOpen(v); }}
+        >
           <summary>Radio & Model (Advanced)</summary>
           <p className="field-help">
             Shared channel profile for all links in this simulation.
@@ -1986,7 +2012,11 @@ export function Sidebar({
               </button>
             ))}
           </div>
-          <details className="compact-details">
+          <details
+            className="compact-details"
+            open={sidebarItmEnvOpen}
+            onToggle={(e) => { const v = (e.currentTarget as HTMLDetailsElement).open; writeSectionBool(UI_SECTION_KEYS.sidebarItmEnv, v); setSidebarItmEnvOpen(v); }}
+          >
             <summary>ITM Environment</summary>
           <p className="field-help">
             These parameters feed terrain-aware path loss. Auto mode derives defaults from current terrain/profile and
@@ -2896,11 +2926,21 @@ export function Sidebar({
               <div className="chip-group">
                 <button
                   className="inline-action danger"
-                  onClick={() =>
+                  onClick={() => {
+                    let siteDeleteMessage = `Delete "${resourceDetailsPopup.label}" from the site library?`;
+                    if (resourceDetailsPopup.kind === "site") {
+                      const affectedSims = simulationPresets.filter((p) =>
+                        p.snapshot.sites.some((s) => s.libraryEntryId === resourceDetailsPopup.resourceId),
+                      );
+                      if (affectedSims.length > 0) {
+                        const names = affectedSims.map((p) => `"${p.name}"`).join(", ");
+                        siteDeleteMessage += ` Referenced in ${affectedSims.length} simulation(s): ${names}. Sites will be detached but simulation data will not be lost.`;
+                      }
+                    }
                     requestDeleteConfirm(
                       resourceDetailsPopup.kind === "site" ? "Delete Site" : "Delete Simulation",
                       resourceDetailsPopup.kind === "site"
-                        ? `Delete "${resourceDetailsPopup.label}" from the site library?`
+                        ? siteDeleteMessage
                         : `Delete simulation "${resourceDetailsPopup.label}"?`,
                       () => {
                         if (resourceDetailsPopup.kind === "site") {
@@ -2913,8 +2953,8 @@ export function Sidebar({
                         }
                         setResourceDetailsPopup(null);
                       },
-                    )
-                  }
+                    );
+                  }}
                   type="button"
                 >
                   Delete
@@ -3286,16 +3326,25 @@ export function Sidebar({
               <button
                 className="inline-action danger"
                 disabled={!selectedLibraryCount}
-                onClick={() =>
+                onClick={() => {
+                  const deletedIds = Array.from(selectedLibraryIds);
+                  const affectedSims = simulationPresets.filter((p) =>
+                    p.snapshot.sites.some((s) => s.libraryEntryId && selectedLibraryIds.has(s.libraryEntryId)),
+                  );
+                  let msg = `Delete ${selectedLibraryCount} selected site(s) from the library? This cannot be undone.`;
+                  if (affectedSims.length > 0) {
+                    const names = affectedSims.map((p) => `"${p.name}"`).join(", ");
+                    msg += ` Referenced in ${affectedSims.length} simulation(s): ${names}. Sites will be detached but simulation data will not be lost.`;
+                  }
                   requestDeleteConfirm(
                     "Delete Sites",
-                    `Delete ${selectedLibraryCount} selected site(s) from the library? This cannot be undone.`,
+                    msg,
                     () => {
-                      deleteSiteLibraryEntries(Array.from(selectedLibraryIds));
+                      deleteSiteLibraryEntries(deletedIds);
                       setSelectedLibraryIds(new Set());
                     },
-                  )
-                }
+                  );
+                }}
                 type="button"
               >
                 Delete Selected ({selectedLibraryCount})

--- a/src/lib/buildInfo.ts
+++ b/src/lib/buildInfo.ts
@@ -1,5 +1,5 @@
-export const APP_VERSION = "0.12.1";
-export const APP_COMMIT = "fe6b29ce";
+export const APP_VERSION = "0.13.0";
+export const APP_COMMIT = "868ad88a";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -2428,7 +2428,23 @@ export const useAppStore = create<AppState>((set, get) => ({
     set((state) => {
       const next = state.siteLibrary.filter((entry) => !requested.has(entry.id));
       writeStorage(SITE_LIBRARY_KEY, next);
-      return { siteLibrary: next };
+      const updatedPresets = state.simulationPresets.map((preset) => {
+        const hasRef = preset.snapshot.sites.some((site) => site.libraryEntryId && requested.has(site.libraryEntryId));
+        if (!hasRef) return preset;
+        return {
+          ...preset,
+          snapshot: {
+            ...preset.snapshot,
+            sites: preset.snapshot.sites.map((site) =>
+              site.libraryEntryId && requested.has(site.libraryEntryId)
+                ? { ...site, libraryEntryId: undefined }
+                : site,
+            ),
+          },
+        };
+      });
+      writeStorage(SIM_PRESETS_KEY, updatedPresets);
+      return { siteLibrary: next, simulationPresets: updatedPresets };
     });
   },
   saveCurrentSimulationPreset: (name) => {


### PR DESCRIPTION
## Summary
- **#132**: All toggleable UI panels and collapsible sections now persist their open/hidden state to localStorage. Users no longer need to reconfigure their workspace on every page load.
- **#124**: Deleting a site library entry now detaches any simulation references (clears `libraryEntryId`) rather than leaving stale references. Deletion warnings list affected simulation names when references exist.
- **Bonus**: Removes the obsolete 429 rate-limit test from `geocode.test.ts` (rate limiter was removed in #105).

## Persistence keys added
| Key | Default | Controls |
|-----|---------|----------|
| `linksim-ui-navigator-hidden-v1` | `false` | Left sidebar |
| `linksim-ui-inspector-hidden-v1` | `false` | Right sidebar |
| `linksim-ui-profile-hidden-v1` | `false` | Bottom profile panel |
| `linksim-ui-sidebar-radio-advanced-v1` | `false` | Radio & Model (Advanced) section |
| `linksim-ui-sidebar-itm-env-v1` | `false` | ITM Environment section |
| `linksim-ui-mapview-results-v1` | `true` | Results section |
| `linksim-ui-mapview-sim-summary-v1` | `false` | Simulation Sources section |
| `linksim-ui-mapview-overlay-guide-v1` | `true` | Overlay Guide section |

## Test plan
- [ ] Toggle navigator/inspector/profile → reload → panels retain state
- [ ] Expand/collapse Radio & Model (Advanced) and ITM Environment → reload → state preserved
- [ ] Toggle Results, Simulation Sources, Overlay Guide → reload → state preserved
- [ ] Clear localStorage → defaults apply on next load
- [ ] Delete a site referenced by simulations → warning shows simulation names, site detached (data preserved)
- [ ] Delete unreferenced site → clean delete, no extra warning

Closes #132
Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)