### PR TITLE
fix: treat access/cors sync failures as sign-out (#385 follow-up)

### DIFF
--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -138,10 +138,17 @@ const isAuthRelatedErrorMessage = (message: string): boolean => {
   return (
     normalized.includes("401") ||
     normalized.includes("unauthorized") ||
+    normalized.includes("forbidden") ||
     normalized.includes("access denied") ||
     normalized.includes("auth") ||
     normalized.includes("sign in") ||
-    normalized.includes("session revoked")
+    normalized.includes("session revoked") ||
+    normalized.includes("load failed") ||
+    normalized.includes("failed to fetch") ||
+    normalized.includes("networkerror when attempting to fetch resource") ||
+    normalized.includes("cloudflare access") ||
+    normalized.includes("not authenticated") ||
+    normalized.includes("unexpected token <")
   );
 };
 


### PR DESCRIPTION
## Summary
- broaden auth error detection for sync failures to include access/CORS failure patterns
- ensure these failures flip session state to signed_out so UI shows sign-in prompt

## Verification
- npm run test -- --run src/store/appStore.test.ts src/lib/appShellGuards.test.ts
- npm run build

## Issue
- Follow-up for #385