### PR TITLE
fix: set effectiveRole owner on locally created sites and simulations

### DIFF
--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -2015,6 +2015,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         lastEditedByUserId: currentUser.id,
         lastEditedByName: currentUser.username,
         lastEditedByAvatarUrl: currentUser.avatarUrl ?? "",
+        effectiveRole: "owner" as const,
       };
       const nextLibrary = normalizeSiteLibrary([entry, ...state.siteLibrary]);
       writeStorage(SITE_LIBRARY_KEY, nextLibrary);
@@ -2188,6 +2189,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       lastEditedByUserId: currentUser.id,
       lastEditedByName: currentUser.username,
       lastEditedByAvatarUrl: currentUser.avatarUrl ?? "",
+      effectiveRole: "owner" as const,
     };
     markDirtySite(entry.id);
     set((state) => {
@@ -2520,6 +2522,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         lastEditedByUserId: user.id,
         lastEditedByName: user.username,
         lastEditedByAvatarUrl: user.avatarUrl ?? "",
+        effectiveRole: existing?.effectiveRole ?? "owner",
       };
       markDirtySim(nextPreset.id);
       const next = [nextPreset, ...current.simulationPresets.filter((preset) => preset.id !== nextPreset.id)];
@@ -2647,6 +2650,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         lastEditedByUserId: user.id,
         lastEditedByName: user.username,
         lastEditedByAvatarUrl: user.avatarUrl ?? "",
+        effectiveRole: existing.effectiveRole ?? "owner",
       };
       const next = [nextPreset, ...current.simulationPresets.filter((preset) => preset.id !== nextPreset.id)];
       writeStorage(SIM_PRESETS_KEY, next);


### PR DESCRIPTION
## Summary
- Newly created sites and simulations were missing `effectiveRole` in local store state
- This caused `canEditResource()` to return `false` for the resource creator, blocking the share flow
- Adds `effectiveRole: "owner"` at both site creation paths and `effectiveRole: existing?.effectiveRole ?? "owner"` at simulation creation/update paths

## Root cause
When a user creates a site, the local `SiteLibraryEntry` was built without `effectiveRole`. The `canEditResource()` function checks this field to determine edit permissions. Without it, the site appeared read-only to its own creator.

Same issue applied to simulation presets created locally.

## Test plan
- [ ] Create a new site
- [ ] Immediately try to share a simulation referencing that site — should succeed
- [ ] Verify site does not show as read-only to creator
- [ ] Verify existing shared sites (from other users) still correctly block elevation

Closes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)