### PR TITLE
Docs: align issue lifecycle with staging sign-off policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,110 +1,146 @@
 # LinkSim Agent Rules
 
-This file is operational law for agent behavior. Follow it strictly.
+## Mandatory Startup (No Exceptions)
+- Treat this file as the single handoff entrypoint.
+- Before any code changes, review open GitHub Issues for the repo and then read:
+  1. `docs/release-flow.md`
+  2. `docs/milestone-release-checklist.md`
+- If instructions conflict, precedence is:
+  1. explicit user instruction in current thread
+  2. this `AGENTS.md`
+  3. GitHub Issues / GitHub Projects state for the repo
+  4. `docs/release-flow.md`
+  5. `docs/milestone-release-checklist.md`
 
-## 1) Instruction Precedence
-If instructions conflict, apply this order:
-1. Explicit user instruction in the current thread
-2. `AGENTS.md` (this file)
-3. GitHub Issues / GitHub Projects state
-4. `docs/release-flow.md`
-5. `docs/milestone-release-checklist.md`
+- Always update the relevant GitHub Issue(s) before and after implementation batches.
+- Default environment workflow:
+  - Unless the user explicitly says otherwise, work in local test environment.
+  - After local verification, deploy to live test/staging for verification.
+  - For every implementation batch by default: do both local verification and staging deployment verification in the same pass.
+  - Only promote to production after explicit user approval, using the same verified commit.
+- Branch workflow:
+  - Use per-issue branches: `issue/<id>-<slug>`.
+  - Merge issue branches into `staging` first.
+  - For normal releases, promote to production only via a direct PR from `staging` into `main` (no release branch).
+  - Use `hotfix/<slug>` only for explicitly approved incidents.
+  - This staging-integration model is the default unless the user explicitly overrides it.
+- Prefer stabilization work (consistency, hardening, tests, UX cleanup) over net-new features unless explicitly requested.
+- Ship in batches: implement, run `npm test` and `npm run build`, then commit and push.
+- Never commit or push directly to `main`; always create/use a separate branch for changes and push that branch.
+- Use TDD methodology for changes and new features: write/update failing tests first, implement the minimal fix to pass, then refactor with tests green.
+- Keep terminology consistent: use `Simulation`, `Site`, `Library`, `Path`, and `Channel` terms across UI and docs.
+- Icon accessibility rule: every UI icon must include accessible text. For icon-only controls, require an explicit `aria-label` on the interactive element (and matching `title` where applicable). Decorative inline icons should be `aria-hidden="true"`.
+- Any modal/popover that can open on top of another dialog must use `tier="raised"` in `ModalOverlay`.
+- When catching UI errors, use `getUiErrorMessage()` from `src/lib/uiError.ts` for consistent messaging.
+- Do not leave issue status in an ambiguous state.
+- Default closure policy: once work is verified on shared staging and the user confirms staging sign-off, close the issue (do not wait for production deploy).
+- Do not start newly created or newly requested issues without explicit user confirmation in the current thread.
+- Maintain GitHub Issues in close dialogue with the user: confirm wording/scope before starting newly added user items, and confirm completion criteria before closing them.
+- Batch size policy:
+  - Default to 3-4 backlog items per pass.
+  - If scope is stable and low risk, target larger passes (~10 items) to reduce deploy churn.
+- For user-added issues:
+  - Keep them labeled `pending-discussion` until discussed.
+  - Do not move them to in-progress automatically.
+- After every live deploy, monitor Cloudflare Pages deployment status (`wrangler pages deployment list --project-name linksim`) and explicitly notify the user when deployment is complete.
+- Follow and maintain `docs/release-flow.md` as the source of truth for release promotion steps.
+- Follow `docs/release-flow.md` versioning policy (SemVer + explicit bump rules) for all releases.
+- Maintain a human-readable `CHANGELOG.md` for every release; do not use raw commit dumps as release notes.
+- Before each production release, verify whether any issues closed since the previous release are missing a milestone and report/fix that metadata drift.
+- Version/channel labeling rule:
+  - Local must display `vX.Y.Z-alpha+<commit>`.
+  - Staging must display `vX.Y.Z-beta+<commit>`.
+  - Production must display `vX.Y.Z`.
+  - Same commit must use the same base version `X.Y.Z` in all environments.
+- Require a SemVer bump before every production release.
+- Deploys must use guarded npm scripts only:
+  - `npm run deploy:staging` → https://staging.linksim.link
+  - `npm run deploy:staging:preview` → Preview URL
+  - `npm run deploy:prod:main` → https://linksim.link
+- Staging deploy default:
+  - Use `npm run deploy:staging` from `staging` branch to deploy to https://staging.linksim.link
+  - Do not use preview deploys for normal verification; default is always the shared staging URL.
+- Never run raw `wrangler pages deploy` for release operations.
+- If a guarded deploy fails, fix the script/preflight issue and re-run the guarded script. Do not bypass with manual Wrangler deploys.
+- Promotion gate:
+  - Promote the exact same verified commit from local -> staging -> production.
+  - If code changes after staging verification, rerun local verification and redeploy staging before production.
+  - Normal production promotion PR must be `staging` -> `main`.
+  - Hotfix promotion PR may be `hotfix/<slug>` -> `main` only with explicit user approval in-thread.
+- **After any hotfix merges to main**: immediately create a `chore/sync-main-to-staging` branch from `origin/staging`, run `git merge origin/main -X ours --no-edit`, PR into `staging`, merge, and redeploy staging. Do not start new feature work until staging is back in sync. The `detect-staging-drift` workflow will open a GitHub Issue as a reminder if this is missed.
+- Local run reliability:
+  - Restart local server whenever runtime/config/env changes can affect behavior.
+  - Re-verify affected flows after restart before marking work as done.
+- Production preflight checklist (required before `deploy:prod:main`):
+  - `npm run test`
+  - `npm run build:bundle`
+  - Confirm build label matches intended SemVer channel rules
+  - Confirm no unresolved issue/project status drift for items in the current pass
+  - Confirm `CHANGELOG.md` is updated with user-readable highlights for the target release
+- Token-efficient execution:
+  - Lock scope for each pass before implementation.
+  - Define done criteria and no-touch areas at pass start.
+  - Avoid mid-pass feature pivots unless explicitly requested by the user.
+- GitHub Issue workflow:
+  - Treat GitHub Issues as the canonical backlog for open and completed work.
+  - Use issue titles as the default source of task naming.
+  - Prefer one issue per discrete task unless the user explicitly wants a grouped batch.
+  - Maintain explicit status labels: `pending-discussion` -> `in-progress` -> `in-staging` (while open) -> issue closed after staging sign-off -> `released` label applied during milestone production release sweep.
+  - After every staging merge/deploy, automatically update the related GitHub Issue(s) label from `in-progress` to `in-staging`. Do not wait for the user to ask.
+  - Milestone release policy: at production release time, apply `released` to the milestone's shipped issues (including already-closed staging-verified issues).
+  - If a historical `docs/BACKLOG.md` file still exists, treat it as legacy reference only unless the user explicitly asks to maintain it.
 
