### PR TITLE
chore: sync main back into staging before 0.15 bug rework

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -598,6 +598,11 @@ export function AppShell() {
     window.location.href = `/api/auth-start?returnTo=${encodeURIComponent(returnTo || "/")}`;
   }, []);
 
+  const signIn = useCallback(() => {
+    const returnTo = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+    window.location.href = `/api/auth-start?returnTo=${encodeURIComponent(returnTo || "/")}`;
+  }, []);
+
   const switchLocalRole = useCallback(
     async (role: "admin" | "moderator" | "user" | "pending") => {
       try {
@@ -1028,6 +1033,57 @@ export function AppShell() {
     updateMapViewport,
     publishAppNotice,
   ]);
+
+  useEffect(() => {
+    if (libraryAutoOpened) return;
+    if (workspaceState !== "no-simulation") return;
+    if (showWelcomeModal) return;
+    if (accessState !== "granted" && accessState !== "readonly") return;
+    if (!activeUserId) return;
+    try {
+      const seen = localStorage.getItem(`${ONBOARDING_SEEN_KEY_PREFIX}${activeUserId}`);
+      if (!seen) return;
+    } catch {
+      return;
+    }
+    setLibraryAutoOpened(true);
+    setShowSimulationLibraryRequest(true);
+  }, [libraryAutoOpened, workspaceState, showWelcomeModal, accessState, activeUserId, setShowSimulationLibraryRequest]);
+
+  useEffect(() => {
+    if (!showSimulationLibraryRequest) return;
+    setShowSimulationLibraryRequest(false);
+    setShowLibraryFromRequest(true);
+  }, [showSimulationLibraryRequest, setShowSimulationLibraryRequest]);
+
+  const openOnboardingTutorial = () => {
+    setShowOnboardingTutorial(true);
+  };
+
+  const openWelcomeFromWelcome = () => {
+    setShowWelcomeModal(false);
+    setShowOnboardingTutorial(true);
+  };
+
+  const openLibraryFromWelcome = () => {
+    setShowWelcomeModal(false);
+    setShowSimulationLibraryRequest(true);
+    try {
+      if (activeUserId) localStorage.setItem(`${ONBOARDING_SEEN_KEY_PREFIX}${activeUserId}`, "1");
+    } catch {
+      // ignore
+    }
+  };
+
+  const createNewFromWelcome = () => {
+    setShowWelcomeModal(false);
+    setShowNewSimulationRequest(true);
+    try {
+      if (activeUserId) localStorage.setItem(`${ONBOARDING_SEEN_KEY_PREFIX}${activeUserId}`, "1");
+    } catch {
+      // ignore
+    }
+  };
 
   useEffect(() => {
     if (libraryAutoOpened) return;

--- a/src/components/UserAdminPanel.tsx
+++ b/src/components/UserAdminPanel.tsx
@@ -51,6 +51,15 @@ const NOTIFICATION_POLL_MS = 30_000;
 const LOCAL_FORCE_READONLY_KEY = "linksim:local-force-readonly:v1";
 const OPEN_SYNC_MODAL_EVENT = "linksim:open-sync-modal";
 
+type SyncIndicatorState = "local" | "offline" | "pending" | "syncing" | "synced" | "error";
+
+type SyncIndicator = {
+  state: SyncIndicatorState;
+  className: string;
+  label: string;
+  title: string;
+};
+
 const readDismissedNotificationIds = (): Set<string> => {
   try {
     const raw = window.localStorage.getItem(NOTIFICATION_DISMISS_KEY);
@@ -681,6 +690,11 @@ export function UserAdminPanel({ onOpenHelp, authBootstrapPending = false, extra
     setAuthState("signed_out");
     window.location.href = "/cdn-cgi/access/logout";
   }, [isLocalRuntime, setAuthState, setCurrentUser]);
+
+  const handleSignUp = useCallback(() => {
+    const returnTo = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+    window.location.href = `/api/auth-start?returnTo=${encodeURIComponent(returnTo || "/")}`;
+  }, []);
 
   const handleSignUp = useCallback(() => {
     const returnTo = `${window.location.pathname}${window.location.search}${window.location.hash}`;


### PR DESCRIPTION
## Summary
- sync `main` back into `staging` to clear branch drift before 0.15.0 bug rework
- merge performed from `origin/staging` using `git merge origin/main -X ours --no-edit`

## Why
AGENTS/release-flow requires drift reconciliation before new issue implementation so staging promotions stay clean.

## Validation
- `git log --oneline origin/staging -5`
- `git log --oneline origin/main -5`
- `git cherry -v origin/staging origin/main` (drift present prior to this PR)
