### PR TITLE
fix: include Simulation names in sync conflict errors (#283)

### DIFF
--- a/src/lib/cloudLibrary.test.ts
+++ b/src/lib/cloudLibrary.test.ts
@@ -63,9 +63,30 @@ describe("cloudLibrary client", () => {
       }),
     );
 
-    await expect(pushCloudLibrary({ siteLibrary: [], simulationPresets: [] })).rejects.toThrow(
-      "Cannot publish/shared a simulation that references private library sites.",
+    await expect(
+      pushCloudLibrary({
+        siteLibrary: [],
+        simulationPresets: [{ id: "sim-1", name: "North Link" }],
+      }),
+    ).rejects.toThrow(
+      "Cannot publish/shared simulation(s) with private Library Site references: North Link.",
     );
+  });
+
+  it("includes simulation names for simulation_name_taken conflicts", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: false, conflicts: ["simulation_name_taken"] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    await expect(
+      pushCloudLibrary({
+        siteLibrary: [],
+        simulationPresets: [{ id: "sim-2", name: "Relay Plan" }],
+      }),
+    ).rejects.toThrow("Simulation name already exists: Relay Plan. Use unique Simulation names.");
   });
 
   it("throws parsed API error for non-OK responses", async () => {

--- a/src/lib/cloudLibrary.ts
+++ b/src/lib/cloudLibrary.ts
@@ -10,6 +10,15 @@ type CloudPushResult = {
   conflicts?: string[];
 };
 
+const listSimulationNames = (payload: CloudLibraryPayload): string[] =>
+  payload.simulationPresets
+    .map((entry) => {
+      if (!entry || typeof entry !== "object") return "";
+      const candidate = (entry as { name?: unknown }).name;
+      return typeof candidate === "string" ? candidate.trim() : "";
+    })
+    .filter(Boolean);
+
 const apiCall = async <T>(path: string, init?: RequestInit): Promise<T> => {
   console.log("[cloudLibrary] API call:", init?.method ?? "GET", path);
   const response = await fetch(path, {
@@ -92,12 +101,16 @@ export const pushCloudLibrary = async (payload: CloudLibraryPayload, opts?: { su
   console.log("[cloudLibrary] Push has conflicts:", allConflicts, "fatal:", conflicts);
   if (!conflicts.length) return;
   if (conflicts.includes("simulation_private_site_reference")) {
+    const simulationNames = listSimulationNames(payload);
+    const suffix = simulationNames.length ? `: ${simulationNames.join(", ")}` : "";
     throw new Error(
-      "Cannot publish/shared a simulation that references private library sites. Set simulation to Private or use non-private site entries.",
+      `Cannot publish/shared simulation(s) with private Library Site references${suffix}. Set Simulation visibility to Private or use non-private Site entries.`,
     );
   }
   if (conflicts.includes("simulation_name_taken")) {
-    throw new Error("Simulation name already exists. Use a unique simulation name.");
+    const simulationNames = listSimulationNames(payload);
+    const suffix = simulationNames.length ? `: ${simulationNames.join(", ")}` : "";
+    throw new Error(`Simulation name already exists${suffix}. Use unique Simulation names.`);
   }
   throw new Error(`Cloud rejected ${conflicts.length} item(s): ${conflicts.join(", ")}`);
 };


### PR DESCRIPTION
## Summary\n- include Simulation names in  sync errors\n- include Simulation names in private-site-reference conflict errors\n- keep sync modal/status messages actionable without relying on console-only detail\n\n## Verification\n- npm run test -- --run src/lib/cloudLibrary.test.ts\n- npm test\n- npm run build\n\n## Issue\n- refs #283