-## 2) Mandatory Startup (No Exceptions)
-- Treat this file as the handoff entrypoint.
-- Before any code changes:
-  1. Review open GitHub Issues.
-  2. Read `docs/release-flow.md`.
-  3. Read `docs/milestone-release-checklist.md`.
-- Run and report drift checks before coding:
-  - `git log --oneline origin/staging -5`
-  - `git log --oneline origin/main -5`
-  - `git cherry -v origin/staging origin/main`
-- If drift exists, open a dedicated `chore/reconcile-...` or sync issue/PR first.
-
-## 3) Issue Workflow (Strict)
-- GitHub Issues are the canonical backlog.
-- Always update relevant issue(s) before and after each implementation batch.
-- Status labels must be explicit and ordered: `pending-discussion` -> `in-progress` -> `in-staging` -> `released`.
-- Do not leave issue status ambiguous.
-- Close issues only after implementation and verification are complete.
-- Do not start newly added issues without explicit user confirmation in-thread.
-- Keep user-added issues as `pending-discussion` until discussed.
-
-## 4) Branching and PR Rules
-- Use per-issue branches: `issue/<id>-<slug>`.
-- Default base branch for issue work: `origin/staging` (unless user explicitly overrides).
-- Never commit or push directly to `main`.
-- Normal release flow is PR `staging` -> `main` only.
-- Use `hotfix/<slug>` only with explicit user approval.
-- Do not open PRs to `main` from `issue/*` or `chore/*` branches.
-- Keep PR scope to one issue.
-
-## 5) Delivery and Verification Defaults
-- Default environment flow per batch:
-  1. Implement and verify locally.
-  2. Merge to `staging`.
-  3. Deploy and verify on `https://staging.linksim.link`.
-  4. Promote to production only with explicit user approval.
-- Required local verification: `npm test` and `npm run build`.
-- For deep-link/API affecting work, also run:
+## Staging-First Milestone Workflow (Single Source)
+- Deploy target policy:
+  - Always validate live on `https://staging.linksim.link`.
+  - Do not use preview URLs unless the user explicitly requests a one-off preview comparison in the current thread.
+- Per-issue branch policy:
+  - Start each issue branch from `origin/staging`.
+  - Branch name format: `issue/<id>-<slug>`.
+  - Keep PR scope to one issue; avoid mixed API/UI/deeplink batches in the same PR.
+  - Agent safety rails:
+    - Do not create normal-release `release/*` branches.
+    - Do not open PRs to `main` from `issue/*` or `chore/*` branches.
+    - If local branch is behind its PR base branch, rebase/refresh before merging.
+- Drift check before coding (required):
+  - Run and report: `git log --oneline origin/staging -5`
+  - Run and report: `git log --oneline origin/main -5`
+  - Run and report: `git cherry -v origin/staging origin/main`
+  - If drift exists, create a dedicated `chore/reconcile-...` PR before feature work.
+- Verification gates for deep-link/API-affecting work:
   - `npm run test -- --run src/lib/deepLink.test.ts`
   - `npm run test -- --run functions/api/v1/calculate.test.ts`
   - `npm run test -- --run src/store/appStore.test.ts`
