### PR TITLE
fix: lock and recover workspace on session loss (#385)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -15,6 +15,7 @@ import { getCurrentRuntimeEnvironment } from "../lib/environment";
 import { getUiErrorMessage } from "../lib/uiError";
 import { initializeMigrations, runMigrations } from "../lib/migrations";
 import { resolveBasemapSelection } from "../lib/basemaps";
+import { APP_BUILD_LABEL } from "../lib/buildInfo";
 import { useThemeVariant } from "../hooks/useThemeVariant";
 import { useAppStore } from "../store/appStore";
 import { LinkProfileChart } from "./LinkProfileChart";
@@ -103,6 +104,31 @@ const copyToClipboard = async (textOrPromise: string | Promise<string>): Promise
   document.body.removeChild(textarea);
 };
 
+const downloadRecoveryWorkspace = (): void => {
+  const state = useAppStore.getState();
+  const payload = {
+    exportedAt: new Date().toISOString(),
+    reason: "session-loss-recovery",
+    build: APP_BUILD_LABEL,
+    selectedScenarioId: state.selectedScenarioId,
+    siteLibrary: state.siteLibrary,
+    simulationPresets: state.simulationPresets,
+    sites: state.sites,
+    links: state.links,
+    systems: state.systems,
+    networks: state.networks,
+  };
+  const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const anchor = document.createElement("a");
+  anchor.href = URL.createObjectURL(blob);
+  anchor.download = `linksim-session-recovery-${stamp}.json`;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(anchor.href);
+};
+
 export function AppShell() {
   const srtmTilesCount = useAppStore((state) => state.srtmTiles.length);
   const recommendAndFetchTerrainForCurrentArea = useAppStore(
@@ -129,7 +155,10 @@ export function AppShell() {
   const initializeCloudSync = useAppStore((state) => state.initializeCloudSync);
   const performCloudSyncPush = useAppStore((state) => state.performCloudSyncPush);
   const setCurrentUser = useAppStore((state) => state.setCurrentUser);
+  const setAuthState = useAppStore((state) => state.setAuthState);
+  const authState = useAppStore((state) => state.authState);
   const currentUser = useAppStore((state) => state.currentUser);
+  const pendingChangesCount = useAppStore((state) => state.pendingChangesCount);
   const isOnline = useAppStore((state) => state.isOnline);
   const setIsOnline = useAppStore((state) => state.setIsOnline);
   const isInitializing = useAppStore((state) => state.isInitializing);
@@ -375,6 +404,7 @@ export function AppShell() {
   useEffect(() => {
     let cancelled = false;
     let timedOut = false;
+    setAuthState("checking");
     const timeoutId = window.setTimeout(() => {
       if (cancelled) return;
       timedOut = true;
@@ -388,6 +418,8 @@ export function AppShell() {
       setAccessDiagnosticMessage(
         "Access check timed out. Reload the page. If this continues, open the console and share the startup error.",
       );
+      setCurrentUser(null);
+      setAuthState("signed_out");
       setAccessState("locked");
     }, ACCESS_CHECK_TIMEOUT_MS);
 
@@ -414,6 +446,8 @@ export function AppShell() {
           if (cancelled || timedOut) return;
           window.clearTimeout(timeoutId);
           setAccessDiagnosticMessage(null);
+          setCurrentUser(null);
+          setAuthState("signed_out");
           setAccessState("readonly");
           return;
         }
@@ -426,6 +460,8 @@ export function AppShell() {
             if (cancelled || timedOut) return;
             window.clearTimeout(timeoutId);
             setAccessDiagnosticMessage(null);
+            setCurrentUser(null);
+            setAuthState("signed_out");
             setAccessState("readonly");
             return;
           }
@@ -435,6 +471,7 @@ export function AppShell() {
         window.clearTimeout(timeoutId);
         setAccessDiagnosticMessage(null);
         setCurrentUser(profile);
+        setAuthState("signed_in");
         setActiveUserId(profile.id);
         try {
           const seen = localStorage.getItem(`${ONBOARDING_SEEN_KEY_PREFIX}${profile.id}`);
@@ -486,6 +523,8 @@ export function AppShell() {
           });
         }
         setAccessDiagnosticMessage(`Access check failed: ${message}`);
+        setCurrentUser(null);
+        setAuthState("signed_out");
         if (message.includes("Session revoked by admin")) {
           window.location.href = "/cdn-cgi/access/logout";
           return;
@@ -511,7 +550,14 @@ export function AppShell() {
       cancelled = true;
       window.clearTimeout(timeoutId);
     };
-  }, [deepLinkParse, isLocalRuntime, isInitializing, setCurrentUser]);
+  }, [deepLinkParse, isLocalRuntime, isInitializing, setAuthState, setCurrentUser]);
+
+  useEffect(() => {
+    if (authState !== "signed_out") return;
+    if (accessState === "checking") return;
+    setAccessDiagnosticMessage("You are signed out. Sign in to continue.");
+    setAccessState("locked");
+  }, [accessState, authState]);
 
   useEffect(() => {
     if (accessState === "granted") {
@@ -540,6 +586,8 @@ export function AppShell() {
   }, [accessState, isAnonymousGuestReadonly, lockedNeedsSignIn, deepLinkParse.ok]);
 
   const signOutOrReadonly = useCallback(() => {
+    setCurrentUser(null);
+    setAuthState("signed_out");
     if (isLocalRuntime) {
       try {
         localStorage.setItem(LOCAL_FORCE_READONLY_KEY, "1");
@@ -554,7 +602,7 @@ export function AppShell() {
       return;
     }
     window.location.href = "/cdn-cgi/access/logout";
-  }, [deepLinkParse.ok, isLocalRuntime]);
+  }, [deepLinkParse.ok, isLocalRuntime, setAuthState, setCurrentUser]);
 
   const signIn = useCallback(() => {
     const returnTo = `${window.location.pathname}${window.location.search}${window.location.hash}`;
@@ -1335,10 +1383,34 @@ export function AppShell() {
             </>
           )}
           <div className="chip-group">
-            {lockedNeedsSignIn ? (
-              <button className="inline-action" onClick={signIn} type="button">
-                Sign In
-              </button>
+          {lockedNeedsSignIn ? (
+              <>
+                <button className="inline-action" onClick={signIn} type="button">
+                  Sign In
+                </button>
+                {pendingChangesCount > 0 ? (
+                  <>
+                    <button
+                      className="inline-action"
+                      onClick={() => {
+                        window.dispatchEvent(new CustomEvent(OPEN_SYNC_MODAL_EVENT));
+                      }}
+                      type="button"
+                    >
+                      Open Sync Status
+                    </button>
+                    <button
+                      className="inline-action"
+                      onClick={() => {
+                        downloadRecoveryWorkspace();
+                      }}
+                      type="button"
+                    >
+                      Export Current Workspace
+                    </button>
+                  </>
+                ) : null}
+              </>
             ) : (
               <button className="inline-action" onClick={signOutOrReadonly} type="button">
                 Sign Out
@@ -1362,6 +1434,11 @@ export function AppShell() {
             ) : null}
           </div>
           {localDevStatus ? <p className="field-help">{localDevStatus}</p> : null}
+          {lockedNeedsSignIn && pendingChangesCount > 0 ? (
+            <p className="field-help">
+              You are signed out. Unsynced local changes are preserved on this device. Sign in, open Sync Status, and retry sync.
+            </p>
+          ) : null}
         </section>
         <WelcomeModal onClose={closeWelcome} onCreateNewSimulation={createNewFromWelcome} onOpenLibrary={openLibraryFromWelcome} onOpenOnboarding={openWelcomeFromWelcome} open={showWelcomeModal} />
         <OnboardingTutorialModal onClose={() => setShowOnboardingTutorial(false)} onOpenLibrary={() => setShowSimulationLibraryRequest(true)} onOpenSiteLibrary={() => setShowSiteLibraryRequest(true)} open={showOnboardingTutorial} />

--- a/src/components/UserAdminPanel.tsx
+++ b/src/components/UserAdminPanel.tsx
@@ -26,6 +26,7 @@ import { fetchNotifications, type NotificationFeed } from "../lib/cloudNotificat
 import { getCurrentRuntimeEnvironment } from "../lib/environment";
 import { getUiErrorMessage } from "../lib/uiError";
 import { formatDate } from "../lib/locale";
+import { deriveSyncIndicator } from "../lib/syncIndicator";
 import { useAppStore } from "../store/appStore";
 import { useThemeVariant } from "../hooks/useThemeVariant";
 import type { UiColorTheme } from "../themes/types";
@@ -49,15 +50,6 @@ const NOTIFICATION_DISMISS_KEY = "linksim:dismissed-notifications";
 const NOTIFICATION_POLL_MS = 30_000;
 const LOCAL_FORCE_READONLY_KEY = "linksim:local-force-readonly:v1";
 const OPEN_SYNC_MODAL_EVENT = "linksim:open-sync-modal";
-
-type SyncIndicatorState = "local" | "offline" | "pending" | "syncing" | "synced" | "error";
-
-type SyncIndicator = {
-  state: SyncIndicatorState;
-  className: string;
-  label: string;
-  title: string;
-};
 
 const readDismissedNotificationIds = (): Set<string> => {
   try {
@@ -151,6 +143,9 @@ export function UserAdminPanel({ onOpenHelp, authBootstrapPending = false, extra
   const syncErrorMessage = useAppStore((state) => state.syncErrorMessage);
   const performManualCloudSync = useAppStore((state) => state.performManualCloudSync);
   const setCurrentUser = useAppStore((state) => state.setCurrentUser);
+  const authState = useAppStore((state) => state.authState);
+  const setAuthState = useAppStore((state) => state.setAuthState);
+  const currentUser = useAppStore((state) => state.currentUser);
   const { activeHolidayTheme } = useThemeVariant();
   const [open, setOpen] = useState(false);
   const [me, setMe] = useState<CloudUser | null>(null);
@@ -205,6 +200,8 @@ export function UserAdminPanel({ onOpenHelp, authBootstrapPending = false, extra
           : "pending";
   const canEditAccessRequestNote = Boolean(canModerate || !me?.isApproved);
   const showAccessRequestNoteField = Boolean(canModerate || !me?.isApproved);
+  const isSignedIn = authState === "signed_in" && Boolean(currentUser);
+  const displayUser = me ?? currentUser;
 
   const refreshAdminData = async () => {
     if (!canModerate) return;
@@ -291,6 +288,7 @@ export function UserAdminPanel({ onOpenHelp, authBootstrapPending = false, extra
       const current = await fetchMe();
       setMe(current);
       setCurrentUser(current);
+      setAuthState("signed_in");
       setNameDraft(current.username);
       setEmailDraft(current.email ?? "");
       setNameError("");
@@ -329,14 +327,21 @@ export function UserAdminPanel({ onOpenHelp, authBootstrapPending = false, extra
     } catch (error) {
       const message = getUiErrorMessage(error);
       setStatus(`User load failed: ${message}`);
+      setMe(null);
+      setCurrentUser(null);
+      setAuthState("signed_out");
     } finally {
       setBusy(false);
     }
   };
 
   useEffect(() => {
+    if (authState === "signed_out") {
+      setMe(null);
+      return;
+    }
     void load();
-  }, []);
+  }, [authState]);
 
   useEffect(() => {
     if (!canModerate) {
@@ -414,6 +419,7 @@ export function UserAdminPanel({ onOpenHelp, authBootstrapPending = false, extra
       });
       setMe(updated);
       setCurrentUser(updated);
+      setAuthState("signed_in");
       setNameDraft(updated.username);
       setEmailDraft(updated.email ?? "");
       setBioDraft(updated.bio ?? "");
@@ -446,6 +452,7 @@ export function UserAdminPanel({ onOpenHelp, authBootstrapPending = false, extra
       setAvatarDraft(uploaded.user.avatarUrl ?? "");
       setMe(uploaded.user);
       setCurrentUser(uploaded.user);
+      setAuthState("signed_in");
       setAvatarStatus("Avatar uploaded and saved.");
       setStatus("Avatar uploaded and saved.");
     } catch (error) {
@@ -669,8 +676,11 @@ export function UserAdminPanel({ onOpenHelp, authBootstrapPending = false, extra
       window.location.reload();
       return;
     }
+    setMe(null);
+    setCurrentUser(null);
+    setAuthState("signed_out");
     window.location.href = "/cdn-cgi/access/logout";
-  }, [isLocalRuntime]);
+  }, [isLocalRuntime, setAuthState, setCurrentUser]);
 
   const handleSignUp = useCallback(() => {
     const returnTo = `${window.location.pathname}${window.location.search}${window.location.hash}`;
@@ -687,51 +697,16 @@ export function UserAdminPanel({ onOpenHelp, authBootstrapPending = false, extra
     };
   }, []);
 
-  const getSyncIndicator = (): SyncIndicator => {
-    const timeLabel = lastSyncedAt
-      ? `Up to date (synced ${new Date(lastSyncedAt).toLocaleTimeString()})`
-      : "Up to date";
-
-    if (isLocalRuntime) {
-      return { state: "local", className: "sync-local", label: "Local mode", title: "Local mode - no cloud sync available" };
-    }
-
-    if (!isOnline) {
-      return {
-        state: "offline",
-        className: "sync-offline",
-        label: "Offline",
-        title: `Offline. ${pendingChangesCount} pending change${pendingChangesCount === 1 ? "" : "s"}. Open Sync Status for details.`,
-      };
-    }
-
-    if (syncPending) {
-      return {
-        state: "pending",
-        className: "sync-pending",
-        label: "Sync pending",
-        title: `${timeLabel}. ${pendingChangesCount} pending change${pendingChangesCount === 1 ? "" : "s"}.`,
-      };
-    }
-
-    switch (syncStatus) {
-      case "syncing":
-        return { state: "syncing", className: "sync-syncing", label: "Syncing...", title: timeLabel };
-      case "synced":
-        return { state: "synced", className: "sync-synced", label: "Up to date", title: `${timeLabel}. Click for details.` };
-      case "error":
-        return {
-          state: "error",
-          className: "sync-error",
-          label: "Sync failed",
-          title: `${timeLabel}. ${syncErrorMessage ?? "Open Sync Status for details."}`,
-        };
-      default:
-        return { state: "synced", className: "sync-synced", label: "Up to date", title: `${timeLabel}. Click for details.` };
-    }
-  };
-
-  const syncIndicator = getSyncIndicator();
+  const syncIndicator = deriveSyncIndicator({
+    isLocalRuntime,
+    isOnline,
+    authState,
+    syncStatus,
+    syncPending,
+    pendingChangesCount,
+    syncErrorMessage,
+    lastSyncedAt,
+  });
 
   const handleSyncIndicatorClick = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -741,9 +716,9 @@ export function UserAdminPanel({ onOpenHelp, authBootstrapPending = false, extra
   return (
     <>
       <div className="user-chip-row">
-        {me ? (
+        {isSignedIn && displayUser ? (
           <button aria-label="Open user settings" className="user-chip" onClick={() => setOpen(true)} type="button">
-            <ProfileAvatar avatarUrl={me.avatarUrl ?? ""} name={me.username ?? "User"} />
+            <ProfileAvatar avatarUrl={displayUser.avatarUrl ?? ""} name={displayUser.username ?? "User"} />
             {canModerate && unreadNotifications.length > 0 ? (
               <span className="notification-badge">{unreadNotifications.length}</span>
             ) : null}
@@ -761,7 +736,7 @@ export function UserAdminPanel({ onOpenHelp, authBootstrapPending = false, extra
           </button>
         )}
         <div className="user-chip-actions">
-          {me ? (
+          {isSignedIn ? (
             <>
               <button
                 aria-label={syncIndicator.label}

--- a/src/lib/syncIndicator.test.ts
+++ b/src/lib/syncIndicator.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { deriveSyncIndicator } from "./syncIndicator";
+
+describe("deriveSyncIndicator", () => {
+  it("returns error (red) when sync status is error even if pending is true", () => {
+    const indicator = deriveSyncIndicator({
+      isLocalRuntime: false,
+      isOnline: true,
+      authState: "signed_in",
+      syncStatus: "error",
+      syncPending: true,
+      pendingChangesCount: 3,
+      syncErrorMessage: "401 Unauthorized",
+      lastSyncedAt: null,
+    });
+    expect(indicator.state).toBe("error");
+    expect(indicator.className).toBe("sync-error");
+  });
+
+  it("returns error (red) when auth state is signed_out", () => {
+    const indicator = deriveSyncIndicator({
+      isLocalRuntime: false,
+      isOnline: true,
+      authState: "signed_out",
+      syncStatus: "synced",
+      syncPending: true,
+      pendingChangesCount: 2,
+      syncErrorMessage: null,
+      lastSyncedAt: null,
+    });
+    expect(indicator.state).toBe("error");
+    expect(indicator.label).toBe("Sync failed");
+    expect(indicator.title).toContain("Not signed in");
+  });
+});

--- a/src/lib/syncIndicator.ts
+++ b/src/lib/syncIndicator.ts
@@ -1,0 +1,74 @@
+export type SyncIndicatorState = "local" | "offline" | "pending" | "syncing" | "synced" | "error";
+
+export type SyncIndicator = {
+  state: SyncIndicatorState;
+  className: string;
+  label: string;
+  title: string;
+};
+
+type Input = {
+  isLocalRuntime: boolean;
+  isOnline: boolean;
+  authState: "checking" | "signed_in" | "signed_out";
+  syncStatus: "syncing" | "synced" | "error";
+  syncPending: boolean;
+  pendingChangesCount: number;
+  syncErrorMessage: string | null;
+  lastSyncedAt: string | null;
+};
+
+export const deriveSyncIndicator = (input: Input): SyncIndicator => {
+  const timeLabel = input.lastSyncedAt
+    ? `Up to date (synced ${new Date(input.lastSyncedAt).toLocaleTimeString()})`
+    : "Up to date";
+
+  if (input.isLocalRuntime) {
+    return { state: "local", className: "sync-local", label: "Local mode", title: "Local mode - no cloud sync available" };
+  }
+
+  if (!input.isOnline) {
+    return {
+      state: "offline",
+      className: "sync-offline",
+      label: "Offline",
+      title: `Offline. ${input.pendingChangesCount} pending change${input.pendingChangesCount === 1 ? "" : "s"}. Open Sync Status for details.`,
+    };
+  }
+
+  if (input.authState === "signed_out") {
+    return {
+      state: "error",
+      className: "sync-error",
+      label: "Sync failed",
+      title: "Not signed in; cloud sync unavailable. Sign in and open Sync Status to recover pending changes.",
+    };
+  }
+
+  if (input.syncStatus === "error") {
+    return {
+      state: "error",
+      className: "sync-error",
+      label: "Sync failed",
+      title: `${timeLabel}. ${input.syncErrorMessage ?? "Open Sync Status for details."}`,
+    };
+  }
+
+  if (input.syncPending) {
+    return {
+      state: "pending",
+      className: "sync-pending",
+      label: "Sync pending",
+      title: `${timeLabel}. ${input.pendingChangesCount} pending change${input.pendingChangesCount === 1 ? "" : "s"}.`,
+    };
+  }
+
+  switch (input.syncStatus) {
+    case "syncing":
+      return { state: "syncing", className: "sync-syncing", label: "Syncing...", title: timeLabel };
+    case "synced":
+      return { state: "synced", className: "sync-synced", label: "Up to date", title: `${timeLabel}. Click for details.` };
+    default:
+      return { state: "synced", className: "sync-synced", label: "Up to date", title: `${timeLabel}. Click for details.` };
+  }
+};

--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -38,6 +38,37 @@ vi.mock("../lib/elevationService", () => ({
 import { useAppStore } from "./appStore";
 import { fetchElevations } from "../lib/elevationService";
 
+describe("appStore auth session state", () => {
+  beforeEach(() => {
+    storage.mock.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("marks auth state signed_in when current user is set and signed_out when cleared", () => {
+    useAppStore.getState().setCurrentUser({
+      id: "user-1",
+      username: "User One",
+      avatarUrl: "",
+      role: "user",
+      accountState: "approved",
+      isApproved: true,
+      isAdmin: false,
+      isModerator: false,
+      createdAt: "",
+      updatedAt: null,
+      approvedAt: null,
+      approvedByUserId: null,
+      email: undefined,
+      emailPublic: true,
+      bio: "",
+    });
+    expect(useAppStore.getState().authState).toBe("signed_in");
+
+    useAppStore.getState().setCurrentUser(null);
+    expect(useAppStore.getState().authState).toBe("signed_out");
+  });
+});
+
 describe("appStore auth guards", () => {
   beforeEach(() => {
     storage.mock.clear();

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -133,6 +133,18 @@ const requireAuth = (currentUser: CloudUser | null, action: string): CloudUser |
   return currentUser;
 };
 
+const isAuthRelatedErrorMessage = (message: string): boolean => {
+  const normalized = message.toLowerCase();
+  return (
+    normalized.includes("401") ||
+    normalized.includes("unauthorized") ||
+    normalized.includes("access denied") ||
+    normalized.includes("auth") ||
+    normalized.includes("sign in") ||
+    normalized.includes("session revoked")
+  );
+};
+
 const canEditItem = (
   item: { ownerUserId?: string; effectiveRole?: string },
   currentUser: CloudUser | null,
@@ -213,6 +225,7 @@ const adoptOrphanedSimulations = (
 };
 
 export type MapOverlayMode = "none" | "heatmap" | "contours" | "passfail" | "relay";
+export type AuthSessionState = "checking" | "signed_in" | "signed_out";
 
 type SiteLibraryEntry = {
   id: string;
@@ -402,6 +415,7 @@ type AppState = {
   syncBusy: boolean;
   syncStatusMessage: string;
   currentUser: CloudUser | null;
+  authState: AuthSessionState;
   isInitializing: boolean;
   initializeCloudSync: () => Promise<void>;
   performCloudSyncPush: () => void;
@@ -411,6 +425,7 @@ type AppState = {
   setLastSyncedAt: (iso: string | null) => void;
   setSyncErrorMessage: (message: string | null) => void;
   setCurrentUser: (user: CloudUser | null) => void;
+  setAuthState: (value: AuthSessionState) => void;
   setIsOnline: (value: boolean) => void;
   triggerSync: () => void;
   setIsInitializing: (value: boolean) => void;
@@ -1198,12 +1213,18 @@ export const useAppStore = create<AppState>((set, get) => ({
   syncBusy: false,
   syncStatusMessage: "",
   currentUser: null,
+  authState: "checking",
   isInitializing: false,
   setLocale: (locale) => set({ locale }),
   setSyncStatus: (status: "syncing" | "synced" | "error") => set({ syncStatus: status }),
   setLastSyncedAt: (iso: string | null) => set({ lastSyncedAt: iso }),
   setSyncErrorMessage: (message: string | null) => set({ syncErrorMessage: message }),
-  setCurrentUser: (user) => set({ currentUser: user }),
+  setCurrentUser: (user) =>
+    set({
+      currentUser: user,
+      authState: user ? "signed_in" : "signed_out",
+    }),
+  setAuthState: (value) => set({ authState: value }),
   setIsOnline: (value) => set({ isOnline: value }),
   triggerSync: () => set((state) => ({ syncTrigger: state.syncTrigger + 1 })),
   setIsInitializing: (value: boolean) => set({ isInitializing: value }),
@@ -1447,6 +1468,9 @@ export const useAppStore = create<AppState>((set, get) => ({
     } catch (error) {
       console.error("[appStore] initializeCloudSync FAILED:", error);
       const message = getUiErrorMessage(error);
+      if (isAuthRelatedErrorMessage(message)) {
+        set({ currentUser: null, authState: "signed_out" });
+      }
       set({
         syncPending: true,
         syncStatus: "error",
@@ -1477,6 +1501,16 @@ export const useAppStore = create<AppState>((set, get) => ({
       return;
     }
     const pendingChangesCount = recordLocalMutation();
+    if (get().authState === "signed_out" || !get().currentUser?.id) {
+      set({
+        syncPending: true,
+        syncStatus: "error",
+        syncErrorMessage: "Not signed in.",
+        syncStatusMessage: "Not signed in; cloud sync unavailable. Sign in and open Sync Status to recover pending changes.",
+        pendingChangesCount,
+      });
+      return;
+    }
     if (!get().isOnline) {
       set({
         syncPending: true,
@@ -1565,14 +1599,16 @@ export const useAppStore = create<AppState>((set, get) => ({
       } catch (error) {
         console.error("[appStore] Auto-push FAILED:", error);
         const message = getUiErrorMessage(error);
-        const isAuthError = message.includes("401") || message.includes("Unauthorized") || message.includes("Access denied");
+        const isAuthError = isAuthRelatedErrorMessage(message);
         if (isAuthError) {
           console.log("[appStore] Auth error - keeping pending changes until auth is restored");
           set({
+            currentUser: null,
+            authState: "signed_out",
             syncPending: true,
             syncStatus: "error",
             syncErrorMessage: message,
-            syncStatusMessage: "Authentication error while syncing. Re-authenticate and open Sync Status.",
+            syncStatusMessage: "Not signed in; cloud sync unavailable. Sign in and open Sync Status to recover pending changes.",
           });
         } else {
           set({
@@ -1605,6 +1641,15 @@ export const useAppStore = create<AppState>((set, get) => ({
         syncStatus: "error",
         syncErrorMessage: null,
         syncStatusMessage: "Offline. Changes are saved locally and will sync when reconnected.",
+      });
+      return;
+    }
+    if (get().authState === "signed_out" || !get().currentUser?.id) {
+      set({
+        syncPending: true,
+        syncStatus: "error",
+        syncErrorMessage: "Not signed in.",
+        syncStatusMessage: "Not signed in; cloud sync unavailable. Sign in and open Sync Status to recover pending changes.",
       });
       return;
     }
@@ -1664,6 +1709,9 @@ export const useAppStore = create<AppState>((set, get) => ({
     } catch (error) {
       console.error("[appStore] performManualCloudSync FAILED:", error);
       const message = getUiErrorMessage(error);
+      if (isAuthRelatedErrorMessage(message)) {
+        set({ currentUser: null, authState: "signed_out" });
+      }
       set({
         syncPending: true,
         syncStatus: "error",


### PR DESCRIPTION
## Summary
- enforce explicit auth session state (`checking|signed_in|signed_out`) in app store
- clear stale signed-in identity immediately on auth/session loss
- escalate sync indicator to error when auth fails (error takes precedence over pending)
- add lock+recover UX actions for signed-out users with unsynced local changes
- add regression tests for sync-indicator severity and auth-state transitions

## Verification
- npm run test -- --run src/lib/syncIndicator.test.ts src/store/appStore.test.ts
- npm run test
- npm run build

## Issue
- Closes #385