### PR TITLE
fix: restore responsive profile geometry resizing without scaling UI glyphs (#108)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@
 - Never commit or push directly to `main`; always create/use a separate branch for changes and push that branch.
 - Use TDD methodology for changes and new features: write/update failing tests first, implement the minimal fix to pass, then refactor with tests green.
 - Keep terminology consistent: use `Simulation`, `Site`, `Library`, `Path`, and `Channel` terms across UI and docs.
+- Do not introduce hardcoded UI colors in code; use existing theme variables/tokens. If a new semantic color is truly required, define it in the shared theme system first.
 - Icon accessibility rule: every UI icon must include accessible text. For icon-only controls, require an explicit `aria-label` on the interactive element (and matching `title` where applicable). Decorative inline icons should be `aria-hidden="true"`.
 - Any modal/popover that can open on top of another dialog must use `tier="raised"` in `ModalOverlay`.
 - When catching UI errors, use `getUiErrorMessage()` from `src/lib/uiError.ts` for consistent messaging.

--- a/src/components/LinkProfileChart.tsx
+++ b/src/components/LinkProfileChart.tsx
@@ -61,7 +61,7 @@ export function LinkProfileChart({
 }: LinkProfileChartProps) {
   const chartHostRef = useRef<HTMLDivElement | null>(null);
   const segmentStateCacheRef = useRef<Map<string, PassFailState[]>>(new Map());
-  const [chartSize, setChartSize] = useState({ width: 1200, height: 190 });
+  const [chartSize, setChartSize] = useState({ width: 1, height: 1 });
   const [terrainSegmentStates, setTerrainSegmentStates] = useState<PassFailState[]>([]);
   const [hoverPosition, setHoverPosition] = useState<{ x: number; y: number } | null>(null);
   const chartWidth = chartSize.width;
@@ -225,8 +225,8 @@ export function LinkProfileChart({
     const element = chartHostRef.current;
     if (!element) return;
     const updateSize = () => {
-      const nextWidth = Math.max(480, Math.round(element.clientWidth));
-      const nextHeight = Math.max(150, Math.round(element.clientHeight));
+      const nextWidth = Math.max(220, Math.round(element.clientWidth));
+      const nextHeight = Math.max(140, Math.round(element.clientHeight));
       setChartSize((current) =>
         Math.abs(current.width - nextWidth) > 1 || Math.abs(current.height - nextHeight) > 1
           ? { width: nextWidth, height: nextHeight }
@@ -272,6 +272,10 @@ export function LinkProfileChart({
 
     const x = scaleLinear().domain(safeDistanceDomain).range([M.l, chartWidth - M.r]);
     const y = scaleLinear().domain([safeElevMin - 5, adjustedMax + 5]).range([chartHeight - M.b, M.t]);
+    const chartInnerWidth = Math.max(1, chartWidth - M.l - M.r);
+    const chartInnerHeight = Math.max(1, chartHeight - M.t - M.b);
+    const xTickCount = clamp(Math.round(chartInnerWidth / 140) + 1, 3, 10);
+    const yTickCount = clamp(Math.round(chartInnerHeight / 72) + 1, 3, 7);
 
     const terrainPoints = profile.map((p) => ({ x: x(p.distanceKm), y: y(p.terrainM) }));
     const terrainLineSegments = terrainPoints.slice(1).map((point, i) => ({
@@ -286,18 +290,20 @@ export function LinkProfileChart({
       terrainPath: `${linePath(terrainPoints)} L${chartWidth - M.r},${chartHeight - M.b} L${M.l},${chartHeight - M.b} Z`,
       terrainStrokePath: linePath(terrainPoints),
       terrainLineSegments,
-      yTicks: Array.from({ length: 5 }, (_, i) => {
-        const value = safeElevMin - 5 + ((adjustedMax - safeElevMin + 10) * i) / 4;
+      yTicks: Array.from({ length: yTickCount }, (_, i) => {
+        const value =
+          safeElevMin - 5 + ((adjustedMax - safeElevMin + 10) * i) / Math.max(1, yTickCount - 1);
         return { value, py: y(value) };
       }),
-      xTicks: Array.from({ length: 6 }, (_, i) => {
+      xTicks: Array.from({ length: xTickCount }, (_, i) => {
         const value =
           safeDistanceDomain[0] +
-          ((safeDistanceDomain[1] - safeDistanceDomain[0]) * i) / 5;
+          ((safeDistanceDomain[1] - safeDistanceDomain[0]) * i) / Math.max(1, xTickCount - 1);
         return {
           value,
           px: x(value),
-          anchor: (i === 0 ? "start" : i === 5 ? "end" : "middle") as "start" | "middle" | "end",
+          anchor:
+            (i === 0 ? "start" : i === xTickCount - 1 ? "end" : "middle") as "start" | "middle" | "end",
         };
       }),
     };


### PR DESCRIPTION
## Summary
- fix profile chart clipping/non-resize behavior by removing too-large minimum chart dimensions
- make chart geometry respond to panel width/height changes (including panel hide/show and profile expand)
- keep text and stroke widths visually stable (no whole-SVG scaling)
- make tick density adaptive to available chart space
- add AGENTS rule: no hardcoded UI colors; use theme tokens

## Verification
- `npm run test -- --run src/lib/profileChartSvg.test.ts src/lib/selectionEffectiveLink.test.ts`
- `npm run build`
