### PR TITLE
Audit inline-action candidates and migrate bounded ActionButton set

### DIFF
--- a/docs/actionbutton-candidate-audit.md
+++ b/docs/actionbutton-candidate-audit.md
@@ -1,0 +1,59 @@
+# ActionButton Candidate Audit (Repo-wide)
+
+Source of truth: `docs/ui-pattern-glossary.md`
+
+Audit target: remaining `inline-action` / `inline-action danger` usages not already migrated to `ActionButton`.
+
+## Classification Inventory
+
+### Migrate to ActionButton now
+
+#### `src/components/NotificationsPanel.tsx`
+- Usage: refresh button in notifications popover (`inline-action`)
+- Classification: migrate to ActionButton now
+- Glossary reason: standard app action in panel content (ActionButton role), not a tool control/selection/tab/specialized trigger.
+
+#### `src/components/SimulationResultsSection.tsx`
+- Usage: LoRa helper action + export manifest action (`inline-action`)
+- Classification: migrate to ActionButton now
+- Glossary reason: standard command actions in normal panel flow (ActionButton role), no special styling semantics beyond default action.
+
+### Keep as exception
+
+#### `src/components/OnboardingTutorialModal.tsx`
+- Usage: report CTA anchor with `inline-action tutorial-report-button`
+- Classification: keep as exception
+- Glossary reason: link-like/document/report CTA pattern, closer to `LinkButton`/contextual documentation action than core ActionButton migration target.
+
+#### `src/components/InlineCloseIconButton.tsx`
+- Usage: close icon affordance (`inline-action inline-action-icon`)
+- Classification: keep as exception
+- Glossary reason: dedicated close icon primitive category in glossary; not part of default/danger ActionButton family.
+
+#### `src/components/WelcomeModal.tsx`
+- Usage: `inline-action welcome-compact-button` onboarding choices
+- Classification: keep as exception
+- Glossary reason: specialized welcome entry-point treatment with custom compact styling; intentionally distinct from baseline action-family migration pass.
+
+### Borderline / defer
+
+#### `src/components/Sidebar.tsx`
+- Usage: many mixed `inline-action`/`danger` controls across simulation/site/link/library/resource/admin flows
+- Classification: borderline / defer
+- Glossary reason: file mixes standard actions with selection-surface adjacency, special inline spans, filter trigger patterns, and high interaction density. Needs sub-slice planning to avoid over-migration risk.
+
+#### `src/components/AppShell.tsx`
+- Usage: mixed auth/dev/share/offline actions, includes icon-only inline-action usage in share modal
+- Classification: borderline / defer
+- Glossary reason: mixed contexts and semantics (some standard actions, some exception/icon flows). Better handled as scoped sub-pass.
+
+#### `src/components/UserAdminPanel.tsx`
+- Usage: large set of admin/moderation/account actions, plus modal management and destructive controls
+- Classification: borderline / defer
+- Glossary reason: high-volume, mixed-risk operational actions. ActionButton migration is likely valid for many controls but should be split by section to keep regression risk low.
+
+## Bounded Migration Pass Implemented
+- Included only “migrate now” set:
+  - `src/components/NotificationsPanel.tsx`
+  - `src/components/SimulationResultsSection.tsx`
+- Excluded all exception and borderline/defer sets above.

--- a/src/components/NotificationsPanel.tsx
+++ b/src/components/NotificationsPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { fetchNotifications, type NotificationFeed, type PendingApprovalUser } from "../lib/cloudNotifications";
 import { getUiErrorMessage } from "../lib/uiError";
 import { formatDate } from "../lib/locale";
+import { ActionButton } from "./ActionButton";
 
 const POLL_MS = 30_000;
 
@@ -57,9 +58,9 @@ export function NotificationsPanel() {
         <div className="notifications-popover">
           <div className="section-heading">
             <p className="field-help">Moderator/Admin notifications</p>
-            <button className="inline-action" onClick={() => void load()} type="button">
+            <ActionButton onClick={() => void load()}>
               Refresh
-            </button>
+            </ActionButton>
           </div>
           {busy ? <p className="field-help">Loading…</p> : null}
           {status ? <p className="field-help">{status}</p> : null}

--- a/src/components/SimulationResultsSection.tsx
+++ b/src/components/SimulationResultsSection.tsx
@@ -8,6 +8,7 @@ import { sampleSrtmElevation } from "../lib/srtm";
 import { useAppStore } from "../store/appStore";
 import type { PropagationEnvironment } from "../types/radio";
 import { InfoTip } from "./InfoTip";
+import { ActionButton } from "./ActionButton";
 
 const metric = (label: string, value: string) => (
   <div className="metric-row" key={label}>
@@ -359,13 +360,11 @@ export function SimulationResultsSection() {
       </label>
       {isLoraEstimateRelevant ? (
         <div className="section-heading">
-          <button
-            className="inline-action"
+          <ActionButton
             onClick={() => setRxSensitivityTargetDbm(Math.round(loraSensitivitySuggestionDbm))}
-            type="button"
           >
             Set RX Target To LoRa Estimate ({loraSensitivitySuggestionDbm.toFixed(1)} dBm)
-          </button>
+          </ActionButton>
           <InfoTip text="Sets RX target to a LoRa sensitivity estimate from current BW and SF (noise floor + NF + SF SNR limit). This is a helper target, not a measured receiver spec." />
         </div>
       ) : (
@@ -390,9 +389,9 @@ export function SimulationResultsSection() {
           </div>
         ))}
       </div>
-      <button className="inline-action" onClick={exportManifest} type="button">
+      <ActionButton onClick={exportManifest}>
         Export Simulation Manifest
-      </button>
+      </ActionButton>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- add repo-wide inline-action candidate audit using UI Pattern Glossary as source of truth
- classify remaining usages into migrate-now / exception / borderline-defer
- migrate only bounded migrate-now set:
  - NotificationsPanel refresh action
  - SimulationResultsSection actions

## Verification
- npm test
- npm run build

Closes #529
