### PR TITLE
fix: prevent stacked modals when editing site from sidebar

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1193,7 +1193,6 @@ export function Sidebar({
   };
   const selectedLibraryCount = selectedLibraryIds.size;
   const openLibraryForSelectedSite = () => {
-    setShowSiteLibraryManager(true);
     const matchedEntry = siteLibrary.find(
       (entry) =>
         entry.name === selectedSite.name &&
@@ -1218,6 +1217,7 @@ export function Sidebar({
       });
       return;
     }
+    setShowSiteLibraryManager(true);
     setShowAddLibraryForm(true);
     setNewLibraryName("");
     setNewLibraryDescription("");


### PR DESCRIPTION
## Summary
- fix Sidebar site Edit flow to avoid opening Site Library modal when selected site already matches a library entry
- keep Site Library modal fallback only for non-library sites

## Validation
- npm test
- npm run build

## Issue
Closes #504