### PR TITLE
Revert #474 to restore profile visibility baseline (#108)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1232,10 +1232,29 @@ export function AppShell() {
   ]);
   const isAnonymousBootstrapShell = accessState === "checking";
   const isReadOnlyShell = isAnonymousGuestReadonly || isAnonymousBootstrapShell;
+  const profileChartLayoutRevision = [
+    isMobileViewport ? "mobile" : "desktop",
+    isMapExpanded ? "map-expanded" : "map-normal",
+    isProfileExpanded ? "profile-expanded" : "profile-normal",
+    isNavigatorHidden ? "nav-hidden" : "nav-visible",
+    isInspectorHidden ? "inspector-hidden" : "inspector-visible",
+    isProfileHidden ? "profile-hidden" : "profile-visible",
+    mobileActivePanel,
+    mobileBottomPanelMode,
+  ].join("|");
+  const emitProfileLayoutPulse = useCallback(() => {
+    if (typeof window === "undefined") return;
+    const fire = () => window.dispatchEvent(new CustomEvent("linksim-profile-layout-pulse"));
+    fire();
+    window.requestAnimationFrame(fire);
+    window.setTimeout(fire, 120);
+  }, []);
+
   const toggleProfileExpanded = () => {
     setIsMapExpanded(false);
     setMobileActivePanel("profile");
     setIsProfileExpanded((prev) => !prev);
+    emitProfileLayoutPulse();
   };
 
   const setMobileBottomPanelVisibility = useCallback((nextMode: MobileBottomPanelMode) => {
@@ -1456,7 +1475,10 @@ export function AppShell() {
             <button
               aria-label="Show Navigator panel"
               className="map-control-btn map-control-btn-icon collapsed-panel-btn collapsed-panel-btn-navigator"
-              onClick={() => setIsNavigatorHidden(false)}
+              onClick={() => {
+                setIsNavigatorHidden(false);
+                emitProfileLayoutPulse();
+              }}
               title="Show Navigator"
               type="button"
             >
@@ -1467,7 +1489,10 @@ export function AppShell() {
             <button
               aria-label="Show Inspector panel"
               className="map-control-btn map-control-btn-icon collapsed-panel-btn collapsed-panel-btn-inspector"
-              onClick={() => setIsInspectorHidden(false)}
+              onClick={() => {
+                setIsInspectorHidden(false);
+                emitProfileLayoutPulse();
+              }}
               title="Show Inspector"
               type="button"
             >
@@ -1478,7 +1503,10 @@ export function AppShell() {
             <button
               aria-label="Show Profile panel"
               className="map-control-btn map-control-btn-icon collapsed-panel-btn collapsed-panel-btn-profile"
-              onClick={() => setIsProfileHidden(false)}
+              onClick={() => {
+                setIsProfileHidden(false);
+                emitProfileLayoutPulse();
+              }}
               title="Show Profile"
               type="button"
             >
@@ -1500,7 +1528,10 @@ export function AppShell() {
                 <button
                   aria-label={isNavigatorHidden ? "Show Navigator panel" : "Hide Navigator panel"}
                   className="user-icon-button"
-                  onClick={() => setIsNavigatorHidden((prev) => !prev)}
+                  onClick={() => {
+                    setIsNavigatorHidden((prev) => !prev);
+                    emitProfileLayoutPulse();
+                  }}
                   title={isNavigatorHidden ? "Show Navigator" : "Hide Navigator"}
                   type="button"
                 >
@@ -1595,7 +1626,10 @@ export function AppShell() {
                 <button
                   aria-label={isInspectorHidden ? "Show Inspector panel" : "Hide Inspector panel"}
                   className="map-control-btn map-control-btn-icon"
-                  onClick={() => setIsInspectorHidden((prev) => !prev)}
+                  onClick={() => {
+                    setIsInspectorHidden((prev) => !prev);
+                    emitProfileLayoutPulse();
+                  }}
                   title={isInspectorHidden ? "Show Inspector" : "Hide Inspector"}
                   type="button"
                 >
@@ -1625,6 +1659,7 @@ export function AppShell() {
               setMobileBottomPanelVisibility("normal");
             }
             setIsMapExpanded((prev) => !prev);
+            emitProfileLayoutPulse();
           }}
           notice={
             appNotice
@@ -1659,6 +1694,7 @@ export function AppShell() {
         {!isMobileViewport && !isMapExpanded && !isProfileHidden ? (
           <LinkProfileChart
             isExpanded={isProfileExpanded}
+            layoutRevision={profileChartLayoutRevision}
             onToggleExpanded={toggleProfileExpanded}
             rowControls={
               <button
@@ -1670,6 +1706,7 @@ export function AppShell() {
                     if (next) setIsProfileExpanded(false);
                     return next;
                   });
+                  emitProfileLayoutPulse();
                 }}
                 title={isProfileHidden ? "Show Profile" : "Hide Profile"}
                 type="button"
@@ -1689,6 +1726,7 @@ export function AppShell() {
           >
             <LinkProfileChart
               isExpanded={mobileBottomPanelMode === "full"}
+              layoutRevision={profileChartLayoutRevision}
               onToggleExpanded={toggleProfileExpanded}
               rowControls={panelSizeControls("Profile", "chart")}
               showExpandToggle={false}

--- a/src/components/LinkProfileChart.tsx
+++ b/src/components/LinkProfileChart.tsx
@@ -51,6 +51,7 @@ type LinkProfileChartProps = {
   onToggleExpanded: () => void;
   showExpandToggle?: boolean;
   rowControls?: ReactNode;
+  layoutRevision?: string;
 };
 
 export function LinkProfileChart({
@@ -58,14 +59,30 @@ export function LinkProfileChart({
   onToggleExpanded,
   showExpandToggle = true,
   rowControls,
+  layoutRevision = "",
 }: LinkProfileChartProps) {
   const chartHostRef = useRef<HTMLDivElement | null>(null);
   const segmentStateCacheRef = useRef<Map<string, PassFailState[]>>(new Map());
-  const [chartSize, setChartSize] = useState<{ width: number; height: number } | null>(null);
+  const [chartSize, setChartSize] = useState({ width: 1200, height: 190 });
+  const [debugSizing] = useState(() => {
+    if (typeof window === "undefined") return false;
+    const localStorageEnabled = (() => {
+      try {
+        return window.localStorage.getItem("linksim-debug-profile-chart-sizing") === "1";
+      } catch {
+        return false;
+      }
+    })();
+    const runtimeEnabled =
+      (window as typeof window & { __LINKSIM_DEBUG_PROFILE_CHART_SIZING__?: boolean })
+        .__LINKSIM_DEBUG_PROFILE_CHART_SIZING__ === true;
+    return localStorageEnabled || runtimeEnabled;
+  });
+  const [layoutPulseRevision, setLayoutPulseRevision] = useState(0);
   const [terrainSegmentStates, setTerrainSegmentStates] = useState<PassFailState[]>([]);
   const [hoverPosition, setHoverPosition] = useState<{ x: number; y: number } | null>(null);
-  const chartWidth = chartSize?.width ?? 220;
-  const chartHeight = chartSize?.height ?? 150;
+  const chartWidth = chartSize.width;
+  const chartHeight = chartSize.height;
   const sites = useAppStore((state) => state.sites);
   const links = useAppStore((state) => state.links);
   const selectedLinkId = useAppStore((state) => state.selectedLinkId);
@@ -92,6 +109,13 @@ export function LinkProfileChart({
     (state) =>
       `${state.selectedScenarioId}|${state.selectedLinkId}|${state.links.length}|${state.sites.length}|${state.srtmTiles.length}|${Object.keys(state.siteDragPreview).length}`,
   );
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onLayoutPulse = () => setLayoutPulseRevision((current) => current + 1);
+    window.addEventListener("linksim-profile-layout-pulse", onLayoutPulse);
+    return () => window.removeEventListener("linksim-profile-layout-pulse", onLayoutPulse);
+  }, []);
 
   const baseProfile = getSelectedProfile();
   const selectedLink = links.find((link) => link.id === selectedLinkId) ?? null;
@@ -225,36 +249,130 @@ export function LinkProfileChart({
     const element = chartHostRef.current;
     if (!element) return;
 
-    const commitSize = (width: number, height: number) => {
-      if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) return;
-      const nextWidth = Math.max(220, Math.round(width));
-      const nextHeight = Math.max(140, Math.round(height));
+    const updateSize = (source: string) => {
+      const hostRect = element.getBoundingClientRect();
+      const parentRect = element.parentElement?.getBoundingClientRect();
+      const measuredWidth = Math.round(hostRect.width || parentRect?.width || 0);
+      const measuredHeight = Math.round(hostRect.height || parentRect?.height || 0);
+      const nextWidth = Math.max(220, measuredWidth);
+      const nextHeight = Math.max(140, measuredHeight);
       setChartSize((current) => {
-        if (
-          current &&
-          Math.abs(current.width - nextWidth) <= 1 &&
-          Math.abs(current.height - nextHeight) <= 1
-        ) {
-          return current;
+        const changed =
+          Math.abs(current.width - nextWidth) > 1 || Math.abs(current.height - nextHeight) > 1;
+        const next = changed ? { width: nextWidth, height: nextHeight } : current;
+        if (debugSizing) {
+          const chartPanelRect = element.closest(".chart-panel")?.getBoundingClientRect();
+          const workspaceRect = element.closest(".workspace-panel")?.getBoundingClientRect();
+          console.info("[profile-chart-sizing]", {
+            source,
+            changed,
+            current,
+            next,
+            host: {
+              width: Math.round(hostRect.width),
+              height: Math.round(hostRect.height),
+              clientWidth: element.clientWidth,
+              clientHeight: element.clientHeight,
+              offsetWidth: element.offsetWidth,
+              offsetHeight: element.offsetHeight,
+            },
+            parent: parentRect
+              ? { width: Math.round(parentRect.width), height: Math.round(parentRect.height) }
+              : null,
+            chartPanel: chartPanelRect
+              ? { width: Math.round(chartPanelRect.width), height: Math.round(chartPanelRect.height) }
+              : null,
+            workspacePanel: workspaceRect
+              ? { width: Math.round(workspaceRect.width), height: Math.round(workspaceRect.height) }
+              : null,
+            profileLength: profile.length,
+            isExpanded,
+          });
         }
-        return { width: nextWidth, height: nextHeight };
+        return next;
       });
     };
 
-    const hostRect = element.getBoundingClientRect();
-    commitSize(hostRect.width, hostRect.height);
+    updateSize("layout-effect-init");
+    const rafIdA = requestAnimationFrame(() => updateSize("raf-1"));
+    const rafIdB = requestAnimationFrame(() => requestAnimationFrame(() => updateSize("raf-2")));
+    const followUpTimerA = window.setTimeout(() => updateSize("timer-120ms"), 120);
+    const followUpTimerB = window.setTimeout(() => updateSize("timer-280ms"), 280);
+    const followUpTimerC = window.setTimeout(() => updateSize("timer-1000ms"), 1000);
+    const followUpTimerD = window.setTimeout(() => updateSize("timer-1800ms"), 1800);
+    const onWindowResize = () => updateSize("window-resize");
+    window.addEventListener("resize", onWindowResize);
 
-    if (typeof ResizeObserver === "undefined") return;
+    const appShell = element.closest(".app-shell");
+    const workspacePanelElement = element.closest(".workspace-panel");
+    const onTransitionEnd = (event: Event) => {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+      if (
+        target.closest(".workspace-panel") ||
+        target.closest(".map-inspector") ||
+        target.closest(".chart-panel")
+      ) {
+        updateSize("transition-end");
+      }
+    };
+    window.addEventListener("transitionend", onTransitionEnd, true);
 
-    const observer = new ResizeObserver((entries) => {
-      const entry = entries[0];
-      if (!entry) return;
-      commitSize(entry.contentRect.width, entry.contentRect.height);
+    const mutationObserver = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        if (mutation.type === "attributes") {
+          updateSize("class-mutation");
+          break;
+        }
+      }
     });
-    observer.observe(element);
+    if (appShell) {
+      mutationObserver.observe(appShell, {
+        attributes: true,
+        attributeFilter: ["class", "style"],
+      });
+    }
+    if (workspacePanelElement) {
+      mutationObserver.observe(workspacePanelElement, {
+        attributes: true,
+        attributeFilter: ["class", "style"],
+      });
+    }
 
-    return () => observer.disconnect();
-  }, [profile.length]);
+    if (typeof ResizeObserver === "undefined") {
+      return () => {
+        cancelAnimationFrame(rafIdA);
+        cancelAnimationFrame(rafIdB);
+        window.clearTimeout(followUpTimerA);
+        window.clearTimeout(followUpTimerB);
+        window.clearTimeout(followUpTimerC);
+        window.clearTimeout(followUpTimerD);
+        window.removeEventListener("resize", onWindowResize);
+        window.removeEventListener("transitionend", onTransitionEnd, true);
+        mutationObserver.disconnect();
+      };
+    }
+
+    const observer = new ResizeObserver(() => updateSize("resize-observer"));
+    observer.observe(element);
+    if (element.parentElement) observer.observe(element.parentElement);
+    const chartPanel = element.closest(".chart-panel");
+    if (chartPanel instanceof HTMLElement) observer.observe(chartPanel);
+    if (workspacePanelElement instanceof HTMLElement) observer.observe(workspacePanelElement);
+
+    return () => {
+      cancelAnimationFrame(rafIdA);
+      cancelAnimationFrame(rafIdB);
+      window.clearTimeout(followUpTimerA);
+      window.clearTimeout(followUpTimerB);
+      window.clearTimeout(followUpTimerC);
+      window.clearTimeout(followUpTimerD);
+      window.removeEventListener("resize", onWindowResize);
+      window.removeEventListener("transitionend", onTransitionEnd, true);
+      mutationObserver.disconnect();
+      observer.disconnect();
+    };
+  }, [debugSizing, isExpanded, layoutPulseRevision, layoutRevision, profile.length]);
 
   const geometry = useMemo(() => {
     if (profile.length < 2) {
@@ -699,7 +817,7 @@ export function LinkProfileChart({
   }
 
   return (
-    <section className={`chart-panel ${isExpanded ? "is-expanded" : ""}`} data-profile-revision={profileRevision}>
+    <section className={`chart-panel ${isExpanded ? "is-expanded" : ""} ${debugSizing ? "chart-panel-debug-sizing" : ""}`} data-profile-revision={profileRevision}>
       <div className="chart-top-row">
         <div className="chart-endpoints" aria-live="polite">
           <span className="chart-endpoint chart-endpoint-left">{fromSiteName}</span>
@@ -750,9 +868,13 @@ export function LinkProfileChart({
           <p>Path profile unavailable for the selected link.</p>
         </div>
       ) : (
-        <div className="chart-svg-wrap" ref={chartHostRef}>
-        {chartSize ? (
-        <svg aria-label="Link profile" height={svgProps.height} role="img" width={svgProps.width}>
+        <div className={`chart-svg-wrap ${debugSizing ? "chart-svg-wrap-debug-sizing" : ""}`} ref={chartHostRef}>
+        <svg
+          aria-label="Link profile"
+          height={svgProps.height}
+          role="img"
+          width={svgProps.width}
+        >
           <defs>
             <linearGradient
               gradientUnits="userSpaceOnUse"
@@ -834,7 +956,6 @@ export function LinkProfileChart({
             onMouseLeave={onSvgLeave}
           />
         </svg>
-        ) : null}
         {splitHoverPopoverPosition && cursorStates && cursorStates.length > 1 ? (
           <div
             className="chart-hover-popover"

--- a/src/index.css
+++ b/src/index.css
@@ -1631,6 +1631,21 @@ input {
   position: relative;
 }
 
+.chart-panel-debug-sizing {
+  outline: 2px dashed var(--danger);
+  outline-offset: -2px;
+}
+
+.chart-panel-debug-sizing .chart-svg-wrap-debug-sizing {
+  outline: 2px dashed var(--accent);
+  outline-offset: -2px;
+}
+
+.chart-panel-debug-sizing .chart-svg-wrap-debug-sizing > svg {
+  outline: 2px dashed var(--success);
+  outline-offset: -2px;
+}
+
 .chart-header {
   display: flex;
   justify-content: space-between;
@@ -1684,6 +1699,8 @@ input {
 
 .chart-panel svg {
   display: block;
+  width: 100%;
+  height: 100%;
   min-height: 150px;
   max-height: 240px;
 }


### PR DESCRIPTION
## Summary
- Revert commit `c6edc42` (`#474`) because it caused the profile/chart to become invisible in staging.
- Restore pre-#474 behavior as a safe baseline before continuing sizing/debugging work for #108.

## Scope
- Revert only; no new behavior introduced.
- Staging-only correction pass.

## Verification
- Confirm profile/chart is visible again on staging.

Closes: #108 (baseline restore only; follow-up sizing work remains in issue discussion).