-- If runtime/config/env changes can affect behavior, restart local server and re-verify.
+  - `npm run build`
+  - Manually verify deep-link matrix on staging:
+    - `/<simulation>`
+    - `/<simulation>/<site>`
+    - `/<simulation>/<site1>+<site2>`
+    - `/<simulation>/<site1>~<site2>`
+- Merge and staging deploy sequence per issue:
+  - Open PR into `staging`, merge, then deploy with `npm run deploy:staging`.
+  - After deploy, always confirm completion with `wrangler pages deployment list --project-name linksim-staging --environment production` and report the commit SHA/build label.
+- Milestone promotion model:
+  - Complete and verify all milestone issues on `staging` first.
+  - Promote to production in one batch with a direct PR from `staging` to `main`.
+  - Use the exact verified staging commit for production; no code changes between staging sign-off and production deploy.
+  - Freeze milestone scope at sign-off: no new feature work lands on `staging` until production deploy completes.
+  - After production deploy, continue new issue work from the updated `origin/staging` baseline.
 
-## 6) Deploy and Promotion Guardrails
-- Use guarded deploy scripts only:
-  - `npm run deploy:staging`
-  - `npm run deploy:staging:preview` (only when explicitly requested)
-  - `npm run deploy:prod:main`
-- Never use raw `wrangler pages deploy` for release operations.
-- If guarded deploy fails, fix the root cause and rerun the guarded script.
-- Promote the exact same verified commit from local -> staging -> production.
-- If code changes after staging verification, restart local + staging verification.
-- After each live deploy, verify via:
-  - `wrangler pages deployment list --project-name linksim-staging --environment production`
-  and report deployed commit SHA/build label to the user.
+## Branch Protection Rollout Safety
+- When introducing a new required status check, roll it out in two phases to avoid PR deadlocks:
+  1. merge the workflow that produces the check
+  2. then add that check to branch protection required checks
 
-## 7) Release and Versioning Policy
-- Follow `docs/release-flow.md` for promotion steps and SemVer policy.
-- Version labels must be:
-  - Local: `vX.Y.Z-alpha+<commit>`
-  - Staging: `vX.Y.Z-beta+<commit>`
-  - Production: `vX.Y.Z`
-- Same commit must keep the same `X.Y.Z` across environments.
-- Require a SemVer bump before each production release.
-- Maintain a human-readable `CHANGELOG.md` for every release.
-- Before production release, check closed issues since last release for missing milestone metadata.
+## Model Selection
+- **Codex 5.3** — use for full implementation passes where quality and breadth of change matter most. Expensive; reserve for when the work warrants it.
+- **Big Pickle / MiMo V2 Pro Free** — good for planning and moderate coding work. Use as the default for most passes.
+- **Plan mode always** — before any implementation pass, always present a plan first. Always recommend which model to use for the next implementation pass.
+- Also available but less experienced with this codebase: GPT-Nano, MiniMax M2.5 Free, Nemotron 3 Super Free.
 
