### PR TITLE
fix(profile): auto-hide panel when selection is not profile-eligible (#222)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -19,6 +19,7 @@ import { initializeMigrations, runMigrations } from "../lib/migrations";
 import { resolveBasemapSelection } from "../lib/basemaps";
 import { useThemeVariant } from "../hooks/useThemeVariant";
 import { useAppStore } from "../store/appStore";
+import { nextProfileHiddenForSelectionChange } from "./app-shell/profilePanelVisibility";
 import { LinkProfileChart } from "./LinkProfileChart";
 import { MapView } from "./MapView";
 import { ModalOverlay } from "./ModalOverlay";
@@ -640,6 +641,19 @@ export function AppShell() {
   useEffect(() => {
     try { localStorage.setItem(UI_PANEL_KEYS.profileHidden, String(isProfileHidden)); } catch {}
   }, [isProfileHidden]);
+
+  useEffect(() => {
+    const selectedSiteCount = selectedSiteIds.length;
+    setIsProfileHidden((currentHidden) =>
+      nextProfileHiddenForSelectionChange({
+        currentHidden,
+        nextSelectedSiteCount: selectedSiteCount,
+      }),
+    );
+    if (selectedSiteCount !== 1 && selectedSiteCount !== 2) {
+      setIsProfileExpanded(false);
+    }
+  }, [selectedSiteIds.length]);
 
   useEffect(() => {
     const mediaQuery = window.matchMedia("(max-width: 980px)");

--- a/src/components/app-shell/profilePanelVisibility.test.ts
+++ b/src/components/app-shell/profilePanelVisibility.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { isProfileSelectionEligible, nextProfileHiddenForSelectionChange } from "./profilePanelVisibility";
+
+describe("isProfileSelectionEligible", () => {
+  it("returns true for single-site selection", () => {
+    expect(isProfileSelectionEligible(1)).toBe(true);
+  });
+
+  it("returns true for two-site selection", () => {
+    expect(isProfileSelectionEligible(2)).toBe(true);
+  });
+
+  it("returns false when no site is selected", () => {
+    expect(isProfileSelectionEligible(0)).toBe(false);
+  });
+
+  it("returns false when more than two sites are selected", () => {
+    expect(isProfileSelectionEligible(3)).toBe(false);
+  });
+});
+
+describe("nextProfileHiddenForSelectionChange", () => {
+  it("auto-hides profile when selection transitions from two to three sites", () => {
+    expect(
+      nextProfileHiddenForSelectionChange({
+        currentHidden: false,
+        nextSelectedSiteCount: 3,
+      }),
+    ).toBe(true);
+  });
+
+  it("auto-hides profile when selection transitions from two sites to zero", () => {
+    expect(
+      nextProfileHiddenForSelectionChange({
+        currentHidden: false,
+        nextSelectedSiteCount: 0,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not auto-unhide profile when selection becomes valid", () => {
+    expect(
+      nextProfileHiddenForSelectionChange({
+        currentHidden: true,
+        nextSelectedSiteCount: 1,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps profile open for valid selection when it is already visible", () => {
+    expect(
+      nextProfileHiddenForSelectionChange({
+        currentHidden: false,
+        nextSelectedSiteCount: 2,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/components/app-shell/profilePanelVisibility.ts
+++ b/src/components/app-shell/profilePanelVisibility.ts
@@ -1,0 +1,17 @@
+export const isProfileSelectionEligible = (selectedSiteCount: number): boolean =>
+  selectedSiteCount === 1 || selectedSiteCount === 2;
+
+type NextProfileHiddenInput = {
+  currentHidden: boolean;
+  nextSelectedSiteCount: number;
+};
+
+export const nextProfileHiddenForSelectionChange = ({
+  currentHidden,
+  nextSelectedSiteCount,
+}: NextProfileHiddenInput): boolean => {
+  if (!isProfileSelectionEligible(nextSelectedSiteCount)) {
+    return true;
+  }
+  return currentHidden;
+};


### PR DESCRIPTION
## Summary
- auto-hide Profile panel when selection is not profile-eligible (`0` or `>2` selected sites)
- keep existing hide/show control flow and restore button behavior
- preserve manual-hide behavior when selection becomes valid (no forced auto-unhide)
- collapse profile expanded mode when selection becomes invalid

## Implementation
- added `nextProfileHiddenForSelectionChange()` helper for shared selection eligibility logic (`1` or `2` sites is eligible)
- wired `AppShell` selection-count effect to reuse existing `isProfileHidden` state
- left `LinkProfileChart` placeholder behavior unchanged, so manual restore on invalid state still shows placeholder text

## Tests
- added focused tests for eligibility and transitions in `profilePanelVisibility.test.ts`
- ran full `npm run test`
- ran `npm run build`

## Issue
- Closes #222