### PR TITLE
UI copy: align sidebar Paths heading with modal terminology (#411)

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1912,7 +1912,7 @@ export function Sidebar({
 
       <section className="panel-section section-path">
         <div className="section-heading">
-          <h2>Links</h2>
+          <h2>Paths</h2>
           <InfoTip text={`Select multiple sites by ${isMac ? "Cmd" : "Ctrl"}+Clicking to instantly view a link. When a link is active on the map, you can save it permanently to this simulation by pressing "Save" in the inspector.`} />
         </div>
         <div className="link-list">


### PR DESCRIPTION
Follow-up #411 consistency fix:
- change sidebar section heading from  to 
- aligns heading with existing path terminology in create/edit modal copy

Verification:
- npm run test
- npm run build