### PR TITLE
feat: replace coverage mode selector with resolution control (#183)

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1050,7 +1050,6 @@ export function MapView({
   const terrainProgressTilesTotal = useAppStore((state) => state.terrainProgressTilesTotal);
   const terrainProgressBytesLoaded = useAppStore((state) => state.terrainProgressBytesLoaded);
   const terrainProgressBytesEstimated = useAppStore((state) => state.terrainProgressBytesEstimated);
-  const selectedCoverageMode = useAppStore((state) => state.selectedCoverageMode);
   const propagationModel = useAppStore((state) => state.propagationModel);
   const selectedNetworkId = useAppStore((state) => state.selectedNetworkId);
   const networks = useAppStore((state) => state.networks);
@@ -1096,6 +1095,8 @@ export function MapView({
   );
   const coverageVizMode = useAppStore((state) => state.mapOverlayMode);
   const setCoverageVizMode = useAppStore((state) => state.setMapOverlayMode);
+  const selectedCoverageResolution = useAppStore((state) => state.selectedCoverageResolution);
+  const setSelectedCoverageResolution = useAppStore((state) => state.setSelectedCoverageResolution);
   const [bandStepMode, setBandStepMode] = useState<BandStepMode>("auto");
   const [showTerrainOverlay, setShowTerrainOverlay] = useState(false);
   const [showResultsSummary, setShowResultsSummary] = useState(() => readSectionBool(UI_SECTION_KEYS.mapViewResults, true));
@@ -2333,6 +2334,19 @@ export function MapView({
                   {allowedOverlayModes.includes("relay") ? <option value="relay">Relay</option> : null}
                 </select>
               </label>
+              {(coverageVizMode === "heatmap" || coverageVizMode === "contours") && (
+                <label className="map-inspector-map-setting">
+                  <span>Coverage Detail</span>
+                  <select
+                    className="locale-select"
+                    onChange={(event) => setSelectedCoverageResolution(event.target.value as "normal" | "high")}
+                    value={selectedCoverageResolution}
+                  >
+                    <option value="normal">Normal</option>
+                    <option value="high">High (slower)</option>
+                  </select>
+                </label>
+              )}
               <label className="map-inspector-map-setting">
                 <span>Visible Sites</span>
                 <select
@@ -2510,7 +2524,7 @@ export function MapView({
           >
             <summary>Simulation Sources</summary>
             <p>
-              Model: {propagationModel} / {selectedCoverageMode} / View: {coverageVizMode}
+              Model: {propagationModel} / {selectedCoverageResolution} / View: {coverageVizMode}
             </p>
             <p>
               Network: {selectedNetwork?.name ?? "n/a"} @ {" "}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -53,7 +53,7 @@ import {
 import { getUiErrorMessage } from "../lib/uiError";
 import { formatDate, formatNumber } from "../lib/locale";
 import { useAppStore } from "../store/appStore";
-import type { CoverageMode, PropagationModel, RadioClimate } from "../types/radio";
+import type { PropagationModel, RadioClimate } from "../types/radio";
 import { siGithub } from "simple-icons";
 import { InfoTip } from "./InfoTip";
 import { ModalOverlay } from "./ModalOverlay";
@@ -304,7 +304,6 @@ export function Sidebar({
   const selectedSiteId = useAppStore((state) => state.selectedSiteId);
   const selectedSiteIds = useAppStore((state) => state.selectedSiteIds);
   const selectedNetworkId = useAppStore((state) => state.selectedNetworkId);
-  const selectedCoverageMode = useAppStore((state) => state.selectedCoverageMode);
   const selectedFrequencyPresetId = useAppStore((state) => state.selectedFrequencyPresetId);
   const propagationEnvironment = useAppStore((state) => state.propagationEnvironment);
   const autoPropagationEnvironment = useAppStore((state) => state.autoPropagationEnvironment);
@@ -317,7 +316,6 @@ export function Sidebar({
   const setSelectedLinkId = useAppStore((state) => state.setSelectedLinkId);
   const selectSiteById = useAppStore((state) => state.selectSiteById);
   const setSelectedNetworkId = useAppStore((state) => state.setSelectedNetworkId);
-  const setSelectedCoverageMode = useAppStore((state) => state.setSelectedCoverageMode);
   const setSelectedFrequencyPresetId = useAppStore((state) => state.setSelectedFrequencyPresetId);
   const basemapProvider = useAppStore((state) => state.basemapProvider);
   const basemapStylePreset = useAppStore((state) => state.basemapStylePreset);
@@ -1005,10 +1003,6 @@ export function Sidebar({
 
   const onModelChange = (next: PropagationModel) => {
     setPropagationModel(next);
-  };
-
-  const onCoverageModeChange = (mode: CoverageMode) => {
-    setSelectedCoverageMode(mode);
   };
 
   useEffect(() => {
@@ -1946,22 +1940,6 @@ export function Sidebar({
           <p className="field-help">
             Shared channel profile for all links in this simulation.
           </p>
-          <div className="section-heading">
-            <p className="field-help">Coverage mode</p>
-            <InfoTip text="BestSite: computes strongest coverage from any site at each sample point. Polar: radial sampling around the selected From site. Cartesian: regular grid sampling over the current simulation area. Route: samples along the selected path corridor." />
-          </div>
-          <div className="chip-group">
-            {(["BestSite", "Polar", "Cartesian", "Route"] as const).map((mode) => (
-              <button
-                className={clsx("chip-button", selectedCoverageMode === mode && "is-selected")}
-                key={mode}
-                onClick={() => onCoverageModeChange(mode)}
-                type="button"
-              >
-                {mode}
-              </button>
-            ))}
-          </div>
           {networks.length > 1 ? (
             <select
               className="locale-select"

--- a/src/components/SimulationResultsSection.tsx
+++ b/src/components/SimulationResultsSection.tsx
@@ -64,7 +64,7 @@ export function SimulationResultsSection() {
   const selectedSiteIds = useAppStore((state) => state.selectedSiteIds);
   const selectedSiteId = useAppStore((state) => state.selectedSiteId);
   const selectedNetworkId = useAppStore((state) => state.selectedNetworkId);
-  const selectedCoverageMode = useAppStore((state) => state.selectedCoverageMode);
+  const selectedCoverageResolution = useAppStore((state) => state.selectedCoverageResolution);
   const selectedFrequencyPresetId = useAppStore((state) => state.selectedFrequencyPresetId);
   const rxSensitivityTargetDbm = useAppStore((state) => state.rxSensitivityTargetDbm);
   const environmentLossDb = useAppStore((state) => state.environmentLossDb);
@@ -250,7 +250,7 @@ export function SimulationResultsSection() {
       scenarioId: selectedScenarioId,
       locale,
       propagationModel: model,
-      selectedCoverageMode,
+      coverageResolution: selectedCoverageResolution,
       selectedFrequencyPresetId,
       terrainDataset,
       terrainRecommendation,
@@ -309,7 +309,7 @@ export function SimulationResultsSection() {
         <InfoTip text="Computed link budget summary for the selected path and current channel/model settings." />
       </div>
       <div className="metrics">
-        {metric("Network", `${selectedNetwork.name} (${selectedCoverageMode})`)}
+        {metric("Network", selectedNetwork.name)}
         {metric(
           "LoRa",
           `${(selectedNetwork.frequencyOverrideMHz ?? selectedNetwork.frequencyMHz).toFixed(3)} MHz / BW ${selectedNetwork.bandwidthKhz} / SF ${selectedNetwork.spreadFactor} / CR ${selectedNetwork.codingRate}`,

--- a/src/lib/coverage.test.ts
+++ b/src/lib/coverage.test.ts
@@ -53,21 +53,25 @@ const network: Network = {
   ],
 };
 
+const NORMAL_GRID = 24;
+const HIGH_GRID = 42;
+
 describe("buildCoverage", () => {
-  it("creates non-empty coverage in BestSite mode", () => {
-    const result = buildCoverage("BestSite", network, sites, systems, "FSPL", defaultPropagationEnvironment());
+  it("creates non-empty coverage at normal resolution (24×24 grid)", () => {
+    const result = buildCoverage(NORMAL_GRID, network, sites, systems, "FSPL", defaultPropagationEnvironment());
     expect(result.length).toBeGreaterThan(100);
     expect(Number.isFinite(result[0].valueDbm)).toBe(true);
   });
 
-  it("creates route samples in Route mode", () => {
-    const result = buildCoverage("Route", network, sites, systems, "FSPL", defaultPropagationEnvironment());
-    expect(result).toHaveLength(120);
+  it("creates more samples at high resolution (42×42 grid)", () => {
+    const normal = buildCoverage(NORMAL_GRID, network, sites, systems, "FSPL", defaultPropagationEnvironment());
+    const high = buildCoverage(HIGH_GRID, network, sites, systems, "FSPL", defaultPropagationEnvironment());
+    expect(high.length).toBeGreaterThan(normal.length);
   });
 
   it("changes computed values when propagation model changes", () => {
-    const fspl = buildCoverage("Polar", network, sites, systems, "FSPL", defaultPropagationEnvironment());
-    const twoRay = buildCoverage("Polar", network, sites, systems, "TwoRay", defaultPropagationEnvironment());
+    const fspl = buildCoverage(NORMAL_GRID, network, sites, systems, "FSPL", defaultPropagationEnvironment());
+    const twoRay = buildCoverage(NORMAL_GRID, network, sites, systems, "TwoRay", defaultPropagationEnvironment());
     const maxDiff = fspl.reduce((max, sample, index) => {
       const diff = Math.abs(sample.valueDbm - twoRay[index].valueDbm);
       return Math.max(max, diff);
@@ -76,15 +80,15 @@ describe("buildCoverage", () => {
     expect(maxDiff).toBeGreaterThan(0.1);
   });
 
-  it("supports ITM mode generation", () => {
-    const itm = buildCoverage("BestSite", network, sites, systems, "ITM", defaultPropagationEnvironment());
+  it("supports ITM model", () => {
+    const itm = buildCoverage(NORMAL_GRID, network, sites, systems, "ITM", defaultPropagationEnvironment());
     expect(itm.length).toBeGreaterThan(100);
     expect(Number.isFinite(itm[0].valueDbm)).toBe(true);
   });
 
   it("buildCoverageAsync matches sync output shape", async () => {
-    const sync = buildCoverage("Polar", network, sites, systems, "FSPL", defaultPropagationEnvironment());
-    const asyncResult = await buildCoverageAsync("Polar", network, sites, systems, "FSPL", defaultPropagationEnvironment());
+    const sync = buildCoverage(NORMAL_GRID, network, sites, systems, "FSPL", defaultPropagationEnvironment());
+    const asyncResult = await buildCoverageAsync(NORMAL_GRID, network, sites, systems, "FSPL", defaultPropagationEnvironment());
     expect(asyncResult).toHaveLength(sync.length);
     expect(Math.abs(asyncResult[0].valueDbm - sync[0].valueDbm)).toBeLessThan(0.0001);
   });

--- a/src/lib/coverage.ts
+++ b/src/lib/coverage.ts
@@ -4,7 +4,6 @@ import { simulationAreaBoundsForSites } from "./simulationArea";
 import { estimateTerrainExcessLossDb } from "./terrainLoss";
 import type {
   Coordinates,
-  CoverageMode,
   CoverageSample,
   Network,
   PropagationEnvironment,
@@ -20,14 +19,6 @@ export type BuildCoverageOptions = {
   terrainCacheKey?: string;
 };
 
-const toRadians = (deg: number): number => (deg * Math.PI) / 180;
-
-const midpoint = (sites: Site[]): { lat: number; lon: number } => ({
-  lat: sites.reduce((sum, site) => sum + site.position.lat, 0) / sites.length,
-  lon: sites.reduce((sum, site) => sum + site.position.lon, 0) / sites.length,
-});
-
-const interpolate = (a: number, b: number, t: number): number => a + (b - a) * t;
 const nUnitsToKFactor = (nUnits: number): number => {
   const n = Math.max(250, Math.min(400, nUnits));
   return Math.max(1, Math.min(2, 1 + (n - 250) / 153));
@@ -141,41 +132,9 @@ const evalRx = (
   return eirp + txSystem.rxGainDbi - (loss + terrainLoss);
 };
 
-const polarOffsets = (maxKm: number, rings: number, spokes: number): { dk: number; az: number }[] => {
-  const out: { dk: number; az: number }[] = [];
-  for (let r = 1; r <= rings; r += 1) {
-    const dk = (maxKm * r) / rings;
-    for (let s = 0; s < spokes; s += 1) {
-      const az = (360 * s) / spokes;
-      out.push({ dk, az });
-    }
-  }
-  return out;
-};
-
-const move = (lat: number, lon: number, distanceKm: number, azimuthDeg: number): { lat: number; lon: number } => {
-  const R = 6371;
-  const brng = toRadians(azimuthDeg);
-  const phi1 = toRadians(lat);
-  const lambda1 = toRadians(lon);
-  const delta = distanceKm / R;
-
-  const phi2 = Math.asin(
-    Math.sin(phi1) * Math.cos(delta) + Math.cos(phi1) * Math.sin(delta) * Math.cos(brng),
-  );
-
-  const lambda2 =
-    lambda1 +
-    Math.atan2(
-      Math.sin(brng) * Math.sin(delta) * Math.cos(phi1),
-      Math.cos(delta) - Math.sin(phi1) * Math.sin(phi2),
-    );
-
-  return { lat: (phi2 * 180) / Math.PI, lon: (lambda2 * 180) / Math.PI };
-};
 
 export const buildCoverage = (
-  mode: CoverageMode,
+  gridSize: number,
   network: Network,
   sites: Site[],
   systems: RadioSystem[],
@@ -203,52 +162,26 @@ export const buildCoverage = (
       ? effectiveMemberships
       : sites.map((site) => ({ siteId: site.id, systemId: fallbackSystemId }));
 
-  const center = midpoint(sites);
-  const networkSites = membershipsToUse
-    .map((m) => sites.find((s) => s.id === m.siteId))
-    .filter((s): s is Site => Boolean(s));
-
   const samples: { lat: number; lon: number }[] = [];
+  const targetSamples = Math.max(64, Math.round(gridSize * gridSize * sampleMultiplier * sampleMultiplier));
+  const bounds = simulationAreaBoundsForSites(sites);
+  if (!bounds) return [];
 
-  if (mode === "Polar") {
-    const rings = Math.max(6, Math.round(10 * sampleMultiplier));
-    const spokes = Math.max(18, Math.round(36 * sampleMultiplier));
-    for (const p of polarOffsets(24, rings, spokes)) {
-      samples.push(move(center.lat, center.lon, p.dk, p.az));
-    }
-  } else if (mode === "Route") {
-    const from = networkSites[0] ?? sites[0];
-    const to = networkSites[1] ?? sites[sites.length - 1] ?? from;
-    const routePoints = Math.max(80, Math.round(120 * sampleMultiplier));
-    for (let i = 0; i < routePoints; i += 1) {
-      const t = routePoints <= 1 ? 0 : i / (routePoints - 1);
-      samples.push({
-        lat: interpolate(from.position.lat, to.position.lat, t),
-        lon: interpolate(from.position.lon, to.position.lon, t),
-      });
-    }
-  } else {
-    const baseGridSize = mode === "Cartesian" ? 42 : 24;
-    const targetSamples = Math.max(64, Math.round(baseGridSize * baseGridSize * sampleMultiplier * sampleMultiplier));
-    const bounds = simulationAreaBoundsForSites(sites);
-    if (!bounds) return [];
+  const centerLat = (bounds.minLat + bounds.maxLat) / 2;
+  const latSpanKm = Math.max(0.001, (bounds.maxLat - bounds.minLat) * 111.32);
+  const lonScale = Math.max(0.1, Math.cos((centerLat * Math.PI) / 180));
+  const lonSpanKm = Math.max(0.001, (bounds.maxLon - bounds.minLon) * 111.32 * lonScale);
+  const aspect = latSpanKm / lonSpanKm;
+  const cols = Math.max(6, Math.round(Math.sqrt(targetSamples / Math.max(0.2, Math.min(5, aspect)))));
+  const rows = Math.max(6, Math.round(targetSamples / cols));
 
-    const centerLat = (bounds.minLat + bounds.maxLat) / 2;
-    const latSpanKm = Math.max(0.001, (bounds.maxLat - bounds.minLat) * 111.32);
-    const lonScale = Math.max(0.1, Math.cos((centerLat * Math.PI) / 180));
-    const lonSpanKm = Math.max(0.001, (bounds.maxLon - bounds.minLon) * 111.32 * lonScale);
-    const aspect = latSpanKm / lonSpanKm;
-    const cols = Math.max(6, Math.round(Math.sqrt(targetSamples / Math.max(0.2, Math.min(5, aspect)))));
-    const rows = Math.max(6, Math.round(targetSamples / cols));
-
-    for (let y = 0; y < rows; y += 1) {
-      const ty = rows <= 1 ? 0 : y / (rows - 1);
-      const lat = bounds.minLat + (bounds.maxLat - bounds.minLat) * ty;
-      for (let x = 0; x < cols; x += 1) {
-        const tx = cols <= 1 ? 0 : x / (cols - 1);
-        const lon = bounds.minLon + (bounds.maxLon - bounds.minLon) * tx;
-        samples.push({ lat, lon });
-      }
+  for (let y = 0; y < rows; y += 1) {
+    const ty = rows <= 1 ? 0 : y / (rows - 1);
+    const lat = bounds.minLat + (bounds.maxLat - bounds.minLat) * ty;
+    for (let x = 0; x < cols; x += 1) {
+      const tx = cols <= 1 ? 0 : x / (cols - 1);
+      const lon = bounds.minLon + (bounds.maxLon - bounds.minLon) * tx;
+      samples.push({ lat, lon });
     }
   }
 
@@ -278,11 +211,7 @@ export const buildCoverage = (
       })
       .filter((v): v is number => v !== null);
 
-    const valueDbm = rxLevels.length
-      ? mode === "BestSite"
-        ? Math.min(...rxLevels)
-        : rxLevels.reduce((sum, x) => sum + x, 0) / rxLevels.length
-      : -140;
+    const valueDbm = rxLevels.length ? Math.min(...rxLevels) : -140;
 
     results.push({ ...sample, valueDbm });
     if ((i + 1) % notifyEvery === 0 || i === samples.length - 1) {
@@ -293,7 +222,7 @@ export const buildCoverage = (
 };
 
 export const buildCoverageAsync = async (
-  mode: CoverageMode,
+  gridSize: number,
   network: Network,
   sites: Site[],
   systems: RadioSystem[],
@@ -321,51 +250,26 @@ export const buildCoverageAsync = async (
       ? effectiveMemberships
       : sites.map((site) => ({ siteId: site.id, systemId: fallbackSystemId }));
 
-  const center = midpoint(sites);
-  const networkSites = membershipsToUse
-    .map((m) => sites.find((s) => s.id === m.siteId))
-    .filter((s): s is Site => Boolean(s));
-
   const samples: { lat: number; lon: number }[] = [];
-  if (mode === "Polar") {
-    const rings = Math.max(6, Math.round(10 * sampleMultiplier));
-    const spokes = Math.max(18, Math.round(36 * sampleMultiplier));
-    for (const p of polarOffsets(24, rings, spokes)) {
-      samples.push(move(center.lat, center.lon, p.dk, p.az));
-    }
-  } else if (mode === "Route") {
-    const from = networkSites[0] ?? sites[0];
-    const to = networkSites[1] ?? sites[sites.length - 1] ?? from;
-    const routePoints = Math.max(80, Math.round(120 * sampleMultiplier));
-    for (let i = 0; i < routePoints; i += 1) {
-      const t = routePoints <= 1 ? 0 : i / (routePoints - 1);
-      samples.push({
-        lat: interpolate(from.position.lat, to.position.lat, t),
-        lon: interpolate(from.position.lon, to.position.lon, t),
-      });
-    }
-  } else {
-    const baseGridSize = mode === "Cartesian" ? 42 : 24;
-    const targetSamples = Math.max(64, Math.round(baseGridSize * baseGridSize * sampleMultiplier * sampleMultiplier));
-    const bounds = simulationAreaBoundsForSites(sites);
-    if (!bounds) return [];
+  const targetSamples = Math.max(64, Math.round(gridSize * gridSize * sampleMultiplier * sampleMultiplier));
+  const bounds = simulationAreaBoundsForSites(sites);
+  if (!bounds) return [];
 
-    const centerLat = (bounds.minLat + bounds.maxLat) / 2;
-    const latSpanKm = Math.max(0.001, (bounds.maxLat - bounds.minLat) * 111.32);
-    const lonScale = Math.max(0.1, Math.cos((centerLat * Math.PI) / 180));
-    const lonSpanKm = Math.max(0.001, (bounds.maxLon - bounds.minLon) * 111.32 * lonScale);
-    const aspect = latSpanKm / lonSpanKm;
-    const cols = Math.max(6, Math.round(Math.sqrt(targetSamples / Math.max(0.2, Math.min(5, aspect)))));
-    const rows = Math.max(6, Math.round(targetSamples / cols));
+  const centerLat = (bounds.minLat + bounds.maxLat) / 2;
+  const latSpanKm = Math.max(0.001, (bounds.maxLat - bounds.minLat) * 111.32);
+  const lonScale = Math.max(0.1, Math.cos((centerLat * Math.PI) / 180));
+  const lonSpanKm = Math.max(0.001, (bounds.maxLon - bounds.minLon) * 111.32 * lonScale);
+  const aspect = latSpanKm / lonSpanKm;
+  const cols = Math.max(6, Math.round(Math.sqrt(targetSamples / Math.max(0.2, Math.min(5, aspect)))));
+  const rows = Math.max(6, Math.round(targetSamples / cols));
 
-    for (let y = 0; y < rows; y += 1) {
-      const ty = rows <= 1 ? 0 : y / (rows - 1);
-      const lat = bounds.minLat + (bounds.maxLat - bounds.minLat) * ty;
-      for (let x = 0; x < cols; x += 1) {
-        const tx = cols <= 1 ? 0 : x / (cols - 1);
-        const lon = bounds.minLon + (bounds.maxLon - bounds.minLon) * tx;
-        samples.push({ lat, lon });
-      }
+  for (let y = 0; y < rows; y += 1) {
+    const ty = rows <= 1 ? 0 : y / (rows - 1);
+    const lat = bounds.minLat + (bounds.maxLat - bounds.minLat) * ty;
+    for (let x = 0; x < cols; x += 1) {
+      const tx = cols <= 1 ? 0 : x / (cols - 1);
+      const lon = bounds.minLon + (bounds.maxLon - bounds.minLon) * tx;
+      samples.push({ lat, lon });
     }
   }
 
@@ -397,11 +301,7 @@ export const buildCoverageAsync = async (
       })
       .filter((v): v is number => v !== null);
 
-    const valueDbm = rxLevels.length
-      ? mode === "BestSite"
-        ? Math.min(...rxLevels)
-        : rxLevels.reduce((sum, x) => sum + x, 0) / rxLevels.length
-      : -140;
+    const valueDbm = rxLevels.length ? Math.min(...rxLevels) : -140;
 
     results.push({ ...sample, valueDbm });
     if ((i + 1) % notifyEvery === 0 || i === samples.length - 1) {

--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -164,7 +164,7 @@ describe("appStore auth guards", () => {
             selectedSiteId: "",
             selectedLinkId: "",
             selectedNetworkId: "",
-            selectedCoverageMode: "BestSite",
+            selectedCoverageResolution: "normal",
             propagationModel: "ITM",
             selectedFrequencyPresetId: "custom",
             rxSensitivityTargetDbm: -120,

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -44,7 +44,7 @@ import type { UiColorTheme } from "../themes/types";
 import { getActiveHolidayTheme } from "../themes/holidayThemes";
 import type { CloudUser } from "../lib/cloudUser";
 import type {
-  CoverageMode,
+  CoverageResolution,
   Link,
   LinkAnalysis,
   MapViewport,
@@ -274,7 +274,7 @@ type SimulationPreset = {
     selectedSiteId: string;
     selectedLinkId: string;
     selectedNetworkId: string;
-    selectedCoverageMode: CoverageMode;
+    selectedCoverageResolution?: CoverageResolution;
     propagationModel: PropagationModel;
     selectedFrequencyPresetId: string;
     rxSensitivityTargetDbm: number;
@@ -352,7 +352,7 @@ type AppState = {
   selectedSiteId: string;
   selectedSiteIds: string[];
   selectedNetworkId: string;
-  selectedCoverageMode: CoverageMode;
+  selectedCoverageResolution: CoverageResolution;
   propagationModel: PropagationModel;
   mapViewport?: MapViewport;
   locale: LocaleCode;
@@ -432,7 +432,7 @@ type AppState = {
   clearActiveSelection: () => void;
   getSelectedSiteIds: () => string[];
   setSelectedNetworkId: (id: string) => void;
-  setSelectedCoverageMode: (mode: CoverageMode) => void;
+  setSelectedCoverageResolution: (resolution: CoverageResolution) => void;
   setSelectedFrequencyPresetId: (id: string) => void;
   setRxSensitivityTargetDbm: (value: number) => void;
   setEnvironmentLossDb: (value: number) => void;
@@ -1151,7 +1151,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   selectedSiteId: "",
   selectedSiteIds: [],
   selectedNetworkId: "",
-  selectedCoverageMode: "BestSite",
+  selectedCoverageResolution: "normal",
   propagationModel: "ITM",
   mapViewport: undefined,
   locale: "eng",
@@ -1919,8 +1919,8 @@ export const useAppStore = create<AppState>((set, get) => ({
     set({ selectedNetworkId: id });
     useCoverageStore.getState().recomputeCoverage();
   },
-  setSelectedCoverageMode: (mode) => {
-    set({ selectedCoverageMode: mode });
+  setSelectedCoverageResolution: (resolution) => {
+    set({ selectedCoverageResolution: resolution });
     useCoverageStore.getState().recomputeCoverage();
     get().updateCurrentSimulationSnapshot();
   },
@@ -2477,7 +2477,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       selectedSiteId: state.selectedSiteId,
       selectedLinkId: state.selectedLinkId,
       selectedNetworkId: state.selectedNetworkId,
-      selectedCoverageMode: state.selectedCoverageMode,
+      selectedCoverageResolution: state.selectedCoverageResolution,
       propagationModel: state.propagationModel,
       selectedFrequencyPresetId: state.selectedFrequencyPresetId,
       rxSensitivityTargetDbm: state.rxSensitivityTargetDbm,
@@ -2554,7 +2554,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         selectedSiteId: "",
         selectedLinkId: "",
         selectedNetworkId: "",
-        selectedCoverageMode: current.selectedCoverageMode,
+        selectedCoverageResolution: current.selectedCoverageResolution,
         propagationModel: current.propagationModel,
         selectedFrequencyPresetId: current.selectedFrequencyPresetId,
         rxSensitivityTargetDbm: current.rxSensitivityTargetDbm,
@@ -2614,7 +2614,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       selectedSiteId: state.selectedSiteId,
       selectedLinkId: state.selectedLinkId,
       selectedNetworkId: state.selectedNetworkId,
-      selectedCoverageMode: state.selectedCoverageMode,
+      selectedCoverageResolution: state.selectedCoverageResolution,
       propagationModel: state.propagationModel,
       selectedFrequencyPresetId: state.selectedFrequencyPresetId,
       rxSensitivityTargetDbm: state.rxSensitivityTargetDbm,
@@ -2698,7 +2698,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         selectedSiteId: get().selectedSiteId,
         selectedLinkId: get().selectedLinkId,
         selectedNetworkId: get().selectedNetworkId,
-        selectedCoverageMode: get().selectedCoverageMode,
+        selectedCoverageResolution: get().selectedCoverageResolution,
         propagationModel: get().propagationModel,
         selectedFrequencyPresetId: get().selectedFrequencyPresetId,
         rxSensitivityTargetDbm: get().rxSensitivityTargetDbm,
@@ -2751,13 +2751,10 @@ export const useAppStore = create<AppState>((set, get) => ({
         selectedLinkId: "",
         temporaryDirectionReversed: false,
         selectedNetworkId: "",
-        selectedCoverageMode:
-          snap.selectedCoverageMode === "BestSite" ||
-          snap.selectedCoverageMode === "Polar" ||
-          snap.selectedCoverageMode === "Cartesian" ||
-          snap.selectedCoverageMode === "Route"
-            ? snap.selectedCoverageMode
-            : "BestSite",
+        selectedCoverageResolution:
+          snap.selectedCoverageResolution === "normal" || snap.selectedCoverageResolution === "high"
+            ? snap.selectedCoverageResolution
+            : "normal",
         propagationModel:
           snap.propagationModel === "FSPL" || snap.propagationModel === "TwoRay" || snap.propagationModel === "ITM"
             ? snap.propagationModel
@@ -2811,13 +2808,10 @@ export const useAppStore = create<AppState>((set, get) => ({
       selectedLinkId,
       temporaryDirectionReversed: false,
       selectedNetworkId,
-      selectedCoverageMode:
-        snap.selectedCoverageMode === "BestSite" ||
-        snap.selectedCoverageMode === "Polar" ||
-        snap.selectedCoverageMode === "Cartesian" ||
-        snap.selectedCoverageMode === "Route"
-          ? snap.selectedCoverageMode
-          : "BestSite",
+      selectedCoverageResolution:
+        snap.selectedCoverageResolution === "normal" || snap.selectedCoverageResolution === "high"
+          ? snap.selectedCoverageResolution
+          : "normal",
       propagationModel:
         snap.propagationModel === "FSPL" || snap.propagationModel === "TwoRay" || snap.propagationModel === "ITM"
           ? snap.propagationModel

--- a/src/store/coverageStore.ts
+++ b/src/store/coverageStore.ts
@@ -58,7 +58,8 @@ export const useCoverageStore = create<CoverageState>((set, get) => ({
         if (get().simulationRunToken !== runId) return;
 
         const appState = appStoreBridge!.getState();
-        const selectedCoverageMode = appState.selectedCoverageMode as string;
+        const selectedCoverageResolution = (appState.selectedCoverageResolution as string) === "high" ? "high" : "normal";
+        const gridSize = selectedCoverageResolution === "high" ? 42 : 24;
         const networks = appState.networks as Array<{ id: string; [key: string]: unknown }>;
         const selectedNetworkId = appState.selectedNetworkId as string;
         const sites = appState.sites as Array<{ id: string; [key: string]: unknown }>;
@@ -127,7 +128,7 @@ export const useCoverageStore = create<CoverageState>((set, get) => ({
         set({ simulationProgress: 8 });
         let lastProgress = 8;
         const coverageSamples = await buildCoverageAsync(
-          selectedCoverageMode as Parameters<typeof buildCoverageAsync>[0],
+          gridSize,
           network as Parameters<typeof buildCoverageAsync>[1],
           sites as Parameters<typeof buildCoverageAsync>[2],
           systems as Parameters<typeof buildCoverageAsync>[3],
@@ -146,7 +147,7 @@ export const useCoverageStore = create<CoverageState>((set, get) => ({
                 set({ simulationProgress: next });
               }
             },
-            terrainCacheKey: `${selectedCoverageMode}|${selectedNetworkId}|${propagationModel}|${terrainLoadEpoch}`,
+            terrainCacheKey: `${selectedCoverageResolution}|${selectedNetworkId}|${propagationModel}|${terrainLoadEpoch}`,
           },
         );
         if (get().simulationRunToken !== runId) return;

--- a/src/types/radio.ts
+++ b/src/types/radio.ts
@@ -29,7 +29,8 @@ export type Link = {
 };
 
 export type PropagationModel = "FSPL" | "TwoRay" | "ITM";
-export type CoverageMode = "BestSite" | "Polar" | "Cartesian" | "Route";
+export type CoverageMode = "BestSite";
+export type CoverageResolution = "normal" | "high";
 export type Polarization = "Vertical" | "Horizontal";
 export type RadioClimate =
   | "Equatorial"


### PR DESCRIPTION
## Summary

- Removes Polar, Cartesian, and Route coverage modes from the UI — BestSite (strongest signal from any transmitter) is the only computation mode, which is what 95%+ of users need
- Removes 4-button coverage mode chip group from Sidebar Radio & Model panel (~120px footprint freed)
- Adds **Coverage Detail** (Normal / High) selector in the MapView overlay panel, visible only when Heatmap or Contours overlay is active
- Simplifies `coverage.ts`: functions accept `gridSize` (24 = normal, 42 = high) instead of `CoverageMode`; dead-code helpers (`polarOffsets`, `move`, `midpoint`, `interpolate`) removed
- Replaces `selectedCoverageMode` with `selectedCoverageResolution: "normal" | "high"` throughout — snapshot backward-compatible (old snapshots default to `"normal"`)
- Export manifest updated: `coverageResolution` replaces `selectedCoverageMode`

## Test plan

- [ ] Sidebar Radio & Model panel no longer shows coverage mode chips
- [ ] Heatmap/Contours overlay active → Coverage Detail selector appears in map panel; Normal and High options present
- [ ] Switching to High recomputes overlay with more samples (denser grid visible)
- [ ] No overlay active (or Pass/Fail/Relay) → Coverage Detail selector hidden
- [ ] Old saved simulations load correctly (no errors, default to Normal)
- [ ] Export manifest includes `coverageResolution` field
- [ ] 209 tests pass, build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)