### PR TITLE
fix: temporary path profile hover honors saved link overrides (#392)

### DIFF
--- a/src/components/LinkProfileChart.tsx
+++ b/src/components/LinkProfileChart.tsx
@@ -13,6 +13,7 @@ import {
 import { buildHoverProfileSegments } from "../lib/profileHoverSegments";
 import { dispatchProfileDraftSiteRequest } from "../lib/profileDraftEvent";
 import { buildProfile } from "../lib/propagation";
+import { buildSelectionEffectiveLink } from "../lib/selectionEffectiveLink";
 import { atmosphericBendingNUnitsToKFactor } from "../lib/terrainLoss";
 import { simulationAreaBoundsForSites } from "../lib/simulationArea";
 import { sampleSrtmElevation } from "../lib/srtm";
@@ -151,18 +152,13 @@ export function LinkProfileChart({
       };
     }
     if (!selectedFromSite || !selectedToSite) return null;
-    return {
-      id: "__selection__",
-      name: `${selectedFromSite.name} -> ${selectedToSite.name}`,
-      fromSiteId: selectedFromSite.id,
-      toSiteId: selectedToSite.id,
+    return buildSelectionEffectiveLink({
+      links,
+      fromSite: selectedFromSite,
+      toSite: selectedToSite,
       frequencyMHz: selectedNetwork.frequencyOverrideMHz ?? selectedNetwork.frequencyMHz,
-      txPowerDbm: selectedFromSite.txPowerDbm,
-      txGainDbi: selectedFromSite.txGainDbi,
-      rxGainDbi: selectedToSite.rxGainDbi,
-      cableLossDb: selectedFromSite.cableLossDb,
-    };
-  }, [selectedLink, selectedNetwork, selectedFromSite, selectedToSite]);
+    });
+  }, [selectedLink, selectedNetwork, selectedFromSite, selectedToSite, links]);
   const profile = useMemo(() => {
     if (!effectiveLink || !selectedFromSiteEffective || !selectedToSiteEffective) return baseProfile;
     const hasPreview =

--- a/src/lib/selectionEffectiveLink.test.ts
+++ b/src/lib/selectionEffectiveLink.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import type { Link, Site } from "../types/radio";
+import { buildSelectionEffectiveLink } from "./selectionEffectiveLink";
+
+const siteA: Site = {
+  id: "site-a",
+  name: "Alpha",
+  position: { lat: 1, lon: 1 },
+  groundElevationM: 100,
+  antennaHeightM: 2,
+  txPowerDbm: 20,
+  txGainDbi: 2,
+  rxGainDbi: 3,
+  cableLossDb: 1,
+};
+
+const siteB: Site = {
+  id: "site-b",
+  name: "Beta",
+  position: { lat: 2, lon: 2 },
+  groundElevationM: 120,
+  antennaHeightM: 2,
+  txPowerDbm: 27,
+  txGainDbi: 4,
+  rxGainDbi: 5,
+  cableLossDb: 2,
+};
+
+describe("buildSelectionEffectiveLink", () => {
+  it("uses saved link for selected pair and preserves saved radio overrides", () => {
+    const links: Link[] = [
+      {
+        id: "saved",
+        name: "A-B",
+        fromSiteId: "site-a",
+        toSiteId: "site-b",
+        frequencyMHz: 433,
+        txPowerDbm: 30,
+        txGainDbi: 9,
+        rxGainDbi: 7,
+        cableLossDb: 0.5,
+      },
+    ];
+
+    const effective = buildSelectionEffectiveLink({
+      links,
+      fromSite: siteA,
+      toSite: siteB,
+      frequencyMHz: 868,
+    });
+
+    expect(effective).toMatchObject({
+      id: "saved",
+      fromSiteId: "site-a",
+      toSiteId: "site-b",
+      frequencyMHz: 868,
+      txPowerDbm: 30,
+      txGainDbi: 9,
+      rxGainDbi: 7,
+      cableLossDb: 0.5,
+    });
+  });
+
+  it("matches saved link regardless of selected direction", () => {
+    const links: Link[] = [
+      {
+        id: "saved",
+        fromSiteId: "site-a",
+        toSiteId: "site-b",
+        frequencyMHz: 433,
+      },
+    ];
+
+    const effective = buildSelectionEffectiveLink({
+      links,
+      fromSite: siteB,
+      toSite: siteA,
+      frequencyMHz: 868,
+    });
+
+    expect(effective?.id).toBe("saved");
+    expect(effective?.frequencyMHz).toBe(868);
+  });
+
+  it("builds temporary link from Site radio when no saved pair exists", () => {
+    const effective = buildSelectionEffectiveLink({
+      links: [],
+      fromSite: siteA,
+      toSite: siteB,
+      frequencyMHz: 868,
+    });
+
+    expect(effective).toMatchObject({
+      id: "__selection__",
+      fromSiteId: "site-a",
+      toSiteId: "site-b",
+      frequencyMHz: 868,
+      txPowerDbm: siteA.txPowerDbm,
+      txGainDbi: siteA.txGainDbi,
+      rxGainDbi: siteB.rxGainDbi,
+      cableLossDb: siteA.cableLossDb,
+    });
+  });
+});

--- a/src/lib/selectionEffectiveLink.ts
+++ b/src/lib/selectionEffectiveLink.ts
@@ -1,0 +1,37 @@
+import type { Link, Site } from "../types/radio";
+
+type SelectionEffectiveLinkInput = {
+  links: Link[];
+  fromSite: Site;
+  toSite: Site;
+  frequencyMHz: number;
+};
+
+export const buildSelectionEffectiveLink = ({
+  links,
+  fromSite,
+  toSite,
+  frequencyMHz,
+}: SelectionEffectiveLinkInput): Link => {
+  const saved = links.find(
+    (link) =>
+      (link.fromSiteId === fromSite.id && link.toSiteId === toSite.id) ||
+      (link.fromSiteId === toSite.id && link.toSiteId === fromSite.id),
+  );
+
+  if (saved) {
+    return { ...saved, frequencyMHz };
+  }
+
+  return {
+    id: "__selection__",
+    name: `${fromSite.name} -> ${toSite.name}`,
+    fromSiteId: fromSite.id,
+    toSiteId: toSite.id,
+    frequencyMHz,
+    txPowerDbm: fromSite.txPowerDbm,
+    txGainDbi: fromSite.txGainDbi,
+    rxGainDbi: toSite.rxGainDbi,
+    cableLossDb: fromSite.cableLossDb,
+  };
+};


### PR DESCRIPTION
## Summary\n- ensure two-site profile preview reuses saved-link radio overrides when a saved pair exists\n- add a dedicated selection-effective-link helper and regression tests\n\n## Verification\n- npm run test -- --run src/lib/selectionEffectiveLink.test.ts src/lib/selectedPairActions.test.ts\n- npm test\n- npm run build\n\n## Issue\n- refs #392