### PR TITLE
Fix profile startup clipping by waiting for measured chart size (#108)

### DIFF
--- a/src/components/LinkProfileChart.tsx
+++ b/src/components/LinkProfileChart.tsx
@@ -63,7 +63,7 @@ export function LinkProfileChart({
 }: LinkProfileChartProps) {
   const chartHostRef = useRef<HTMLDivElement | null>(null);
   const segmentStateCacheRef = useRef<Map<string, PassFailState[]>>(new Map());
-  const [chartSize, setChartSize] = useState({ width: 1200, height: 190 });
+  const [chartSize, setChartSize] = useState<{ width: number; height: number } | null>(null);
   const [debugSizing] = useState(() => {
     if (typeof window === "undefined") return false;
     const localStorageEnabled = (() => {
@@ -81,8 +81,8 @@ export function LinkProfileChart({
   const [layoutPulseRevision, setLayoutPulseRevision] = useState(0);
   const [terrainSegmentStates, setTerrainSegmentStates] = useState<PassFailState[]>([]);
   const [hoverPosition, setHoverPosition] = useState<{ x: number; y: number } | null>(null);
-  const chartWidth = chartSize.width;
-  const chartHeight = chartSize.height;
+  const chartWidth = chartSize?.width ?? 220;
+  const chartHeight = chartSize?.height ?? 150;
   const sites = useAppStore((state) => state.sites);
   const links = useAppStore((state) => state.links);
   const selectedLinkId = useAppStore((state) => state.selectedLinkId);
@@ -258,7 +258,9 @@ export function LinkProfileChart({
       const nextHeight = Math.max(140, measuredHeight);
       setChartSize((current) => {
         const changed =
-          Math.abs(current.width - nextWidth) > 1 || Math.abs(current.height - nextHeight) > 1;
+          !current ||
+          Math.abs(current.width - nextWidth) > 1 ||
+          Math.abs(current.height - nextHeight) > 1;
         const next = changed ? { width: nextWidth, height: nextHeight } : current;
         if (debugSizing) {
           const chartPanelRect = element.closest(".chart-panel")?.getBoundingClientRect();
@@ -289,7 +291,7 @@ export function LinkProfileChart({
             isExpanded,
           });
         }
-        return next;
+        return next ?? current;
       });
     };
 
@@ -869,6 +871,7 @@ export function LinkProfileChart({
         </div>
       ) : (
         <div className={`chart-svg-wrap ${debugSizing ? "chart-svg-wrap-debug-sizing" : ""}`} ref={chartHostRef}>
+        {chartSize ? (
         <svg
           aria-label="Link profile"
           height={svgProps.height}
@@ -956,6 +959,7 @@ export function LinkProfileChart({
             onMouseLeave={onSvgLeave}
           />
         </svg>
+        ) : null}
         {splitHoverPopoverPosition && cursorStates && cursorStates.length > 1 ? (
           <div
             className="chart-hover-popover"

--- a/src/index.css
+++ b/src/index.css
@@ -1699,8 +1699,6 @@ input {
 
 .chart-panel svg {
   display: block;
-  width: 100%;
-  height: 100%;
   min-height: 150px;
   max-height: 240px;
 }


### PR DESCRIPTION
## Summary
- Prevent startup render of the profile SVG until host size is measured.
- Remove CSS `width/height: 100%` on the chart SVG to avoid viewport/user-unit mismatch.

## Why
On startup, the chart could render with stale `width="1200"` while the panel was narrower, clipping plotted geometry until a later interaction forced remeasure.

## Validation
- `npm run build`
- Browser automation confirmed startup clipping signature (stale width attr) before fix and drove this patch.

Staging-only pass for #108.