### PR TITLE
Issue #529: broaden ActionButton migration for standard actions

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -20,6 +20,7 @@ import { resolveBasemapSelection } from "../lib/basemaps";
 import { useThemeVariant } from "../hooks/useThemeVariant";
 import { useAppStore } from "../store/appStore";
 import { LinkProfileChart } from "./LinkProfileChart";
+import { ActionButton } from "./ActionButton";
 import { InlineCloseIconButton } from "./InlineCloseIconButton";
 import { MapView } from "./MapView";
 import { ModalOverlay } from "./ModalOverlay";
@@ -1355,18 +1356,18 @@ export function AppShell() {
           </ul>
           {isLocalRuntime ? (
             <div className="chip-group">
-              <button className="inline-action" onClick={() => void switchLocalRole("admin")} type="button">
+              <ActionButton onClick={() => void switchLocalRole("admin")} type="button">
                 Use Admin (Local)
-              </button>
-              <button className="inline-action" onClick={() => void switchLocalRole("moderator")} type="button">
+              </ActionButton>
+              <ActionButton onClick={() => void switchLocalRole("moderator")} type="button">
                 Use Moderator (Local)
-              </button>
-              <button className="inline-action" onClick={() => void switchLocalRole("user")} type="button">
+              </ActionButton>
+              <ActionButton onClick={() => void switchLocalRole("user")} type="button">
                 Use User (Local)
-              </button>
-              <button className="inline-action" onClick={() => void switchLocalRole("pending")} type="button">
+              </ActionButton>
+              <ActionButton onClick={() => void switchLocalRole("pending")} type="button">
                 Use Pending (Local)
-              </button>
+              </ActionButton>
             </div>
           ) : null}
            {localDevStatus ? <p className="field-help">{localDevStatus}</p> : null}
@@ -1404,30 +1405,30 @@ export function AppShell() {
           <div className="chip-group">
           {shouldPromptSignIn ? (
               <>
-                <button className="inline-action" onClick={signIn} type="button">
+                <ActionButton onClick={signIn} type="button">
                   <CircleUserRound aria-hidden="true" strokeWidth={1.8} />
                   <span>Sign In</span>
-                </button>
+                </ActionButton>
               </>
             ) : (
-              <button className="inline-action" onClick={signOutOrReadonly} type="button">
+              <ActionButton onClick={signOutOrReadonly} type="button">
                 Sign Out
-              </button>
+              </ActionButton>
             )}
             {isLocalRuntime ? (
               <>
-                <button className="inline-action" onClick={() => void switchLocalRole("admin")} type="button">
+                <ActionButton onClick={() => void switchLocalRole("admin")} type="button">
                   Use Admin (Local)
-                </button>
-                <button className="inline-action" onClick={() => void switchLocalRole("moderator")} type="button">
+                </ActionButton>
+                <ActionButton onClick={() => void switchLocalRole("moderator")} type="button">
                   Use Moderator (Local)
-                </button>
-                <button className="inline-action" onClick={() => void switchLocalRole("user")} type="button">
+                </ActionButton>
+                <ActionButton onClick={() => void switchLocalRole("user")} type="button">
                   Use User (Local)
-                </button>
-                <button className="inline-action" onClick={() => void switchLocalRole("pending")} type="button">
+                </ActionButton>
+                <ActionButton onClick={() => void switchLocalRole("pending")} type="button">
                   Use Pending (Local)
-                </button>
+                </ActionButton>
               </>
             ) : null}
           </div>
@@ -1550,18 +1551,17 @@ export function AppShell() {
           <div className="offline-banner" role="status">
             <span>Offline. Changes are saved locally and will sync when connection returns.</span>
             <div className="chip-group">
-              <button
-                className="inline-action"
+              <ActionButton
                 onClick={() => {
                   window.dispatchEvent(new CustomEvent(OPEN_SYNC_MODAL_EVENT));
                 }}
                 type="button"
               >
                 Open Sync Status
-              </button>
-              <button className="inline-action" onClick={() => setOfflineBannerDismissed(true)} type="button">
+              </ActionButton>
+              <ActionButton onClick={() => setOfflineBannerDismissed(true)} type="button">
                 Dismiss
-              </button>
+              </ActionButton>
             </div>
           </div>
         ) : null}
@@ -1569,13 +1569,12 @@ export function AppShell() {
           <div className="empty-workspace-overlay">
             <div className="empty-workspace-message">
               <p>Open an existing simulation or create a new one to continue.</p>
-              <button
-                className="inline-action"
+              <ActionButton
                 onClick={() => setShowSimulationLibraryRequest(true)}
                 type="button"
               >
                 Open Library
-              </button>
+              </ActionButton>
             </div>
           </div>
         ) : null}
