### PR TITLE
Fix: remove fetchDeepLinkStatus pre-check from access check (CORS)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -391,19 +391,6 @@ export function AppShell() {
           setAccessState("readonly");
           return;
         }
-        if (deepLinkParse.ok && !isLocalRuntime) {
-          const deepLinkStatus = await fetchDeepLinkStatus({
-            simulationId: deepLinkParse.payload.simulationId,
-            simulationSlug: deepLinkParse.payload.simulationSlug,
-          });
-          if (!deepLinkStatus.authenticated) {
-            if (cancelled || timedOut) return;
-            window.clearTimeout(timeoutId);
-            setAccessDiagnosticMessage(null);
-            setAccessState("readonly");
-            return;
-          }
-        }
         const profile = await fetchMe();
         if (cancelled || timedOut) return;
         window.clearTimeout(timeoutId);


### PR DESCRIPTION
Part of issue 385. Removes the pre-check that called the deep-link-status endpoint during the access check for deep-link mode. Cloudflare Access was blocking this endpoint for anonymous users with a CORS redirect, causing console errors. Since fetchMe() achieves the same result (fails CORS → sets readonly), the pre-check is redundant. All 209 tests pass.