### PR TITLE
Add regression tests for oversized UI refactor (#436)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1014,57 +1014,6 @@ export function AppShell() {
     setShowLibraryFromRequest(true);
   }, [showSimulationLibraryRequest, setShowSimulationLibraryRequest]);
 
-  const openOnboardingTutorial = () => {
-    setShowOnboardingTutorial(true);
-  };
-
-  const openWelcomeFromWelcome = () => {
-    setShowWelcomeModal(false);
-    setShowOnboardingTutorial(true);
-  };
-
-  const openLibraryFromWelcome = () => {
-    setShowWelcomeModal(false);
-    setShowSimulationLibraryRequest(true);
-    try {
-      if (activeUserId) localStorage.setItem(`${ONBOARDING_SEEN_KEY_PREFIX}${activeUserId}`, "1");
-    } catch {
-      // ignore
-    }
-  };
-
-  const createNewFromWelcome = () => {
-    setShowWelcomeModal(false);
-    setShowNewSimulationRequest(true);
-    try {
-      if (activeUserId) localStorage.setItem(`${ONBOARDING_SEEN_KEY_PREFIX}${activeUserId}`, "1");
-    } catch {
-      // ignore
-    }
-  };
-
-  useEffect(() => {
-    if (libraryAutoOpened) return;
-    if (workspaceState !== "no-simulation") return;
-    if (showWelcomeModal) return;
-    if (accessState !== "granted" && accessState !== "readonly") return;
-    if (!activeUserId) return;
-    try {
-      const seen = localStorage.getItem(`${ONBOARDING_SEEN_KEY_PREFIX}${activeUserId}`);
-      if (!seen) return;
-    } catch {
-      return;
-    }
-    setLibraryAutoOpened(true);
-    setShowSimulationLibraryRequest(true);
-  }, [libraryAutoOpened, workspaceState, showWelcomeModal, accessState, activeUserId, setShowSimulationLibraryRequest]);
-
-  useEffect(() => {
-    if (!showSimulationLibraryRequest) return;
-    setShowSimulationLibraryRequest(false);
-    setShowLibraryFromRequest(true);
-  }, [showSimulationLibraryRequest, setShowSimulationLibraryRequest]);
-
   const copyCurrentLink = useCallback(async () => {
     if (!activeSimulation) {
       publishAppNotice({

--- a/src/components/app-shell/MobileWorkspaceTabs.test.ts
+++ b/src/components/app-shell/MobileWorkspaceTabs.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { isActiveMobilePanelTab } from "./MobileWorkspaceTabs";
+
+describe("isActiveMobilePanelTab", () => {
+  it("returns true for active panel when mode is visible", () => {
+    expect(isActiveMobilePanelTab("normal", "navigator", "navigator")).toBe(true);
+  });
+
+  it("returns false for inactive panel", () => {
+    expect(isActiveMobilePanelTab("full", "navigator", "inspector")).toBe(false);
+  });
+
+  it("returns false when mode is hidden", () => {
+    expect(isActiveMobilePanelTab("hidden", "navigator", "navigator")).toBe(false);
+  });
+});

--- a/src/components/app-shell/MobileWorkspaceTabs.tsx
+++ b/src/components/app-shell/MobileWorkspaceTabs.tsx
@@ -17,6 +17,12 @@ type MobileWorkspaceTabsProps = {
   setMobileBottomPanelVisibility: (mode: MobileBottomPanelMode) => void;
 };
 
+export const isActiveMobilePanelTab = (
+  mode: MobileBottomPanelMode,
+  activePanel: MobileWorkspacePanel,
+  panel: MobileWorkspacePanel,
+) => mode !== "hidden" && activePanel === panel;
+
 export function MobileWorkspaceTabs({
   activePanel,
   mode,
@@ -42,8 +48,8 @@ export function MobileWorkspaceTabs({
     <div className="mobile-workspace-tabs" role="tablist" aria-label="Mobile workspace panels">
       <button
         aria-controls={navigatorPanelId}
-        aria-selected={mode !== "hidden" && activePanel === "navigator"}
-        className={`mobile-workspace-tab ${mode !== "hidden" && activePanel === "navigator" ? "is-active" : ""}`}
+        aria-selected={isActiveMobilePanelTab(mode, activePanel, "navigator")}
+        className={`mobile-workspace-tab ${isActiveMobilePanelTab(mode, activePanel, "navigator") ? "is-active" : ""}`}
         id={navigatorTabId}
         onClick={() => selectPanel("navigator")}
         role="tab"
@@ -53,8 +59,8 @@ export function MobileWorkspaceTabs({
       </button>
       <button
         aria-controls={inspectorPanelId}
-        aria-selected={mode !== "hidden" && activePanel === "inspector"}
-        className={`mobile-workspace-tab ${mode !== "hidden" && activePanel === "inspector" ? "is-active" : ""}`}
+        aria-selected={isActiveMobilePanelTab(mode, activePanel, "inspector")}
+        className={`mobile-workspace-tab ${isActiveMobilePanelTab(mode, activePanel, "inspector") ? "is-active" : ""}`}
         id={inspectorTabId}
         onClick={() => selectPanel("inspector")}
         role="tab"
@@ -64,8 +70,8 @@ export function MobileWorkspaceTabs({
       </button>
       <button
         aria-controls={profilePanelId}
-        aria-selected={mode !== "hidden" && activePanel === "profile"}
-        className={`mobile-workspace-tab ${mode !== "hidden" && activePanel === "profile" ? "is-active" : ""}`}
+        aria-selected={isActiveMobilePanelTab(mode, activePanel, "profile")}
+        className={`mobile-workspace-tab ${isActiveMobilePanelTab(mode, activePanel, "profile") ? "is-active" : ""}`}
         id={profileTabId}
         onClick={() => selectPanel("profile")}
         role="tab"

--- a/src/components/app-shell/useOnboardingFlow.test.ts
+++ b/src/components/app-shell/useOnboardingFlow.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { getOnboardingSeenKey } from "./useOnboardingFlow";
+
+describe("getOnboardingSeenKey", () => {
+  it("uses the onboarding key prefix", () => {
+    expect(getOnboardingSeenKey("user-123")).toBe("linksim:onboarding-seen:v1:user-123");
+  });
+});

--- a/src/components/app-shell/useOnboardingFlow.ts
+++ b/src/components/app-shell/useOnboardingFlow.ts
@@ -19,7 +19,7 @@ export function useOnboardingFlow({
   const markSeen = () => {
     if (!activeUserId) return;
     try {
-      localStorage.setItem(`${ONBOARDING_SEEN_KEY_PREFIX}${activeUserId}`, "1");
+      localStorage.setItem(getOnboardingSeenKey(activeUserId), "1");
     } catch {
       // ignore storage errors
     }
@@ -63,3 +63,5 @@ export function useOnboardingFlow({
     createNewFromWelcome,
   };
 }
+
+export const getOnboardingSeenKey = (userId: string) => `${ONBOARDING_SEEN_KEY_PREFIX}${userId}`;

--- a/src/components/map/useMapControls.test.ts
+++ b/src/components/map/useMapControls.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { computeNextZoom } from "./useMapControls";
+
+const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+
+describe("computeNextZoom", () => {
+  it("increments within bounds", () => {
+    expect(computeNextZoom(8, 1, 15, clamp)).toBe(9);
+  });
+
+  it("clamps to min zoom", () => {
+    expect(computeNextZoom(2, -4, 15, clamp)).toBe(2);
+  });
+
+  it("clamps to provider max zoom", () => {
+    expect(computeNextZoom(14.5, 2, 15, clamp)).toBe(15);
+  });
+});

--- a/src/components/map/useMapControls.ts
+++ b/src/components/map/useMapControls.ts
@@ -19,6 +19,13 @@ type UseMapControlsParams = {
   updateMapViewport: (patch: { zoom?: number }) => void;
 };
 
+export const computeNextZoom = (
+  currentZoom: number,
+  delta: number,
+  providerMaxZoom: number,
+  clamp: (value: number, min: number, max: number) => number,
+) => clamp(currentZoom + delta, 2, providerMaxZoom);
+
 export function useMapControls({
   activeViewState,
   fitBottomInset,
@@ -36,7 +43,7 @@ export function useMapControls({
 
   const zoomBy = (delta: number) => {
     setFitControlActive(false);
-    const nextZoom = clamp(activeViewState.zoom + delta, 2, providerMaxZoom);
+    const nextZoom = computeNextZoom(activeViewState.zoom, delta, providerMaxZoom, clamp);
     setInteractionViewState(null);
     updateMapViewport({ zoom: nextZoom });
   };

--- a/src/components/sidebar/useLibraryManager.test.ts
+++ b/src/components/sidebar/useLibraryManager.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { toggleLibraryIdSelection } from "./useLibraryManager";
+
+describe("toggleLibraryIdSelection", () => {
+  it("adds an id when not selected", () => {
+    const next = toggleLibraryIdSelection(new Set(["a"]), "b");
+    expect(Array.from(next).sort()).toEqual(["a", "b"]);
+  });
+
+  it("removes an id when already selected", () => {
+    const next = toggleLibraryIdSelection(new Set(["a", "b"]), "a");
+    expect(Array.from(next).sort()).toEqual(["b"]);
+  });
+});

--- a/src/components/sidebar/useLibraryManager.ts
+++ b/src/components/sidebar/useLibraryManager.ts
@@ -5,6 +5,13 @@ type UseLibraryManagerParams = {
   initialFilters: LibraryFilterState;
 };
 
+export const toggleLibraryIdSelection = (current: Set<string>, entryId: string): Set<string> => {
+  const next = new Set(current);
+  if (next.has(entryId)) next.delete(entryId);
+  else next.add(entryId);
+  return next;
+};
+
 export function useLibraryManager({ initialFilters }: UseLibraryManagerParams) {
   const [showSimulationLibraryManager, setShowSimulationLibraryManager] = useState(false);
   const [showSiteLibraryManager, setShowSiteLibraryManager] = useState(false);
@@ -13,12 +20,7 @@ export function useLibraryManager({ initialFilters }: UseLibraryManagerParams) {
   const [showAddLibraryForm, setShowAddLibraryForm] = useState(false);
 
   const toggleLibrarySelection = (entryId: string) => {
-    setSelectedLibraryIds((current) => {
-      const next = new Set(current);
-      if (next.has(entryId)) next.delete(entryId);
-      else next.add(entryId);
-      return next;
-    });
+    setSelectedLibraryIds((current) => toggleLibraryIdSelection(current, entryId));
   };
 
   return {


### PR DESCRIPTION
## Summary
- add regression tests for extracted refactor primitives in `Sidebar`, `MapView`, and `AppShell` splits
- cover selection toggling, zoom clamping, mobile tab active semantics, and onboarding key generation
- keep refactor behavior unchanged while hardening contracts around the new hooks/components

## Verification
- npm run test
- npm run build
