### PR TITLE
fix: debounce path override autosave and improve chart load sizing

### DIFF
--- a/src/components/LinkProfileChart.tsx
+++ b/src/components/LinkProfileChart.tsx
@@ -2,7 +2,7 @@ import { extent, max } from "d3-array";
 import { scaleLinear } from "d3-scale";
 import { ArrowLeftRight, Maximize2, Minimize2 } from "lucide-react";
 import type { MouseEvent } from "react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
 import {
   classifyPassFailState,
@@ -220,7 +220,7 @@ export function LinkProfileChart({
     setProfileCursorIndex(profile.length - 1);
   }, [profile.length, selectedLinkId, temporaryDirectionReversed, setProfileCursorIndex]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const element = chartHostRef.current;
     if (!element) return;
 
@@ -239,12 +239,18 @@ export function LinkProfileChart({
     };
 
     updateSize();
-    const rafId = requestAnimationFrame(updateSize);
+    const rafIdA = requestAnimationFrame(updateSize);
+    const rafIdB = requestAnimationFrame(() => requestAnimationFrame(updateSize));
+    const followUpTimerA = window.setTimeout(updateSize, 120);
+    const followUpTimerB = window.setTimeout(updateSize, 280);
     window.addEventListener("resize", updateSize);
 
     if (typeof ResizeObserver === "undefined") {
       return () => {
-        cancelAnimationFrame(rafId);
+        cancelAnimationFrame(rafIdA);
+        cancelAnimationFrame(rafIdB);
+        window.clearTimeout(followUpTimerA);
+        window.clearTimeout(followUpTimerB);
         window.removeEventListener("resize", updateSize);
       };
     }
@@ -252,9 +258,16 @@ export function LinkProfileChart({
     const observer = new ResizeObserver(updateSize);
     observer.observe(element);
     if (element.parentElement) observer.observe(element.parentElement);
+    const chartPanel = element.closest(".chart-panel");
+    if (chartPanel instanceof HTMLElement) observer.observe(chartPanel);
+    const workspacePanel = element.closest(".workspace-panel");
+    if (workspacePanel instanceof HTMLElement) observer.observe(workspacePanel);
 
     return () => {
-      cancelAnimationFrame(rafId);
+      cancelAnimationFrame(rafIdA);
+      cancelAnimationFrame(rafIdB);
+      window.clearTimeout(followUpTimerA);
+      window.clearTimeout(followUpTimerB);
       window.removeEventListener("resize", updateSize);
       observer.disconnect();
     };

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -68,6 +68,7 @@ const parseNumber = (value: string): number => {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : 0;
 };
+const PATH_MODAL_AUTOSAVE_DEBOUNCE_MS = 350;
 
 const normalizeAccessVisibility = (value: unknown): "private" | "public" | "shared" => {
   if (value === "shared" || value === "public_write") return "shared";
@@ -1027,6 +1028,8 @@ export function Sidebar({
     selectedSite,
     sites,
   });
+  const pathAutosaveTimerRef = useRef<number | null>(null);
+  const pendingPathAutosaveRef = useRef<NonNullable<LinkModalState> | null>(null);
 
   const persistEditedPathFromModal = (modal: LinkModalState) => {
     if (!modal || modal.mode !== "edit" || !modal.linkId) return;
@@ -1045,16 +1048,49 @@ export function Sidebar({
     });
   };
 
+  const flushPendingPathAutosave = () => {
+    if (pathAutosaveTimerRef.current !== null) {
+      window.clearTimeout(pathAutosaveTimerRef.current);
+      pathAutosaveTimerRef.current = null;
+    }
+    if (!pendingPathAutosaveRef.current) return;
+    persistEditedPathFromModal(pendingPathAutosaveRef.current);
+    pendingPathAutosaveRef.current = null;
+  };
+
+  const closeLinkModal = () => {
+    flushPendingPathAutosave();
+    setLinkModal(null);
+  };
+
   const setLinkModalWithAutosave = (updater: (current: NonNullable<LinkModalState>) => NonNullable<LinkModalState>) => {
     setLinkModal((current) => {
       if (!current) return current;
       const next = updater(current);
       if (next.mode === "edit" && next.linkId) {
-        queueMicrotask(() => persistEditedPathFromModal(next));
+        pendingPathAutosaveRef.current = next;
+        if (pathAutosaveTimerRef.current !== null) {
+          window.clearTimeout(pathAutosaveTimerRef.current);
+        }
+        pathAutosaveTimerRef.current = window.setTimeout(() => {
+          pathAutosaveTimerRef.current = null;
+          if (!pendingPathAutosaveRef.current) return;
+          persistEditedPathFromModal(pendingPathAutosaveRef.current);
+          pendingPathAutosaveRef.current = null;
+        }, PATH_MODAL_AUTOSAVE_DEBOUNCE_MS);
       }
       return next;
     });
   };
+
+  useEffect(
+    () => () => {
+      if (pathAutosaveTimerRef.current !== null) {
+        window.clearTimeout(pathAutosaveTimerRef.current);
+      }
+    },
+    [],
+  );
 
   const saveLinkModal = () => {
     if (!linkModal) return;
@@ -1953,11 +1989,11 @@ export function Sidebar({
       </section>
 
       {linkModal ? (
-        <ModalOverlay aria-label={linkModal.mode === "add" ? "Add Path" : "Edit Path"} onClose={() => setLinkModal(null)} tier="raised">
+        <ModalOverlay aria-label={linkModal.mode === "add" ? "Add Path" : "Edit Path"} onClose={closeLinkModal} tier="raised">
           <div className="library-manager-card user-profile-popup">
             <div className="library-manager-header">
               <h2>{linkModal.mode === "add" ? "Add Path" : "Edit Path"}</h2>
-              <button aria-label="Close" className="inline-action inline-action-icon" onClick={() => setLinkModal(null)} title="Close" type="button">
+              <button aria-label="Close" className="inline-action inline-action-icon" onClick={closeLinkModal} title="Close" type="button">
                 <CircleX aria-hidden="true" strokeWidth={1.8} />
               </button>
             </div>


### PR DESCRIPTION
## Summary
- debounce Path modal auto-save in edit mode to avoid recalculation on every keystroke
- flush pending debounced save when closing Path modal
- harden initial profile chart sizing on page load with additional layout follow-up measurements

## Verification
- npm run test -- --run src/store/appStore.test.ts src/components/sidebar/useLibraryManager.test.ts src/lib/profileChartSvg.test.ts
- npm run build

## Issues
- Follow-up for #221
- Follow-up for #108