### PR TITLE
ci: allow approved no-milestone closures

### DIFF
--- a/.github/workflows/require-milestone-on-close.yml
+++ b/.github/workflows/require-milestone-on-close.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   enforce-milestone:
-    if: github.event.issue.state_reason == 'completed' && github.event.issue.milestone == null
+    if: github.event.issue.state_reason == 'completed' && github.event.issue.milestone == null && !contains(toJson(github.event.issue.labels), '\"name\":\"no-milestone-close-ok\"')
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -18,4 +18,4 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           gh issue reopen "$ISSUE_NUMBER" --repo "$REPO"
-          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "⚠️ Issues closed as completed must have a milestone assigned. Please assign a milestone before closing."
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "⚠️ Issues closed as completed must have a milestone assigned. Please assign a milestone before closing, or add label \`no-milestone-close-ok\` for an approved exception."


### PR DESCRIPTION
## Summary
- allow an explicit issue-label override for the milestone-on-close enforcement
- keep milestone enforcement as default behavior
- update bot comment to mention the override label

## Override label
- no-milestone-close-ok

## Why
Issue #412 is already implemented and should be closable without assigning a milestone when explicitly approved.