-## 8) Hotfix Sync Rule
-- After a hotfix merges to `main`, immediately sync `main` back to `staging` before new feature work:
-  1. Create `chore/sync-main-to-staging` from `origin/staging`
-  2. `git merge origin/main -X ours --no-edit`
-  3. PR into `staging`, merge, redeploy staging
+## AGENTS.md Feedback
+- If this file feels counterintuitive or is missing something, suggestions are welcome — but nothing changes without explicit approval.
 
-## 9) Engineering Quality Rules
-- Use TDD for changes/new features: failing test -> minimal fix -> refactor green.
-- Prefer stabilization (hardening, consistency, tests, UX cleanup) over net-new features unless explicitly requested.
-- Keep terminology consistent in UI/docs: `Simulation`, `Site`, `Library`, `Path`, `Channel`.
-- Icon accessibility is mandatory:
-  - Icon-only interactive controls must have `aria-label` (and matching `title` where applicable).
-  - Decorative icons must use `aria-hidden="true"`.
-- Any modal/popover that can appear above another dialog must use `tier="raised"` in `ModalOverlay`.
-- For caught UI errors, use `getUiErrorMessage()` from `src/lib/uiError.ts`.
-
-## 10) Planning, Scope, and Batch Size
-- Plan mode is required before implementation; recommend the model for the next pass.
-- Lock scope for each pass; define done criteria and no-touch areas.
-- Avoid mid-pass scope pivots unless user explicitly requests them.
-- Default batch size is 3-4 items; larger batches (~10) are acceptable when risk is low and scope is stable.
-
-## 11) Branch Protection Rollout Safety
-- For new required status checks:
-  1. Merge workflow that produces the check.
-  2. Then add it to branch protection required checks.
-
-## 12) Maintenance of This File
-- Suggestions are welcome, but rule changes require explicit approval.
-- Keep this file concise, strict, and sufficient for zero-context handoff.
-- Do not rely on undocumented tribal knowledge.
+## Handoff Guarantee
+- A new agent should be able to continue by being pointed only to this file.
+- Do not rely on undocumented tribal knowledge; if a rule is repeated in chat, add it here (or in the linked source-of-truth docs) before ending the pass.

--- a/docs/milestone-release-checklist.md
+++ b/docs/milestone-release-checklist.md
@@ -5,7 +5,7 @@ Use this checklist before opening a normal production promotion PR (`staging` ->
 ## Scope and freeze
 - [ ] Milestone scope is frozen for release.
 - [ ] No new feature PRs are merged into `staging` after sign-off.
-- [ ] All in-scope issues are labeled `in-staging` or `released`.
+- [ ] All in-scope issues are either closed after staging sign-off or explicitly labeled `released`.
 
 ## Verification
 - [ ] `npm test` passes on the release candidate.

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -95,7 +95,7 @@
 - Promotion must use the same verified staging commit SHA.
 - If any code changes after staging sign-off, restart staging verification before production.
 - Before opening the promotion PR, require:
-  - all in-scope milestone issues are `in-staging` or `released`
+  - all in-scope milestone issues are either closed after staging sign-off or explicitly labeled `released`
   - `npm test` passes
   - `npm run build` passes
   - `CHANGELOG.md` includes a human-readable entry for the release
@@ -110,7 +110,8 @@
   - `in-progress`
   - `in-staging`
   - `released`
-- Close issue only when release is deployed and verified in production.
+- Default closure policy: close issue after staging verification and explicit user sign-off.
+- Milestone production release policy: apply `released` label during the milestone release sweep for shipped issues.
 
 ## CI/CD Controls
 - GitHub Actions deploy workflow is manual (`workflow_dispatch`) with explicit target selection:


### PR DESCRIPTION
## Summary
- update AGENTS and release docs to close issues after staging verification + user sign-off
- keep `released` labeling for milestone production release sweep
- align milestone checklist wording with the new issue lifecycle
