### PR TITLE
ActionButton visual pass 1: scoped typography and min-height

### DIFF
--- a/src/components/ActionButton.tsx
+++ b/src/components/ActionButton.tsx
@@ -16,7 +16,7 @@ export function ActionButton({
   return (
     <button
       {...buttonProps}
-      className={clsx("inline-action", variant === "danger" && "danger", className)}
+      className={clsx("inline-action", "action-button", variant === "danger" && "danger", className)}
       type={type}
     >
       {children}

--- a/src/index.css
+++ b/src/index.css
@@ -2319,6 +2319,12 @@ input {
   gap: 8px;
 }
 
+.action-button {
+  font-size: 0.82rem;
+  font-weight: 600;
+  min-height: 34px;
+}
+
 .inline-action.danger {
   border-color: color-mix(in srgb, var(--danger) 78%, var(--border));
   background: var(--danger);


### PR DESCRIPTION
## Summary
- scope first visual alignment pass to `.action-button` only
- add `action-button` class in `ActionButton` primitive
- standardize ActionButton family metrics:
  - font-size: 0.82rem
  - font-weight: 600
  - min-height: 34px

## Constraints kept
- no global `.inline-action` changes
- no line-height changes
- no padding changes
- no variant expansion

## Verification
- npm test
- npm run build

Closes #525
