### PR TITLE
refactor(ui): extract shared library filter helpers

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -44,13 +44,19 @@ import { toAccessVisibility, toInitials } from "../lib/uiFormatting";
 import {
   DEFAULT_LIBRARY_FILTER_STATE,
   filterAndSortLibraryItems,
-  parsePersistedLibraryFilterState,
-  serializeLibraryFilterState,
   type LibraryFilterRole,
   type LibraryFilterSource,
   type LibraryFilterState,
   type LibraryFilterVisibility,
 } from "../lib/libraryFilters";
+import {
+  effectiveSelection,
+  persistLibraryFilterState,
+  readLibraryFilterState,
+  selectionIsFiltered,
+  selectionLabel,
+  toggleValue,
+} from "../lib/libraryFilterUi";
 import { getUiErrorMessage } from "../lib/uiError";
 import { formatDate, formatNumber } from "../lib/locale";
 import { useAppStore } from "../store/appStore";
@@ -144,35 +150,6 @@ const ALL_VISIBILITY_FILTERS = VISIBILITY_FILTER_OPTIONS.map((option) => option.
 const ALL_SITE_SOURCE_FILTERS = SITE_SOURCE_FILTER_OPTIONS.map((option) => option.key);
 
 type SiteFilterGroupKey = "role" | "visibility" | "source";
-
-const readLibraryFilterState = (key: string): LibraryFilterState => {
-  try {
-    return parsePersistedLibraryFilterState(localStorage.getItem(key), DEFAULT_LIBRARY_FILTER_STATE);
-  } catch {
-    return DEFAULT_LIBRARY_FILTER_STATE;
-  }
-};
-
-const persistLibraryFilterState = (key: string, state: LibraryFilterState): void => {
-  try {
-    localStorage.setItem(key, serializeLibraryFilterState(state));
-  } catch {
-    // Best effort only.
-  }
-};
-
-const effectiveSelection = <T extends string>(selected: T[], allValues: T[]): T[] =>
-  selected.length ? selected : allValues;
-
-const selectionLabel = <T extends string>(selected: T[], allValues: T[]): string => {
-  const effective = effectiveSelection(selected, allValues);
-  return `${effective.length}/${allValues.length}`;
-};
-
-const selectionIsFiltered = <T extends string>(selected: T[], allValues: T[]): boolean => {
-  const effective = effectiveSelection(selected, allValues);
-  return effective.length !== allValues.length;
-};
 
 const formatChangeSummary = (action: string, note: string | null): string => {
   if (note && note.trim()) return note;
@@ -580,8 +557,6 @@ export function Sidebar({
     onConfirm: () => void;
   } | null>(null);
   const currentUserId = currentUser?.id ?? null;
-  const toggleValue = <T extends string>(values: T[], key: T): T[] =>
-    values.includes(key) ? values.filter((value) => value !== key) : [...values, key];
   const commitSiteRoleFilters = (roleFilters: LibraryFilterRole[]) => {
     if (!roleFilters.length) return;
     setSiteLibraryFilters((state) => ({ ...state, roleFilters }));

--- a/src/components/SimulationLibraryPanel.tsx
+++ b/src/components/SimulationLibraryPanel.tsx
@@ -4,12 +4,18 @@ import { CircleX, Funnel } from "lucide-react";
 import {
   DEFAULT_LIBRARY_FILTER_STATE,
   filterAndSortLibraryItems,
-  parsePersistedLibraryFilterState,
-  serializeLibraryFilterState,
   type LibraryFilterRole,
   type LibraryFilterState,
   type LibraryFilterVisibility,
 } from "../lib/libraryFilters";
+import {
+  effectiveSelection,
+  persistLibraryFilterState,
+  readLibraryFilterState,
+  selectionIsFiltered,
+  selectionLabel,
+  toggleValue,
+} from "../lib/libraryFilterUi";
 import { formatDate } from "../lib/locale";
 import { toAccessVisibility, toInitials } from "../lib/uiFormatting";
 import { duplicateSimulationNameMessage, hasDuplicateSimulationNameForOwner } from "../lib/simulationNameValidation";
@@ -33,38 +39,6 @@ const VISIBILITY_FILTER_OPTIONS: Array<{ key: LibraryFilterVisibility; label: st
 
 const ALL_ROLE_FILTERS = ROLE_FILTER_OPTIONS.map((option) => option.key);
 const ALL_VISIBILITY_FILTERS = VISIBILITY_FILTER_OPTIONS.map((option) => option.key);
-
-const effectiveSelection = <T extends string>(selected: T[], allValues: T[]): T[] =>
-  selected.length ? selected : allValues;
-
-const selectionLabel = <T extends string>(selected: T[], allValues: T[]): string => {
-  const effective = effectiveSelection(selected, allValues);
-  return `${effective.length}/${allValues.length}`;
-};
-
-const selectionIsFiltered = <T extends string>(selected: T[], allValues: T[]): boolean => {
-  const effective = effectiveSelection(selected, allValues);
-  return effective.length !== allValues.length;
-};
-
-const toggleValue = <T extends string>(values: T[], key: T): T[] =>
-  values.includes(key) ? values.filter((value) => value !== key) : [...values, key];
-
-const readLibraryFilterState = (key: string): LibraryFilterState => {
-  try {
-    return parsePersistedLibraryFilterState(localStorage.getItem(key), DEFAULT_LIBRARY_FILTER_STATE);
-  } catch {
-    return DEFAULT_LIBRARY_FILTER_STATE;
-  }
-};
-
-const persistLibraryFilterState = (key: string, state: LibraryFilterState): void => {
-  try {
-    localStorage.setItem(key, serializeLibraryFilterState(state));
-  } catch {
-    // Best effort only.
-  }
-};
 
 type ResourceOpenParams = {
   kind: "site" | "simulation";

--- a/src/lib/libraryFilterUi.test.ts
+++ b/src/lib/libraryFilterUi.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_LIBRARY_FILTER_STATE,
+  parsePersistedLibraryFilterState,
+  serializeLibraryFilterState,
+  type LibraryFilterState,
+} from "./libraryFilters";
+import {
+  effectiveSelection,
+  persistLibraryFilterState,
+  readLibraryFilterState,
+  selectionIsFiltered,
+  selectionLabel,
+  toggleValue,
+} from "./libraryFilterUi";
+
+describe("libraryFilterUi", () => {
+  it("treats empty selected values as all values", () => {
+    expect(effectiveSelection<string>([], ["owned", "editable"])).toEqual(["owned", "editable"]);
+  });
+
+  it("formats selection label as x/y using effective selection", () => {
+    expect(selectionLabel<string>([], ["owned", "editable"])).toBe("2/2");
+    expect(selectionLabel<string>(["owned"], ["owned", "editable"])).toBe("1/2");
+  });
+
+  it("marks filtered only when effective selection is not full set", () => {
+    expect(selectionIsFiltered<string>([], ["owned", "editable"])).toBe(false);
+    expect(selectionIsFiltered<string>(["owned"], ["owned", "editable"])).toBe(true);
+  });
+
+  it("toggles values by removing existing key and adding missing key", () => {
+    expect(toggleValue(["owned", "editable"], "owned")).toEqual(["editable"]);
+    expect(toggleValue(["owned"], "editable")).toEqual(["owned", "editable"]);
+  });
+
+  it("reads persisted filter state and falls back on storage errors", () => {
+    const state: LibraryFilterState = {
+      searchQuery: "abc",
+      roleFilters: ["owned"],
+      visibilityFilters: ["private"],
+      sourceFilters: ["mqtt"],
+      sort: "nameAsc",
+    };
+    const stored = serializeLibraryFilterState(state);
+    const getItem = vi.fn().mockReturnValue(stored);
+    vi.stubGlobal("localStorage", { getItem, setItem: vi.fn() });
+    expect(readLibraryFilterState("test-key")).toEqual(
+      parsePersistedLibraryFilterState(stored, DEFAULT_LIBRARY_FILTER_STATE),
+    );
+
+    getItem.mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    expect(readLibraryFilterState("test-key")).toEqual(DEFAULT_LIBRARY_FILTER_STATE);
+    vi.unstubAllGlobals();
+  });
+
+  it("persists filter state with best-effort storage", () => {
+    const setItem = vi.fn();
+    vi.stubGlobal("localStorage", { getItem: vi.fn(), setItem });
+    const state: LibraryFilterState = {
+      searchQuery: "",
+      roleFilters: ["owned"],
+      visibilityFilters: ["private"],
+      sourceFilters: [],
+      sort: "nameAsc",
+    };
+    persistLibraryFilterState("persist-key", state);
+    expect(setItem).toHaveBeenCalledWith("persist-key", serializeLibraryFilterState(state));
+
+    setItem.mockImplementation(() => {
+      throw new Error("quota");
+    });
+    expect(() => persistLibraryFilterState("persist-key", state)).not.toThrow();
+    vi.unstubAllGlobals();
+  });
+});

--- a/src/lib/libraryFilterUi.ts
+++ b/src/lib/libraryFilterUi.ts
@@ -1,0 +1,38 @@
+import {
+  DEFAULT_LIBRARY_FILTER_STATE,
+  parsePersistedLibraryFilterState,
+  serializeLibraryFilterState,
+  type LibraryFilterState,
+} from "./libraryFilters";
+
+export const readLibraryFilterState = (key: string): LibraryFilterState => {
+  try {
+    return parsePersistedLibraryFilterState(localStorage.getItem(key), DEFAULT_LIBRARY_FILTER_STATE);
+  } catch {
+    return DEFAULT_LIBRARY_FILTER_STATE;
+  }
+};
+
+export const persistLibraryFilterState = (key: string, state: LibraryFilterState): void => {
+  try {
+    localStorage.setItem(key, serializeLibraryFilterState(state));
+  } catch {
+    // Best effort only.
+  }
+};
+
+export const effectiveSelection = <T extends string>(selected: T[], allValues: T[]): T[] =>
+  selected.length ? selected : allValues;
+
+export const selectionLabel = <T extends string>(selected: T[], allValues: T[]): string => {
+  const effective = effectiveSelection(selected, allValues);
+  return `${effective.length}/${allValues.length}`;
+};
+
+export const selectionIsFiltered = <T extends string>(selected: T[], allValues: T[]): boolean => {
+  const effective = effectiveSelection(selected, allValues);
+  return effective.length !== allValues.length;
+};
+
+export const toggleValue = <T extends string>(values: T[], key: T): T[] =>
+  values.includes(key) ? values.filter((value) => value !== key) : [...values, key];


### PR DESCRIPTION
## Summary
- extract duplicated filter helper logic into 
- reuse exact copied helpers in  and 
- add behavior-lock tests for shared helper semantics in 

## Constraints honored
- no hook added
- no shared filter UI introduced
- localStorage keys/state shape/selection semantics unchanged
- no CSS/visual changes

## Validation
- npm test
- npm run build

## Issue
Closes #506