### PR TITLE
hotfix(ci): robust no-milestone override check

### DIFF
--- a/.github/workflows/require-milestone-on-close.yml
+++ b/.github/workflows/require-milestone-on-close.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   enforce-milestone:
-    if: github.event.issue.state_reason == 'completed' && github.event.issue.milestone == null && !contains(toJson(github.event.issue.labels), '\"name\":\"no-milestone-close-ok\"')
+    if: github.event.issue.state_reason == 'completed' && github.event.issue.milestone == null
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -17,5 +17,9 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
         run: |
+          if jq -e '.issue.labels[]? | select(.name == "no-milestone-close-ok")' "$GITHUB_EVENT_PATH" > /dev/null; then
+            echo "Skipping milestone enforcement due to no-milestone-close-ok label."
+            exit 0
+          fi
           gh issue reopen "$ISSUE_NUMBER" --repo "$REPO"
           gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "⚠️ Issues closed as completed must have a milestone assigned. Please assign a milestone before closing, or add label \`no-milestone-close-ok\` for an approved exception."


### PR DESCRIPTION
## Summary
- keep milestone enforcement for completed issues without a milestone
- skip enforcement only when issue label no-milestone-close-ok is present
- evaluate label directly from GITHUB_EVENT_PATH via jq for deterministic behavior

## Why
Expression-based label filtering still reopened issue #412. This makes the override check explicit and reliable.
