### PR TITLE
fix: 2s path autosave debounce and stronger chart startup sizing

### DIFF
--- a/src/components/LinkProfileChart.tsx
+++ b/src/components/LinkProfileChart.tsx
@@ -227,8 +227,24 @@ export function LinkProfileChart({
     const updateSize = () => {
       const hostRect = element.getBoundingClientRect();
       const parentRect = element.parentElement?.getBoundingClientRect();
-      const measuredWidth = Math.round(hostRect.width || parentRect?.width || 0);
-      const measuredHeight = Math.round(hostRect.height || parentRect?.height || 0);
+      const widthCandidates = [
+        hostRect.width,
+        element.clientWidth,
+        element.offsetWidth,
+        parentRect?.width ?? 0,
+        element.parentElement?.clientWidth ?? 0,
+        element.parentElement?.offsetWidth ?? 0,
+      ];
+      const heightCandidates = [
+        hostRect.height,
+        element.clientHeight,
+        element.offsetHeight,
+        parentRect?.height ?? 0,
+        element.parentElement?.clientHeight ?? 0,
+        element.parentElement?.offsetHeight ?? 0,
+      ];
+      const measuredWidth = Math.round(Math.max(...widthCandidates, 0));
+      const measuredHeight = Math.round(Math.max(...heightCandidates, 0));
       const nextWidth = Math.max(220, measuredWidth);
       const nextHeight = Math.max(140, measuredHeight);
       setChartSize((current) =>
@@ -243,6 +259,8 @@ export function LinkProfileChart({
     const rafIdB = requestAnimationFrame(() => requestAnimationFrame(updateSize));
     const followUpTimerA = window.setTimeout(updateSize, 120);
     const followUpTimerB = window.setTimeout(updateSize, 280);
+    const startupPollTimer = window.setInterval(updateSize, 120);
+    const startupPollStopTimer = window.setTimeout(() => window.clearInterval(startupPollTimer), 2600);
     window.addEventListener("resize", updateSize);
 
     if (typeof ResizeObserver === "undefined") {
@@ -251,6 +269,8 @@ export function LinkProfileChart({
         cancelAnimationFrame(rafIdB);
         window.clearTimeout(followUpTimerA);
         window.clearTimeout(followUpTimerB);
+        window.clearInterval(startupPollTimer);
+        window.clearTimeout(startupPollStopTimer);
         window.removeEventListener("resize", updateSize);
       };
     }
@@ -268,6 +288,8 @@ export function LinkProfileChart({
       cancelAnimationFrame(rafIdB);
       window.clearTimeout(followUpTimerA);
       window.clearTimeout(followUpTimerB);
+      window.clearInterval(startupPollTimer);
+      window.clearTimeout(startupPollStopTimer);
       window.removeEventListener("resize", updateSize);
       observer.disconnect();
     };

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -68,7 +68,7 @@ const parseNumber = (value: string): number => {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : 0;
 };
-const PATH_MODAL_AUTOSAVE_DEBOUNCE_MS = 350;
+const PATH_MODAL_AUTOSAVE_DEBOUNCE_MS = 2000;
 
 const normalizeAccessVisibility = (value: unknown): "private" | "public" | "shared" => {
   if (value === "shared" || value === "public_write") return "shared";


### PR DESCRIPTION
## Summary
- set Path modal edit autosave debounce to 2000ms
- harden profile chart startup sizing by widening measurement sources and adding short startup re-measure polling window

## Verification
- npm run test -- --run src/store/appStore.test.ts src/components/sidebar/useLibraryManager.test.ts src/lib/profileChartSvg.test.ts
- npm run build

## Issues
- Follow-up for #221
- Follow-up for #108