@@ -1586,8 +1585,7 @@ export function AppShell() {
         ) : null}
         <div className="workspace-header-actions">
           {accessState === "readonly" && isLocalRuntime ? (
-            <button
-              className="inline-action"
+            <ActionButton
               onClick={() => {
                 try {
                   localStorage.removeItem(LOCAL_FORCE_READONLY_KEY);
@@ -1599,7 +1597,7 @@ export function AppShell() {
               type="button"
             >
               Return to Local User
-            </button>
+            </ActionButton>
           ) : null}
         </div>
         <MapView
@@ -1818,9 +1816,9 @@ export function AppShell() {
                           {referencedPrivateSites.length ? ` and ${referencedPrivateSites.length} referenced site(s)` : ""} will be set to Shared.
                           {referencedPrivateSites.some((site) => !canEditResource(site)) ? " Some sites require owner access." : ""}
                         </p>
-                        <button className="inline-action" disabled={shareBusy} onClick={() => void runUpgradeAndShare()} type="button">
+                        <ActionButton disabled={shareBusy} onClick={() => void runUpgradeAndShare()} type="button">
                           Upgrade &amp; Copy Link
-                        </button>
+                        </ActionButton>
                       </div>
                       {/* Option B: Specific users */}
                       <div className="panel-section compact-panel" style={{ display: "flex", flexDirection: "column", gap: "0.5em" }}>
@@ -1845,13 +1843,12 @@ export function AppShell() {
                                     <option value="viewer">Viewer</option>
                                     <option value="editor">Editor</option>
                                   </select>
-                                  <button
-                                    className="inline-action"
+                                  <ActionButton
                                     onClick={() => setShareSpecificUsers((prev) => prev.filter((id) => id !== uid))}
                                     type="button"
                                   >
                                     Remove
-                                  </button>
+                                  </ActionButton>
                                 </span>
                               );
                             })}
@@ -1900,8 +1897,7 @@ export function AppShell() {
                           </div>
                         ) : null}
                         <div style={{ marginTop: "auto" }}>
-                          <button
-                            className="inline-action"
+                          <ActionButton
                             disabled={shareSpecificBusy || !shareSpecificUsers.length}
                             onClick={() => void runShareWithSpecificUsers()}
                             style={{ display: "flex", alignItems: "center", gap: "0.35em" }}
@@ -1909,7 +1905,7 @@ export function AppShell() {
                           >
                             <Copy aria-hidden="true" size={14} strokeWidth={1.8} />
                             Save &amp; Copy Link
-                          </button>
+                          </ActionButton>
                         </div>
                         {shareSpecificStatus ? <p className="field-help">{shareSpecificStatus}</p> : null}
                       </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -63,6 +63,7 @@ import { useAppStore } from "../store/appStore";
 import type { RadioClimate } from "../types/radio";
 import { siGithub } from "simple-icons";
 import { InfoTip } from "./InfoTip";
+import { ActionButton } from "./ActionButton";
 import { AvatarBadge } from "./AvatarBadge";
 import { InlineCloseIconButton } from "./InlineCloseIconButton";
 import { ModalOverlay } from "./ModalOverlay";
@@ -1782,15 +1783,13 @@ export function Sidebar({
         <div className="chip-group simulation-buttons">
           {!hideLibraryBrowsing ? (
             <>
-              <button
-                className="inline-action"
+              <ActionButton
                 onClick={() => setShowSimulationLibraryManager(true)}
                 type="button"
               >
                 Library
-              </button>
-              <button
-                className="inline-action"
+              </ActionButton>
+              <ActionButton
                 onClick={() => {
                   setNewSimulationName("");
                   setNewSimulationDescription("");
@@ -1802,14 +1801,14 @@ export function Sidebar({
                 type="button"
               >
                 New
-              </button>
-              <button className="inline-action" onClick={saveSimulationAsNew} type="button">
+              </ActionButton>
+              <ActionButton onClick={saveSimulationAsNew} type="button">
                 Duplicate
-              </button>
+              </ActionButton>
               {selectedSimulationRef.startsWith("saved:") ? (
-                <button className="inline-action" onClick={openActiveSimulationDetails} type="button">
+                <ActionButton onClick={openActiveSimulationDetails} type="button">
                   Edit
-                </button>
+                </ActionButton>
               ) : null}
             </>
           ) : (
@@ -1843,22 +1842,21 @@ export function Sidebar({
         <div className="chip-group">
           {!hideLibraryBrowsing ? (
             <>
-              <button className="inline-action" onClick={() => setShowSiteLibraryManager(true)} type="button">
+              <ActionButton onClick={() => setShowSiteLibraryManager(true)} type="button">
                 Library
-              </button>
+              </ActionButton>
               {newestSiteLibraryEntryId ? (
-                <button className="inline-action" onClick={() => insertSiteFromLibrary(newestSiteLibraryEntryId)} type="button">
+                <ActionButton onClick={() => insertSiteFromLibrary(newestSiteLibraryEntryId)} type="button">
                   Insert newest
-                </button>
+                </ActionButton>
               ) : null}
-              <button className="inline-action" onClick={openLibraryForSelectedSite} type="button">
+              <ActionButton onClick={openLibraryForSelectedSite} type="button">
                 Edit
-              </button>
+              </ActionButton>
             </>
           ) : null}
           {!readOnly ? (
-            <button
-              className="inline-action danger"
+            <ActionButton
               disabled={sites.length <= 1}
               onClick={() =>
                 requestDeleteConfirm(
@@ -1869,9 +1867,10 @@ export function Sidebar({
                 )
               }
               type="button"
+              variant="danger"
             >
               Remove
-            </button>
+            </ActionButton>
           ) : null}
         </div>
       </section>
@@ -1896,14 +1895,13 @@ export function Sidebar({
         <div className="chip-group">
           {!readOnly ? (
             <>
-              <button className="inline-action" disabled={sites.length < 2} onClick={openAddLinkModal} type="button">
+              <ActionButton disabled={sites.length < 2} onClick={openAddLinkModal} type="button">
                 New
-              </button>
-              <button className="inline-action" onClick={openEditLinkModal} type="button">
+              </ActionButton>
+              <ActionButton onClick={openEditLinkModal} type="button">
                 Edit
-              </button>
-              <button
-                className="inline-action danger"
+              </ActionButton>
+              <ActionButton
                 disabled={!links.length}
                 onClick={() =>
                   requestDeleteConfirm(
@@ -1913,9 +1911,10 @@ export function Sidebar({
                   )
                 }
                 type="button"
+                variant="danger"
               >
                 Remove
-              </button>
+              </ActionButton>
             </>
           ) : null}
         </div>
@@ -2054,9 +2053,9 @@ export function Sidebar({
               ) : null}
             </details>
             <div className="chip-group">
-              <button className="inline-action" onClick={saveLinkModal} type="button">
+              <ActionButton onClick={saveLinkModal} type="button">
                 {linkModal.mode === "add" ? "Create Link" : "Save Link"}
-              </button>
+              </ActionButton>
             </div>
             {linkModal.status ? <p className="field-help">{linkModal.status}</p> : null}
           </div>
@@ -2170,14 +2169,13 @@ export function Sidebar({
                 </select>
               </label>
               {!profilePopupUser.isApproved ? (
-                <button
-                  className="inline-action"
+                <ActionButton
                   disabled={profilePopupBusy}
                   onClick={() => void changeProfileRole("user")}
                   type="button"
                 >
                   Approve Access
-                </button>
+                </ActionButton>
               ) : null}
             </div>
             {profilePopupStatus ? <p className="field-help">{profilePopupStatus}</p> : null}
@@ -3680,22 +3678,21 @@ export function Sidebar({
                   </div>
                 </div>
                 <div className="chip-group">
-                  <button className="inline-action" onClick={addLibraryEntryNow} type="button">
-                    Add To Library
-                  </button>
-                  <button
-                    className="inline-action"
-                    onClick={() => {
-                      setShowAddLibraryForm(false);
-                      setNewLibraryNameError("");
+                <ActionButton onClick={addLibraryEntryNow} type="button">
+                  Add To Library
+                </ActionButton>
+                <ActionButton
+                  onClick={() => {
+                    setShowAddLibraryForm(false);
+                    setNewLibraryNameError("");
                       setNewLibraryDescription("");
                       setNewLibrarySourceMeta(undefined);
                       setPendingDraftAutoInsert(false);
-                    }}
-                    type="button"
-                  >
-                    Cancel
-                  </button>
+                  }}
+                  type="button"
+                >
+                  Cancel
+                </ActionButton>
                 </div>
               </div>
             ) : null}
@@ -3765,11 +3762,10 @@ export function Sidebar({
                     );
                   })()}
                   <div className="library-row-actions">
-                    <button className="inline-action" onClick={() => insertSiteFromLibrary(entry.id)} type="button">
+                    <ActionButton onClick={() => insertSiteFromLibrary(entry.id)} type="button">
                       Add to simulation
-                    </button>
-                    <button
-                      className="inline-action"
+                    </ActionButton>
+                    <ActionButton
                       onClick={() =>
                         openResourceDetailsPopup({
                           kind: "site",
@@ -3790,7 +3786,7 @@ export function Sidebar({
                       type="button"
                     >
                       Open
-                    </button>
+                    </ActionButton>
                   </div>
                 </div>
               ))}
@@ -3808,20 +3804,20 @@ export function Sidebar({
             </div>
             <p className="field-help">{deleteConfirm.message}</p>
             <div className="chip-group">
-              <button className="inline-action" onClick={() => setDeleteConfirm(null)} type="button">
+              <ActionButton onClick={() => setDeleteConfirm(null)} type="button">
                 Cancel
-              </button>
-              <button
-                className="inline-action danger"
+              </ActionButton>
+              <ActionButton
                 onClick={() => {
                   const action = deleteConfirm.onConfirm;
                   setDeleteConfirm(null);
                   action();
                 }}
                 type="button"
+                variant="danger"
               >
                 {deleteConfirm.confirmLabel}
-              </button>
+              </ActionButton>
             </div>
           </div>
         </ModalOverlay>

--- a/src/components/UserAdminPanel.tsx
+++ b/src/components/UserAdminPanel.tsx
@@ -32,6 +32,7 @@ import { useAppStore } from "../store/appStore";
 import { useThemeVariant } from "../hooks/useThemeVariant";
 import type { UiColorTheme } from "../themes/types";
 import { AvatarBadge } from "./AvatarBadge";
+import { ActionButton } from "./ActionButton";
 import { InfoTip } from "./InfoTip";
 import { InlineCloseIconButton } from "./InlineCloseIconButton";
 import { ModalOverlay } from "./ModalOverlay";
@@ -840,8 +841,7 @@ export function UserAdminPanel({ onOpenHelp, authBootstrapPending = false, extra
               </div>
               <div className="chip-group">
                 {syncStatus !== "syncing" ? (
-                  <button
-                    className="inline-action"
+                  <ActionButton
                     disabled={!isOnline}
                     onClick={() => {
                       void performManualCloudSync();
@@ -849,7 +849,7 @@ export function UserAdminPanel({ onOpenHelp, authBootstrapPending = false, extra
                     type="button"
                   >
                     Sync Now
-                  </button>
+                  </ActionButton>
                 ) : null}
               </div>
             </div>
@@ -863,9 +863,9 @@ export function UserAdminPanel({ onOpenHelp, authBootstrapPending = false, extra
             <div className="library-manager-header">
               <h2>User Settings</h2>
               <div className="chip-group">
-                <button className="inline-action" onClick={handleSignOut} type="button">
+                <ActionButton onClick={handleSignOut} type="button">
                   Sign Out
-                </button>
+                </ActionButton>
                 <InlineCloseIconButton onClick={() => setOpen(false)} />
               </div>
             </div>
@@ -1010,17 +1010,16 @@ export function UserAdminPanel({ onOpenHelp, authBootstrapPending = false, extra
                   </label>
                 ) : null}
                 <div className="chip-group">
-                  <button
-                    className="inline-action"
+                  <ActionButton
                     disabled={busy || !nameDraft.trim() || !emailDraft.trim()}
                     onClick={() => void saveMyProfile()}
                     type="button"
                   >
                     Save Profile
-                  </button>
-                  <button className="inline-action" disabled={busy} onClick={() => void load()} type="button">
+                  </ActionButton>
+                  <ActionButton disabled={busy} onClick={() => void load()} type="button">
                     Refresh
-                  </button>
+                  </ActionButton>
                 </div>
               </div>
             </div>
@@ -1030,12 +1029,12 @@ export function UserAdminPanel({ onOpenHelp, authBootstrapPending = false, extra
                 <div className="section-heading">
                   <p className="field-help">System diagnostics</p>
                   <div className="chip-group">
-                    <button className="inline-action" disabled={busy} onClick={() => void load()} type="button">
+                    <ActionButton disabled={busy} onClick={() => void load()} type="button">
                       Refresh
-                    </button>
-                    <button className="inline-action" disabled={busy} onClick={() => void repairMetadata()} type="button">
+                    </ActionButton>
+                    <ActionButton disabled={busy} onClick={() => void repairMetadata()} type="button">
                       Repair Metadata
-                    </button>
+                    </ActionButton>
                   </div>
                 </div>
                 {authWarnings.length ? (
@@ -1066,9 +1065,9 @@ export function UserAdminPanel({ onOpenHelp, authBootstrapPending = false, extra
                 <div className="section-heading">
                   <p className="field-help">Admin ownership tools</p>
                   <div className="chip-group">
-                    <button className="inline-action" disabled={busy || auditBusy} onClick={() => void loadAdminAudit()} type="button">
+                    <ActionButton disabled={busy || auditBusy} onClick={() => void loadAdminAudit()} type="button">
                       Refresh Audit
-                    </button>
+                    </ActionButton>
                   </div>
                 </div>
                 <label className="field-grid user-field-grid">
@@ -1101,9 +1100,9 @@ export function UserAdminPanel({ onOpenHelp, authBootstrapPending = false, extra
                     value={ownershipNewOwnerId}
                   />
                 </label>
-                <button className="inline-action" disabled={busy} onClick={() => void runOwnerReassign()} type="button">
+                <ActionButton disabled={busy} onClick={() => void runOwnerReassign()} type="button">
                   Reassign Owner
-                </button>
+                </ActionButton>
 
                 <label className="field-grid user-field-grid">
                   <span>Bulk from owner ID</span>
@@ -1125,9 +1124,9 @@ export function UserAdminPanel({ onOpenHelp, authBootstrapPending = false, extra
                     value={bulkToOwnerId}
                   />
                 </label>
-                <button className="inline-action" disabled={busy} onClick={() => void runBulkOwnerReassign()} type="button">
+                <ActionButton disabled={busy} onClick={() => void runBulkOwnerReassign()} type="button">
                   Bulk Reassign Ownership
-                </button>
+                </ActionButton>
 
                 <p className="field-help">Recent admin audit events</p>
                 {auditBusy ? <p className="field-help">Loading audit events…</p> : null}
@@ -1165,12 +1164,12 @@ export function UserAdminPanel({ onOpenHelp, authBootstrapPending = false, extra
                 <div className="section-heading">
                   <p className="field-help">Notification Center</p>
                   <div className="chip-group">
-                    <button className="inline-action" onClick={() => setNotificationOpen((prev) => !prev)} type="button">
+                    <ActionButton onClick={() => setNotificationOpen((prev) => !prev)} type="button">
                       {notificationOpen ? "Hide" : "Open"}
-                    </button>
-                    <button className="inline-action" onClick={() => void loadNotifications()} type="button">
+                    </ActionButton>
+                    <ActionButton onClick={() => void loadNotifications()} type="button">
                       Refresh
-                    </button>
+                    </ActionButton>
                   </div>
                 </div>
                 {notificationOpen ? (
@@ -1187,14 +1186,13 @@ export function UserAdminPanel({ onOpenHelp, authBootstrapPending = false, extra
                               <p className="field-help">{item.message}</p>
                               <p className="field-help">Updated: {fmtDate(item.createdAt)}</p>
                               <div className="chip-group">
-                                <button
-                                  className="inline-action"
+                                <ActionButton
                                   disabled={isDismissed}
                                   onClick={() => dismissNotification(item.id)}
                                   type="button"
                                 >
                                   {isDismissed ? "Dismissed" : "Dismiss Badge"}
-                                </button>
+                                </ActionButton>
                               </div>
                             </div>
                           );
@@ -1266,9 +1264,9 @@ export function UserAdminPanel({ onOpenHelp, authBootstrapPending = false, extra
                     <p className="field-help">Deleted: {fmtDate(entry.deletedAt)}</p>
                     <p className="field-help">Deleted by: {entry.deletedByUserId ?? "-"}</p>
                     <div className="chip-group">
-                      <button className="inline-action" onClick={() => void restoreDeletedUser(entry.id)} type="button">
+                      <ActionButton onClick={() => void restoreDeletedUser(entry.id)} type="button">
                         Restore
-                      </button>
+                      </ActionButton>
                     </div>
                   </div>
                 ))}
@@ -1333,13 +1331,12 @@ export function UserAdminPanel({ onOpenHelp, authBootstrapPending = false, extra
                     <p className="field-help">No access request note.</p>
                   )}
                   <div className="chip-group">
-                    <button
-                      className="inline-action"
+                    <ActionButton
                       onClick={() => void saveManagedProfile(managedUser, { username: managedNameDraft, email: managedEmailDraft })}
                       type="button"
                     >
                       Save Profile
-                    </button>
+                    </ActionButton>
                     <label className="field-grid user-field-grid">
                       <span>
                         Role{" "}
@@ -1370,23 +1367,22 @@ export function UserAdminPanel({ onOpenHelp, authBootstrapPending = false, extra
                       </select>
                     </label>
                     {!managedUser.isApproved ? (
-                      <button
-                        className="inline-action"
+                      <ActionButton
                         onClick={() => void updateRole(managedUser, "user")}
                         type="button"
                       >
                         Approve Access
-                      </button>
+                      </ActionButton>
                     ) : null}
                     {canAdmin ? (
-                      <button
-                        className="inline-action danger"
+                      <ActionButton
                         disabled={managedUser.id === me?.id || resolveRole(managedUser) === "admin"}
                         onClick={() => void deleteUserAccount(managedUser)}
                         type="button"
+                        variant="danger"
                       >
                         Delete User
-                      </button>
+                      </ActionButton>
                     ) : null}
                   </div>
                   <p className="field-help">


### PR DESCRIPTION
## Summary
- migrate remaining clear standard-action  usages to 
- keep dense ActionButton baseline unchanged
- leave icon-only, link-like, filter-trigger/field-inline, and specialized/compact patterns untouched

## Verification
- npm test
- npm run build

## Scope notes
- touched: AppShell, Sidebar, UserAdminPanel
- untouched: tool/map controls, selection surfaces, tabs, specialized triggers