### PR TITLE
hotfix: restore Save Selected Link action for two-site selection

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -25,6 +25,7 @@ import { useCoverageStore } from "../store/coverageStore";
 import { TERRAIN_DATASET_LABEL } from "../lib/terrainDataset";
 import type { Link, PropagationEnvironment, Site } from "../types/radio";
 import { fetchMeshmapNodes, type MeshmapNode } from "../lib/meshtasticMqtt";
+import { canShowSaveSelectedLinkAction } from "../lib/selectedPairActions";
 import { SimulationResultsSection } from "./SimulationResultsSection";
 
 const UI_SECTION_KEYS = {
@@ -1669,9 +1670,9 @@ export function MapView({
   };
 
   const saveSelectedSitesAsLink = () => {
-    if (!canPersist || selectedSites.length < 2) return;
-    const fromSite = selectedSites[0];
-    const toSite = selectedSites[selectedSites.length - 1];
+    if (!canPersist) return;
+    const fromSite = selectedFromSite;
+    const toSite = selectedToSite;
     if (!fromSite || !toSite || fromSite.id === toSite.id) return;
     createLink(fromSite.id, toSite.id);
     setSiteDraftStatus(`Saved link ${fromSite.name} -> ${toSite.name}.`);
@@ -1975,6 +1976,15 @@ export function MapView({
     canPersist &&
     Boolean(selectedDiscoveryLibraryEntry) &&
     !sites.some((site) => site.libraryEntryId === selectedDiscoveryLibraryEntry?.id);
+  const canRemoveSelectedSite = Boolean(selectedSite && canPersist && sites.length > 1);
+  const canSaveSelectedLink = canShowSaveSelectedLinkAction({
+    canPersist,
+    fromSiteId: selectedFromSite?.id ?? null,
+    toSiteId: selectedToSite?.id ?? null,
+  });
+  const hasInspectorActions = Boolean(
+    inspectorPrimaryLibraryEntryId || canAddSelectedDiscoverySite || canRemoveSelectedSite || canSaveSelectedLink,
+  );
   const inspectorLines: string[] = [];
   if (!hasSimulationTerrain) inspectorLines.push("No terrain loaded: simulation currently uses site elevations only.");
   if (resolvedBasemap.fallbackReason && !useFallbackMapStyle) inspectorLines.push(resolvedBasemap.fallbackReason);
@@ -2104,10 +2114,10 @@ export function MapView({
               </span>
             </div>
           ) : null}
-          {inspectorPrimary ? (
+          {inspectorPrimary || hasInspectorActions ? (
             <div className="map-inspector-section">
-              <p className="map-inspector-primary">{inspectorPrimary}</p>
-              {inspectorPrimaryLibraryEntryId || canAddSelectedDiscoverySite || (selectedSite && canPersist && sites.length > 1) || (canPersist && selectedSites.length >= 2) ? (
+              {inspectorPrimary ? <p className="map-inspector-primary">{inspectorPrimary}</p> : null}
+              {hasInspectorActions ? (
                 <div className="chip-group">
                   {inspectorPrimaryLibraryEntryId ? (
                     <button
@@ -2118,7 +2128,7 @@ export function MapView({
                       Open
                     </button>
                   ) : null}
-                  {selectedSite && canPersist && sites.length > 1 ? (
+                  {canRemoveSelectedSite ? (
                     <button className="inline-action danger" onClick={removeSelectedSiteFromSimulation} type="button">
                       Remove From Simulation
                     </button>
@@ -2132,7 +2142,7 @@ export function MapView({
                       Add To Simulation
                     </button>
                   ) : null}
-                  {canPersist && selectedSites.length >= 2 ? (
+                  {canSaveSelectedLink ? (
                     <button className="inline-action" onClick={saveSelectedSitesAsLink} type="button">
                       Save Selected Link
                     </button>

--- a/src/lib/selectedPairActions.test.ts
+++ b/src/lib/selectedPairActions.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { canShowSaveSelectedLinkAction } from "./selectedPairActions";
+
+describe("canShowSaveSelectedLinkAction", () => {
+  it("returns true for editable workspace with a valid two-site pair", () => {
+    expect(
+      canShowSaveSelectedLinkAction({
+        canPersist: true,
+        fromSiteId: "site-a",
+        toSiteId: "site-b",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when workspace is read-only", () => {
+    expect(
+      canShowSaveSelectedLinkAction({
+        canPersist: false,
+        fromSiteId: "site-a",
+        toSiteId: "site-b",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when selection is missing one endpoint", () => {
+    expect(
+      canShowSaveSelectedLinkAction({
+        canPersist: true,
+        fromSiteId: "site-a",
+        toSiteId: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when both endpoints are the same site", () => {
+    expect(
+      canShowSaveSelectedLinkAction({
+        canPersist: true,
+        fromSiteId: "site-a",
+        toSiteId: "site-a",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when effective pair exists even if raw selection state is unreliable", () => {
+    expect(
+      canShowSaveSelectedLinkAction({
+        canPersist: true,
+        fromSiteId: "from-selected-link",
+        toSiteId: "to-selected-link",
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/lib/selectedPairActions.ts
+++ b/src/lib/selectedPairActions.ts
@@ -1,0 +1,11 @@
+type SaveSelectedLinkActionInput = {
+  canPersist: boolean;
+  fromSiteId: string | null;
+  toSiteId: string | null;
+};
+
+export const canShowSaveSelectedLinkAction = (input: SaveSelectedLinkActionInput): boolean => {
+  if (!input.canPersist) return false;
+  if (!input.fromSiteId || !input.toSiteId) return false;
+  return input.fromSiteId !== input.toSiteId;
+};


### PR DESCRIPTION
Fixes #415

## What changed
- Added canShowSaveSelectedLinkAction helper for action eligibility.
- Updated map inspector save-action gating to use effective selected endpoints.
- Decoupled inspector action chip rendering from optional primary inspector text.
- Added regression tests for save-action eligibility.

## Verification
- npm run test
- npm run build
