### PR TITLE
refactor(ui): extract shared AvatarBadge logic

### DIFF
--- a/src/components/AvatarBadge.tsx
+++ b/src/components/AvatarBadge.tsx
@@ -1,0 +1,26 @@
+import { toInitials } from "../lib/uiFormatting";
+
+type AvatarBadgeProps = {
+  name: string;
+  avatarUrl?: string | null;
+  imageClassName: string;
+  fallbackClassName?: string;
+  fallbackAs?: "span" | "div";
+};
+
+export function AvatarBadge({
+  name,
+  avatarUrl,
+  imageClassName,
+  fallbackClassName,
+  fallbackAs = "span",
+}: AvatarBadgeProps) {
+  if (avatarUrl && avatarUrl.trim()) {
+    return <img alt={name} className={imageClassName} src={avatarUrl} />;
+  }
+  const className = fallbackClassName ?? imageClassName;
+  if (fallbackAs === "div") {
+    return <div className={className}>{toInitials(name)}</div>;
+  }
+  return <span className={className}>{toInitials(name)}</span>;
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -40,7 +40,7 @@ import {
 import { deriveDynamicPropagationEnvironment } from "../lib/propagationEnvironment";
 import { resolveLinkRadio, STANDARD_SITE_RADIO } from "../lib/linkRadio";
 import { sampleSrtmElevation } from "../lib/srtm";
-import { toAccessVisibility, toInitials } from "../lib/uiFormatting";
+import { toAccessVisibility } from "../lib/uiFormatting";
 import {
   DEFAULT_LIBRARY_FILTER_STATE,
   filterAndSortLibraryItems,
@@ -63,6 +63,7 @@ import { useAppStore } from "../store/appStore";
 import type { RadioClimate } from "../types/radio";
 import { siGithub } from "simple-icons";
 import { InfoTip } from "./InfoTip";
+import { AvatarBadge } from "./AvatarBadge";
 import { ModalOverlay } from "./ModalOverlay";
 import SimulationLibraryPanel from "./SimulationLibraryPanel";
 import { UserAdminPanel } from "./UserAdminPanel";
@@ -74,11 +75,7 @@ const parseNumber = (value: string): number => {
 
 const UserBadge = ({ name, avatarUrl }: { name: string; avatarUrl?: string | null }) => (
   <span className="user-list-row">
-    {avatarUrl && avatarUrl.trim() ? (
-      <img alt={name} className="profile-avatar" src={avatarUrl} />
-    ) : (
-      <span className="profile-avatar">{toInitials(name)}</span>
-    )}
+    <AvatarBadge avatarUrl={avatarUrl} imageClassName="profile-avatar" name={name} />
     <span>{name}</span>
   </span>
 );
@@ -3752,15 +3749,7 @@ export function Sidebar({
                       title={`Owner: ${owner.name}`}
                       type="button"
                     >
-                      {owner.avatarUrl ? (
-                        <img
-                          alt={owner.name}
-                          className="row-avatar-image"
-                          src={owner.avatarUrl}
-                        />
-                      ) : (
-                        toInitials(owner.name)
-                      )}
+                      <AvatarBadge avatarUrl={owner.avatarUrl} imageClassName="row-avatar-image" name={owner.name} />
                     </button>
                     {((entry.sharedWith ?? [])
                       .filter((grant) => grant.userId !== (entry as { ownerUserId?: string }).ownerUserId)
@@ -3777,11 +3766,7 @@ export function Sidebar({
                             title={name}
                             type="button"
                           >
-                            {avatarUrl ? (
-                              <img alt={name} className="row-avatar-image" src={avatarUrl} />
-                            ) : (
-                              toInitials(name)
-                            )}
+                            <AvatarBadge avatarUrl={avatarUrl} imageClassName="row-avatar-image" name={name} />
                           </button>
                         );
                       }))}

--- a/src/components/SimulationLibraryPanel.tsx
+++ b/src/components/SimulationLibraryPanel.tsx
@@ -17,9 +17,10 @@ import {
   toggleValue,
 } from "../lib/libraryFilterUi";
 import { formatDate } from "../lib/locale";
-import { toAccessVisibility, toInitials } from "../lib/uiFormatting";
+import { toAccessVisibility } from "../lib/uiFormatting";
 import { duplicateSimulationNameMessage, hasDuplicateSimulationNameForOwner } from "../lib/simulationNameValidation";
 import { useAppStore } from "../store/appStore";
+import { AvatarBadge } from "./AvatarBadge";
 
 type FilterGroupKey = "role" | "visibility";
 
@@ -440,11 +441,7 @@ export default function SimulationLibraryPanel({
                     {toAccessVisibility((preset as { visibility?: unknown }).visibility)}
                   </span>
                   <span className="row-avatar owner-avatar" title={`Owner: ${owner.name}`}>
-                    {owner.avatarUrl ? (
-                      <img alt={owner.name} className="row-avatar-image" src={owner.avatarUrl} />
-                    ) : (
-                      toInitials(owner.name)
-                    )}
+                    <AvatarBadge avatarUrl={owner.avatarUrl} imageClassName="row-avatar-image" name={owner.name} />
                   </span>
                 </span>
                 <div className="library-row-actions">

--- a/src/components/UserAdminPanel.tsx
+++ b/src/components/UserAdminPanel.tsx
@@ -28,10 +28,10 @@ import { FREQUENCY_PRESETS, frequencyPresetGroups } from "../lib/frequencyPlans"
 import { getUiErrorMessage } from "../lib/uiError";
 import { formatDate } from "../lib/locale";
 import { deriveSyncIndicator } from "../lib/syncIndicator";
-import { toInitials } from "../lib/uiFormatting";
 import { useAppStore } from "../store/appStore";
 import { useThemeVariant } from "../hooks/useThemeVariant";
 import type { UiColorTheme } from "../themes/types";
+import { AvatarBadge } from "./AvatarBadge";
 import { InfoTip } from "./InfoTip";
 import { ModalOverlay } from "./ModalOverlay";
 import { SettingsIcon, SyncStatusIcon } from "./icons/AppIcons";
@@ -1420,8 +1420,12 @@ function ProfileAvatar({
   size?: "small" | "large";
 }) {
   const className = size === "large" ? "profile-avatar profile-avatar-large" : "profile-avatar";
-  if (avatarUrl.trim()) {
-    return <img alt={name} className={className} src={avatarUrl} />;
-  }
-  return <div className={className}>{toInitials(name)}</div>;
+  return (
+    <AvatarBadge
+      avatarUrl={avatarUrl}
+      fallbackAs="div"
+      imageClassName={className}
+      name={name}
+    />
+  );
 }


### PR DESCRIPTION
## Summary
- add shared  component for avatar image vs initials fallback
- migrate , , and  to use  for avatar rendering decisions
- preserve existing wrapper DOM/class structures and fallback tag behavior ( vs )

## Constraints honored
- no visual/CSS changes
- no broader identity/user-row abstraction
-  reuse preserved via shared component

## Validation
- npm test
- npm run build

## Issue
Closes #508