### PR TITLE
debug: add profile chart sizing instrumentation for #108

### DIFF
--- a/src/components/LinkProfileChart.tsx
+++ b/src/components/LinkProfileChart.tsx
@@ -62,6 +62,7 @@ export function LinkProfileChart({
   const chartHostRef = useRef<HTMLDivElement | null>(null);
   const segmentStateCacheRef = useRef<Map<string, PassFailState[]>>(new Map());
   const [chartSize, setChartSize] = useState({ width: 1200, height: 190 });
+  const [debugSizing, setDebugSizing] = useState(false);
   const [terrainSegmentStates, setTerrainSegmentStates] = useState<PassFailState[]>([]);
   const [hoverPosition, setHoverPosition] = useState<{ x: number; y: number } | null>(null);
   const chartWidth = chartSize.width;
@@ -92,6 +93,21 @@ export function LinkProfileChart({
     (state) =>
       `${state.selectedScenarioId}|${state.selectedLinkId}|${state.links.length}|${state.sites.length}|${state.srtmTiles.length}|${Object.keys(state.siteDragPreview).length}`,
   );
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const localStorageEnabled = (() => {
+      try {
+        return window.localStorage.getItem("linksim-debug-profile-chart-sizing") === "1";
+      } catch {
+        return false;
+      }
+    })();
+    const runtimeEnabled =
+      (window as typeof window & { __LINKSIM_DEBUG_PROFILE_CHART_SIZING__?: boolean })
+        .__LINKSIM_DEBUG_PROFILE_CHART_SIZING__ === true;
+    setDebugSizing(localStorageEnabled || runtimeEnabled);
+  }, []);
   const baseProfile = getSelectedProfile();
   const selectedLink = links.find((link) => link.id === selectedLinkId) ?? null;
   const selectedSites = useMemo(
@@ -224,28 +240,59 @@ export function LinkProfileChart({
     const element = chartHostRef.current;
     if (!element) return;
 
-    const updateSize = () => {
+    const updateSize = (source: string) => {
       const hostRect = element.getBoundingClientRect();
       const parentRect = element.parentElement?.getBoundingClientRect();
       const measuredWidth = Math.round(hostRect.width || parentRect?.width || 0);
       const measuredHeight = Math.round(hostRect.height || parentRect?.height || 0);
       const nextWidth = Math.max(220, measuredWidth);
       const nextHeight = Math.max(140, measuredHeight);
-      setChartSize((current) =>
-        Math.abs(current.width - nextWidth) > 1 || Math.abs(current.height - nextHeight) > 1
-          ? { width: nextWidth, height: nextHeight }
-          : current,
-      );
+      setChartSize((current) => {
+        const changed =
+          Math.abs(current.width - nextWidth) > 1 || Math.abs(current.height - nextHeight) > 1;
+        const next = changed ? { width: nextWidth, height: nextHeight } : current;
+        if (debugSizing) {
+          const chartPanelRect = element.closest(".chart-panel")?.getBoundingClientRect();
+          const workspaceRect = element.closest(".workspace-panel")?.getBoundingClientRect();
+          console.info("[profile-chart-sizing]", {
+            source,
+            changed,
+            current,
+            next,
+            host: {
+              width: Math.round(hostRect.width),
+              height: Math.round(hostRect.height),
+              clientWidth: element.clientWidth,
+              clientHeight: element.clientHeight,
+              offsetWidth: element.offsetWidth,
+              offsetHeight: element.offsetHeight,
+            },
+            parent: parentRect
+              ? { width: Math.round(parentRect.width), height: Math.round(parentRect.height) }
+              : null,
+            chartPanel: chartPanelRect
+              ? { width: Math.round(chartPanelRect.width), height: Math.round(chartPanelRect.height) }
+              : null,
+            workspacePanel: workspaceRect
+              ? { width: Math.round(workspaceRect.width), height: Math.round(workspaceRect.height) }
+              : null,
+            profileLength: profile.length,
+            isExpanded,
+          });
+        }
+        return next;
+      });
     };
 
-    updateSize();
-    const rafIdA = requestAnimationFrame(updateSize);
-    const rafIdB = requestAnimationFrame(() => requestAnimationFrame(updateSize));
-    const followUpTimerA = window.setTimeout(updateSize, 120);
-    const followUpTimerB = window.setTimeout(updateSize, 280);
-    const followUpTimerC = window.setTimeout(updateSize, 1000);
-    const followUpTimerD = window.setTimeout(updateSize, 1800);
-    window.addEventListener("resize", updateSize);
+    updateSize("layout-effect-init");
+    const rafIdA = requestAnimationFrame(() => updateSize("raf-1"));
+    const rafIdB = requestAnimationFrame(() => requestAnimationFrame(() => updateSize("raf-2")));
+    const followUpTimerA = window.setTimeout(() => updateSize("timer-120ms"), 120);
+    const followUpTimerB = window.setTimeout(() => updateSize("timer-280ms"), 280);
+    const followUpTimerC = window.setTimeout(() => updateSize("timer-1000ms"), 1000);
+    const followUpTimerD = window.setTimeout(() => updateSize("timer-1800ms"), 1800);
+    const onWindowResize = () => updateSize("window-resize");
+    window.addEventListener("resize", onWindowResize);
 
     if (typeof ResizeObserver === "undefined") {
       return () => {
@@ -255,11 +302,11 @@ export function LinkProfileChart({
         window.clearTimeout(followUpTimerB);
         window.clearTimeout(followUpTimerC);
         window.clearTimeout(followUpTimerD);
-        window.removeEventListener("resize", updateSize);
+        window.removeEventListener("resize", onWindowResize);
       };
     }
 
-    const observer = new ResizeObserver(updateSize);
+    const observer = new ResizeObserver(() => updateSize("resize-observer"));
     observer.observe(element);
     if (element.parentElement) observer.observe(element.parentElement);
     const chartPanel = element.closest(".chart-panel");
@@ -274,10 +321,10 @@ export function LinkProfileChart({
       window.clearTimeout(followUpTimerB);
       window.clearTimeout(followUpTimerC);
       window.clearTimeout(followUpTimerD);
-      window.removeEventListener("resize", updateSize);
+      window.removeEventListener("resize", onWindowResize);
       observer.disconnect();
     };
-  }, [isExpanded, profile.length]);
+  }, [debugSizing, isExpanded, profile.length]);
 
   const geometry = useMemo(() => {
     if (profile.length < 2) {
@@ -722,7 +769,7 @@ export function LinkProfileChart({
   }
 
   return (
-    <section className={`chart-panel ${isExpanded ? "is-expanded" : ""}`} data-profile-revision={profileRevision}>
+    <section className={`chart-panel ${isExpanded ? "is-expanded" : ""} ${debugSizing ? "chart-panel-debug-sizing" : ""}`} data-profile-revision={profileRevision}>
       <div className="chart-top-row">
         <div className="chart-endpoints" aria-live="polite">
           <span className="chart-endpoint chart-endpoint-left">{fromSiteName}</span>
@@ -773,7 +820,7 @@ export function LinkProfileChart({
           <p>Path profile unavailable for the selected link.</p>
         </div>
       ) : (
-        <div className="chart-svg-wrap" ref={chartHostRef}>
+        <div className={`chart-svg-wrap ${debugSizing ? "chart-svg-wrap-debug-sizing" : ""}`} ref={chartHostRef}>
         <svg
           aria-label="Link profile"
           height={svgProps.height}

--- a/src/index.css
+++ b/src/index.css
@@ -1631,6 +1631,21 @@ input {
   position: relative;
 }
 
+.chart-panel-debug-sizing {
+  outline: 2px dashed var(--danger);
+  outline-offset: -2px;
+}
+
+.chart-panel-debug-sizing .chart-svg-wrap-debug-sizing {
+  outline: 2px dashed var(--accent);
+  outline-offset: -2px;
+}
+
+.chart-panel-debug-sizing .chart-svg-wrap-debug-sizing > svg {
+  outline: 2px dashed var(--success);
+  outline-offset: -2px;
+}
+
 .chart-header {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## Summary
- add source-tagged chart sizing debug logs in LinkProfileChart
- add optional visual outlines for chart containers to inspect layout chain
- gate all debug behavior behind opt-in runtime/localStorage flag

## How to enable
- in browser console: `localStorage.setItem('linksim-debug-profile-chart-sizing', '1'); location.reload();`
- disable: `localStorage.removeItem('linksim-debug-profile-chart-sizing'); location.reload();`

## Verification
- npm run test -- --run src/lib/profileChartSvg.test.ts src/store/appStore.test.ts
- npm run build

## Issues
- Follow-up for #108