### PR TITLE
fix: recover chart sizing regression from #468

### DIFF
--- a/src/components/LinkProfileChart.tsx
+++ b/src/components/LinkProfileChart.tsx
@@ -227,24 +227,8 @@ export function LinkProfileChart({
     const updateSize = () => {
       const hostRect = element.getBoundingClientRect();
       const parentRect = element.parentElement?.getBoundingClientRect();
-      const widthCandidates = [
-        hostRect.width,
-        element.clientWidth,
-        element.offsetWidth,
-        parentRect?.width ?? 0,
-        element.parentElement?.clientWidth ?? 0,
-        element.parentElement?.offsetWidth ?? 0,
-      ];
-      const heightCandidates = [
-        hostRect.height,
-        element.clientHeight,
-        element.offsetHeight,
-        parentRect?.height ?? 0,
-        element.parentElement?.clientHeight ?? 0,
-        element.parentElement?.offsetHeight ?? 0,
-      ];
-      const measuredWidth = Math.round(Math.max(...widthCandidates, 0));
-      const measuredHeight = Math.round(Math.max(...heightCandidates, 0));
+      const measuredWidth = Math.round(hostRect.width || parentRect?.width || 0);
+      const measuredHeight = Math.round(hostRect.height || parentRect?.height || 0);
       const nextWidth = Math.max(220, measuredWidth);
       const nextHeight = Math.max(140, measuredHeight);
       setChartSize((current) =>
@@ -259,8 +243,8 @@ export function LinkProfileChart({
     const rafIdB = requestAnimationFrame(() => requestAnimationFrame(updateSize));
     const followUpTimerA = window.setTimeout(updateSize, 120);
     const followUpTimerB = window.setTimeout(updateSize, 280);
-    const startupPollTimer = window.setInterval(updateSize, 120);
-    const startupPollStopTimer = window.setTimeout(() => window.clearInterval(startupPollTimer), 2600);
+    const followUpTimerC = window.setTimeout(updateSize, 1000);
+    const followUpTimerD = window.setTimeout(updateSize, 1800);
     window.addEventListener("resize", updateSize);
 
     if (typeof ResizeObserver === "undefined") {
@@ -269,8 +253,8 @@ export function LinkProfileChart({
         cancelAnimationFrame(rafIdB);
         window.clearTimeout(followUpTimerA);
         window.clearTimeout(followUpTimerB);
-        window.clearInterval(startupPollTimer);
-        window.clearTimeout(startupPollStopTimer);
+        window.clearTimeout(followUpTimerC);
+        window.clearTimeout(followUpTimerD);
         window.removeEventListener("resize", updateSize);
       };
     }
@@ -288,8 +272,8 @@ export function LinkProfileChart({
       cancelAnimationFrame(rafIdB);
       window.clearTimeout(followUpTimerA);
       window.clearTimeout(followUpTimerB);
-      window.clearInterval(startupPollTimer);
-      window.clearTimeout(startupPollStopTimer);
+      window.clearTimeout(followUpTimerC);
+      window.clearTimeout(followUpTimerD);
       window.removeEventListener("resize", updateSize);
       observer.disconnect();
     };


### PR DESCRIPTION
## Summary
- revert the aggressive startup sizing logic introduced in #468 that regressed chart behavior
- keep the previously stable sizing path and add two delayed startup remeasure passes (1.0s and 1.8s)

## Verification
- npm run test -- --run src/lib/profileChartSvg.test.ts src/store/appStore.test.ts
- npm run build

## Issues
- Follow-up for #108