### PR TITLE
fix: avoid path profile SVG default-size scaling artifacts (#108)

### DIFF
--- a/src/components/LinkProfileChart.tsx
+++ b/src/components/LinkProfileChart.tsx
@@ -10,6 +10,7 @@ import {
   passFailStateLabel,
   type PassFailState,
 } from "../lib/passFailState";
+import { buildProfileChartSvgProps } from "../lib/profileChartSvg";
 import { buildHoverProfileSegments } from "../lib/profileHoverSegments";
 import { dispatchProfileDraftSiteRequest } from "../lib/profileDraftEvent";
 import { buildProfile } from "../lib/propagation";
@@ -302,6 +303,7 @@ export function LinkProfileChart({
       }),
     };
   }, [profile, chartWidth, chartHeight]);
+  const svgProps = useMemo(() => buildProfileChartSvgProps(chartWidth, chartHeight), [chartWidth, chartHeight]);
 
   const segmentStateKey = useMemo(
     () =>
@@ -728,7 +730,14 @@ export function LinkProfileChart({
         </div>
       ) : (
         <div className="chart-svg-wrap" ref={chartHostRef}>
-        <svg aria-label="Link profile" role="img" viewBox={`0 0 ${chartWidth} ${chartHeight}`}>
+        <svg
+          aria-label="Link profile"
+          height={svgProps.height}
+          preserveAspectRatio={svgProps.preserveAspectRatio}
+          role="img"
+          viewBox={svgProps.viewBox}
+          width={svgProps.width}
+        >
           <defs>
             <linearGradient
               gradientUnits="userSpaceOnUse"

--- a/src/lib/profileChartSvg.test.ts
+++ b/src/lib/profileChartSvg.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { buildProfileChartSvgProps } from "./profileChartSvg";
+
+describe("buildProfileChartSvgProps", () => {
+  it("returns explicit width/height to avoid browser default SVG sizing", () => {
+    expect(buildProfileChartSvgProps(960, 240)).toEqual({
+      width: 960,
+      height: 240,
+      viewBox: "0 0 960 240",
+      preserveAspectRatio: "none",
+    });
+  });
+
+  it("normalizes non-finite sizes to safe minimums", () => {
+    expect(buildProfileChartSvgProps(Number.NaN, Number.POSITIVE_INFINITY)).toEqual({
+      width: 1,
+      height: 1,
+      viewBox: "0 0 1 1",
+      preserveAspectRatio: "none",
+    });
+  });
+});

--- a/src/lib/profileChartSvg.ts
+++ b/src/lib/profileChartSvg.ts
@@ -1,0 +1,22 @@
+export type ProfileChartSvgProps = {
+  width: number;
+  height: number;
+  viewBox: string;
+  preserveAspectRatio: "none";
+};
+
+const toSafeSize = (value: number): number => {
+  if (!Number.isFinite(value)) return 1;
+  return Math.max(1, Math.round(value));
+};
+
+export const buildProfileChartSvgProps = (width: number, height: number): ProfileChartSvgProps => {
+  const safeWidth = toSafeSize(width);
+  const safeHeight = toSafeSize(height);
+  return {
+    width: safeWidth,
+    height: safeHeight,
+    viewBox: `0 0 ${safeWidth} ${safeHeight}`,
+    preserveAspectRatio: "none",
+  };
+};


### PR DESCRIPTION
## Summary\n- render Link profile SVG with explicit width/height instead of relying on browser default intrinsic size\n- keep controlled viewBox generation in a dedicated helper\n- add regression tests for SVG sizing props\n\n## Verification\n- npm run test -- --run src/lib/profileChartSvg.test.ts\n- npm test\n- npm run build\n\n## Issue\n- refs #108