### PR TITLE
Normalize app chrome font-family inheritance for sidebar and inspector

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -191,6 +191,7 @@ input {
   display: flex;
   flex-direction: column;
   gap: 16px;
+  font-family: "Space Grotesk", "Avenir Next", sans-serif;
   max-height: calc(100vh - 36px);
   overflow: auto;
 }
@@ -1104,6 +1105,7 @@ input {
   display: grid;
   gap: 0;
   font-size: 0.76rem;
+  font-family: "Space Grotesk", "Avenir Next", sans-serif;
 }
 
 .map-inspector-header-row {


### PR DESCRIPTION
## Summary
- audit typography inheritance across app chrome and lock font-family at container level for sidebar/inspector
- keep ActionButton untouched and avoid role/taxonomy changes

## Changes
- set explicit `font-family: "Space Grotesk", "Avenir Next", sans-serif;` on:
  - `.sidebar-panel`
  - `.map-inspector`

## Why
- prevent accidental font-family drift from parent/third-party inheritance boundaries
- keep current visual language while standardizing chrome text-family source of truth at container level

## Verification
- npm test
- npm run build