### PR TITLE
fix: close Simulation Library modal after load in both flows (#391)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -8,10 +8,10 @@ import {
   formatPrivateSiteReferenceBlockMessage,
   type DeepLinkApplyOutcome,
   isAuthSignInRequiredMessage,
-  shouldCloseSimulationLibraryOnLoad,
   shouldRewritePathAfterDeepLinkApply,
   shouldUseReadonlyFallbackForAuthBootstrap,
 } from "../lib/appShellGuards";
+import { handleSimulationLibraryLoad } from "../lib/simulationLibraryLoad";
 import { emptyWorkspaceState } from "../lib/emptyWorkspaceState";
 import { getCurrentRuntimeEnvironment } from "../lib/environment";
 import { getUiErrorMessage } from "../lib/uiError";
@@ -598,11 +598,6 @@ export function AppShell() {
     window.location.href = `/api/auth-start?returnTo=${encodeURIComponent(returnTo || "/")}`;
   }, []);
 
-  const signIn = useCallback(() => {
-    const returnTo = `${window.location.pathname}${window.location.search}${window.location.hash}`;
-    window.location.href = `/api/auth-start?returnTo=${encodeURIComponent(returnTo || "/")}`;
-  }, []);
-
   const switchLocalRole = useCallback(
     async (role: "admin" | "moderator" | "user" | "pending") => {
       try {
@@ -1033,57 +1028,6 @@ export function AppShell() {
     updateMapViewport,
     publishAppNotice,
   ]);
-
-  useEffect(() => {
-    if (libraryAutoOpened) return;
-    if (workspaceState !== "no-simulation") return;
-    if (showWelcomeModal) return;
-    if (accessState !== "granted" && accessState !== "readonly") return;
-    if (!activeUserId) return;
-    try {
-      const seen = localStorage.getItem(`${ONBOARDING_SEEN_KEY_PREFIX}${activeUserId}`);
-      if (!seen) return;
-    } catch {
-      return;
-    }
-    setLibraryAutoOpened(true);
-    setShowSimulationLibraryRequest(true);
-  }, [libraryAutoOpened, workspaceState, showWelcomeModal, accessState, activeUserId, setShowSimulationLibraryRequest]);
-
-  useEffect(() => {
-    if (!showSimulationLibraryRequest) return;
-    setShowSimulationLibraryRequest(false);
-    setShowLibraryFromRequest(true);
-  }, [showSimulationLibraryRequest, setShowSimulationLibraryRequest]);
-
-  const openOnboardingTutorial = () => {
-    setShowOnboardingTutorial(true);
-  };
-
-  const openWelcomeFromWelcome = () => {
-    setShowWelcomeModal(false);
-    setShowOnboardingTutorial(true);
-  };
-
-  const openLibraryFromWelcome = () => {
-    setShowWelcomeModal(false);
-    setShowSimulationLibraryRequest(true);
-    try {
-      if (activeUserId) localStorage.setItem(`${ONBOARDING_SEEN_KEY_PREFIX}${activeUserId}`, "1");
-    } catch {
-      // ignore
-    }
-  };
-
-  const createNewFromWelcome = () => {
-    setShowWelcomeModal(false);
-    setShowNewSimulationRequest(true);
-    try {
-      if (activeUserId) localStorage.setItem(`${ONBOARDING_SEEN_KEY_PREFIX}${activeUserId}`, "1");
-    } catch {
-      // ignore
-    }
-  };
 
   useEffect(() => {
     if (libraryAutoOpened) return;
@@ -1793,15 +1737,18 @@ export function AppShell() {
           <SimulationLibraryPanel
             onClose={() => setShowLibraryFromRequest(false)}
             onLoadSimulation={(presetId) => {
-              loadSimulationPreset(presetId);
-              if (shouldCloseSimulationLibraryOnLoad({ presetId })) {
-                setShowLibraryFromRequest(false);
-              }
-              try {
-                localStorage.setItem(LAST_SIMULATION_REF_KEY, `saved:${presetId}`);
-              } catch {
-                // ignore storage errors
-              }
+              handleSimulationLibraryLoad({
+                presetId,
+                loadSimulationPreset,
+                persistSimulationRef: (loadedPresetId) => {
+                  try {
+                    localStorage.setItem(LAST_SIMULATION_REF_KEY, `saved:${loadedPresetId}`);
+                  } catch {
+                    // ignore storage errors
+                  }
+                },
+                closeLibraryModal: () => setShowLibraryFromRequest(false),
+              });
             }}
           />
         </ModalOverlay>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -50,6 +50,7 @@ import {
   type LibraryFilterState,
   type LibraryFilterVisibility,
 } from "../lib/libraryFilters";
+import { handleSimulationLibraryLoad } from "../lib/simulationLibraryLoad";
 import { getUiErrorMessage } from "../lib/uiError";
 import { formatDate, formatNumber } from "../lib/locale";
 import { useAppStore } from "../store/appStore";
@@ -3030,8 +3031,12 @@ export function Sidebar({
           <SimulationLibraryPanel
             onClose={() => setShowSimulationLibraryManager(false)}
             onLoadSimulation={(presetId) => {
-              loadSimulationPreset(presetId);
-              persistSelectedSimulationRef(`saved:${presetId}`);
+              handleSimulationLibraryLoad({
+                presetId,
+                loadSimulationPreset,
+                persistSimulationRef: (loadedPresetId) => persistSelectedSimulationRef(`saved:${loadedPresetId}`),
+                closeLibraryModal: () => setShowSimulationLibraryManager(false),
+              });
             }}
             onOpenDetails={openResourceDetailsPopup}
           />

--- a/src/components/UserAdminPanel.tsx
+++ b/src/components/UserAdminPanel.tsx
@@ -51,15 +51,6 @@ const NOTIFICATION_POLL_MS = 30_000;
 const LOCAL_FORCE_READONLY_KEY = "linksim:local-force-readonly:v1";
 const OPEN_SYNC_MODAL_EVENT = "linksim:open-sync-modal";
 
-type SyncIndicatorState = "local" | "offline" | "pending" | "syncing" | "synced" | "error";
-
-type SyncIndicator = {
-  state: SyncIndicatorState;
-  className: string;
-  label: string;
-  title: string;
-};
-
 const readDismissedNotificationIds = (): Set<string> => {
   try {
     const raw = window.localStorage.getItem(NOTIFICATION_DISMISS_KEY);
@@ -690,11 +681,6 @@ export function UserAdminPanel({ onOpenHelp, authBootstrapPending = false, extra
     setAuthState("signed_out");
     window.location.href = "/cdn-cgi/access/logout";
   }, [isLocalRuntime, setAuthState, setCurrentUser]);
-
-  const handleSignUp = useCallback(() => {
-    const returnTo = `${window.location.pathname}${window.location.search}${window.location.hash}`;
-    window.location.href = `/api/auth-start?returnTo=${encodeURIComponent(returnTo || "/")}`;
-  }, []);
 
   const handleSignUp = useCallback(() => {
     const returnTo = `${window.location.pathname}${window.location.search}${window.location.hash}`;

--- a/src/lib/simulationLibraryLoad.test.ts
+++ b/src/lib/simulationLibraryLoad.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleSimulationLibraryLoad } from "./simulationLibraryLoad";
+
+describe("handleSimulationLibraryLoad", () => {
+  it("loads, persists, and closes for valid preset id", () => {
+    const loadSimulationPreset = vi.fn();
+    const persistSimulationRef = vi.fn();
+    const closeLibraryModal = vi.fn();
+
+    const handled = handleSimulationLibraryLoad({
+      presetId: " sim-123 ",
+      loadSimulationPreset,
+      persistSimulationRef,
+      closeLibraryModal,
+    });
+
+    expect(handled).toBe(true);
+    expect(loadSimulationPreset).toHaveBeenCalledWith("sim-123");
+    expect(persistSimulationRef).toHaveBeenCalledWith("sim-123");
+    expect(closeLibraryModal).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing for empty preset id", () => {
+    const loadSimulationPreset = vi.fn();
+    const persistSimulationRef = vi.fn();
+    const closeLibraryModal = vi.fn();
+
+    const handled = handleSimulationLibraryLoad({
+      presetId: "  ",
+      loadSimulationPreset,
+      persistSimulationRef,
+      closeLibraryModal,
+    });
+
+    expect(handled).toBe(false);
+    expect(loadSimulationPreset).not.toHaveBeenCalled();
+    expect(persistSimulationRef).not.toHaveBeenCalled();
+    expect(closeLibraryModal).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/simulationLibraryLoad.ts
+++ b/src/lib/simulationLibraryLoad.ts
@@ -1,0 +1,20 @@
+type HandleSimulationLibraryLoadInput = {
+  presetId: string;
+  loadSimulationPreset: (presetId: string) => void;
+  persistSimulationRef?: (presetId: string) => void;
+  closeLibraryModal?: () => void;
+};
+
+export const handleSimulationLibraryLoad = ({
+  presetId,
+  loadSimulationPreset,
+  persistSimulationRef,
+  closeLibraryModal,
+}: HandleSimulationLibraryLoadInput): boolean => {
+  const normalizedPresetId = String(presetId ?? "").trim();
+  if (!normalizedPresetId) return false;
+  loadSimulationPreset(normalizedPresetId);
+  persistSimulationRef?.(normalizedPresetId);
+  closeLibraryModal?.();
+  return true;
+};


### PR DESCRIPTION
## Summary
- close Simulation Library modal immediately after loading a simulation in both entry flows:
  - Sidebar library modal
  - AppShell request/welcome modal
- add shared load handler + regression tests for valid and invalid preset ids
- remove duplicate declarations introduced by drift reconciliation that broke `npm run build`

## Verification
- `npm run test -- --run src/lib/simulationLibraryLoad.test.ts src/lib/appShellGuards.test.ts`
- `npm run build`
