### PR TITLE
fix: keep path profile UI fixed while graph geometry resizes (#108)

### DIFF
--- a/src/components/LinkProfileChart.tsx
+++ b/src/components/LinkProfileChart.tsx
@@ -733,9 +733,7 @@ export function LinkProfileChart({
         <svg
           aria-label="Link profile"
           height={svgProps.height}
-          preserveAspectRatio={svgProps.preserveAspectRatio}
           role="img"
-          viewBox={svgProps.viewBox}
           width={svgProps.width}
         >
           <defs>

--- a/src/lib/profileChartSvg.test.ts
+++ b/src/lib/profileChartSvg.test.ts
@@ -2,12 +2,10 @@ import { describe, expect, it } from "vitest";
 import { buildProfileChartSvgProps } from "./profileChartSvg";
 
 describe("buildProfileChartSvgProps", () => {
-  it("returns explicit width/height to avoid browser default SVG sizing", () => {
+  it("returns explicit width/height in fixed pixel coordinates", () => {
     expect(buildProfileChartSvgProps(960, 240)).toEqual({
       width: 960,
       height: 240,
-      viewBox: "0 0 960 240",
-      preserveAspectRatio: "none",
     });
   });
 
@@ -15,8 +13,6 @@ describe("buildProfileChartSvgProps", () => {
     expect(buildProfileChartSvgProps(Number.NaN, Number.POSITIVE_INFINITY)).toEqual({
       width: 1,
       height: 1,
-      viewBox: "0 0 1 1",
-      preserveAspectRatio: "none",
     });
   });
 });

--- a/src/lib/profileChartSvg.ts
+++ b/src/lib/profileChartSvg.ts
@@ -1,8 +1,6 @@
 export type ProfileChartSvgProps = {
   width: number;
   height: number;
-  viewBox: string;
-  preserveAspectRatio: "none";
 };
 
 const toSafeSize = (value: number): number => {
@@ -16,7 +14,5 @@ export const buildProfileChartSvgProps = (width: number, height: number): Profil
   return {
     width: safeWidth,
     height: safeHeight,
-    viewBox: `0 0 ${safeWidth} ${safeHeight}`,
-    preserveAspectRatio: "none",
   };
 };


### PR DESCRIPTION
## Summary
- remove non-uniform full-SVG scaling path (`preserveAspectRatio="none"` + `viewBox` coupling)
- keep path profile chart in fixed pixel coordinate space so text and stroke thickness remain stable
- retain responsive chart geometry by continuing to recompute coordinates from measured container size
- update SVG prop tests to reflect fixed-coordinate behavior

## Verification
- `npm run test -- --run src/lib/profileChartSvg.test.ts`
- `npm run build`
