### PR TITLE
Issue #512: consolidate exact close icon button primitive

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,5 +1,5 @@
 import { type CSSProperties, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { CircleUserRound, CircleX, CloudAlert, Copy, Globe, Maximize2, PanelBottom, PanelBottomClose, PanelLeft, PanelLeftClose, PanelRight, PanelRightClose, Share, UserRoundPlus, UserRoundSearch, Users } from "lucide-react";
+import { CircleUserRound, CloudAlert, Copy, Globe, Maximize2, PanelBottom, PanelBottomClose, PanelLeft, PanelLeftClose, PanelRight, PanelRightClose, Share, UserRoundPlus, UserRoundSearch, Users } from "lucide-react";
 import { type CollaboratorDirectoryUser, fetchCollaboratorDirectory, fetchDeepLinkStatus, fetchMe, setLocalDevRole } from "../lib/cloudUser";
 import { fetchCloudLibrary, fetchPublicSimulationLibrary, pushCloudLibrary } from "../lib/cloudLibrary";
 import { buildDeepLinkPathname, buildDeepLinkUrl, canonicalizeDeepLinkKey, parseDeepLinkFromLocation, slugifyName } from "../lib/deepLink";
@@ -20,6 +20,7 @@ import { resolveBasemapSelection } from "../lib/basemaps";
 import { useThemeVariant } from "../hooks/useThemeVariant";
 import { useAppStore } from "../store/appStore";
 import { LinkProfileChart } from "./LinkProfileChart";
+import { InlineCloseIconButton } from "./InlineCloseIconButton";
 import { MapView } from "./MapView";
 import { ModalOverlay } from "./ModalOverlay";
 import OnboardingTutorialModal from "./OnboardingTutorialModal";
@@ -1801,9 +1802,7 @@ export function AppShell() {
           <div className="library-manager-card">
             <div className="library-manager-header">
               <h2>Share Simulation</h2>
-              <button aria-label="Close" className="inline-action inline-action-icon" onClick={closeShareModal} title="Close" type="button">
-                <CircleX aria-hidden="true" strokeWidth={1.8} />
-              </button>
+              <InlineCloseIconButton onClick={closeShareModal} />
             </div>
             {!activeSimulation ? (
               <p className="field-help">Open a saved simulation first. Unsaved workspace state cannot be deep-linked.</p>

--- a/src/components/InlineCloseIconButton.tsx
+++ b/src/components/InlineCloseIconButton.tsx
@@ -1,0 +1,13 @@
+import { CircleX } from "lucide-react";
+
+type InlineCloseIconButtonProps = {
+  onClick: () => void;
+};
+
+export function InlineCloseIconButton({ onClick }: InlineCloseIconButtonProps) {
+  return (
+    <button aria-label="Close" className="inline-action inline-action-icon" onClick={onClick} title="Close" type="button">
+      <CircleX aria-hidden="true" strokeWidth={1.8} />
+    </button>
+  );
+}

--- a/src/components/OnboardingTutorialModal.tsx
+++ b/src/components/OnboardingTutorialModal.tsx
@@ -1,8 +1,8 @@
 import { useMemo } from "react";
-import { CircleX } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import onboardingMarkdown from "../../docs/onboarding.md?raw";
+import { InlineCloseIconButton } from "./InlineCloseIconButton";
 import { ModalOverlay } from "./ModalOverlay";
 
 const FEEDBACK_ISSUES_URL = "https://github.com/wilhel1812/LinkSim/issues/new/choose";
@@ -44,9 +44,7 @@ export default function OnboardingTutorialModal({
         <div className="library-manager-header">
           <h2>Getting Started</h2>
           <div className="chip-group">
-            <button aria-label="Close" className="inline-action inline-action-icon" onClick={onClose} title="Close" type="button">
-              <CircleX aria-hidden="true" strokeWidth={1.8} />
-            </button>
+            <InlineCloseIconButton onClick={onClose} />
           </div>
         </div>
         <div className="tutorial-markdown">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import clsx from "clsx";
-import { CircleX, Funnel, Handshake, HatGlasses, RefreshCw } from "lucide-react";
+import { Funnel, Handshake, HatGlasses, RefreshCw } from "lucide-react";
 import Map, {
   Layer,
   Marker,
@@ -64,6 +64,7 @@ import type { RadioClimate } from "../types/radio";
 import { siGithub } from "simple-icons";
 import { InfoTip } from "./InfoTip";
 import { AvatarBadge } from "./AvatarBadge";
+import { InlineCloseIconButton } from "./InlineCloseIconButton";
 import { ModalOverlay } from "./ModalOverlay";
 import SimulationLibraryPanel from "./SimulationLibraryPanel";
 import { UserAdminPanel } from "./UserAdminPanel";
@@ -1924,9 +1925,7 @@ export function Sidebar({
           <div className="library-manager-card user-profile-popup">
             <div className="library-manager-header">
               <h2>{linkModal.mode === "add" ? "Add Link" : "Edit Link"}</h2>
-              <button aria-label="Close" className="inline-action inline-action-icon" onClick={() => setLinkModal(null)} title="Close" type="button">
-                <CircleX aria-hidden="true" strokeWidth={1.8} />
-              </button>
+              <InlineCloseIconButton onClick={() => setLinkModal(null)} />
             </div>
             <label className="field-grid">
               <span>Link name</span>
@@ -2109,9 +2108,7 @@ export function Sidebar({
           <div className="library-manager-card user-profile-popup">
             <div className="library-manager-header">
               <h2>User Profile</h2>
-              <button aria-label="Close" className="inline-action inline-action-icon" onClick={() => setProfilePopupUser(null)} title="Close" type="button">
-                <CircleX aria-hidden="true" strokeWidth={1.8} />
-              </button>
+              <InlineCloseIconButton onClick={() => setProfilePopupUser(null)} />
             </div>
             <p className="field-help">
               <strong>
@@ -2192,9 +2189,7 @@ export function Sidebar({
           <div className="library-manager-card">
             <div className="library-manager-header">
               <h2>Change Log · {changeLogPopup.label}</h2>
-              <button aria-label="Close" className="inline-action inline-action-icon" onClick={() => setChangeLogPopup(null)} title="Close" type="button">
-                <CircleX aria-hidden="true" strokeWidth={1.8} />
-              </button>
+              <InlineCloseIconButton onClick={() => setChangeLogPopup(null)} />
             </div>
             {changeLogPopup.busy ? <p className="field-help">Loading changes...</p> : null}
             {changeLogPopup.status ? <p className="field-help">{changeLogPopup.status}</p> : null}
@@ -2265,9 +2260,7 @@ export function Sidebar({
           <div className="library-manager-card user-profile-popup resource-details-card">
             <div className="library-manager-header">
               <h2>Edit · {resourceDetailsPopup.label}</h2>
-              <button aria-label="Close" className="inline-action inline-action-icon" onClick={() => setResourceDetailsPopup(null)} title="Close" type="button">
-                <CircleX aria-hidden="true" strokeWidth={1.8} />
-              </button>
+              <InlineCloseIconButton onClick={() => setResourceDetailsPopup(null)} />
             </div>
             <p className="field-help">Type: {resourceDetailsPopup.kind === "site" ? "Site" : "Simulation"}</p>
             <p className="field-help">ID: {resourceDetailsPopup.resourceId}</p>
@@ -2869,18 +2862,12 @@ export function Sidebar({
           <div className="library-manager-card user-profile-popup">
             <div className="library-manager-header">
               <h2>New Simulation</h2>
-                <button
-                  aria-label="Close"
-                  className="inline-action inline-action-icon"
+                <InlineCloseIconButton
                   onClick={() => {
                     setShowNewSimulationModal(false);
                     setNewSimulationNameError("");
                   }}
-                  title="Close"
-                  type="button"
-                >
-                  <CircleX aria-hidden="true" strokeWidth={1.8} />
-                </button>
+                />
             </div>
             <label className="field-grid">
               <span>Name</span>
@@ -3070,9 +3057,7 @@ export function Sidebar({
           <div className="library-manager-card user-profile-popup">
             <div className="library-manager-header">
               <h2>Visibility Change Confirmation</h2>
-              <button aria-label="Close" className="inline-action inline-action-icon" onClick={() => setPendingSimulationVisibilityPrompt(null)} title="Close" type="button">
-                <CircleX aria-hidden="true" strokeWidth={1.8} />
-              </button>
+              <InlineCloseIconButton onClick={() => setPendingSimulationVisibilityPrompt(null)} />
             </div>
             <p className="field-help">
               You are setting this simulation to{" "}
@@ -3106,19 +3091,13 @@ export function Sidebar({
           <div className="library-manager-card">
             <div className="library-manager-header">
               <h2>Site Library</h2>
-              <button
-                aria-label="Close"
-                className="inline-action inline-action-icon"
+              <InlineCloseIconButton
                 onClick={() => {
                   setShowSiteLibraryManager(false);
                   setPendingDraftAutoInsert(false);
                   closeSiteFilterEditors();
                 }}
-                title="Close"
-                type="button"
-              >
-                <CircleX aria-hidden="true" strokeWidth={1.8} />
-              </button>
+              />
             </div>
             <p className="field-help">
               Built for large libraries. Select one or more entries to add into this simulation.
@@ -3824,9 +3803,7 @@ export function Sidebar({
           <div className="library-manager-card user-profile-popup">
             <div className="library-manager-header">
               <h2>{deleteConfirm.title}</h2>
-              <button aria-label="Close" className="inline-action inline-action-icon" onClick={() => setDeleteConfirm(null)} title="Close" type="button">
-                <CircleX aria-hidden="true" strokeWidth={1.8} />
-              </button>
+              <InlineCloseIconButton onClick={() => setDeleteConfirm(null)} />
             </div>
             <p className="field-help">{deleteConfirm.message}</p>
             <div className="chip-group">

--- a/src/components/SimulationLibraryPanel.tsx
+++ b/src/components/SimulationLibraryPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import clsx from "clsx";
-import { CircleX, Funnel } from "lucide-react";
+import { Funnel } from "lucide-react";
 import {
   DEFAULT_LIBRARY_FILTER_STATE,
   filterAndSortLibraryItems,
@@ -21,6 +21,7 @@ import { toAccessVisibility } from "../lib/uiFormatting";
 import { duplicateSimulationNameMessage, hasDuplicateSimulationNameForOwner } from "../lib/simulationNameValidation";
 import { useAppStore } from "../store/appStore";
 import { AvatarBadge } from "./AvatarBadge";
+import { InlineCloseIconButton } from "./InlineCloseIconButton";
 
 type FilterGroupKey = "role" | "visibility";
 
@@ -245,9 +246,7 @@ export default function SimulationLibraryPanel({
     <div className="library-manager-card">
       <div className="library-manager-header">
         <h2>Simulation Library</h2>
-        <button aria-label="Close" className="inline-action inline-action-icon" onClick={onClose} title="Close" type="button">
-          <CircleX aria-hidden="true" strokeWidth={1.8} />
-        </button>
+        <InlineCloseIconButton onClick={onClose} />
       </div>
       <p className="field-help">
         Manage saved simulations here. Site/node editing still happens in the main workspace.
@@ -479,18 +478,12 @@ export default function SimulationLibraryPanel({
           <div className="library-manager-card user-profile-popup welcome-modal-new-simulation">
             <div className="library-manager-header">
               <h2>New Simulation</h2>
-              <button
-                aria-label="Close"
-                className="inline-action inline-action-icon"
+              <InlineCloseIconButton
                 onClick={() => {
                   setShowNewSimulationModal(false);
                   setNewSimulationNameError("");
                 }}
-                title="Close"
-                type="button"
-              >
-                <CircleX aria-hidden="true" strokeWidth={1.8} />
-              </button>
+              />
             </div>
             <label className="field-grid">
               <span>Name</span>

--- a/src/components/UserAdminPanel.tsx
+++ b/src/components/UserAdminPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState, type ChangeEvent, type ReactNode } from "react";
-import { CircleQuestionMark, CircleUserRound, CircleX } from "lucide-react";
+import { CircleQuestionMark, CircleUserRound } from "lucide-react";
 import {
   bulkReassignOwnership,
   fetchAdminAuditEvents,
@@ -33,6 +33,7 @@ import { useThemeVariant } from "../hooks/useThemeVariant";
 import type { UiColorTheme } from "../themes/types";
 import { AvatarBadge } from "./AvatarBadge";
 import { InfoTip } from "./InfoTip";
+import { InlineCloseIconButton } from "./InlineCloseIconButton";
 import { ModalOverlay } from "./ModalOverlay";
 import { SettingsIcon, SyncStatusIcon } from "./icons/AppIcons";
 
@@ -769,9 +770,7 @@ export function UserAdminPanel({ onOpenHelp, authBootstrapPending = false, extra
           <div className="library-manager-card sync-modal">
             <div className="library-manager-header">
               <h2>Cloud Sync</h2>
-              <button aria-label="Close" className="inline-action inline-action-icon" onClick={() => setSyncModalOpen(false)} title="Close" type="button">
-                <CircleX aria-hidden="true" strokeWidth={1.8} />
-              </button>
+              <InlineCloseIconButton onClick={() => setSyncModalOpen(false)} />
             </div>
             <div className="sync-modal-content">
               <div className="sync-info-grid">
@@ -867,9 +866,7 @@ export function UserAdminPanel({ onOpenHelp, authBootstrapPending = false, extra
                 <button className="inline-action" onClick={handleSignOut} type="button">
                   Sign Out
                 </button>
-                <button aria-label="Close" className="inline-action inline-action-icon" onClick={() => setOpen(false)} title="Close" type="button">
-                  <CircleX aria-hidden="true" strokeWidth={1.8} />
-                </button>
+                <InlineCloseIconButton onClick={() => setOpen(false)} />
               </div>
             </div>
 
@@ -1284,9 +1281,7 @@ export function UserAdminPanel({ onOpenHelp, authBootstrapPending = false, extra
                 <div className="library-manager-card user-profile-popup">
                   <div className="library-manager-header">
                     <h2>User Profile</h2>
-                    <button aria-label="Close" className="inline-action inline-action-icon" onClick={closeManagedUser} title="Close" type="button">
-                      <CircleX aria-hidden="true" strokeWidth={1.8} />
-                    </button>
+                    <InlineCloseIconButton onClick={closeManagedUser} />
                   </div>
                   <div className="user-list-row">
                     <ProfileAvatar avatarUrl={managedUser.avatarUrl} name={managedUser.username} size="large" />


### PR DESCRIPTION
## Summary\n- add  with exact existing close-button classes/attrs/icon payload\n- migrate exact close-pattern matches in Sidebar, SimulationLibraryPanel, OnboardingTutorialModal, UserAdminPanel, and close action in AppShell\n- leave non-close icon actions unchanged\n\n## Notes\n-  is not present on this branch, so no header wiring was introduced in this pass\n- no CSS changes\n\n## Validation\n- npm test\n- npm run build\n- grep verification for close-pattern consolidation