### PR TITLE
fix: refine signed-out UX and restore anonymous behavior (#385 follow-up)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,5 +1,5 @@
 import { type CSSProperties, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { CircleX, Copy, Globe, Maximize2, PanelBottom, PanelBottomClose, PanelLeft, PanelLeftClose, PanelRight, PanelRightClose, Share, UserRoundPlus, UserRoundSearch, Users } from "lucide-react";
+import { CircleUserRound, CircleX, CloudAlert, Copy, Globe, Maximize2, PanelBottom, PanelBottomClose, PanelLeft, PanelLeftClose, PanelRight, PanelRightClose, Share, UserRoundPlus, UserRoundSearch, Users } from "lucide-react";
 import { type CollaboratorDirectoryUser, fetchCollaboratorDirectory, fetchDeepLinkStatus, fetchMe, setLocalDevRole } from "../lib/cloudUser";
 import { fetchCloudLibrary, fetchPublicSimulationLibrary, pushCloudLibrary } from "../lib/cloudLibrary";
 import { buildDeepLinkPathname, buildDeepLinkUrl, canonicalizeDeepLinkKey, parseDeepLinkFromLocation, slugifyName } from "../lib/deepLink";
@@ -15,7 +15,6 @@ import { getCurrentRuntimeEnvironment } from "../lib/environment";
 import { getUiErrorMessage } from "../lib/uiError";
 import { initializeMigrations, runMigrations } from "../lib/migrations";
 import { resolveBasemapSelection } from "../lib/basemaps";
-import { APP_BUILD_LABEL } from "../lib/buildInfo";
 import { useThemeVariant } from "../hooks/useThemeVariant";
 import { useAppStore } from "../store/appStore";
 import { LinkProfileChart } from "./LinkProfileChart";
@@ -104,31 +103,6 @@ const copyToClipboard = async (textOrPromise: string | Promise<string>): Promise
   document.body.removeChild(textarea);
 };
 
-const downloadRecoveryWorkspace = (): void => {
-  const state = useAppStore.getState();
-  const payload = {
-    exportedAt: new Date().toISOString(),
-    reason: "session-loss-recovery",
-    build: APP_BUILD_LABEL,
-    selectedScenarioId: state.selectedScenarioId,
-    siteLibrary: state.siteLibrary,
-    simulationPresets: state.simulationPresets,
-    sites: state.sites,
-    links: state.links,
-    systems: state.systems,
-    networks: state.networks,
-  };
-  const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
-  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
-  const anchor = document.createElement("a");
-  anchor.href = URL.createObjectURL(blob);
-  anchor.download = `linksim-session-recovery-${stamp}.json`;
-  document.body.appendChild(anchor);
-  anchor.click();
-  document.body.removeChild(anchor);
-  URL.revokeObjectURL(anchor.href);
-};
-
 export function AppShell() {
   const srtmTilesCount = useAppStore((state) => state.srtmTiles.length);
   const recommendAndFetchTerrainForCurrentArea = useAppStore(
@@ -158,7 +132,6 @@ export function AppShell() {
   const setAuthState = useAppStore((state) => state.setAuthState);
   const authState = useAppStore((state) => state.authState);
   const currentUser = useAppStore((state) => state.currentUser);
-  const pendingChangesCount = useAppStore((state) => state.pendingChangesCount);
   const isOnline = useAppStore((state) => state.isOnline);
   const setIsOnline = useAppStore((state) => state.setIsOnline);
   const isInitializing = useAppStore((state) => state.isInitializing);
@@ -201,6 +174,7 @@ export function AppShell() {
   const cloudInitSeenRef = useRef(false);
   const cloudInitSettledRef = useRef(false);
   const appShellRef = useRef<HTMLElement | null>(null);
+  const hadAuthenticatedSessionRef = useRef(false);
   const {
     showWelcomeModal,
     setShowWelcomeModal,
@@ -472,6 +446,7 @@ export function AppShell() {
         setAccessDiagnosticMessage(null);
         setCurrentUser(profile);
         setAuthState("signed_in");
+        hadAuthenticatedSessionRef.current = true;
         setActiveUserId(profile.id);
         try {
           const seen = localStorage.getItem(`${ONBOARDING_SEEN_KEY_PREFIX}${profile.id}`);
@@ -523,8 +498,11 @@ export function AppShell() {
           });
         }
         setAccessDiagnosticMessage(`Access check failed: ${message}`);
-        setCurrentUser(null);
-        setAuthState("signed_out");
+        const hadAuthenticatedSession = hadAuthenticatedSessionRef.current;
+        if (hadAuthenticatedSession) {
+          setCurrentUser(null);
+          setAuthState("signed_out");
+        }
         if (message.includes("Session revoked by admin")) {
           window.location.href = "/cdn-cgi/access/logout";
           return;
@@ -534,13 +512,22 @@ export function AppShell() {
           return;
         }
         if (fallbackToReadonly) {
-          setAccessDiagnosticMessage("You are signed out. Sign in to continue.");
-          setAccessState("locked");
+          if (hadAuthenticatedSession) {
+            setAccessDiagnosticMessage("You are signed out. Sign in to continue.");
+            setAccessState("locked");
+          } else {
+            setAccessDiagnosticMessage("Sign-in check was blocked by browser auth redirects. Continuing in read-only demo mode.");
+            setAccessState("readonly");
+          }
           return;
         }
         if (isAuthSignInRequiredMessage(message)) {
-          setAccessDiagnosticMessage("You are signed out. Sign in to continue.");
-          setAccessState("locked");
+          if (hadAuthenticatedSession) {
+            setAccessDiagnosticMessage("You are signed out. Sign in to continue.");
+            setAccessState("locked");
+          } else {
+            setAccessState("readonly");
+          }
           return;
         }
         setAccessState("locked");
@@ -555,6 +542,7 @@ export function AppShell() {
   useEffect(() => {
     if (authState !== "signed_out") return;
     if (accessState === "checking") return;
+    if (!hadAuthenticatedSessionRef.current) return;
     setAccessDiagnosticMessage("You are signed out. Sign in to continue.");
     setAccessState("locked");
   }, [accessState, authState]);
@@ -586,6 +574,7 @@ export function AppShell() {
   const signOutOrReadonly = useCallback(() => {
     setCurrentUser(null);
     setAuthState("signed_out");
+    hadAuthenticatedSessionRef.current = true;
     if (isLocalRuntime) {
       try {
         localStorage.setItem(LOCAL_FORCE_READONLY_KEY, "1");
@@ -1367,10 +1356,15 @@ export function AppShell() {
     return (
       <main className="app-shell access-locked-shell">
         <section className="panel-section access-locked-panel">
+          {shouldPromptSignIn ? (
+            <div className="access-locked-alert-icon sync-error" aria-hidden="true">
+              <CloudAlert strokeWidth={1.8} />
+            </div>
+          ) : null}
           <h2>{shouldPromptSignIn ? "Signed out" : "Access unavailable"}</h2>
           {accessDiagnosticMessage ? <p className="field-help">{accessDiagnosticMessage}</p> : null}
           {shouldPromptSignIn ? (
-            <p className="field-help">Sign in with your approved account to continue.</p>
+            <p className="field-help">Sign in again to continue where you left off.</p>
           ) : (
             <>
               <p className="field-help">
@@ -1385,30 +1379,9 @@ export function AppShell() {
           {shouldPromptSignIn ? (
               <>
                 <button className="inline-action" onClick={signIn} type="button">
-                  Sign In
+                  <CircleUserRound aria-hidden="true" strokeWidth={1.8} />
+                  <span>Sign In</span>
                 </button>
-                {pendingChangesCount > 0 ? (
-                  <>
-                    <button
-                      className="inline-action"
-                      onClick={() => {
-                        window.dispatchEvent(new CustomEvent(OPEN_SYNC_MODAL_EVENT));
-                      }}
-                      type="button"
-                    >
-                      Open Sync Status
-                    </button>
-                    <button
-                      className="inline-action"
-                      onClick={() => {
-                        downloadRecoveryWorkspace();
-                      }}
-                      type="button"
-                    >
-                      Export Current Workspace
-                    </button>
-                  </>
-                ) : null}
               </>
             ) : (
               <button className="inline-action" onClick={signOutOrReadonly} type="button">
@@ -1433,11 +1406,6 @@ export function AppShell() {
             ) : null}
           </div>
           {localDevStatus ? <p className="field-help">{localDevStatus}</p> : null}
-          {shouldPromptSignIn && pendingChangesCount > 0 ? (
-            <p className="field-help">
-              You are signed out. Unsynced local changes are preserved on this device. Sign in, open Sync Status, and retry sync.
-            </p>
-          ) : null}
         </section>
         <WelcomeModal onClose={closeWelcome} onCreateNewSimulation={createNewFromWelcome} onOpenLibrary={openLibraryFromWelcome} onOpenOnboarding={openWelcomeFromWelcome} open={showWelcomeModal} />
         <OnboardingTutorialModal onClose={() => setShowOnboardingTutorial(false)} onOpenLibrary={() => setShowSimulationLibraryRequest(true)} onOpenSiteLibrary={() => setShowSiteLibraryRequest(true)} open={showOnboardingTutorial} />

--- a/src/index.css
+++ b/src/index.css
@@ -138,6 +138,23 @@ input {
   margin-top: 28px;
 }
 
+.access-locked-alert-icon {
+  width: 84px;
+  height: 84px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 2px 0 8px;
+  background: color-mix(in srgb, var(--danger) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--danger) 45%, var(--border));
+}
+
+.access-locked-alert-icon svg {
+  width: 48px;
+  height: 48px;
+}
+
 .access-pending-list {
   margin: 0;
   padding-left: 18px;
@@ -2297,6 +2314,9 @@ input {
   color: var(--text);
   padding: 8px 10px;
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .inline-action.danger {


### PR DESCRIPTION
## Summary
- simplify signed-out lock panel content and remove duplicate/non-actionable messaging
- remove Open Sync Status + Export Current Workspace actions from signed-out lock panel
- add prominent red cloud-alert visual + sign-in icon treatment
- restore anonymous behavior by only forcing signed-out lock for sessions that were previously authenticated in this tab

## Verification
- npm run test -- --run src/lib/appShellGuards.test.ts src/store/appStore.test.ts
- npm run build

## Issue
- Follow-up for #385