### PR TITLE
fix: stabilize AppShell hook order on access lock path

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1168,6 +1168,99 @@ export function AppShell() {
   const isAnonymousBootstrapShell = accessState === "checking" || (accessState === "locked" && lockedNeedsSignIn);
   const isReadOnlyShell = isAnonymousGuestReadonly || isAnonymousBootstrapShell;
 
+  const toggleProfileExpanded = () => {
+    setIsMapExpanded(false);
+    setMobileActivePanel("profile");
+    setIsProfileExpanded((prev) => !prev);
+  };
+
+  const setMobileBottomPanelVisibility = useCallback((nextMode: MobileBottomPanelMode) => {
+    setMobileBottomPanelMode(nextMode);
+  }, []);
+
+  const closeShareModal = useCallback(() => {
+    setShowShareModal(false);
+    setShareSpecificUsers([]);
+    setShareSpecificRoles({});
+    setShareUserQuery("");
+    setShareSpecificStatus("");
+  }, []);
+
+  const openShareModalOrCopy = useCallback(() => {
+    setAppNotice(null);
+    if (!activeSimulation) {
+      publishAppNotice({
+        id: "share-open-simulation-first",
+        message: "Open a saved simulation first. Unsaved workspace state cannot be shared as a deep link.",
+        tone: "warning",
+        persistent: true,
+      });
+      return;
+    }
+    if (toVisibility(activeSimulation.visibility) === "private") {
+      setShareSpecificUsers([]);
+      setShareSpecificRoles({});
+      setShareUserQuery("");
+      setShareSpecificStatus("");
+      setShareDirectory([]);
+      setShareDirectoryBusy(true);
+      setShowShareModal(true);
+      void fetchCollaboratorDirectory()
+        .then((users) => setShareDirectory(users))
+        .catch(() => {})
+        .finally(() => setShareDirectoryBusy(false));
+      return;
+    }
+    void copyCurrentLink().catch((error) => {
+      publishAppNotice({
+        id: "share-copy-failed",
+        message: getUiErrorMessage(error),
+        tone: "error",
+        persistent: true,
+      });
+    });
+  }, [activeSimulation, copyCurrentLink, publishAppNotice]);
+
+  const panelSizeControls = useCallback(
+    (labelPrefix: string, variant: "map" | "chart" = "map") => (
+      <div className="panel-size-controls">
+        {mobileBottomPanelMode === "full" ? (
+          <button
+            aria-label={`Set ${labelPrefix} panel to normal size`}
+            className={variant === "chart" ? "chart-endpoint-swap chart-endpoint-icon" : "map-control-btn map-control-btn-icon"}
+            onClick={() => setMobileBottomPanelVisibility("normal")}
+            title="Normal size"
+            type="button"
+          >
+            <PanelBottom aria-hidden="true" strokeWidth={1.8} />
+          </button>
+        ) : (
+          <>
+            <button
+              aria-label={`Hide ${labelPrefix} panel`}
+              className={variant === "chart" ? "chart-endpoint-swap chart-endpoint-icon" : "map-control-btn map-control-btn-icon"}
+              onClick={() => setMobileBottomPanelVisibility("hidden")}
+              title="Hide panel"
+              type="button"
+            >
+              <PanelBottomClose aria-hidden="true" strokeWidth={1.8} />
+            </button>
+            <button
+              aria-label={`Expand ${labelPrefix} panel to full height`}
+              className={variant === "chart" ? "chart-endpoint-swap chart-endpoint-icon" : "map-control-btn map-control-btn-icon"}
+              onClick={() => setMobileBottomPanelVisibility("full")}
+              title="Full size"
+              type="button"
+            >
+              <Maximize2 aria-hidden="true" strokeWidth={1.8} />
+            </button>
+          </>
+        )}
+      </div>
+    ),
+    [mobileBottomPanelMode, setMobileBottomPanelVisibility],
+  );
+
   if (accessState === "pending") {
     return (
       <main className="app-shell access-locked-shell">
@@ -1261,99 +1354,6 @@ export function AppShell() {
       </main>
     );
   }
-
-  const toggleProfileExpanded = () => {
-    setIsMapExpanded(false);
-    setMobileActivePanel("profile");
-    setIsProfileExpanded((prev) => !prev);
-  };
-
-  const setMobileBottomPanelVisibility = useCallback((nextMode: MobileBottomPanelMode) => {
-    setMobileBottomPanelMode(nextMode);
-  }, []);
-
-  const closeShareModal = useCallback(() => {
-    setShowShareModal(false);
-    setShareSpecificUsers([]);
-    setShareSpecificRoles({});
-    setShareUserQuery("");
-    setShareSpecificStatus("");
-  }, []);
-
-  const openShareModalOrCopy = useCallback(() => {
-    setAppNotice(null);
-    if (!activeSimulation) {
-      publishAppNotice({
-        id: "share-open-simulation-first",
-        message: "Open a saved simulation first. Unsaved workspace state cannot be shared as a deep link.",
-        tone: "warning",
-        persistent: true,
-      });
-      return;
-    }
-    if (toVisibility(activeSimulation.visibility) === "private") {
-      setShareSpecificUsers([]);
-      setShareSpecificRoles({});
-      setShareUserQuery("");
-      setShareSpecificStatus("");
-      setShareDirectory([]);
-      setShareDirectoryBusy(true);
-      setShowShareModal(true);
-      void fetchCollaboratorDirectory()
-        .then((users) => setShareDirectory(users))
-        .catch(() => {})
-        .finally(() => setShareDirectoryBusy(false));
-      return;
-    }
-    void copyCurrentLink().catch((error) => {
-      publishAppNotice({
-        id: "share-copy-failed",
-        message: getUiErrorMessage(error),
-        tone: "error",
-        persistent: true,
-      });
-    });
-  }, [activeSimulation, copyCurrentLink, publishAppNotice]);
-
-  const panelSizeControls = useCallback(
-    (labelPrefix: string, variant: "map" | "chart" = "map") => (
-      <div className="panel-size-controls">
-        {mobileBottomPanelMode === "full" ? (
-          <button
-            aria-label={`Set ${labelPrefix} panel to normal size`}
-            className={variant === "chart" ? "chart-endpoint-swap chart-endpoint-icon" : "map-control-btn map-control-btn-icon"}
-            onClick={() => setMobileBottomPanelVisibility("normal")}
-            title="Normal size"
-            type="button"
-          >
-            <PanelBottom aria-hidden="true" strokeWidth={1.8} />
-          </button>
-        ) : (
-          <>
-            <button
-              aria-label={`Hide ${labelPrefix} panel`}
-              className={variant === "chart" ? "chart-endpoint-swap chart-endpoint-icon" : "map-control-btn map-control-btn-icon"}
-              onClick={() => setMobileBottomPanelVisibility("hidden")}
-              title="Hide panel"
-              type="button"
-            >
-              <PanelBottomClose aria-hidden="true" strokeWidth={1.8} />
-            </button>
-            <button
-              aria-label={`Expand ${labelPrefix} panel to full height`}
-              className={variant === "chart" ? "chart-endpoint-swap chart-endpoint-icon" : "map-control-btn map-control-btn-icon"}
-              onClick={() => setMobileBottomPanelVisibility("full")}
-              title="Full size"
-              type="button"
-            >
-              <Maximize2 aria-hidden="true" strokeWidth={1.8} />
-            </button>
-          </>
-        )}
-      </div>
-    ),
-    [mobileBottomPanelMode, setMobileBottomPanelVisibility],
-  );
 
   return (
     <main


### PR DESCRIPTION
## Summary
- move AppShell callback hooks above conditional pending/locked returns
- keep hook ordering stable when access check failures transition to locked state
- prevent React error #300 crash on Firefox startup failure path

## Verification
- npm test
- npm run build