### PR TITLE
fix(profile): preserve startup sizing guardrails on staging

### DIFF
--- a/functions/_lib/linkProfileChart.regression.test.ts
+++ b/functions/_lib/linkProfileChart.regression.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("LinkProfileChart startup sizing regression guard", () => {
+  it("does not contain hardcoded fallback chart dimensions", () => {
+    const sourcePath = path.join(process.cwd(), "src/components/LinkProfileChart.tsx");
+    const source = readFileSync(sourcePath, "utf8");
+
+    expect(source).not.toContain("useState({ width: 1200, height: 190 })");
+    expect(source).not.toContain("{ width: 1200, height: 190 }");
+  });
+});
+

--- a/scripts/deploy-pages-safe.mjs
+++ b/scripts/deploy-pages-safe.mjs
@@ -11,6 +11,7 @@ const distDir = path.join(root, "dist");
 const releaseManifestPath = path.join(distDir, "release.json");
 const ALLOWED_DIRTY_PATHS = new Set(["src/lib/buildInfo.ts", "functions/_lib/buildInfo.ts"]);
 const ENV_FILES_FOR_VITE = [".env", ".env.local", ".env.production", ".env.production.local"];
+const LINK_PROFILE_CHART_PATH = path.join(root, "src", "components", "LinkProfileChart.tsx");
 
 const REQUIRED_ENV_BY_TARGET = {
   staging: ["VITE_MAPTILER_KEY"],
@@ -158,6 +159,26 @@ const assert = (condition, message) => {
   if (!condition) throw new Error(message);
 };
 
+async function verifyChartRegressionGuards() {
+  const chartSource = await readFile(LINK_PROFILE_CHART_PATH, "utf8");
+  const forbiddenPatterns = [
+    {
+      pattern: "useState({ width: 1200, height: 190 })",
+      message:
+        "Preflight failed: LinkProfileChart.tsx reintroduced hardcoded fallback chartSize 1200x190.",
+    },
+    {
+      pattern: "{ width: 1200, height: 190 }",
+      message:
+        "Preflight failed: LinkProfileChart.tsx contains hardcoded fallback dimensions 1200x190.",
+    },
+  ];
+
+  for (const { pattern, message } of forbiddenPatterns) {
+    assert(!chartSource.includes(pattern), message);
+  }
+}
+
 const parseWranglerJsonPayload = (stdout) => {
   const start = stdout.indexOf("[");
   const end = stdout.lastIndexOf("]");
@@ -245,6 +266,8 @@ async function preflight(targetName, target) {
   if (targetName === "prod-main") {
     await run("node", ["scripts/validate-prod-release.mjs"]);
   }
+
+  await verifyChartRegressionGuards();
 
   return { branch, commit };
 }

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1254,16 +1254,6 @@ export function AppShell() {
   ]);
   const isAnonymousBootstrapShell = accessState === "checking";
   const isReadOnlyShell = isAnonymousGuestReadonly || isAnonymousBootstrapShell;
-  const profileChartLayoutRevision = [
-    isMobileViewport ? "mobile" : "desktop",
-    isMapExpanded ? "map-expanded" : "map-normal",
-    isProfileExpanded ? "profile-expanded" : "profile-normal",
-    isNavigatorHidden ? "nav-hidden" : "nav-visible",
-    isInspectorHidden ? "inspector-hidden" : "inspector-visible",
-    isProfileHidden ? "profile-hidden" : "profile-visible",
-    mobileActivePanel,
-    mobileBottomPanelMode,
-  ].join("|");
   const emitProfileLayoutPulse = useCallback(() => {
     if (typeof window === "undefined") return;
     const fire = () => window.dispatchEvent(new CustomEvent("linksim-profile-layout-pulse"));
@@ -1716,7 +1706,6 @@ export function AppShell() {
         {!isMobileViewport && !isMapExpanded && !isProfileHidden ? (
           <LinkProfileChart
             isExpanded={isProfileExpanded}
-            layoutRevision={profileChartLayoutRevision}
             onToggleExpanded={toggleProfileExpanded}
             rowControls={
               <button
@@ -1748,7 +1737,6 @@ export function AppShell() {
           >
             <LinkProfileChart
               isExpanded={mobileBottomPanelMode === "full"}
-              layoutRevision={profileChartLayoutRevision}
               onToggleExpanded={toggleProfileExpanded}
               rowControls={panelSizeControls("Profile", "chart")}
               showExpandToggle={false}

--- a/src/components/LinkProfileChart.tsx
+++ b/src/components/LinkProfileChart.tsx
@@ -2,7 +2,7 @@ import { extent, max } from "d3-array";
 import { scaleLinear } from "d3-scale";
 import { ArrowLeftRight, Maximize2, Minimize2 } from "lucide-react";
 import type { MouseEvent } from "react";
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
 import {
   classifyPassFailState,
@@ -46,19 +46,11 @@ const earthBulgeM = (distanceKm: number, t: number): number => {
   return (x * (dTotalM - x)) / (2 * earthRadiusM);
 };
 
-type ProfileTraceEvent = {
-  seq: number;
-  tMs: number;
-  event: string;
-  payload: Record<string, unknown>;
-};
-
 type LinkProfileChartProps = {
   isExpanded: boolean;
   onToggleExpanded: () => void;
   showExpandToggle?: boolean;
   rowControls?: ReactNode;
-  layoutRevision?: string;
 };
 
 export function LinkProfileChart({
@@ -66,48 +58,16 @@ export function LinkProfileChart({
   onToggleExpanded,
   showExpandToggle = true,
   rowControls,
-  layoutRevision = "",
 }: LinkProfileChartProps) {
   const chartHostRef = useRef<HTMLDivElement | null>(null);
+  const [hostAttachRevision, setHostAttachRevision] = useState(0);
   const segmentStateCacheRef = useRef<Map<string, PassFailState[]>>(new Map());
-  const [chartSize, setChartSize] = useState({ width: 1200, height: 190 });
-  const [debugSizing] = useState(() => {
-    if (typeof window === "undefined") return false;
-    const localStorageEnabled = (() => {
-      try {
-        return window.localStorage.getItem("linksim-debug-profile-chart-sizing") === "1";
-      } catch {
-        return false;
-      }
-    })();
-    const runtimeEnabled =
-      (window as typeof window & { __LINKSIM_DEBUG_PROFILE_CHART_SIZING__?: boolean })
-        .__LINKSIM_DEBUG_PROFILE_CHART_SIZING__ === true;
-    return localStorageEnabled || runtimeEnabled;
-  });
-  const [layoutPulseRevision, setLayoutPulseRevision] = useState(0);
+  const [chartSize, setChartSize] = useState<{ width: number; height: number } | null>(null);
   const [terrainSegmentStates, setTerrainSegmentStates] = useState<PassFailState[]>([]);
   const [hoverPosition, setHoverPosition] = useState<{ x: number; y: number } | null>(null);
-  const chartWidth = chartSize.width;
-  const chartHeight = chartSize.height;
-  const [debugTrace] = useState(() => {
-    if (typeof window === "undefined") return false;
-    const localStorageEnabled = (() => {
-      try {
-        return window.localStorage.getItem("linksim-debug-profile-trace") === "1";
-      } catch {
-        return false;
-      }
-    })();
-    const runtimeEnabled =
-      (window as typeof window & { __LINKSIM_DEBUG_PROFILE_TRACE__?: boolean })
-        .__LINKSIM_DEBUG_PROFILE_TRACE__ === true;
-    return localStorageEnabled || runtimeEnabled;
-  });
-  const traceSeqRef = useRef(0);
-  const traceStartRef = useRef<number | null>(null);
-  const firstCorrectedByRef = useRef<string | null>(null);
-  const lastSizeSourceRef = useRef<string>("init");
+  const hasMeasuredSize = Boolean(chartSize && chartSize.width > 1 && chartSize.height > 1);
+  const chartWidth = chartSize?.width ?? 0;
+  const chartHeight = chartSize?.height ?? 0;
   const sites = useAppStore((state) => state.sites);
   const links = useAppStore((state) => state.links);
   const selectedLinkId = useAppStore((state) => state.selectedLinkId);
@@ -135,90 +95,10 @@ export function LinkProfileChart({
       `${state.selectedScenarioId}|${state.selectedLinkId}|${state.links.length}|${state.sites.length}|${state.srtmTiles.length}|${Object.keys(state.siteDragPreview).length}`,
   );
 
-  const getDomSnapshot = () => {
-    const host = chartHostRef.current;
-    const panel = host?.closest(".chart-panel") as HTMLElement | null;
-    const svg = host?.querySelector("svg");
-    const hostRect = host?.getBoundingClientRect();
-    const panelRect = panel?.getBoundingClientRect();
-    return {
-      host: hostRect
-        ? {
-            width: Math.round(hostRect.width),
-            height: Math.round(hostRect.height),
-            clientWidth: host?.clientWidth ?? 0,
-            clientHeight: host?.clientHeight ?? 0,
-          }
-        : null,
-      panel: panelRect
-        ? {
-            width: Math.round(panelRect.width),
-            height: Math.round(panelRect.height),
-          }
-        : null,
-      svgAttrs: svg
-        ? {
-            width: svg.getAttribute("width"),
-            height: svg.getAttribute("height"),
-            viewBox: svg.getAttribute("viewBox"),
-          }
-        : null,
-      svgRect: svg
-        ? (() => {
-            const rect = svg.getBoundingClientRect();
-            return { width: Math.round(rect.width), height: Math.round(rect.height) };
-          })()
-        : null,
-      layoutState: {
-        chartSizeWidth: chartSize.width,
-        chartSizeHeight: chartSize.height,
-        chartWidthUsed: chartWidth,
-        chartHeightUsed: chartHeight,
-        fallbackUsed: chartSize.width === 1200 && chartSize.height === 190,
-      },
-    };
-  };
-
-  const pushTrace = (event: string, payload: Record<string, unknown>) => {
-    if (!debugTrace || typeof window === "undefined") return;
-    const now = performance.now();
-    if (traceStartRef.current === null) traceStartRef.current = now;
-    const tMs = Math.round(now - traceStartRef.current);
-    const traceEvent: ProfileTraceEvent = {
-      seq: ++traceSeqRef.current,
-      tMs,
-      event,
-      payload,
-    };
-    const traceWindow = window as typeof window & {
-      __LINKSIM_PROFILE_TRACE__?: { events: ProfileTraceEvent[] };
-    };
-    const store = traceWindow.__LINKSIM_PROFILE_TRACE__ ?? { events: [] };
-    store.events.push(traceEvent);
-    if (store.events.length > 1200) {
-      store.events.splice(0, store.events.length - 1200);
-    }
-    traceWindow.__LINKSIM_PROFILE_TRACE__ = store;
-  };
-
-  pushTrace("render", {
-    profileLength: profileRevision,
-    ...getDomSnapshot(),
-  });
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    pushTrace("useEffect-layout-pulse-subscribe", {
-      ...getDomSnapshot(),
-    });
-    const onLayoutPulse = () => setLayoutPulseRevision((current) => current + 1);
-    window.addEventListener("linksim-profile-layout-pulse", onLayoutPulse);
-    return () => {
-      pushTrace("useEffect-layout-pulse-cleanup", {
-        ...getDomSnapshot(),
-      });
-      window.removeEventListener("linksim-profile-layout-pulse", onLayoutPulse);
-    };
+  const setChartHostElement = useCallback((element: HTMLDivElement | null) => {
+    if (chartHostRef.current === element) return;
+    chartHostRef.current = element;
+    setHostAttachRevision((current) => current + 1);
   }, []);
 
   const baseProfile = getSelectedProfile();
@@ -350,193 +230,48 @@ export function LinkProfileChart({
   }, [profile.length, selectedLinkId, temporaryDirectionReversed, setProfileCursorIndex]);
 
   useLayoutEffect(() => {
-    pushTrace("useLayoutEffect-enter", {
-      profileLength: profile.length,
-      ...getDomSnapshot(),
-    });
-    if (profile.length < 2) return;
     const element = chartHostRef.current;
     if (!element) return;
 
-    const updateSize = (source: string) => {
-      lastSizeSourceRef.current = source;
+    const updateSize = () => {
       const hostRect = element.getBoundingClientRect();
       const parentRect = element.parentElement?.getBoundingClientRect();
       const measuredWidth = Math.round(hostRect.width || parentRect?.width || 0);
       const measuredHeight = Math.round(hostRect.height || parentRect?.height || 0);
-      const nextWidth = Math.max(220, measuredWidth);
-      const nextHeight = Math.max(140, measuredHeight);
-      pushTrace("measure", {
-        measuredWidth,
-        measuredHeight,
-        nextWidth,
-        nextHeight,
-        ...getDomSnapshot(),
-      });
+      if (measuredWidth <= 1 || measuredHeight <= 1) return;
+      const nextWidth = measuredWidth;
+      const nextHeight = measuredHeight;
       setChartSize((current) => {
         const changed =
-          Math.abs(current.width - nextWidth) > 1 || Math.abs(current.height - nextHeight) > 1;
-        const next = changed ? { width: nextWidth, height: nextHeight } : current;
-        pushTrace("setChartSize", {
-          changed,
-          current,
-          next,
-          ...getDomSnapshot(),
-        });
-        if (debugSizing) {
-          const chartPanelRect = element.closest(".chart-panel")?.getBoundingClientRect();
-          const workspaceRect = element.closest(".workspace-panel")?.getBoundingClientRect();
-          console.info("[profile-chart-sizing]", {
-            changed,
-            current,
-            next,
-            host: {
-              width: Math.round(hostRect.width),
-              height: Math.round(hostRect.height),
-              clientWidth: element.clientWidth,
-              clientHeight: element.clientHeight,
-              offsetWidth: element.offsetWidth,
-              offsetHeight: element.offsetHeight,
-            },
-            parent: parentRect
-              ? { width: Math.round(parentRect.width), height: Math.round(parentRect.height) }
-              : null,
-            chartPanel: chartPanelRect
-              ? { width: Math.round(chartPanelRect.width), height: Math.round(chartPanelRect.height) }
-              : null,
-            workspacePanel: workspaceRect
-              ? { width: Math.round(workspaceRect.width), height: Math.round(workspaceRect.height) }
-              : null,
-            profileLength: profile.length,
-            isExpanded,
-          });
-        }
-        return next;
+          !current ||
+          Math.abs(current.width - nextWidth) > 1 ||
+          Math.abs(current.height - nextHeight) > 1;
+        return changed ? { width: nextWidth, height: nextHeight } : current;
       });
     };
 
-    updateSize("layout-effect-init");
-    const rafIdA = requestAnimationFrame(() => updateSize("raf-1"));
-    const rafIdB = requestAnimationFrame(() => requestAnimationFrame(() => updateSize("raf-2")));
-    const followUpTimerA = window.setTimeout(() => updateSize("timer-120ms"), 120);
-    const followUpTimerB = window.setTimeout(() => updateSize("timer-280ms"), 280);
-    const followUpTimerC = window.setTimeout(() => updateSize("timer-1000ms"), 1000);
-    const followUpTimerD = window.setTimeout(() => updateSize("timer-1800ms"), 1800);
-    const onWindowResize = () => updateSize("window-resize");
-    window.addEventListener("resize", onWindowResize);
-
-    const appShell = element.closest(".app-shell");
-    const workspacePanelElement = element.closest(".workspace-panel");
-    const onTransitionEnd = (event: Event) => {
-      const target = event.target;
-      if (!(target instanceof Element)) return;
-      if (
-        target.closest(".workspace-panel") ||
-        target.closest(".map-inspector") ||
-        target.closest(".chart-panel")
-      ) {
-        updateSize("transition-end");
-      }
-    };
-    window.addEventListener("transitionend", onTransitionEnd, true);
-
-    const mutationObserver = new MutationObserver((mutations) => {
-      for (const mutation of mutations) {
-        if (mutation.type === "attributes") {
-          updateSize("class-mutation");
-          break;
-        }
-      }
-    });
-    if (appShell) {
-      mutationObserver.observe(appShell, {
-        attributes: true,
-        attributeFilter: ["class", "style"],
-      });
-    }
-    if (workspacePanelElement) {
-      mutationObserver.observe(workspacePanelElement, {
-        attributes: true,
-        attributeFilter: ["class", "style"],
-      });
-    }
+    updateSize();
+    const rafId = requestAnimationFrame(updateSize);
 
     if (typeof ResizeObserver === "undefined") {
       return () => {
-        cancelAnimationFrame(rafIdA);
-        cancelAnimationFrame(rafIdB);
-        window.clearTimeout(followUpTimerA);
-        window.clearTimeout(followUpTimerB);
-        window.clearTimeout(followUpTimerC);
-        window.clearTimeout(followUpTimerD);
-        window.removeEventListener("resize", onWindowResize);
-        window.removeEventListener("transitionend", onTransitionEnd, true);
-        mutationObserver.disconnect();
+        cancelAnimationFrame(rafId);
       };
     }
 
-    const observer = new ResizeObserver(() => updateSize("resize-observer"));
+    const observer = new ResizeObserver(updateSize);
     observer.observe(element);
     if (element.parentElement) observer.observe(element.parentElement);
-    const chartPanel = element.closest(".chart-panel");
-    if (chartPanel instanceof HTMLElement) observer.observe(chartPanel);
-    if (workspacePanelElement instanceof HTMLElement) observer.observe(workspacePanelElement);
 
     return () => {
-      pushTrace("useLayoutEffect-cleanup", {
-        ...getDomSnapshot(),
-      });
-      cancelAnimationFrame(rafIdA);
-      cancelAnimationFrame(rafIdB);
-      window.clearTimeout(followUpTimerA);
-      window.clearTimeout(followUpTimerB);
-      window.clearTimeout(followUpTimerC);
-      window.clearTimeout(followUpTimerD);
-      window.removeEventListener("resize", onWindowResize);
-      window.removeEventListener("transitionend", onTransitionEnd, true);
-      mutationObserver.disconnect();
+      cancelAnimationFrame(rafId);
       observer.disconnect();
     };
-  }, [debugSizing, isExpanded, layoutPulseRevision, layoutRevision, profile.length]);
-
-  useEffect(() => {
-    pushTrace("useEffect-post-commit", {
-      profileLength: profile.length,
-      ...getDomSnapshot(),
-    });
-  }, [profile.length, chartWidth, chartHeight, layoutRevision, isExpanded]);
-
-  useEffect(() => {
-    const host = chartHostRef.current;
-    const svg = host?.querySelector("svg");
-    if (!host || !svg) return;
-    const hostRect = host.getBoundingClientRect();
-    const attrWidth = Number(svg.getAttribute("width") ?? "0");
-    const attrHeight = Number(svg.getAttribute("height") ?? "0");
-    const widthAligned = Number.isFinite(attrWidth) && Math.abs(attrWidth - hostRect.width) <= 1;
-    const heightAligned = Number.isFinite(attrHeight) && Math.abs(attrHeight - hostRect.height) <= 1;
-    if (!widthAligned || !heightAligned || firstCorrectedByRef.current) return;
-    firstCorrectedByRef.current = lastSizeSourceRef.current;
-    pushTrace("first-corrected", {
-      correctedBySource: firstCorrectedByRef.current,
-      hostWidth: Math.round(hostRect.width),
-      hostHeight: Math.round(hostRect.height),
-      attrWidth,
-      attrHeight,
-      ...getDomSnapshot(),
-    });
-  }, [chartWidth, chartHeight, profile.length, layoutRevision, isExpanded]);
+  }, [profile.length, hasMinimumTopology, hostAttachRevision]);
 
   const geometry = useMemo(() => {
-    pushTrace("geometry-compute-enter", {
-      profileLength: profile.length,
-      chartWidthUsed: chartWidth,
-      chartHeightUsed: chartHeight,
-      fallbackUsed: chartWidth === 1200 && chartHeight === 190,
-      ...getDomSnapshot(),
-    });
-    if (profile.length < 2) {
-      const noDataGeometry = {
+    if (!hasMeasuredSize || profile.length < 2) {
+      return {
         hasData: false,
         xForDistance: () => M.l,
         yForElevation: () => chartHeight - M.b,
@@ -546,14 +281,6 @@ export function LinkProfileChart({
         yTicks: [] as { value: number; py: number }[],
         xTicks: [] as { value: number; px: number; anchor: "start" | "middle" | "end" }[],
       };
-      pushTrace("geometry-compute-exit", {
-        hasData: false,
-        xTickCount: 0,
-        yTickCount: 0,
-        chartWidthUsed: chartWidth,
-        chartHeightUsed: chartHeight,
-      });
-      return noDataGeometry;
     }
 
     const rawDistanceDomain = extent(profile, (p) => p.distanceKm);
@@ -585,7 +312,7 @@ export function LinkProfileChart({
       state: "pass_clear" as PassFailState,
     }));
 
-    const computed = {
+    return {
       hasData: true,
       xForDistance: (distanceKm: number) => x(distanceKm),
       yForElevation: (elevation: number) => y(elevation),
@@ -609,16 +336,7 @@ export function LinkProfileChart({
         };
       }),
     };
-    pushTrace("geometry-compute-exit", {
-      hasData: true,
-      xTickCount: computed.xTicks.length,
-      yTickCount: computed.yTicks.length,
-      chartWidthUsed: chartWidth,
-      chartHeightUsed: chartHeight,
-      fallbackUsed: chartWidth === 1200 && chartHeight === 190,
-    });
-    return computed;
-  }, [profile, chartWidth, chartHeight]);
+  }, [profile, chartWidth, chartHeight, hasMeasuredSize]);
   const svgProps = useMemo(() => buildProfileChartSvgProps(chartWidth, chartHeight), [chartWidth, chartHeight]);
 
   const segmentStateKey = useMemo(
@@ -994,7 +712,7 @@ export function LinkProfileChart({
   }
 
   return (
-    <section className={`chart-panel ${isExpanded ? "is-expanded" : ""} ${debugSizing ? "chart-panel-debug-sizing" : ""}`} data-profile-revision={profileRevision}>
+    <section className={`chart-panel ${isExpanded ? "is-expanded" : ""}`} data-profile-revision={profileRevision}>
       <div className="chart-top-row">
         <div className="chart-endpoints" aria-live="polite">
           <span className="chart-endpoint chart-endpoint-left">{fromSiteName}</span>
@@ -1040,12 +758,13 @@ export function LinkProfileChart({
           ) : null}
         </div>
       </div>
-      {!geometry.hasData ? (
+      <div className="chart-svg-wrap" ref={setChartHostElement}>
+      {profile.length < 2 ? (
         <div className="chart-empty">
           <p>Path profile unavailable for the selected link.</p>
         </div>
-      ) : (
-        <div className={`chart-svg-wrap ${debugSizing ? "chart-svg-wrap-debug-sizing" : ""}`} ref={chartHostRef}>
+      ) : hasMeasuredSize && geometry.hasData ? (
+        <>
         <svg
           aria-label="Link profile"
           height={svgProps.height}
@@ -1152,8 +871,11 @@ export function LinkProfileChart({
             ))}
           </div>
         ) : null}
-        </div>
+        </>
+      ) : (
+        <div className="chart-empty" aria-hidden="true" />
       )}
+      </div>
     </section>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1606,7 +1606,7 @@ input {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  min-height: 0;
+  min-height: 220px;
   position: relative;
   z-index: 35;
   grid-row: 2;
@@ -1626,24 +1626,9 @@ input {
 
 .chart-svg-wrap {
   flex: 1;
-  min-height: 150px;
+  min-height: 90px;
   width: 100%;
   position: relative;
-}
-
-.chart-panel-debug-sizing {
-  outline: 2px dashed var(--danger);
-  outline-offset: -2px;
-}
-
-.chart-panel-debug-sizing .chart-svg-wrap-debug-sizing {
-  outline: 2px dashed var(--accent);
-  outline-offset: -2px;
-}
-
-.chart-panel-debug-sizing .chart-svg-wrap-debug-sizing > svg {
-  outline: 2px dashed var(--success);
-  outline-offset: -2px;
 }
 
 .chart-header {
@@ -1701,8 +1686,8 @@ input {
   display: block;
   width: 100%;
   height: 100%;
-  min-height: 150px;
-  max-height: 240px;
+  min-height: 90px;
+  max-height: none;
 }
 
 .chart-panel.is-expanded .chart-svg-wrap {
@@ -1847,7 +1832,7 @@ input {
 .chart-empty {
   display: grid;
   place-items: center;
-  min-height: 180px;
+  min-height: 120px;
   color: var(--muted);
   font-size: 0.9rem;
 }


### PR DESCRIPTION
## Summary
- restore the measured-size startup chart pipeline in LinkProfileChart
- remove stale AppShell layoutRevision prop usage
- remove svg max-height cap that caused vertical clipping regressions
- add deploy preflight guard + regression test to block hardcoded 1200x190 fallback

## Verification
- npm run test -- --run functions/_lib/linkProfileChart.regression.test.ts
- npm run build