### PR TITLE
fix: honor saved-link radio overrides for selected Site pair (#221)

### DIFF
--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -487,6 +487,84 @@ describe("appStore blank simulation loading", () => {
   });
 });
 
+describe("appStore selected pair link resolution", () => {
+  beforeEach(() => {
+    storage.mock.clear();
+    vi.restoreAllMocks();
+    useAppStore.setState({
+      selectedLinkId: "",
+      selectedSiteIds: ["site-2", "site-1"],
+      sites: [
+        {
+          id: "site-1",
+          name: "Alpha",
+          position: { lat: 1, lon: 1 },
+          groundElevationM: 100,
+          antennaHeightM: 2,
+          txPowerDbm: 20,
+          txGainDbi: 2,
+          rxGainDbi: 2,
+          cableLossDb: 1,
+        },
+        {
+          id: "site-2",
+          name: "Beta",
+          position: { lat: 2, lon: 2 },
+          groundElevationM: 120,
+          antennaHeightM: 2,
+          txPowerDbm: 21,
+          txGainDbi: 3,
+          rxGainDbi: 3,
+          cableLossDb: 2,
+        },
+      ],
+      links: [
+        {
+          id: "link-other",
+          fromSiteId: "site-9",
+          toSiteId: "site-10",
+          frequencyMHz: 869.618,
+          txPowerDbm: 5,
+          txGainDbi: 1,
+          rxGainDbi: 1,
+          cableLossDb: 9,
+        },
+        {
+          id: "link-primary",
+          fromSiteId: "site-1",
+          toSiteId: "site-2",
+          frequencyMHz: 869.618,
+          txPowerDbm: 30,
+          txGainDbi: 9,
+          rxGainDbi: 8,
+          cableLossDb: 0.5,
+        },
+      ],
+      networks: [
+        {
+          id: "network-1",
+          name: "n1",
+          frequencyMHz: 869.618,
+          bandwidthKhz: 125,
+          spreadFactor: 7,
+          codingRate: 5,
+          memberships: [],
+        },
+      ],
+      selectedNetworkId: "network-1",
+    });
+  });
+
+  it("returns saved pair link overrides when two-site selection has no selectedLinkId", () => {
+    const selectedLink = useAppStore.getState().getSelectedLink();
+    expect(selectedLink.id).toBe("link-primary");
+    expect(selectedLink.txPowerDbm).toBe(30);
+    expect(selectedLink.txGainDbi).toBe(9);
+    expect(selectedLink.rxGainDbi).toBe(8);
+    expect(selectedLink.cableLossDb).toBe(0.5);
+  });
+});
+
 describe("appStore blank simulation loading", () => {
   beforeEach(() => {
     storage.mock.clear();

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -3807,13 +3807,49 @@ export const useAppStore = create<AppState>((set, get) => ({
     useCoverageStore.getState().recomputeCoverage();
   },
   getSelectedLink: () => {
-    const { links, selectedLinkId, sites, networks, selectedNetworkId } = get();
+    const { links, selectedLinkId, selectedSiteIds, temporaryDirectionReversed, sites, networks, selectedNetworkId } = get();
     const link = links.find((candidate) => candidate.id === selectedLinkId);
     if (link) {
       const fromSite = sites.find((site) => site.id === link.fromSiteId) ?? null;
       const toSite = sites.find((site) => site.id === link.toSiteId) ?? null;
       const radio = resolveLinkRadio(link, fromSite, toSite);
       return { ...link, ...radio };
+    }
+    const selectedPair = normalizeSelectedSiteIds(selectedSiteIds, sites);
+    if (selectedPair.length >= 2) {
+      const fromId = selectedPair[0];
+      const toId = selectedPair[selectedPair.length - 1];
+      const effectiveFromId = temporaryDirectionReversed ? toId : fromId;
+      const effectiveToId = temporaryDirectionReversed ? fromId : toId;
+      const pairLink = links.find(
+        (candidate) =>
+          (candidate.fromSiteId === effectiveFromId && candidate.toSiteId === effectiveToId) ||
+          (candidate.fromSiteId === effectiveToId && candidate.toSiteId === effectiveFromId),
+      );
+      if (pairLink) {
+        const fromSite = sites.find((site) => site.id === pairLink.fromSiteId) ?? null;
+        const toSite = sites.find((site) => site.id === pairLink.toSiteId) ?? null;
+        const radio = resolveLinkRadio(pairLink, fromSite, toSite);
+        return { ...pairLink, ...radio };
+      }
+      const selectedNetwork = networks.find((network) => network.id === selectedNetworkId);
+      const inheritedFrequencyMHz =
+        selectedNetwork?.frequencyOverrideMHz ?? selectedNetwork?.frequencyMHz ?? 869.618;
+      const fromSite = sites.find((site) => site.id === effectiveFromId) ?? null;
+      const toSite = sites.find((site) => site.id === effectiveToId) ?? null;
+      if (fromSite && toSite) {
+        return {
+          id: "__selection__",
+          name: `${fromSite.name} -> ${toSite.name}`,
+          fromSiteId: fromSite.id,
+          toSiteId: toSite.id,
+          frequencyMHz: inheritedFrequencyMHz,
+          txPowerDbm: fromSite.txPowerDbm,
+          txGainDbi: fromSite.txGainDbi,
+          rxGainDbi: toSite.rxGainDbi,
+          cableLossDb: fromSite.cableLossDb,
+        };
+      }
     }
     if (links[0]) {
       const base = links[0];


### PR DESCRIPTION
## Summary\n- make getSelectedLink prefer the active two-Site selected pair instead of unrelated fallback links\n- honor saved-link radio overrides for the selected pair\n- use temporary selected-pair link when no saved pair exists\n- add regression coverage in appStore tests\n\n## Verification\n- npm run test -- --run src/store/appStore.test.ts\n- npm test\n- npm run build\n\n## Issue\n- refs #221