### PR TITLE
fix: close simulation library modal after loading simulation (#391)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -7,6 +7,7 @@ import { canRunDeepLinkApply } from "../lib/deepLinkApplyGate";
 import {
   type DeepLinkApplyOutcome,
   isAuthSignInRequiredMessage,
+  shouldCloseSimulationLibraryOnLoad,
   shouldRewritePathAfterDeepLinkApply,
   shouldUseReadonlyFallbackForAuthBootstrap,
 } from "../lib/appShellGuards";
@@ -1722,6 +1723,9 @@ export function AppShell() {
             onClose={() => setShowLibraryFromRequest(false)}
             onLoadSimulation={(presetId) => {
               loadSimulationPreset(presetId);
+              if (shouldCloseSimulationLibraryOnLoad({ presetId })) {
+                setShowLibraryFromRequest(false);
+              }
               try {
                 localStorage.setItem(LAST_SIMULATION_REF_KEY, `saved:${presetId}`);
               } catch {

--- a/src/lib/appShellGuards.test.ts
+++ b/src/lib/appShellGuards.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   isAuthSignInRequiredMessage,
+  shouldCloseSimulationLibraryOnLoad,
   shouldRewritePathAfterDeepLinkApply,
   shouldUseReadonlyFallbackForAuthBootstrap,
 } from "./appShellGuards";
@@ -98,5 +99,16 @@ describe("shouldUseReadonlyFallbackForAuthBootstrap", () => {
         userAgent: "Mozilla/5.0 Firefox/124.0",
       }),
     ).toBe(false);
+  });
+});
+
+describe("shouldCloseSimulationLibraryOnLoad", () => {
+  it("closes the simulation library modal after selecting a simulation", () => {
+    expect(shouldCloseSimulationLibraryOnLoad({ presetId: "sim-123" })).toBe(true);
+  });
+
+  it("does not close for empty simulation selection", () => {
+    expect(shouldCloseSimulationLibraryOnLoad({ presetId: "" })).toBe(false);
+    expect(shouldCloseSimulationLibraryOnLoad({ presetId: "   " })).toBe(false);
   });
 });

--- a/src/lib/appShellGuards.ts
+++ b/src/lib/appShellGuards.ts
@@ -43,3 +43,6 @@ export const shouldUseReadonlyFallbackForAuthBootstrap = (input: {
   if (!isFirefox) return false;
   return normalized.includes("networkerror when attempting to fetch resource");
 };
+
+export const shouldCloseSimulationLibraryOnLoad = (input: { presetId: string | null | undefined }): boolean =>
+  String(input.presetId ?? "").trim().length > 0;


### PR DESCRIPTION
## Summary\n- close Simulation Library modal immediately after selecting a Simulation to load\n- add explicit AppShell guard for modal-close behavior\n- add regression tests for load-close guard\n\n## Verification\n- npm run test -- --run src/lib/appShellGuards.test.ts\n- npm test\n- npm run build\n\n## Issue\n- refs #391