### PR TITLE
fix: pre-validate private-site refs before share flow (#252)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -5,6 +5,7 @@ import { fetchCloudLibrary, fetchPublicSimulationLibrary, pushCloudLibrary } fro
 import { buildDeepLinkPathname, buildDeepLinkUrl, canonicalizeDeepLinkKey, parseDeepLinkFromLocation, slugifyName } from "../lib/deepLink";
 import { canRunDeepLinkApply } from "../lib/deepLinkApplyGate";
 import {
+  formatPrivateSiteReferenceBlockMessage,
   type DeepLinkApplyOutcome,
   isAuthSignInRequiredMessage,
   shouldCloseSimulationLibraryOnLoad,
@@ -1156,6 +1157,12 @@ export function AppShell() {
 
   const runShareWithSpecificUsers = useCallback(async () => {
     if (!activeSimulation || !currentUser) return;
+    if (toVisibility(activeSimulation.visibility) !== "private" && referencedPrivateSites.length) {
+      setShareSpecificStatus(
+        formatPrivateSiteReferenceBlockMessage(referencedPrivateSites.map((site) => site.name)),
+      );
+      return;
+    }
     if (!shareSpecificUsers.length) {
       setShareSpecificStatus("Add at least one user first.");
       return;
@@ -1193,7 +1200,15 @@ export function AppShell() {
     } finally {
       setShareSpecificBusy(false);
     }
-  }, [activeSimulation, currentShareLink, currentUser, shareSpecificRoles, shareSpecificUsers, updateSimulationPresetEntry]);
+  }, [
+    activeSimulation,
+    currentShareLink,
+    currentUser,
+    referencedPrivateSites,
+    shareSpecificRoles,
+    shareSpecificUsers,
+    updateSimulationPresetEntry,
+  ]);
 
   const shellStyle = useMemo<CSSProperties | undefined>(() => {
     const style: CSSProperties = {

--- a/src/lib/appShellGuards.test.ts
+++ b/src/lib/appShellGuards.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  formatPrivateSiteReferenceBlockMessage,
   isAuthSignInRequiredMessage,
   shouldCloseSimulationLibraryOnLoad,
   shouldRewritePathAfterDeepLinkApply,
@@ -110,5 +111,13 @@ describe("shouldCloseSimulationLibraryOnLoad", () => {
   it("does not close for empty simulation selection", () => {
     expect(shouldCloseSimulationLibraryOnLoad({ presetId: "" })).toBe(false);
     expect(shouldCloseSimulationLibraryOnLoad({ presetId: "   " })).toBe(false);
+  });
+});
+
+describe("formatPrivateSiteReferenceBlockMessage", () => {
+  it("lists private Library Site names in the validation message", () => {
+    expect(formatPrivateSiteReferenceBlockMessage(["Alpha", "Beta"])).toBe(
+      "Cannot share this Simulation while private Library Site references exist (Alpha, Beta). Set Simulation visibility to Private or use non-private Site entries.",
+    );
   });
 });

--- a/src/lib/appShellGuards.ts
+++ b/src/lib/appShellGuards.ts
@@ -46,3 +46,9 @@ export const shouldUseReadonlyFallbackForAuthBootstrap = (input: {
 
 export const shouldCloseSimulationLibraryOnLoad = (input: { presetId: string | null | undefined }): boolean =>
   String(input.presetId ?? "").trim().length > 0;
+
+export const formatPrivateSiteReferenceBlockMessage = (siteNames: string[]): string => {
+  const cleaned = siteNames.map((name) => String(name).trim()).filter(Boolean);
+  const nameList = cleaned.length ? ` (${cleaned.join(", ")})` : "";
+  return `Cannot share this Simulation while private Library Site references exist${nameList}. Set Simulation visibility to Private or use non-private Site entries.`;
+};


### PR DESCRIPTION
## Summary\n- block share-with-users flow earlier when Simulation is non-private and references private Library Sites\n- show actionable validation message with affected Site names before cloud push\n- add guard helper coverage for this messaging behavior\n\n## Verification\n- npm run test -- --run src/lib/appShellGuards.test.ts\n- npm test\n- npm run build\n\n## Issue\n- refs #252