### PR TITLE
fix(ui): restore row avatar initials fallback rendering

### DIFF
--- a/src/components/AvatarBadge.tsx
+++ b/src/components/AvatarBadge.tsx
@@ -6,6 +6,7 @@ type AvatarBadgeProps = {
   imageClassName: string;
   fallbackClassName?: string;
   fallbackAs?: "span" | "div";
+  fallbackRawText?: boolean;
 };
 
 export function AvatarBadge({
@@ -14,9 +15,13 @@ export function AvatarBadge({
   imageClassName,
   fallbackClassName,
   fallbackAs = "span",
+  fallbackRawText = false,
 }: AvatarBadgeProps) {
   if (avatarUrl && avatarUrl.trim()) {
     return <img alt={name} className={imageClassName} src={avatarUrl} />;
+  }
+  if (fallbackRawText) {
+    return <>{toInitials(name)}</>;
   }
   const className = fallbackClassName ?? imageClassName;
   if (fallbackAs === "div") {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3749,7 +3749,12 @@ export function Sidebar({
                       title={`Owner: ${owner.name}`}
                       type="button"
                     >
-                      <AvatarBadge avatarUrl={owner.avatarUrl} imageClassName="row-avatar-image" name={owner.name} />
+                      <AvatarBadge
+                        avatarUrl={owner.avatarUrl}
+                        fallbackRawText
+                        imageClassName="row-avatar-image"
+                        name={owner.name}
+                      />
                     </button>
                     {((entry.sharedWith ?? [])
                       .filter((grant) => grant.userId !== (entry as { ownerUserId?: string }).ownerUserId)
@@ -3766,7 +3771,12 @@ export function Sidebar({
                             title={name}
                             type="button"
                           >
-                            <AvatarBadge avatarUrl={avatarUrl} imageClassName="row-avatar-image" name={name} />
+                            <AvatarBadge
+                              avatarUrl={avatarUrl}
+                              fallbackRawText
+                              imageClassName="row-avatar-image"
+                              name={name}
+                            />
                           </button>
                         );
                       }))}

--- a/src/components/SimulationLibraryPanel.tsx
+++ b/src/components/SimulationLibraryPanel.tsx
@@ -441,7 +441,12 @@ export default function SimulationLibraryPanel({
                     {toAccessVisibility((preset as { visibility?: unknown }).visibility)}
                   </span>
                   <span className="row-avatar owner-avatar" title={`Owner: ${owner.name}`}>
-                    <AvatarBadge avatarUrl={owner.avatarUrl} imageClassName="row-avatar-image" name={owner.name} />
+                    <AvatarBadge
+                      avatarUrl={owner.avatarUrl}
+                      fallbackRawText
+                      imageClassName="row-avatar-image"
+                      name={owner.name}
+                    />
                   </span>
                 </span>
                 <div className="library-row-actions">


### PR DESCRIPTION
## Summary
- fix AvatarBadge regression in row-avatar contexts by restoring raw-text initials fallback
- keep user-list/profile-avatar behavior unchanged
- preserve existing wrapper DOM/class structures

## Validation
- npm test
- npm run build

## Issue
Closes #510