### PR TITLE
Issue #514: avoid opening Site Library when opening site details

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -927,7 +927,6 @@ export function Sidebar({
   useEffect(() => {
     if (!pendingSiteLibraryOpenEntryId) return;
     const entry = siteLibrary.find((candidate) => candidate.id === pendingSiteLibraryOpenEntryId);
-    setShowSiteLibraryManager(true);
     if (entry) {
       openResourceDetailsPopup({
         kind: "site",
@@ -940,6 +939,8 @@ export function Sidebar({
         lastEditedByName: (entry as unknown as { lastEditedByName?: string }).lastEditedByName ?? "Unknown",
         lastEditedByAvatarUrl: (entry as unknown as { lastEditedByAvatarUrl?: string }).lastEditedByAvatarUrl ?? "",
       });
+    } else {
+      setShowSiteLibraryManager(true);
     }
     clearOpenSiteLibraryEntryRequest();
   }, [pendingSiteLibraryOpenEntryId, siteLibrary, clearOpenSiteLibraryEntryRequest]);


### PR DESCRIPTION
## Summary\n- fix Sidebar pending site-entry open effect\n- when entry exists: open Resource Details only\n- when entry does not exist: open Site Library manager fallback\n\n## Validation\n- npm test\n- npm run build