### PR TITLE
fix(debug): force chart remeasure on panel-toggle pulses

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1242,11 +1242,19 @@ export function AppShell() {
     mobileActivePanel,
     mobileBottomPanelMode,
   ].join("|");
+  const emitProfileLayoutPulse = useCallback(() => {
+    if (typeof window === "undefined") return;
+    const fire = () => window.dispatchEvent(new CustomEvent("linksim-profile-layout-pulse"));
+    fire();
+    window.requestAnimationFrame(fire);
+    window.setTimeout(fire, 120);
+  }, []);
 
   const toggleProfileExpanded = () => {
     setIsMapExpanded(false);
     setMobileActivePanel("profile");
     setIsProfileExpanded((prev) => !prev);
+    emitProfileLayoutPulse();
   };
 
   const setMobileBottomPanelVisibility = useCallback((nextMode: MobileBottomPanelMode) => {
@@ -1467,7 +1475,10 @@ export function AppShell() {
             <button
               aria-label="Show Navigator panel"
               className="map-control-btn map-control-btn-icon collapsed-panel-btn collapsed-panel-btn-navigator"
-              onClick={() => setIsNavigatorHidden(false)}
+              onClick={() => {
+                setIsNavigatorHidden(false);
+                emitProfileLayoutPulse();
+              }}
               title="Show Navigator"
               type="button"
             >
@@ -1478,7 +1489,10 @@ export function AppShell() {
             <button
               aria-label="Show Inspector panel"
               className="map-control-btn map-control-btn-icon collapsed-panel-btn collapsed-panel-btn-inspector"
-              onClick={() => setIsInspectorHidden(false)}
+              onClick={() => {
+                setIsInspectorHidden(false);
+                emitProfileLayoutPulse();
+              }}
               title="Show Inspector"
               type="button"
             >
@@ -1489,7 +1503,10 @@ export function AppShell() {
             <button
               aria-label="Show Profile panel"
               className="map-control-btn map-control-btn-icon collapsed-panel-btn collapsed-panel-btn-profile"
-              onClick={() => setIsProfileHidden(false)}
+              onClick={() => {
+                setIsProfileHidden(false);
+                emitProfileLayoutPulse();
+              }}
               title="Show Profile"
               type="button"
             >
@@ -1511,7 +1528,10 @@ export function AppShell() {
                 <button
                   aria-label={isNavigatorHidden ? "Show Navigator panel" : "Hide Navigator panel"}
                   className="user-icon-button"
-                  onClick={() => setIsNavigatorHidden((prev) => !prev)}
+                  onClick={() => {
+                    setIsNavigatorHidden((prev) => !prev);
+                    emitProfileLayoutPulse();
+                  }}
                   title={isNavigatorHidden ? "Show Navigator" : "Hide Navigator"}
                   type="button"
                 >
@@ -1606,7 +1626,10 @@ export function AppShell() {
                 <button
                   aria-label={isInspectorHidden ? "Show Inspector panel" : "Hide Inspector panel"}
                   className="map-control-btn map-control-btn-icon"
-                  onClick={() => setIsInspectorHidden((prev) => !prev)}
+                  onClick={() => {
+                    setIsInspectorHidden((prev) => !prev);
+                    emitProfileLayoutPulse();
+                  }}
                   title={isInspectorHidden ? "Show Inspector" : "Hide Inspector"}
                   type="button"
                 >
@@ -1636,6 +1659,7 @@ export function AppShell() {
               setMobileBottomPanelVisibility("normal");
             }
             setIsMapExpanded((prev) => !prev);
+            emitProfileLayoutPulse();
           }}
           notice={
             appNotice
@@ -1682,6 +1706,7 @@ export function AppShell() {
                     if (next) setIsProfileExpanded(false);
                     return next;
                   });
+                  emitProfileLayoutPulse();
                 }}
                 title={isProfileHidden ? "Show Profile" : "Hide Profile"}
                 type="button"

--- a/src/components/LinkProfileChart.tsx
+++ b/src/components/LinkProfileChart.tsx
@@ -78,6 +78,7 @@ export function LinkProfileChart({
         .__LINKSIM_DEBUG_PROFILE_CHART_SIZING__ === true;
     return localStorageEnabled || runtimeEnabled;
   });
+  const [layoutPulseRevision, setLayoutPulseRevision] = useState(0);
   const [terrainSegmentStates, setTerrainSegmentStates] = useState<PassFailState[]>([]);
   const [hoverPosition, setHoverPosition] = useState<{ x: number; y: number } | null>(null);
   const chartWidth = chartSize.width;
@@ -108,6 +109,13 @@ export function LinkProfileChart({
     (state) =>
       `${state.selectedScenarioId}|${state.selectedLinkId}|${state.links.length}|${state.sites.length}|${state.srtmTiles.length}|${Object.keys(state.siteDragPreview).length}`,
   );
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onLayoutPulse = () => setLayoutPulseRevision((current) => current + 1);
+    window.addEventListener("linksim-profile-layout-pulse", onLayoutPulse);
+    return () => window.removeEventListener("linksim-profile-layout-pulse", onLayoutPulse);
+  }, []);
 
   const baseProfile = getSelectedProfile();
   const selectedLink = links.find((link) => link.id === selectedLinkId) ?? null;
@@ -364,7 +372,7 @@ export function LinkProfileChart({
       mutationObserver.disconnect();
       observer.disconnect();
     };
-  }, [debugSizing, isExpanded, layoutRevision, profile.length]);
+  }, [debugSizing, isExpanded, layoutPulseRevision, layoutRevision, profile.length]);
 
   const geometry = useMemo(() => {
     if (profile.length < 2) {


### PR DESCRIPTION
## Summary
- emit explicit profile-layout pulse events from panel toggle handlers in AppShell
- consume pulse events in LinkProfileChart and force remeasure cycle
- keep existing debug instrumentation for source traces

## Verification
- npm run test -- --run src/lib/profileChartSvg.test.ts src/store/appStore.test.ts
- npm run build

## Issues
- Follow-up for #108