### PR TITLE
Refactor AppShell into mobile tabs + onboarding hook (#436)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -25,6 +25,8 @@ import SimulationLibraryPanel from "./SimulationLibraryPanel";
 import WelcomeModal from "./WelcomeModal";
 import { Sidebar } from "./Sidebar";
 import { UserAdminPanel } from "./UserAdminPanel";
+import { MobileWorkspaceTabs } from "./app-shell/MobileWorkspaceTabs";
+import { useOnboardingFlow } from "./app-shell/useOnboardingFlow";
 
 initializeMigrations();
 
@@ -146,8 +148,6 @@ export function AppShell() {
   const lockedNeedsSignIn = isAuthSignInRequiredMessage(accessDiagnosticMessage);
   const isAnonymousGuestReadonly = accessState === "readonly" && !currentUser;
   const [activeUserId, setActiveUserId] = useState("");
-  const [showWelcomeModal, setShowWelcomeModal] = useState(false);
-  const [showOnboardingTutorial, setShowOnboardingTutorial] = useState(false);
   const [libraryAutoOpened, setLibraryAutoOpened] = useState(false);
   const [showShareModal, setShowShareModal] = useState(false);
   const [shareBusy, setShareBusy] = useState(false);
@@ -172,6 +172,21 @@ export function AppShell() {
   const cloudInitSeenRef = useRef(false);
   const cloudInitSettledRef = useRef(false);
   const appShellRef = useRef<HTMLElement | null>(null);
+  const {
+    showWelcomeModal,
+    setShowWelcomeModal,
+    showOnboardingTutorial,
+    setShowOnboardingTutorial,
+    closeWelcome,
+    openOnboardingTutorial,
+    openWelcomeFromWelcome,
+    openLibraryFromWelcome,
+    createNewFromWelcome,
+  } = useOnboardingFlow({
+    activeUserId,
+    setShowSimulationLibraryRequest,
+    setShowNewSimulationRequest,
+  });
 
   const { theme, colorTheme, variant } = useThemeVariant();
   const basemapProvider = useAppStore((state) => state.basemapProvider);
@@ -977,45 +992,6 @@ export function AppShell() {
     publishAppNotice,
   ]);
 
-  const closeWelcome = () => {
-    setShowWelcomeModal(false);
-    if (!activeUserId) return;
-    try {
-      localStorage.setItem(`${ONBOARDING_SEEN_KEY_PREFIX}${activeUserId}`, "1");
-    } catch {
-      // ignore storage errors
-    }
-  };
-
-  const openOnboardingTutorial = () => {
-    setShowOnboardingTutorial(true);
-  };
-
-  const openWelcomeFromWelcome = () => {
-    setShowWelcomeModal(false);
-    setShowOnboardingTutorial(true);
-  };
-
-  const openLibraryFromWelcome = () => {
-    setShowWelcomeModal(false);
-    setShowSimulationLibraryRequest(true);
-    try {
-      if (activeUserId) localStorage.setItem(`${ONBOARDING_SEEN_KEY_PREFIX}${activeUserId}`, "1");
-    } catch {
-      // ignore
-    }
-  };
-
-  const createNewFromWelcome = () => {
-    setShowWelcomeModal(false);
-    setShowNewSimulationRequest(true);
-    try {
-      if (activeUserId) localStorage.setItem(`${ONBOARDING_SEEN_KEY_PREFIX}${activeUserId}`, "1");
-    } catch {
-      // ignore
-    }
-  };
-
   useEffect(() => {
     if (libraryAutoOpened) return;
     if (workspaceState !== "no-simulation") return;
@@ -1609,59 +1585,19 @@ export function AppShell() {
           }
         />
         {isMobileViewport ? (
-          <div className="mobile-workspace-tabs" role="tablist" aria-label="Mobile workspace panels">
-            <button
-              aria-controls={mobileNavigatorPanelId}
-              aria-selected={mobileBottomPanelMode !== "hidden" && mobileActivePanel === "navigator"}
-              className={`mobile-workspace-tab ${mobileBottomPanelMode !== "hidden" && mobileActivePanel === "navigator" ? "is-active" : ""}`}
-              id={mobileNavigatorTabId}
-              onClick={() => {
-                setIsMapExpanded(false);
-                setMobileActivePanel("navigator");
-                if (mobileBottomPanelMode === "hidden") {
-                  setMobileBottomPanelVisibility("normal");
-                }
-              }}
-              role="tab"
-              type="button"
-            >
-              Navigator
-            </button>
-            <button
-              aria-controls={mobileInspectorPanelId}
-              aria-selected={mobileBottomPanelMode !== "hidden" && mobileActivePanel === "inspector"}
-              className={`mobile-workspace-tab ${mobileBottomPanelMode !== "hidden" && mobileActivePanel === "inspector" ? "is-active" : ""}`}
-              id={mobileInspectorTabId}
-              onClick={() => {
-                setIsMapExpanded(false);
-                setMobileActivePanel("inspector");
-                if (mobileBottomPanelMode === "hidden") {
-                  setMobileBottomPanelVisibility("normal");
-                }
-              }}
-              role="tab"
-              type="button"
-            >
-              Inspector
-            </button>
-            <button
-              aria-controls={mobileProfilePanelId}
-              aria-selected={mobileBottomPanelMode !== "hidden" && mobileActivePanel === "profile"}
-              className={`mobile-workspace-tab ${mobileBottomPanelMode !== "hidden" && mobileActivePanel === "profile" ? "is-active" : ""}`}
-              id={mobileProfileTabId}
-              onClick={() => {
-                setIsMapExpanded(false);
-                setMobileActivePanel("profile");
-                if (mobileBottomPanelMode === "hidden") {
-                  setMobileBottomPanelVisibility("normal");
-                }
-              }}
-              role="tab"
-              type="button"
-            >
-              Profile
-            </button>
-          </div>
+          <MobileWorkspaceTabs
+            activePanel={mobileActivePanel}
+            inspectorPanelId={mobileInspectorPanelId}
+            inspectorTabId={mobileInspectorTabId}
+            mode={mobileBottomPanelMode}
+            navigatorPanelId={mobileNavigatorPanelId}
+            navigatorTabId={mobileNavigatorTabId}
+            profilePanelId={mobileProfilePanelId}
+            profileTabId={mobileProfileTabId}
+            setIsMapExpanded={setIsMapExpanded}
+            setMobileActivePanel={setMobileActivePanel}
+            setMobileBottomPanelVisibility={setMobileBottomPanelVisibility}
+          />
         ) : null}
         {!isMobileViewport && !isMapExpanded && !isProfileHidden ? (
           <LinkProfileChart

--- a/src/components/app-shell/MobileWorkspaceTabs.tsx
+++ b/src/components/app-shell/MobileWorkspaceTabs.tsx
@@ -1,0 +1,78 @@
+import type { Dispatch, SetStateAction } from "react";
+
+type MobileWorkspacePanel = "navigator" | "inspector" | "profile";
+type MobileBottomPanelMode = "normal" | "hidden" | "full";
+
+type MobileWorkspaceTabsProps = {
+  activePanel: MobileWorkspacePanel;
+  mode: MobileBottomPanelMode;
+  navigatorPanelId: string;
+  navigatorTabId: string;
+  inspectorPanelId: string;
+  inspectorTabId: string;
+  profilePanelId: string;
+  profileTabId: string;
+  setIsMapExpanded: Dispatch<SetStateAction<boolean>>;
+  setMobileActivePanel: Dispatch<SetStateAction<MobileWorkspacePanel>>;
+  setMobileBottomPanelVisibility: (mode: MobileBottomPanelMode) => void;
+};
+
+export function MobileWorkspaceTabs({
+  activePanel,
+  mode,
+  navigatorPanelId,
+  navigatorTabId,
+  inspectorPanelId,
+  inspectorTabId,
+  profilePanelId,
+  profileTabId,
+  setIsMapExpanded,
+  setMobileActivePanel,
+  setMobileBottomPanelVisibility,
+}: MobileWorkspaceTabsProps) {
+  const selectPanel = (panel: MobileWorkspacePanel) => {
+    setIsMapExpanded(false);
+    setMobileActivePanel(panel);
+    if (mode === "hidden") {
+      setMobileBottomPanelVisibility("normal");
+    }
+  };
+
+  return (
+    <div className="mobile-workspace-tabs" role="tablist" aria-label="Mobile workspace panels">
+      <button
+        aria-controls={navigatorPanelId}
+        aria-selected={mode !== "hidden" && activePanel === "navigator"}
+        className={`mobile-workspace-tab ${mode !== "hidden" && activePanel === "navigator" ? "is-active" : ""}`}
+        id={navigatorTabId}
+        onClick={() => selectPanel("navigator")}
+        role="tab"
+        type="button"
+      >
+        Navigator
+      </button>
+      <button
+        aria-controls={inspectorPanelId}
+        aria-selected={mode !== "hidden" && activePanel === "inspector"}
+        className={`mobile-workspace-tab ${mode !== "hidden" && activePanel === "inspector" ? "is-active" : ""}`}
+        id={inspectorTabId}
+        onClick={() => selectPanel("inspector")}
+        role="tab"
+        type="button"
+      >
+        Inspector
+      </button>
+      <button
+        aria-controls={profilePanelId}
+        aria-selected={mode !== "hidden" && activePanel === "profile"}
+        className={`mobile-workspace-tab ${mode !== "hidden" && activePanel === "profile" ? "is-active" : ""}`}
+        id={profileTabId}
+        onClick={() => selectPanel("profile")}
+        role="tab"
+        type="button"
+      >
+        Profile
+      </button>
+    </div>
+  );
+}

--- a/src/components/app-shell/useOnboardingFlow.ts
+++ b/src/components/app-shell/useOnboardingFlow.ts
@@ -1,0 +1,65 @@
+import { useState } from "react";
+
+const ONBOARDING_SEEN_KEY_PREFIX = "linksim:onboarding-seen:v1:";
+
+type UseOnboardingFlowParams = {
+  activeUserId: string;
+  setShowSimulationLibraryRequest: (show: boolean) => void;
+  setShowNewSimulationRequest: (show: boolean) => void;
+};
+
+export function useOnboardingFlow({
+  activeUserId,
+  setShowSimulationLibraryRequest,
+  setShowNewSimulationRequest,
+}: UseOnboardingFlowParams) {
+  const [showWelcomeModal, setShowWelcomeModal] = useState(false);
+  const [showOnboardingTutorial, setShowOnboardingTutorial] = useState(false);
+
+  const markSeen = () => {
+    if (!activeUserId) return;
+    try {
+      localStorage.setItem(`${ONBOARDING_SEEN_KEY_PREFIX}${activeUserId}`, "1");
+    } catch {
+      // ignore storage errors
+    }
+  };
+
+  const closeWelcome = () => {
+    setShowWelcomeModal(false);
+    markSeen();
+  };
+
+  const openOnboardingTutorial = () => {
+    setShowOnboardingTutorial(true);
+  };
+
+  const openWelcomeFromWelcome = () => {
+    setShowWelcomeModal(false);
+    setShowOnboardingTutorial(true);
+  };
+
+  const openLibraryFromWelcome = () => {
+    setShowWelcomeModal(false);
+    setShowSimulationLibraryRequest(true);
+    markSeen();
+  };
+
+  const createNewFromWelcome = () => {
+    setShowWelcomeModal(false);
+    setShowNewSimulationRequest(true);
+    markSeen();
+  };
+
+  return {
+    showWelcomeModal,
+    setShowWelcomeModal,
+    showOnboardingTutorial,
+    setShowOnboardingTutorial,
+    closeWelcome,
+    openOnboardingTutorial,
+    openWelcomeFromWelcome,
+    openLibraryFromWelcome,
+    createNewFromWelcome,
+  };
+}


### PR DESCRIPTION
## Summary
- extract `MobileWorkspaceTabs` from `AppShell` with explicit props for active panel, tab/panel ids, and toggle behavior
- extract onboarding modal orchestration into `useOnboardingFlow` hook
- keep existing behavior and labels unchanged while reducing `AppShell` inline UI/control logic

## Verification
- npm run test
- npm run build
