### PR TITLE
fix(profile): auto-show panel when selection becomes profile-eligible (#222)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -644,9 +644,8 @@ export function AppShell() {
 
   useEffect(() => {
     const selectedSiteCount = selectedSiteIds.length;
-    setIsProfileHidden((currentHidden) =>
+    setIsProfileHidden(
       nextProfileHiddenForSelectionChange({
-        currentHidden,
         nextSelectedSiteCount: selectedSiteCount,
       }),
     );

--- a/src/components/app-shell/profilePanelVisibility.test.ts
+++ b/src/components/app-shell/profilePanelVisibility.test.ts
@@ -23,7 +23,6 @@ describe("nextProfileHiddenForSelectionChange", () => {
   it("auto-hides profile when selection transitions from two to three sites", () => {
     expect(
       nextProfileHiddenForSelectionChange({
-        currentHidden: false,
         nextSelectedSiteCount: 3,
       }),
     ).toBe(true);
@@ -32,25 +31,22 @@ describe("nextProfileHiddenForSelectionChange", () => {
   it("auto-hides profile when selection transitions from two sites to zero", () => {
     expect(
       nextProfileHiddenForSelectionChange({
-        currentHidden: false,
         nextSelectedSiteCount: 0,
       }),
     ).toBe(true);
   });
 
-  it("does not auto-unhide profile when selection becomes valid", () => {
+  it("auto-unhides profile when selection becomes valid", () => {
     expect(
       nextProfileHiddenForSelectionChange({
-        currentHidden: true,
         nextSelectedSiteCount: 1,
       }),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("keeps profile open for valid selection when it is already visible", () => {
     expect(
       nextProfileHiddenForSelectionChange({
-        currentHidden: false,
         nextSelectedSiteCount: 2,
       }),
     ).toBe(false);

--- a/src/components/app-shell/profilePanelVisibility.ts
+++ b/src/components/app-shell/profilePanelVisibility.ts
@@ -2,16 +2,14 @@ export const isProfileSelectionEligible = (selectedSiteCount: number): boolean =
   selectedSiteCount === 1 || selectedSiteCount === 2;
 
 type NextProfileHiddenInput = {
-  currentHidden: boolean;
   nextSelectedSiteCount: number;
 };
 
 export const nextProfileHiddenForSelectionChange = ({
-  currentHidden,
   nextSelectedSiteCount,
 }: NextProfileHiddenInput): boolean => {
   if (!isProfileSelectionEligible(nextSelectedSiteCount)) {
     return true;
   }
-  return currentHidden;
+  return false;
 };


### PR DESCRIPTION
## Summary
Follow-up fix for issue #222 staging feedback.

- restore auto-show behavior when selection becomes profile-eligible
- keep auto-hide behavior for invalid selection (`0` or `>2` selected sites)

## Details
- `nextProfileHiddenForSelectionChange()` now returns `false` for valid selection counts (`1` or `2`)
- removed unused `currentHidden` helper input and simplified AppShell callsite
- updated helper tests to assert auto-unhide on valid transitions

## Verification
- `npm run test`
- `npm run build`

## Issue
- Refines #222 behavior per staging feedback