### PR TITLE
fix: rework Path override UX and selected-pair override persistence (#221 #392)

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -61,7 +61,7 @@ import { ModalOverlay } from "./ModalOverlay";
 import SimulationLibraryPanel from "./SimulationLibraryPanel";
 import { UserAdminPanel } from "./UserAdminPanel";
 import { useLibraryManager } from "./sidebar/useLibraryManager";
-import { useInspectorActions } from "./sidebar/useInspectorActions";
+import { type LinkModalState, useInspectorActions } from "./sidebar/useInspectorActions";
 
 const parseNumber = (value: string): number => {
   const parsed = Number(value);
@@ -1019,12 +1019,40 @@ export function Sidebar({
   ) => {
     setDeleteConfirm({ title, message, confirmLabel, onConfirm });
   };
-  const { linkModal, setLinkModal, openAddLinkModal, openEditLinkModal } = useInspectorActions({
+  const { linkModal, setLinkModal, openAddLinkModal, openEditLinkModal, canEditExistingPath } = useInspectorActions({
     selectedLink,
     selectedLinkRaw,
     selectedSite,
     sites,
   });
+
+  const persistEditedPathFromModal = (modal: LinkModalState) => {
+    if (!modal || modal.mode !== "edit" || !modal.linkId) return;
+    if (!links.some((link) => link.id === modal.linkId)) return;
+    const fromExists = sites.some((site) => site.id === modal.fromSiteId);
+    const toExists = sites.some((site) => site.id === modal.toSiteId);
+    if (!fromExists || !toExists || modal.fromSiteId === modal.toSiteId) return;
+    updateLink(modal.linkId, {
+      name: modal.name.trim() || undefined,
+      fromSiteId: modal.fromSiteId,
+      toSiteId: modal.toSiteId,
+      txPowerDbm: modal.overrideRadio ? modal.txPowerDbm : undefined,
+      txGainDbi: modal.overrideRadio ? modal.txGainDbi : undefined,
+      rxGainDbi: modal.overrideRadio ? modal.rxGainDbi : undefined,
+      cableLossDb: modal.overrideRadio ? modal.cableLossDb : undefined,
+    });
+  };
+
+  const setLinkModalWithAutosave = (updater: (current: NonNullable<LinkModalState>) => NonNullable<LinkModalState>) => {
+    setLinkModal((current) => {
+      if (!current) return current;
+      const next = updater(current);
+      if (next.mode === "edit" && next.linkId) {
+        queueMicrotask(() => persistEditedPathFromModal(next));
+      }
+      return next;
+    });
+  };
 
   const saveLinkModal = () => {
     if (!linkModal) return;
@@ -1056,30 +1084,30 @@ export function Sidebar({
         return;
       }
       if (createdId) {
-        updateLink(createdId, {
-          name: linkModal.name.trim() || undefined,
-          fromSiteId: linkModal.fromSiteId,
-          toSiteId: linkModal.toSiteId,
-          txPowerDbm: linkModal.overrideRadio ? linkModal.txPowerDbm : undefined,
-          txGainDbi: linkModal.overrideRadio ? linkModal.txGainDbi : undefined,
-          rxGainDbi: linkModal.overrideRadio ? linkModal.rxGainDbi : undefined,
-          cableLossDb: linkModal.overrideRadio ? linkModal.cableLossDb : undefined,
-        });
+        const createdModal: NonNullable<LinkModalState> = {
+          ...linkModal,
+          mode: "edit",
+          linkId: createdId,
+          status: "Path created. Further edits auto-save.",
+        };
+        persistEditedPathFromModal(createdModal);
+        setLinkModal(createdModal);
+      } else {
+        setLinkModal((current) =>
+          current ? { ...current, status: "Path created, but could not open it for editing." } : current,
+        );
       }
-      setLinkModal(null);
       return;
     }
-    if (!linkModal.linkId) return;
-    updateLink(linkModal.linkId, {
-      name: linkModal.name.trim() || undefined,
-      fromSiteId: linkModal.fromSiteId,
-      toSiteId: linkModal.toSiteId,
-      txPowerDbm: linkModal.overrideRadio ? linkModal.txPowerDbm : undefined,
-      txGainDbi: linkModal.overrideRadio ? linkModal.txGainDbi : undefined,
-      rxGainDbi: linkModal.overrideRadio ? linkModal.rxGainDbi : undefined,
-      cableLossDb: linkModal.overrideRadio ? linkModal.cableLossDb : undefined,
-    });
-    setLinkModal(null);
+  };
+
+  const updateLinkModalField = (updater: (current: NonNullable<LinkModalState>) => NonNullable<LinkModalState>) => {
+    if (!linkModal) return;
+    if (linkModal.mode === "add") {
+      setLinkModal((current) => (current ? updater(current) : current));
+      return;
+    }
+    setLinkModalWithAutosave(updater);
   };
   const saveSimulationAsNew = () => {
     const trimmed = newPresetName.trim();
@@ -1875,7 +1903,7 @@ export function Sidebar({
               <button className="inline-action" disabled={sites.length < 2} onClick={openAddLinkModal} type="button">
                 New
               </button>
-              <button className="inline-action" onClick={openEditLinkModal} type="button">
+              <button className="inline-action" disabled={!canEditExistingPath} onClick={openEditLinkModal} type="button">
                 Details
               </button>
               <button
@@ -1909,9 +1937,7 @@ export function Sidebar({
             <label className="field-grid">
               <span>Path name</span>
               <input
-                onChange={(event) =>
-                  setLinkModal((current) => (current ? { ...current, name: event.target.value, status: "" } : current))
-                }
+                onChange={(event) => updateLinkModalField((current) => ({ ...current, name: event.target.value, status: "" }))}
                 placeholder="Backhaul A"
                 type="text"
                 value={linkModal.name}
@@ -1922,7 +1948,7 @@ export function Sidebar({
               <select
                 className="locale-select"
                 onChange={(event) =>
-                  setLinkModal((current) => {
+                  updateLinkModalField((current) => {
                     if (!current) return current;
                     const nextFrom = event.target.value;
                     const nextTo =
@@ -1946,7 +1972,7 @@ export function Sidebar({
               <select
                 className="locale-select"
                 onChange={(event) =>
-                  setLinkModal((current) => (current ? { ...current, toSiteId: event.target.value, status: "" } : current))
+                  updateLinkModalField((current) => ({ ...current, toSiteId: event.target.value, status: "" }))
                 }
                 value={linkModal.toSiteId}
               >
@@ -1959,82 +1985,85 @@ export function Sidebar({
                   ))}
               </select>
             </label>
-            <details className="compact-details">
-              <summary>Path Radio Overrides</summary>
-              <label className="field-grid">
-                <span>Use site radio defaults</span>
-                <input
-                  checked={!linkModal.overrideRadio}
-                  onChange={(event) =>
-                    setLinkModal((current) =>
-                      current ? { ...current, overrideRadio: !event.target.checked, status: "" } : current,
-                    )
-                  }
-                  type="checkbox"
-                />
-              </label>
-              {!linkModal.overrideRadio ? (
-                <p className="field-help">
-                  This Path uses the selected From/To Site radio settings.
-                </p>
-              ) : null}
-              {linkModal.overrideRadio ? (
-                <>
-              <label className="field-grid">
-                <span>Tx power (dBm)</span>
-                <input
-                  onChange={(event) =>
-                    setLinkModal((current) =>
-                      current ? { ...current, txPowerDbm: parseNumber(event.target.value), status: "" } : current,
-                    )
-                  }
-                  type="number"
-                  value={linkModal.txPowerDbm}
-                />
-              </label>
-              <label className="field-grid">
-                <span>Tx gain (dBi)</span>
-                <input
-                  onChange={(event) =>
-                    setLinkModal((current) =>
-                      current ? { ...current, txGainDbi: parseNumber(event.target.value), status: "" } : current,
-                    )
-                  }
-                  type="number"
-                  value={linkModal.txGainDbi}
-                />
-              </label>
-              <label className="field-grid">
-                <span>Rx gain (dBi)</span>
-                <input
-                  onChange={(event) =>
-                    setLinkModal((current) =>
-                      current ? { ...current, rxGainDbi: parseNumber(event.target.value), status: "" } : current,
-                    )
-                  }
-                  type="number"
-                  value={linkModal.rxGainDbi}
-                />
-              </label>
-              <label className="field-grid">
-                <span>Cable loss (dB)</span>
-                <input
-                  onChange={(event) =>
-                    setLinkModal((current) =>
-                      current ? { ...current, cableLossDb: parseNumber(event.target.value), status: "" } : current,
-                    )
-                  }
-                  type="number"
-                  value={linkModal.cableLossDb}
-                />
-              </label>
-                </>
-              ) : null}
-            </details>
+            <label className="checkbox-field">
+              <input
+                checked={linkModal.overrideRadio}
+                onChange={(event) =>
+                  updateLinkModalField((current) => ({ ...current, overrideRadio: event.target.checked, status: "" }))
+                }
+                type="checkbox"
+              />
+              <span>Override site settings</span>
+            </label>
+            {!linkModal.overrideRadio ? <p className="field-help">This Path currently uses Site defaults.</p> : null}
+            <label className="field-grid">
+              <span>Tx power (dBm)</span>
+              <input
+                disabled={!linkModal.overrideRadio}
+                onChange={(event) =>
+                  updateLinkModalField((current) => ({
+                    ...current,
+                    txPowerDbm: parseNumber(event.target.value),
+                    status: "",
+                  }))
+                }
+                type="number"
+                value={linkModal.txPowerDbm}
+              />
+            </label>
+            <label className="field-grid">
+              <span>Tx gain (dBi)</span>
+              <input
+                disabled={!linkModal.overrideRadio}
+                onChange={(event) =>
+                  updateLinkModalField((current) => ({
+                    ...current,
+                    txGainDbi: parseNumber(event.target.value),
+                    status: "",
+                  }))
+                }
+                type="number"
+                value={linkModal.txGainDbi}
+              />
+            </label>
+            <label className="field-grid">
+              <span>Rx gain (dBi)</span>
+              <input
+                disabled={!linkModal.overrideRadio}
+                onChange={(event) =>
+                  updateLinkModalField((current) => ({
+                    ...current,
+                    rxGainDbi: parseNumber(event.target.value),
+                    status: "",
+                  }))
+                }
+                type="number"
+                value={linkModal.rxGainDbi}
+              />
+            </label>
+            <label className="field-grid">
+              <span>Cable loss (dB)</span>
+              <input
+                disabled={!linkModal.overrideRadio}
+                onChange={(event) =>
+                  updateLinkModalField((current) => ({
+                    ...current,
+                    cableLossDb: parseNumber(event.target.value),
+                    status: "",
+                  }))
+                }
+                type="number"
+                value={linkModal.cableLossDb}
+              />
+            </label>
             <div className="chip-group">
-              <button className="inline-action" onClick={saveLinkModal} type="button">
-                {linkModal.mode === "add" ? "Create Path" : "Save Path"}
-              </button>
+              {linkModal.mode === "add" ? (
+                <button className="inline-action" onClick={saveLinkModal} type="button">
+                  Create Path
+                </button>
+              ) : (
+                <p className="field-help">Edits auto-save.</p>
+              )}
             </div>
             {linkModal.status ? <p className="field-help">{linkModal.status}</p> : null}
           </div>

--- a/src/components/sidebar/useInspectorActions.ts
+++ b/src/components/sidebar/useInspectorActions.ts
@@ -30,6 +30,7 @@ export function useInspectorActions({
   sites,
 }: UseInspectorActionsParams) {
   const [linkModal, setLinkModal] = useState<LinkModalState>(null);
+  const canEditExistingPath = Boolean(selectedLinkRaw && !selectedLinkRaw.id.startsWith("__"));
 
   const openAddLinkModal = () => {
     const hasFromInSites = sites.some((site) => site.id === selectedLink.fromSiteId);
@@ -57,6 +58,7 @@ export function useInspectorActions({
   };
 
   const openEditLinkModal = () => {
+    if (!canEditExistingPath || !selectedLinkRaw) return;
     const fromSite = sites.find((site) => site.id === selectedLink.fromSiteId) ?? null;
     const toSite = sites.find((site) => site.id === selectedLink.toSiteId) ?? null;
     const baseRadio = resolveLinkRadio(selectedLink, fromSite, toSite);
@@ -69,7 +71,7 @@ export function useInspectorActions({
     );
     setLinkModal({
       mode: "edit",
-      linkId: selectedLink.id,
+      linkId: selectedLinkRaw.id,
       name: selectedLink.name ?? "",
       fromSiteId: selectedLink.fromSiteId,
       toSiteId: selectedLink.toSiteId,
@@ -87,5 +89,6 @@ export function useInspectorActions({
     setLinkModal,
     openAddLinkModal,
     openEditLinkModal,
+    canEditExistingPath,
   };
 }

--- a/src/lib/linkRadio.test.ts
+++ b/src/lib/linkRadio.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import type { Link, Site } from "../types/radio";
+import { stripRedundantLinkRadioOverrides } from "./linkRadio";
+
+const fromSite: Site = {
+  id: "from",
+  name: "From",
+  position: { lat: 1, lon: 1 },
+  groundElevationM: 10,
+  antennaHeightM: 2,
+  txPowerDbm: 20,
+  txGainDbi: 2,
+  rxGainDbi: 2,
+  cableLossDb: 1,
+};
+
+const toSite: Site = {
+  id: "to",
+  name: "To",
+  position: { lat: 2, lon: 2 },
+  groundElevationM: 12,
+  antennaHeightM: 3,
+  txPowerDbm: 21,
+  txGainDbi: 3,
+  rxGainDbi: 4,
+  cableLossDb: 1.5,
+};
+
+const baseLink: Link = {
+  id: "link-1",
+  fromSiteId: "from",
+  toSiteId: "to",
+  frequencyMHz: 868,
+};
+
+describe("stripRedundantLinkRadioOverrides", () => {
+  it("keeps overrides that differ from Site defaults", () => {
+    const result = stripRedundantLinkRadioOverrides(
+      {
+        ...baseLink,
+        txPowerDbm: 33,
+        txGainDbi: 8,
+        rxGainDbi: 9,
+        cableLossDb: 0.2,
+      },
+      fromSite,
+      toSite,
+    );
+
+    expect(result.txPowerDbm).toBe(33);
+    expect(result.txGainDbi).toBe(8);
+    expect(result.rxGainDbi).toBe(9);
+    expect(result.cableLossDb).toBe(0.2);
+  });
+
+  it("removes overrides when values match Site defaults", () => {
+    const result = stripRedundantLinkRadioOverrides(
+      {
+        ...baseLink,
+        txPowerDbm: fromSite.txPowerDbm,
+        txGainDbi: fromSite.txGainDbi,
+        rxGainDbi: toSite.rxGainDbi,
+        cableLossDb: fromSite.cableLossDb,
+      },
+      fromSite,
+      toSite,
+    );
+
+    expect(result.txPowerDbm).toBeUndefined();
+    expect(result.txGainDbi).toBeUndefined();
+    expect(result.rxGainDbi).toBeUndefined();
+    expect(result.cableLossDb).toBeUndefined();
+  });
+});

--- a/src/lib/linkRadio.ts
+++ b/src/lib/linkRadio.ts
@@ -69,23 +69,28 @@ export const stripRedundantLinkRadioOverrides = (
   fromSite?: Site | null,
   toSite?: Site | null,
 ): Link => {
-  const resolved = resolveLinkRadio(link, fromSite, toSite);
+  const baseline = {
+    txPowerDbm: fromSite?.txPowerDbm ?? STANDARD_SITE_RADIO.txPowerDbm,
+    txGainDbi: fromSite?.txGainDbi ?? STANDARD_SITE_RADIO.txGainDbi,
+    rxGainDbi: toSite?.rxGainDbi ?? STANDARD_SITE_RADIO.rxGainDbi,
+    cableLossDb: fromSite?.cableLossDb ?? STANDARD_SITE_RADIO.cableLossDb,
+  };
   return {
     ...link,
     txPowerDbm:
-      typeof link.txPowerDbm === "number" && !sameNumber(link.txPowerDbm, resolved.txPowerDbm)
+      typeof link.txPowerDbm === "number" && !sameNumber(link.txPowerDbm, baseline.txPowerDbm)
         ? link.txPowerDbm
         : undefined,
     txGainDbi:
-      typeof link.txGainDbi === "number" && !sameNumber(link.txGainDbi, resolved.txGainDbi)
+      typeof link.txGainDbi === "number" && !sameNumber(link.txGainDbi, baseline.txGainDbi)
         ? link.txGainDbi
         : undefined,
     rxGainDbi:
-      typeof link.rxGainDbi === "number" && !sameNumber(link.rxGainDbi, resolved.rxGainDbi)
+      typeof link.rxGainDbi === "number" && !sameNumber(link.rxGainDbi, baseline.rxGainDbi)
         ? link.rxGainDbi
         : undefined,
     cableLossDb:
-      typeof link.cableLossDb === "number" && !sameNumber(link.cableLossDb, resolved.cableLossDb)
+      typeof link.cableLossDb === "number" && !sameNumber(link.cableLossDb, baseline.cableLossDb)
         ? link.cableLossDb
         : undefined,
   };

--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -492,6 +492,24 @@ describe("appStore selected pair link resolution", () => {
     storage.mock.clear();
     vi.restoreAllMocks();
     useAppStore.setState({
+      currentUser: {
+        id: "owner-1",
+        username: "owner",
+        avatarUrl: "",
+        role: "user",
+        accountState: "approved",
+        isApproved: true,
+        isAdmin: false,
+        isModerator: false,
+        createdAt: "",
+        updatedAt: null,
+        approvedAt: null,
+        approvedByUserId: null,
+        email: undefined,
+        emailPublic: true,
+        bio: "",
+      },
+      selectedScenarioId: "",
       selectedLinkId: "",
       selectedSiteIds: ["site-2", "site-1"],
       sites: [
@@ -562,6 +580,22 @@ describe("appStore selected pair link resolution", () => {
     expect(selectedLink.txGainDbi).toBe(9);
     expect(selectedLink.rxGainDbi).toBe(8);
     expect(selectedLink.cableLossDb).toBe(0.5);
+  });
+
+  it("reflects updated Path overrides in selected-pair analysis state", () => {
+    useAppStore.getState().updateLink("link-primary", {
+      txPowerDbm: 33,
+      txGainDbi: 11,
+      rxGainDbi: 10,
+      cableLossDb: 0.2,
+    });
+
+    const selectedLink = useAppStore.getState().getSelectedLink();
+    expect(selectedLink.id).toBe("link-primary");
+    expect(selectedLink.txPowerDbm).toBe(33);
+    expect(selectedLink.txGainDbi).toBe(11);
+    expect(selectedLink.rxGainDbi).toBe(10);
+    expect(selectedLink.cableLossDb).toBe(0.2);
   });
 });
 


### PR DESCRIPTION
## Summary
- redesign Path override UI in modal:
  - remove collapsible section
  - add `Override site settings` checkbox
  - keep override fields visible but disabled until checked
- switch edit mode to immediate auto-save for Path name/endpoints/override fields
- keep add mode as `Create Path`, then switch modal to edit+autosave after create
- block editing synthetic non-persisted links (`__selection__` / `__auto__`) from Details
- fix `stripRedundantLinkRadioOverrides` so real override values persist (previous logic always stripped overrides)
- add regression tests for override persistence and selected-pair effective link behavior

## Verification
- `npm run test -- --run src/lib/linkRadio.test.ts src/store/appStore.test.ts src/lib/selectionEffectiveLink.test.ts`
- `npm run build`
