### PR TITLE
fix: separate temporary two-site path behavior from saved path overrides (#221 #392)

### DIFF
--- a/src/components/LinkProfileChart.tsx
+++ b/src/components/LinkProfileChart.tsx
@@ -154,12 +154,11 @@ export function LinkProfileChart({
     }
     if (!selectedFromSite || !selectedToSite) return null;
     return buildSelectionEffectiveLink({
-      links,
       fromSite: selectedFromSite,
       toSite: selectedToSite,
       frequencyMHz: selectedNetwork.frequencyOverrideMHz ?? selectedNetwork.frequencyMHz,
     });
-  }, [selectedLink, selectedNetwork, selectedFromSite, selectedToSite, links]);
+  }, [selectedLink, selectedNetwork, selectedFromSite, selectedToSite]);
   const profile = useMemo(() => {
     if (!effectiveLink || !selectedFromSiteEffective || !selectedToSiteEffective) return baseProfile;
     const hasPreview =

--- a/src/components/SimulationResultsSection.tsx
+++ b/src/components/SimulationResultsSection.tsx
@@ -134,13 +134,10 @@ export function SimulationResultsSection() {
   // Effective link for 2-site selection (saved link for that pair, or temp link)
   const selectionEffectiveLink = useMemo(() => {
     if (selectionCount !== 2 || !sourceSite || !destinationSite) return null;
-    const saved = links.find(
-      (l) =>
-        (l.fromSiteId === sourceSite.id && l.toSiteId === destinationSite.id) ||
-        (l.fromSiteId === destinationSite.id && l.toSiteId === sourceSite.id),
-    );
-    if (saved) {
-      return { ...saved, frequencyMHz: effectiveNetworkFrequencyMHz };
+    const explicitSavedSelection =
+      selectedLinkId && links.find((link) => link.id === selectedLinkId && link.id === selectedLink.id);
+    if (explicitSavedSelection) {
+      return { ...explicitSavedSelection, frequencyMHz: effectiveNetworkFrequencyMHz };
     }
     return {
       id: "__selection__",
@@ -153,7 +150,7 @@ export function SimulationResultsSection() {
       rxGainDbi: destinationSite.rxGainDbi,
       cableLossDb: sourceSite.cableLossDb,
     };
-  }, [selectionCount, sourceSite, destinationSite, links, effectiveNetworkFrequencyMHz]);
+  }, [selectionCount, sourceSite, destinationSite, links, selectedLinkId, selectedLink, effectiveNetworkFrequencyMHz]);
 
   // The link used for analysis and what-if
   const activeLink = selectionEffectiveLink ?? selectedLink;

--- a/src/lib/selectionEffectiveLink.test.ts
+++ b/src/lib/selectionEffectiveLink.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { Link, Site } from "../types/radio";
+import type { Site } from "../types/radio";
 import { buildSelectionEffectiveLink } from "./selectionEffectiveLink";
 
 const siteA: Site = {
@@ -27,64 +27,38 @@ const siteB: Site = {
 };
 
 describe("buildSelectionEffectiveLink", () => {
-  it("uses saved link for selected pair and preserves saved radio overrides", () => {
-    const links: Link[] = [
-      {
-        id: "saved",
-        name: "A-B",
-        fromSiteId: "site-a",
-        toSiteId: "site-b",
-        frequencyMHz: 433,
-        txPowerDbm: 30,
-        txGainDbi: 9,
-        rxGainDbi: 7,
-        cableLossDb: 0.5,
-      },
-    ];
-
+  it("builds temporary link from Site radio defaults", () => {
     const effective = buildSelectionEffectiveLink({
-      links,
       fromSite: siteA,
       toSite: siteB,
       frequencyMHz: 868,
     });
 
     expect(effective).toMatchObject({
-      id: "saved",
+      id: "__selection__",
       fromSiteId: "site-a",
       toSiteId: "site-b",
       frequencyMHz: 868,
-      txPowerDbm: 30,
-      txGainDbi: 9,
-      rxGainDbi: 7,
-      cableLossDb: 0.5,
+      txPowerDbm: siteA.txPowerDbm,
+      txGainDbi: siteA.txGainDbi,
+      rxGainDbi: siteB.rxGainDbi,
+      cableLossDb: siteA.cableLossDb,
     });
   });
 
-  it("matches saved link regardless of selected direction", () => {
-    const links: Link[] = [
-      {
-        id: "saved",
-        fromSiteId: "site-a",
-        toSiteId: "site-b",
-        frequencyMHz: 433,
-      },
-    ];
-
+  it("keeps temporary selection id regardless of selected direction", () => {
     const effective = buildSelectionEffectiveLink({
-      links,
       fromSite: siteB,
       toSite: siteA,
       frequencyMHz: 868,
     });
 
-    expect(effective?.id).toBe("saved");
+    expect(effective?.id).toBe("__selection__");
     expect(effective?.frequencyMHz).toBe(868);
   });
 
   it("builds temporary link from Site radio when no saved pair exists", () => {
     const effective = buildSelectionEffectiveLink({
-      links: [],
       fromSite: siteA,
       toSite: siteB,
       frequencyMHz: 868,

--- a/src/lib/selectionEffectiveLink.ts
+++ b/src/lib/selectionEffectiveLink.ts
@@ -1,28 +1,16 @@
 import type { Link, Site } from "../types/radio";
 
 type SelectionEffectiveLinkInput = {
-  links: Link[];
   fromSite: Site;
   toSite: Site;
   frequencyMHz: number;
 };
 
 export const buildSelectionEffectiveLink = ({
-  links,
   fromSite,
   toSite,
   frequencyMHz,
 }: SelectionEffectiveLinkInput): Link => {
-  const saved = links.find(
-    (link) =>
-      (link.fromSiteId === fromSite.id && link.toSiteId === toSite.id) ||
-      (link.fromSiteId === toSite.id && link.toSiteId === fromSite.id),
-  );
-
-  if (saved) {
-    return { ...saved, frequencyMHz };
-  }
-
   return {
     id: "__selection__",
     name: `${fromSite.name} -> ${toSite.name}`,

--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -630,7 +630,17 @@ describe("appStore selected pair link resolution", () => {
     });
   });
 
-  it("returns saved pair link overrides when two-site selection has no selectedLinkId", () => {
+  it("uses temporary Site defaults when selecting two sites without selecting a saved path", () => {
+    const selectedLink = useAppStore.getState().getSelectedLink();
+    expect(selectedLink.id).toBe("__selection__");
+    expect(selectedLink.txPowerDbm).toBe(21);
+    expect(selectedLink.txGainDbi).toBe(3);
+    expect(selectedLink.rxGainDbi).toBe(2);
+    expect(selectedLink.cableLossDb).toBe(2);
+  });
+
+  it("uses saved path overrides when a saved path is explicitly selected", () => {
+    useAppStore.setState({ selectedLinkId: "link-primary" });
     const selectedLink = useAppStore.getState().getSelectedLink();
     expect(selectedLink.id).toBe("link-primary");
     expect(selectedLink.txPowerDbm).toBe(30);
@@ -639,7 +649,8 @@ describe("appStore selected pair link resolution", () => {
     expect(selectedLink.cableLossDb).toBe(0.5);
   });
 
-  it("reflects updated Path overrides in selected-pair analysis state", () => {
+  it("reflects updated overrides when a saved path is selected", () => {
+    useAppStore.setState({ selectedLinkId: "link-primary" });
     useAppStore.getState().updateLink("link-primary", {
       txPowerDbm: 33,
       txGainDbi: 11,

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -3815,17 +3815,6 @@ export const useAppStore = create<AppState>((set, get) => ({
       const toId = selectedPair[selectedPair.length - 1];
       const effectiveFromId = temporaryDirectionReversed ? toId : fromId;
       const effectiveToId = temporaryDirectionReversed ? fromId : toId;
-      const pairLink = links.find(
-        (candidate) =>
-          (candidate.fromSiteId === effectiveFromId && candidate.toSiteId === effectiveToId) ||
-          (candidate.fromSiteId === effectiveToId && candidate.toSiteId === effectiveFromId),
-      );
-      if (pairLink) {
-        const fromSite = sites.find((site) => site.id === pairLink.fromSiteId) ?? null;
-        const toSite = sites.find((site) => site.id === pairLink.toSiteId) ?? null;
-        const radio = resolveLinkRadio(pairLink, fromSite, toSite);
-        return { ...pairLink, ...radio };
-      }
       const selectedNetwork = networks.find((network) => network.id === selectedNetworkId);
       const inheritedFrequencyMHz =
         selectedNetwork?.frequencyOverrideMHz ?? selectedNetwork?.frequencyMHz ?? 869.618;


### PR DESCRIPTION
## Summary
- enforce explicit distinction between saved Path vs temporary two-site selection:
  - selecting two sites manually now always uses temporary `__selection__` path with Site settings
  - saved Path overrides apply only when a saved Path is explicitly selected (`selectedLinkId`)
- remove fallback behavior that auto-resolved saved pair overrides during plain two-site selection
- update tests to cover both semantics paths

## Verification
- `npm run test -- --run src/store/appStore.test.ts src/lib/selectionEffectiveLink.test.ts`
- `npm run build`
