### PR TITLE
fix: follow-up for #221 override persistence and #108 chart sizing

### DIFF
--- a/src/components/LinkProfileChart.tsx
+++ b/src/components/LinkProfileChart.tsx
@@ -61,7 +61,7 @@ export function LinkProfileChart({
 }: LinkProfileChartProps) {
   const chartHostRef = useRef<HTMLDivElement | null>(null);
   const segmentStateCacheRef = useRef<Map<string, PassFailState[]>>(new Map());
-  const [chartSize, setChartSize] = useState({ width: 1, height: 1 });
+  const [chartSize, setChartSize] = useState({ width: 1200, height: 190 });
   const [terrainSegmentStates, setTerrainSegmentStates] = useState<PassFailState[]>([]);
   const [hoverPosition, setHoverPosition] = useState<{ x: number; y: number } | null>(null);
   const chartWidth = chartSize.width;
@@ -221,24 +221,44 @@ export function LinkProfileChart({
   }, [profile.length, selectedLinkId, temporaryDirectionReversed, setProfileCursorIndex]);
 
   useEffect(() => {
-    if (profile.length < 2) return;
     const element = chartHostRef.current;
     if (!element) return;
+
     const updateSize = () => {
-      const nextWidth = Math.max(220, Math.round(element.clientWidth));
-      const nextHeight = Math.max(140, Math.round(element.clientHeight));
+      const hostRect = element.getBoundingClientRect();
+      const parentRect = element.parentElement?.getBoundingClientRect();
+      const measuredWidth = Math.round(hostRect.width || parentRect?.width || 0);
+      const measuredHeight = Math.round(hostRect.height || parentRect?.height || 0);
+      const nextWidth = Math.max(220, measuredWidth);
+      const nextHeight = Math.max(140, measuredHeight);
       setChartSize((current) =>
         Math.abs(current.width - nextWidth) > 1 || Math.abs(current.height - nextHeight) > 1
           ? { width: nextWidth, height: nextHeight }
           : current,
       );
     };
+
     updateSize();
-    if (typeof ResizeObserver === "undefined") return;
-    const observer = new ResizeObserver(() => updateSize());
+    const rafId = requestAnimationFrame(updateSize);
+    window.addEventListener("resize", updateSize);
+
+    if (typeof ResizeObserver === "undefined") {
+      return () => {
+        cancelAnimationFrame(rafId);
+        window.removeEventListener("resize", updateSize);
+      };
+    }
+
+    const observer = new ResizeObserver(updateSize);
     observer.observe(element);
-    return () => observer.disconnect();
-  }, [profile.length]);
+    if (element.parentElement) observer.observe(element.parentElement);
+
+    return () => {
+      cancelAnimationFrame(rafId);
+      window.removeEventListener("resize", updateSize);
+      observer.disconnect();
+    };
+  }, [isExpanded, profile.length]);
 
   const geometry = useMemo(() => {
     if (profile.length < 2) {

--- a/src/lib/linkRadio.test.ts
+++ b/src/lib/linkRadio.test.ts
@@ -53,7 +53,7 @@ describe("stripRedundantLinkRadioOverrides", () => {
     expect(result.cableLossDb).toBe(0.2);
   });
 
-  it("removes overrides when values match Site defaults", () => {
+  it("keeps explicit overrides when values match Site defaults", () => {
     const result = stripRedundantLinkRadioOverrides(
       {
         ...baseLink,
@@ -66,9 +66,9 @@ describe("stripRedundantLinkRadioOverrides", () => {
       toSite,
     );
 
-    expect(result.txPowerDbm).toBeUndefined();
-    expect(result.txGainDbi).toBeUndefined();
-    expect(result.rxGainDbi).toBeUndefined();
-    expect(result.cableLossDb).toBeUndefined();
+    expect(result.txPowerDbm).toBe(fromSite.txPowerDbm);
+    expect(result.txGainDbi).toBe(fromSite.txGainDbi);
+    expect(result.rxGainDbi).toBe(toSite.rxGainDbi);
+    expect(result.cableLossDb).toBe(fromSite.cableLossDb);
   });
 });

--- a/src/lib/linkRadio.ts
+++ b/src/lib/linkRadio.ts
@@ -31,8 +31,6 @@ const pickModeNumber = (values: number[]): number | null => {
   return bestValue;
 };
 
-const sameNumber = (a: number, b: number): boolean => Math.abs(a - b) < 1e-9;
-
 export const withSiteRadioDefaults = (site: Site): Site => ({
   ...site,
   txPowerDbm:
@@ -69,30 +67,14 @@ export const stripRedundantLinkRadioOverrides = (
   fromSite?: Site | null,
   toSite?: Site | null,
 ): Link => {
-  const baseline = {
-    txPowerDbm: fromSite?.txPowerDbm ?? STANDARD_SITE_RADIO.txPowerDbm,
-    txGainDbi: fromSite?.txGainDbi ?? STANDARD_SITE_RADIO.txGainDbi,
-    rxGainDbi: toSite?.rxGainDbi ?? STANDARD_SITE_RADIO.rxGainDbi,
-    cableLossDb: fromSite?.cableLossDb ?? STANDARD_SITE_RADIO.cableLossDb,
-  };
+  void fromSite;
+  void toSite;
   return {
     ...link,
-    txPowerDbm:
-      typeof link.txPowerDbm === "number" && !sameNumber(link.txPowerDbm, baseline.txPowerDbm)
-        ? link.txPowerDbm
-        : undefined,
-    txGainDbi:
-      typeof link.txGainDbi === "number" && !sameNumber(link.txGainDbi, baseline.txGainDbi)
-        ? link.txGainDbi
-        : undefined,
-    rxGainDbi:
-      typeof link.rxGainDbi === "number" && !sameNumber(link.rxGainDbi, baseline.rxGainDbi)
-        ? link.rxGainDbi
-        : undefined,
-    cableLossDb:
-      typeof link.cableLossDb === "number" && !sameNumber(link.cableLossDb, baseline.cableLossDb)
-        ? link.cableLossDb
-        : undefined,
+    txPowerDbm: typeof link.txPowerDbm === "number" ? link.txPowerDbm : undefined,
+    txGainDbi: typeof link.txGainDbi === "number" ? link.txGainDbi : undefined,
+    rxGainDbi: typeof link.rxGainDbi === "number" ? link.rxGainDbi : undefined,
+    cableLossDb: typeof link.cableLossDb === "number" ? link.cableLossDb : undefined,
   };
 };
 


### PR DESCRIPTION
## Summary
- persist explicit Path radio overrides even when values equal inherited Site defaults
- stabilize Link profile chart sizing by measuring host/parent bounds and reacting to resize changes

## Verification
- npm test
- npm run test -- --run src/lib/linkRadio.test.ts src/store/appStore.test.ts src/lib/profileChartSvg.test.ts src/lib/selectionEffectiveLink.test.ts
- npm run build

## Issues
- Closes #221
- Follow-up for #108