### PR TITLE
Document panel-shell vocabulary and preserve legacy naming boundaries

### DIFF
--- a/docs/ui-pattern-glossary.md
+++ b/docs/ui-pattern-glossary.md
@@ -15,6 +15,33 @@ Status labels:
 
 ## Standard Patterns
 
+### Panel Shells
+- Role: structural app chrome shells that host content families; shell naming is independent from the feature content rendered inside.
+- Use when: discussing layout/frame behavior (left side, right side, bottom shell) instead of feature-specific content.
+- Do not use when: describing the internals of a feature module (map settings, profile chart details, library forms).
+- Variants:
+  - `LeftSidePanel` (current shell class: `sidebar-panel`)
+  - `RightSidePanel` (current shell class: `map-inspector`, legacy name retained temporarily)
+  - `BottomPanel` (current shell class: `chart-panel`, mobile host: `mobile-workspace-panel`)
+- Known examples/files:
+  - `src/components/AppShell.tsx`
+  - `src/components/MapView.tsx`
+  - `src/components/LinkProfileChart.tsx`
+  - `src/index.css` (`.sidebar-panel`, `.map-inspector`, `.chart-panel`, `.mobile-workspace-panel*`)
+- Status: `under migration`
+
+Shell concerns vs content concerns:
+- Shell concerns:
+  - panel placement, visibility/expand/collapse, mobile tab hosting, shell spacing/chrome
+- Content concerns:
+  - Sidebar sections (Simulation/Site/Path/Radio/Data)
+  - Right-panel inspector/details/map settings content
+  - Bottom-panel path profile chart content
+
+Legacy names to keep temporarily for stability:
+- Keep `map-inspector` class/props for now (widely used selectors/props), but treat it as `RightSidePanel` in planning vocabulary.
+- Keep `profile` naming for the bottom chart shell toggles/keys in current code until a dedicated rename pass is scoped.
+
 ### ActionButton
 - Role: standard app action control (inline actions in modals, panels, and inspector actions).
 - Use when: triggering an app action like Save, Load, Details, Create, Dismiss, or Remove.

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -38,6 +38,10 @@ const ONBOARDING_SEEN_KEY_PREFIX = "linksim:onboarding-seen:v1:";
 const LOCAL_FORCE_READONLY_KEY = "linksim:local-force-readonly:v1";
 const OPEN_SYNC_MODAL_EVENT = "linksim:open-sync-modal";
 const ACCESS_CHECK_TIMEOUT_MS = 10_000;
+// Shell vocabulary mapping for cleanup work:
+// - navigator => LeftSidePanel
+// - inspector => RightSidePanel (legacy term retained in code for stability)
+// - profile => BottomPanel shell (legacy term retained in code for stability)
 type MobileWorkspacePanel = "navigator" | "inspector" | "profile";
 type MobileBottomPanelMode = "hidden" | "normal" | "full";
 type AppNotice = {
@@ -48,6 +52,7 @@ type AppNotice = {
 };
 
 const UI_PANEL_KEYS = {
+  // Storage keys keep legacy names to avoid migration churn.
   navigatorHidden: "linksim-ui-navigator-hidden-v1",
   inspectorHidden: "linksim-ui-inspector-hidden-v1",
   profileHidden: "linksim-ui-profile-hidden-v1",

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -968,6 +968,7 @@ type MapViewProps = {
   readOnly?: boolean;
   canPersist?: boolean;
   onToggleMapExpanded: () => void;
+  // Legacy prop name retained for stability; this renders in the RightSidePanel shell.
   inspectorHeaderActions?: ReactNode;
   notice?: {
     message: string;


### PR DESCRIPTION
## Summary
Minimal panel-shell vocabulary cleanup with no behavior/layout changes.

## Changes
- Update UI glossary with shell taxonomy:
  - LeftSidePanel (`sidebar-panel`)
  - RightSidePanel (`map-inspector` legacy class)
  - BottomPanel (`chart-panel`, mobile host `mobile-workspace-panel`)
- Add explicit shell-vs-content concern separation in glossary.
- Add code comments preserving legacy naming intentionally for stability in:
  - `AppShell` panel type/storage-key naming
  - `MapView` `inspectorHeaderActions` prop

## Out of scope
- No CSS/class renames
- No behavior changes
- No layout redesign

## Verification
- npm test
- npm run build