### PR TITLE
fix: modal duplicate-dismiss regression and runtime slowdown

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -346,11 +346,8 @@ export function AppShell() {
 
   useEffect(() => {
     if (isInitializing) {
-      console.log("[AppShell] Skipping sync - initialization in progress");
       return;
     }
-    console.log("[AppShell] siteLibrary/simulationPresets/sites changed, calling performCloudSyncPush");
-    console.log("[AppShell] siteLibrary length:", siteLibrary.length, "simulationPresets length:", simulationPresets.length, "sites length:", sites.length);
     void performCloudSyncPush();
   }, [performCloudSyncPush, isInitializing, siteLibrary, simulationPresets, sites]);
 
@@ -551,7 +548,6 @@ export function AppShell() {
 
   useEffect(() => {
     if (accessState === "granted") {
-      console.log("[AppShell] Access granted, running migrations and initializing cloud sync...");
       void runMigrations().then(() => initializeCloudSync());
     }
   }, [accessState, initializeCloudSync]);

--- a/src/components/ModalOverlay.tsx
+++ b/src/components/ModalOverlay.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useMemo, type ReactNode } from "react";
+import { useEffect, useId, useMemo, useRef, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 
 type ModalOverlayProps = {
@@ -14,6 +14,8 @@ let modalLayerSeed = 0;
 
 export function ModalOverlay({ children, onClose, tier = "base", ...rest }: ModalOverlayProps) {
   const modalId = useId();
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
   const layer = useMemo(() => {
     modalLayerSeed += 1;
     return modalLayerSeed;
@@ -32,10 +34,10 @@ export function ModalOverlay({ children, onClose, tier = "base", ...rest }: Moda
       if (event.key !== "Escape") return;
       const top = openModalStack[openModalStack.length - 1];
       if (top !== modalId) return;
-      if (!onClose) return;
+      if (!onCloseRef.current) return;
       event.preventDefault();
       event.stopPropagation();
-      onClose();
+      onCloseRef.current();
     };
     window.addEventListener("keydown", onKeyDown);
     return () => {
@@ -47,18 +49,18 @@ export function ModalOverlay({ children, onClose, tier = "base", ...rest }: Moda
         document.body.style.overflow = previousOverflow;
       }
     };
-  }, [modalId, onClose]);
+  }, [modalId]);
 
   return createPortal(
     <div
       aria-modal="true"
       className="library-manager-overlay"
       onMouseDown={(event) => {
-        if (!onClose) return;
+        if (!onCloseRef.current) return;
         if (event.target !== event.currentTarget) return;
         const top = openModalStack[openModalStack.length - 1];
         if (top !== modalId) return;
-        onClose();
+        onCloseRef.current();
       }}
       role="dialog"
       style={{ zIndex }}

--- a/src/lib/cloudLibrary.ts
+++ b/src/lib/cloudLibrary.ts
@@ -20,7 +20,6 @@ const listSimulationNames = (payload: CloudLibraryPayload): string[] =>
     .filter(Boolean);
 
 const apiCall = async <T>(path: string, init?: RequestInit): Promise<T> => {
-  console.log("[cloudLibrary] API call:", init?.method ?? "GET", path);
   const response = await fetch(path, {
     ...init,
     headers: {
@@ -28,10 +27,8 @@ const apiCall = async <T>(path: string, init?: RequestInit): Promise<T> => {
       ...(init?.headers ?? {}),
     },
   });
-  console.log("[cloudLibrary] Response:", response.status, response.statusText);
   if (!response.ok) {
     const message = await parseApiErrorMessage(response);
-    console.log("[cloudLibrary] Error response:", message);
     throw new Error(`${response.status} ${response.statusText}: ${message}`);
   }
   return (await response.json()) as T;
@@ -39,14 +36,8 @@ const apiCall = async <T>(path: string, init?: RequestInit): Promise<T> => {
 
 export const fetchCloudLibrary = async (opts?: { since?: string }): Promise<CloudLibraryPayload & { isDelta?: boolean }> => {
   const url = opts?.since ? `/api/library?since=${encodeURIComponent(opts.since)}` : "/api/library";
-  console.log("[cloudLibrary] Fetching cloud library...", opts?.since ? `(delta since ${opts.since})` : "(full)");
   const data = await apiCall<{ siteLibrary?: unknown[]; simulationPresets?: unknown[]; isDelta?: boolean }>(url, {
     method: "GET",
-  });
-  console.log("[cloudLibrary] Cloud data received:", {
-    sites: data.siteLibrary?.length ?? 0,
-    simulations: data.simulationPresets?.length ?? 0,
-    isDelta: data.isDelta,
   });
   return {
     siteLibrary: Array.isArray(data.siteLibrary) ? data.siteLibrary : [],
@@ -62,18 +53,12 @@ export const fetchPublicSimulationLibrary = async (params: {
   const query = new URLSearchParams();
   if (params.simulationId?.trim()) query.set("sim", params.simulationId.trim());
   if (params.simulationSlug?.trim()) query.set("slug", params.simulationSlug.trim());
-  console.log("[cloudLibrary] Fetching public simulation:", query.toString());
   const data = await apiCall<{ siteLibrary?: unknown[]; simulationPresets?: unknown[]; simulationId?: unknown }>(
     `/api/public-simulation?${query.toString()}`,
     {
       method: "GET",
     },
   );
-  console.log("[cloudLibrary] Public simulation data received:", {
-    sites: data.siteLibrary?.length ?? 0,
-    simulations: data.simulationPresets?.length ?? 0,
-    simulationId: data.simulationId,
-  });
   return {
     siteLibrary: Array.isArray(data.siteLibrary) ? data.siteLibrary : [],
     simulationPresets: Array.isArray(data.simulationPresets) ? data.simulationPresets : [],
@@ -82,23 +67,13 @@ export const fetchPublicSimulationLibrary = async (params: {
 };
 
 export const pushCloudLibrary = async (payload: CloudLibraryPayload, opts?: { suppressConflicts?: string[] }): Promise<void> => {
-  console.log("[cloudLibrary] Pushing library to cloud:", {
-    sites: payload.siteLibrary.length,
-    simulations: payload.simulationPresets.length,
-    payloadSize: JSON.stringify(payload).length,
-  });
   const result = await apiCall<CloudPushResult>("/api/library", {
     method: "PUT",
     body: JSON.stringify(payload),
   });
-  console.log("[cloudLibrary] Push response:", result);
   const allConflicts = Array.isArray(result.conflicts) ? result.conflicts : [];
   const conflicts = allConflicts.filter((c) => !(opts?.suppressConflicts ?? []).includes(c));
-  if (!allConflicts.length) {
-    console.log("[cloudLibrary] Push succeeded with no conflicts");
-    return;
-  }
-  console.log("[cloudLibrary] Push has conflicts:", allConflicts, "fatal:", conflicts);
+  if (!allConflicts.length) return;
   if (!conflicts.length) return;
   if (conflicts.includes("simulation_private_site_reference")) {
     const simulationNames = listSimulationNames(payload);


### PR DESCRIPTION
## Summary
- fix modal overlay stack/listener churn by mounting modal lifecycle once per overlay instance
- keep latest onClose behavior via ref to avoid stale closure while preventing repeated stack push/pop on parent rerenders
- remove high-frequency sync/cloud debug logging that was reintroduced and adds runtime overhead

## Validation
- npm test
- npm run build

## Issue
Closes #502