### PR TITLE
fix: fallback to readonly demo on firefox auth bootstrap network error

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -4,7 +4,12 @@ import { type CollaboratorDirectoryUser, fetchCollaboratorDirectory, fetchDeepLi
 import { fetchCloudLibrary, fetchPublicSimulationLibrary, pushCloudLibrary } from "../lib/cloudLibrary";
 import { buildDeepLinkPathname, buildDeepLinkUrl, canonicalizeDeepLinkKey, parseDeepLinkFromLocation, slugifyName } from "../lib/deepLink";
 import { canRunDeepLinkApply } from "../lib/deepLinkApplyGate";
-import { type DeepLinkApplyOutcome, isAuthSignInRequiredMessage, shouldRewritePathAfterDeepLinkApply } from "../lib/appShellGuards";
+import {
+  type DeepLinkApplyOutcome,
+  isAuthSignInRequiredMessage,
+  shouldRewritePathAfterDeepLinkApply,
+  shouldUseReadonlyFallbackForAuthBootstrap,
+} from "../lib/appShellGuards";
 import { emptyWorkspaceState } from "../lib/emptyWorkspaceState";
 import { getCurrentRuntimeEnvironment } from "../lib/environment";
 import { getUiErrorMessage } from "../lib/uiError";
@@ -422,19 +427,28 @@ export function AppShell() {
         if (cancelled || timedOut) return;
         window.clearTimeout(timeoutId);
         const message = getUiErrorMessage(error);
+        const isOnlineNow = typeof navigator === "undefined" ? true : navigator.onLine;
+        const fallbackToReadonly = shouldUseReadonlyFallbackForAuthBootstrap({
+          message,
+          deepLinkMode: deepLinkParse.ok,
+          isLocalRuntime,
+          isOnline: isOnlineNow,
+          userAgent: typeof navigator === "undefined" ? "" : navigator.userAgent,
+        });
         if (deepLinkParse.ok) {
           console.info("[AppShell] Guest deep-link bootstrap using read-only fallback", {
             message,
             isLocalRuntime,
             deepLinkMode: deepLinkParse.ok,
-            online: typeof navigator === "undefined" ? true : navigator.onLine,
+            online: isOnlineNow,
           });
         } else {
           console.error("[AppShell] Access check failed", {
             message,
             isLocalRuntime,
             deepLinkMode: deepLinkParse.ok,
-            online: typeof navigator === "undefined" ? true : navigator.onLine,
+            online: isOnlineNow,
+            fallbackToReadonly,
           });
         }
         setAccessDiagnosticMessage(`Access check failed: ${message}`);
@@ -443,6 +457,11 @@ export function AppShell() {
           return;
         }
         if (deepLinkParse.ok) {
+          setAccessState("readonly");
+          return;
+        }
+        if (fallbackToReadonly) {
+          setAccessDiagnosticMessage("Sign-in check was blocked by browser auth redirects. Continuing in read-only demo mode.");
           setAccessState("readonly");
           return;
         }

--- a/src/lib/appShellGuards.test.ts
+++ b/src/lib/appShellGuards.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { isAuthSignInRequiredMessage, shouldRewritePathAfterDeepLinkApply } from "./appShellGuards";
+import {
+  isAuthSignInRequiredMessage,
+  shouldRewritePathAfterDeepLinkApply,
+  shouldUseReadonlyFallbackForAuthBootstrap,
+} from "./appShellGuards";
 
 describe("shouldRewritePathAfterDeepLinkApply", () => {
   it("rewrites only after successful deep-link apply", () => {
@@ -44,6 +48,55 @@ describe("isAuthSignInRequiredMessage", () => {
 
   it("ignores unrelated errors", () => {
     expect(isAuthSignInRequiredMessage("Network timeout")).toBe(false);
+    expect(isAuthSignInRequiredMessage("NetworkError when attempting to fetch resource.")).toBe(false);
     expect(isAuthSignInRequiredMessage("This shared simulation is unavailable.")).toBe(false);
+  });
+});
+
+describe("shouldUseReadonlyFallbackForAuthBootstrap", () => {
+  it("uses readonly fallback for Firefox auth bootstrap network failure", () => {
+    expect(
+      shouldUseReadonlyFallbackForAuthBootstrap({
+        message: "NetworkError when attempting to fetch resource.",
+        deepLinkMode: false,
+        isLocalRuntime: false,
+        isOnline: true,
+        userAgent: "Mozilla/5.0 Firefox/124.0",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not use readonly fallback for unrelated failures", () => {
+    expect(
+      shouldUseReadonlyFallbackForAuthBootstrap({
+        message: "Network timeout",
+        deepLinkMode: false,
+        isLocalRuntime: false,
+        isOnline: true,
+        userAgent: "Mozilla/5.0 Firefox/124.0",
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldUseReadonlyFallbackForAuthBootstrap({
+        message: "NetworkError when attempting to fetch resource.",
+        deepLinkMode: false,
+        isLocalRuntime: false,
+        isOnline: true,
+        userAgent: "Mozilla/5.0 AppleWebKit Safari/605.1.15",
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps deep-link flow unchanged", () => {
+    expect(
+      shouldUseReadonlyFallbackForAuthBootstrap({
+        message: "NetworkError when attempting to fetch resource.",
+        deepLinkMode: true,
+        isLocalRuntime: false,
+        isOnline: true,
+        userAgent: "Mozilla/5.0 Firefox/124.0",
+      }),
+    ).toBe(false);
   });
 });

--- a/src/lib/appShellGuards.ts
+++ b/src/lib/appShellGuards.ts
@@ -26,3 +26,20 @@ export const isAuthSignInRequiredMessage = (message: string | null | undefined):
     normalized.includes("not authenticated")
   );
 };
+
+export const shouldUseReadonlyFallbackForAuthBootstrap = (input: {
+  message: string | null | undefined;
+  deepLinkMode: boolean;
+  isLocalRuntime: boolean;
+  isOnline: boolean;
+  userAgent: string;
+}): boolean => {
+  if (input.deepLinkMode) return false;
+  if (input.isLocalRuntime) return false;
+  if (!input.isOnline) return false;
+  const normalized = String(input.message ?? "").trim().toLowerCase();
+  if (!normalized) return false;
+  const isFirefox = /firefox/i.test(input.userAgent);
+  if (!isFirefox) return false;
+  return normalized.includes("networkerror when attempting to fetch resource");
+};


### PR DESCRIPTION
## Summary
- add Firefox-specific auth-bootstrap network-error classifier for Cloudflare Access redirect failures
- route non-deeplink startup into readonly/demo fallback instead of access-unavailable lockout
- keep deep-link bootstrap behavior unchanged

## Verification
- npm test
- npm run build