### PR TITLE
Issue #539: unify app-action buttons and expand tabbed UI gallery

### DIFF
--- a/docs/ui-pattern-glossary.md
+++ b/docs/ui-pattern-glossary.md
@@ -7,10 +7,12 @@ Status labels:
 - `under migration`: actively converging to this pattern
 - `exception`: intentional non-standard case
 - `legacy`: older pattern retained until migrated
+- `mapped only`: inventoried/visible in gallery, intentionally not converged in current pass
 
-Current snapshot (after ActionButton consolidation + shell/header/action-row convergence pass):
-- Role boundaries are now mostly stable for `ActionButton` vs `ToolButton` vs `SelectionSurface`.
-- Remaining legacy `inline-action` usage is concentrated in Sidebar library/filter/editor utility zones and explicit exceptions.
+Current snapshot (after tabbed gallery and broad action convergence pass):
+- Normal text-bearing app actions continue converging into one shared `ActionButton` family.
+- `ToolButton` is restricted to true map/workspace overlay controls.
+- Icon-only controls are mapped and tracked (`mapped only`) but not visually converged in this run.
 
 ## Proposed Outline
 1. Standard patterns
@@ -59,9 +61,9 @@ Legacy names to keep temporarily for stability:
   - `src/components/MapView.tsx` (inspector action group + inline notice dismiss)
 - Status: `under migration`
 
-Boundary (stabilized):
-- Includes standard app actions in side panels, inspector sections, dialogs, and modal form actions.
-- Excludes tool/map controls, icon-only close controls, tab controls, selectable rows/cards, and link-style low-emphasis actions.
+Boundary (simplified):
+- Includes standard text-bearing app actions in side panels, inspector sections, dialogs, popovers, and modal form actions.
+- Excludes true overlay tool controls, link-style actions, tabs, selection surfaces, and icon-only utilities.
 
 ### ToolButton
 - Role: map/workspace overlay controls and view tools.
@@ -77,9 +79,9 @@ Boundary (stabilized):
   - `src/index.css` (`.map-control-btn*`)
 - Status: `standard`
 
-Boundary (stabilized):
+Boundary (strict):
 - Includes map/workspace overlay controls and panel visibility/resize controls in workspace chrome.
-- Must not be used for form submit/cancel/app-flow actions inside panel/modal content.
+- Must not be used for text-bearing form/app-flow actions inside panel/modal content.
 
 ### SelectionSurface
 - Role: selectable rows/cards/items representing entities or choices.
@@ -163,6 +165,43 @@ Exception policy:
 - Keep as exception when visual intent is contextual/link-like and intentionally lower emphasis than ActionButton.
 - Do not migrate to ActionButton unless the control should read as a primary/standard command.
 
+### Icon-only Utility Controls
+- Role: icon-only actions (close, compact utility icons, icon-only overlay controls).
+- Use when: control is intentionally icon-only and discoverable via aria-label/title.
+- Do not use when: action needs readable text label for normal app-flow operations.
+- Variants:
+  - `inline-action-icon`
+  - `map-control-btn-icon`
+  - `chart-endpoint-icon`
+- Known examples/files:
+  - `src/components/InlineCloseIconButton.tsx`
+  - `src/components/MapView.tsx`
+  - `src/components/AppShell.tsx`
+- Status: `mapped only`
+
+Policy:
+- Mapped and tracked in gallery for coverage.
+- Out of scope for visual convergence in the current pass.
+
+## Notification / Notice Inventory
+
+### Should converge next
+- `map-inline-notice`
+- `offline-banner`
+- `notification-banner`
+- shared helper/error container rhythm around sync/status messaging blocks
+
+### Intentional exceptions
+- `notification-bell` + `notification-badge` (trigger/badge behavior pattern)
+- `map-holiday-note` (seasonal/context-specific content treatment)
+
+### Borderline / defer
+- `field-help-error` inline validation text (form-level, not always banner-level)
+- domain-specific status tiles (`margin-status`, `terrain-alert`) that encode simulation semantics
+
+Recommended next cleanup pass:
+- Introduce one shared notice container baseline (surface/border/padding/title-row/action-slot) and migrate `map-inline-notice`, `offline-banner`, and `notification-banner` to it while keeping bell/badge and domain tiles as exceptions.
+
 ### Specialized Triggers
 - Role: controls with distinct meaning and visual behavior that should not be forced into generic button taxonomy.
 - Use when: control carries unique domain meaning (account chip, bell/badge trigger, upload label, info tip).
@@ -198,20 +237,21 @@ Exception policy:
 - Icon-only close remains a dedicated primitive and is not part of ActionButton family.
 
 ## Borderline / Too Early to Standardize
-- Sidebar library/filter/editor utility controls still contain mixed `inline-action` patterns (`library-filter-trigger`, `field-inline-btn`, mesh/search utility actions).
-- Compact welcome/tutorial actions remain intentionally distinct; keep until a dedicated compact-action policy pass exists.
-- Some utility controls in mixed data/editor contexts are visually near ActionButton but still role-ambiguous; defer until role boundary is explicit.
+- Sidebar library/filter/editor utility controls with embedded data/edit semantics (for example collaborator candidate row affordances) still need role cleanup.
+- Some mixed utility controls remain near ActionButton visually but need one more semantics pass before forced convergence.
 
 Recommendation: keep this glossary compact until ActionButton migration coverage is broader and ToolButton vs ActionButton boundaries are fully settled.
 
 ## Migration Coverage Snapshot
 - `ActionButton` migrated:
-  - `SimulationLibraryPanel` standard actions
-  - `MapView` inspector standard actions
-  - broad standard actions in `AppShell`, `UserAdminPanel`, and core `Sidebar` section actions
-- Intentionally not migrated:
-  - `ToolButton` (`map-control-btn*`) families
-  - icon-only close/action primitives
-  - tab controls, selection surfaces, link-style actions, specialized triggers
+  - `SimulationLibraryPanel`, `MapView` inspector standard actions
+  - broad standard actions in `AppShell`, `UserAdminPanel`, and expanded `Sidebar` modal/library flows
+  - welcome modal primary actions
+- Intentionally separate:
+  - `ToolButton` overlay controls
+  - `LinkButton`
+  - tab controls, selection surfaces
+- Mapped-only:
+  - icon-only utility controls
 - Remaining legacy concentration:
-  - Sidebar library manager/filter/editor utility subflows
+  - a small number of role-ambiguous Sidebar utility affordances

--- a/src/components/OnboardingTutorialModal.tsx
+++ b/src/components/OnboardingTutorialModal.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import onboardingMarkdown from "../../docs/onboarding.md?raw";
+import { ActionButton } from "./ActionButton";
 import { InlineCloseIconButton } from "./InlineCloseIconButton";
 import { ModalOverlay } from "./ModalOverlay";
 
@@ -88,9 +89,15 @@ export default function OnboardingTutorialModal({
           </ReactMarkdown>
         </div>
         <div className="tutorial-report-cta">
-          <a className="inline-action tutorial-report-button" href={FEEDBACK_ISSUES_URL} rel="noreferrer" target="_blank">
+          <ActionButton
+            className="tutorial-report-button"
+            onClick={() => {
+              window.open(FEEDBACK_ISSUES_URL, "_blank", "noopener,noreferrer");
+            }}
+            type="button"
+          >
             Report Issue or Suggestion
-          </a>
+          </ActionButton>
           <div className="asset-list">
             <a href={PRIVACY_URL} rel="noreferrer" target="_blank">
               Privacy Notice

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2233,15 +2233,14 @@ export function Sidebar({
                   ) : null}
                   {canWriteResource(changeLogPopup.kind, changeLogPopup.resourceId) ? (
                     <div className="chip-group">
-                      <button
-                        className="inline-action"
+                      <ActionButton
                         onClick={() =>
                           void revertChangeAsCopy(changeLogPopup.kind, changeLogPopup.resourceId, change.id)
                         }
                         type="button"
                       >
                         Revert
-                      </button>
+                      </ActionButton>
                     </div>
                   ) : null}
                 </div>
@@ -2355,8 +2354,8 @@ export function Sidebar({
                         type="number"
                         value={resourceGroundDraft}
                       />
-                      <button
-                        className="inline-action field-inline-btn"
+                      <ActionButton
+                        className="field-inline-btn"
                         disabled={isEditorTerrainFetching}
                         onClick={() => {
                           const elevation = fetchGroundFromLoadedTerrain(resourceLatDraft, resourceLonDraft);
@@ -2373,7 +2372,7 @@ export function Sidebar({
                         type="button"
                       >
                         {isEditorTerrainFetching ? "Loading…" : "Fetch"}
-                      </button>
+                      </ActionButton>
                     </div>
                   </label>
                   <label className="field-grid">
@@ -2541,23 +2540,20 @@ export function Sidebar({
               </div>
             ) : null}
             <div className="chip-group">
-              <button
-                className="inline-action"
+              <ActionButton
                 onClick={() => void openUserProfilePopup(resourceDetailsPopup.createdByUserId)}
                 type="button"
               >
                 Created by <UserBadge avatarUrl={resourceDetailsPopup.createdByAvatarUrl} name={resourceDetailsPopup.createdByName} />
-              </button>
-              <button
-                className="inline-action"
+              </ActionButton>
+              <ActionButton
                 onClick={() => void openUserProfilePopup(resourceDetailsPopup.lastEditedByUserId)}
                 type="button"
               >
                 Last edited by{" "}
                 <UserBadge avatarUrl={resourceDetailsPopup.lastEditedByAvatarUrl} name={resourceDetailsPopup.lastEditedByName} />
-              </button>
-              <button
-                className="inline-action"
+              </ActionButton>
+              <ActionButton
                 onClick={() =>
                   void openChangeLogPopup(
                     resourceDetailsPopup.kind,
@@ -2568,7 +2564,7 @@ export function Sidebar({
                 type="button"
               >
                 Open change log
-              </button>
+              </ActionButton>
             </div>
             {resourceDetailsPopup.kind === "site" && currentResourceMqttMetaLines.length ? (
               <details className="compact-details">
@@ -2625,9 +2621,9 @@ export function Sidebar({
                             <option value="viewer">Viewer</option>
                             <option value="editor">Editor</option>
                           </select>
-                          <button className="inline-action" onClick={() => removeCollaborator(user.id)} type="button">
+                          <ActionButton onClick={() => removeCollaborator(user.id)} type="button">
                             Remove
-                          </button>
+                          </ActionButton>
                         </span>
                       ))
                     ) : (
@@ -2809,8 +2805,7 @@ export function Sidebar({
             ) : null}
             {resourceCanWrite ? (
               <div className="chip-group">
-                <button
-                  className="inline-action danger"
+                <ActionButton
                   onClick={() => {
                     let siteDeleteMessage = `Delete "${resourceDetailsPopup.label}" from the site library?`;
                     if (resourceDetailsPopup.kind === "site") {
@@ -2841,9 +2836,10 @@ export function Sidebar({
                     );
                   }}
                   type="button"
+                  variant="danger"
                 >
                   Delete
-                </button>
+                </ActionButton>
               </div>
             ) : null}
           </div>
@@ -3023,9 +3019,9 @@ export function Sidebar({
                 </label>
             </div>
             <div className="chip-group">
-              <button className="inline-action" onClick={createBlankSimulation} type="button">
+              <ActionButton onClick={createBlankSimulation} type="button">
                 Create
-              </button>
+              </ActionButton>
             </div>
           </div>
         </ModalOverlay>
@@ -3068,12 +3064,12 @@ export function Sidebar({
               <strong>{pendingSimulationVisibilityPrompt.targetVisibility}</strong> as well?
             </p>
             <div className="chip-group">
-              <button className="inline-action" onClick={applyPendingSimulationVisibilityChange} type="button">
+              <ActionButton onClick={applyPendingSimulationVisibilityChange} type="button">
                 Change
-              </button>
-              <button className="inline-action" onClick={() => setPendingSimulationVisibilityPrompt(null)} type="button">
+              </ActionButton>
+              <ActionButton onClick={() => setPendingSimulationVisibilityPrompt(null)} type="button">
                 Cancel
-              </button>
+              </ActionButton>
             </div>
           </div>
         </ModalOverlay>
@@ -3113,8 +3109,8 @@ export function Sidebar({
             <div className="library-filter-toolbar" ref={siteFilterToolbarRef}>
               <span className="library-filter-row-label">Filters:</span>
               <div className="library-filter-menu">
-                <button
-                  className={clsx("inline-action", "library-filter-trigger", {
+                <ActionButton
+                  className={clsx("library-filter-trigger", {
                     "library-filter-trigger-active": selectionIsFiltered(siteLibraryFilters.roleFilters, ALL_ROLE_FILTERS),
                   })}
                   onClick={openSiteRoleEditor}
@@ -3124,16 +3120,16 @@ export function Sidebar({
                   <span className="library-filter-trigger-chevron" aria-hidden="true">
                     <Funnel aria-hidden="true" strokeWidth={1.8} />
                   </span>
-                </button>
+                </ActionButton>
                 {openSiteFilterGroup === "role" ? (
                   <div className="library-filter-popover">
                     <div className="library-filter-popover-actions">
-                      <button className="inline-action" onClick={() => commitSiteRoleFilters(ALL_ROLE_FILTERS)} type="button">
+                      <ActionButton onClick={() => commitSiteRoleFilters(ALL_ROLE_FILTERS)} type="button">
                         All
-                      </button>
-                      <button className="inline-action" onClick={() => setSiteRoleDraft([])} type="button">
+                      </ActionButton>
+                      <ActionButton onClick={() => setSiteRoleDraft([])} type="button">
                         None
-                      </button>
+                      </ActionButton>
                     </div>
                     <div className="library-filter-popover-options">
                       {ROLE_FILTER_OPTIONS.map((option) => {
@@ -3160,8 +3156,8 @@ export function Sidebar({
               </div>
 
               <div className="library-filter-menu">
-                <button
-                  className={clsx("inline-action", "library-filter-trigger", {
+                <ActionButton
+                  className={clsx("library-filter-trigger", {
                     "library-filter-trigger-active": selectionIsFiltered(
                       siteLibraryFilters.visibilityFilters,
                       ALL_VISIBILITY_FILTERS,
@@ -3174,20 +3170,19 @@ export function Sidebar({
                   <span className="library-filter-trigger-chevron" aria-hidden="true">
                     <Funnel aria-hidden="true" strokeWidth={1.8} />
                   </span>
-                </button>
+                </ActionButton>
                 {openSiteFilterGroup === "visibility" ? (
                   <div className="library-filter-popover">
                     <div className="library-filter-popover-actions">
-                      <button
-                        className="inline-action"
+                      <ActionButton
                         onClick={() => commitSiteVisibilityFilters(ALL_VISIBILITY_FILTERS)}
                         type="button"
                       >
                         All
-                      </button>
-                      <button className="inline-action" onClick={() => setSiteVisibilityDraft([])} type="button">
+                      </ActionButton>
+                      <ActionButton onClick={() => setSiteVisibilityDraft([])} type="button">
                         None
-                      </button>
+                      </ActionButton>
                     </div>
                     <div className="library-filter-popover-options">
                       {VISIBILITY_FILTER_OPTIONS.map((option) => {
@@ -3215,8 +3210,8 @@ export function Sidebar({
               </div>
 
               <div className="library-filter-menu">
-                <button
-                  className={clsx("inline-action", "library-filter-trigger", {
+                <ActionButton
+                  className={clsx("library-filter-trigger", {
                     "library-filter-trigger-active": selectionIsFiltered(siteLibraryFilters.sourceFilters, ALL_SITE_SOURCE_FILTERS),
                   })}
                   onClick={openSiteSourceEditor}
@@ -3226,20 +3221,19 @@ export function Sidebar({
                   <span className="library-filter-trigger-chevron" aria-hidden="true">
                     <Funnel aria-hidden="true" strokeWidth={1.8} />
                   </span>
-                </button>
+                </ActionButton>
                 {openSiteFilterGroup === "source" ? (
                   <div className="library-filter-popover">
                     <div className="library-filter-popover-actions">
-                      <button
-                        className="inline-action"
+                      <ActionButton
                         onClick={() => commitSiteSourceFilters(ALL_SITE_SOURCE_FILTERS)}
                         type="button"
                       >
                         All
-                      </button>
-                      <button className="inline-action" onClick={() => setSiteSourceDraft([])} type="button">
+                      </ActionButton>
+                      <ActionButton onClick={() => setSiteSourceDraft([])} type="button">
                         None
-                      </button>
+                      </ActionButton>
                     </div>
                     <div className="library-filter-popover-options">
                       {SITE_SOURCE_FILTER_OPTIONS.map((option) => {
@@ -3265,8 +3259,7 @@ export function Sidebar({
                 ) : null}
               </div>
 
-              <button
-                className="inline-action"
+              <ActionButton
                 onClick={() => {
                   setSiteLibraryFilters(DEFAULT_LIBRARY_FILTER_STATE);
                   closeSiteFilterEditors();
@@ -3274,11 +3267,10 @@ export function Sidebar({
                 type="button"
               >
                 Clear Filters
-              </button>
+              </ActionButton>
             </div>
             <div className="chip-group">
-              <button
-                className="inline-action"
+              <ActionButton
                 onClick={() => {
                   setShowAddLibraryForm((current) => !current);
                   if (showAddLibraryForm) {
@@ -3289,19 +3281,17 @@ export function Sidebar({
                 type="button"
               >
                 {showAddLibraryForm ? "Hide Add Form" : "Add Site"}
-              </button>
-              <button
-                className="inline-action"
+              </ActionButton>
+              <ActionButton
                 onClick={() => setSelectedLibraryIds(new Set(filteredSiteLibrary.map((entry) => entry.id)))}
                 type="button"
               >
                 Select Filtered ({filteredSiteLibrary.length})
-              </button>
-              <button className="inline-action" onClick={() => setSelectedLibraryIds(new Set())} type="button">
+              </ActionButton>
+              <ActionButton onClick={() => setSelectedLibraryIds(new Set())} type="button">
                 Clear Selection
-              </button>
-              <button
-                className="inline-action"
+              </ActionButton>
+              <ActionButton
                 disabled={!selectedLibraryCount}
                 onClick={() => {
                   insertSitesFromLibrary(Array.from(selectedLibraryIds));
@@ -3310,9 +3300,8 @@ export function Sidebar({
                 type="button"
               >
                 Add Selected To Simulation ({selectedLibraryCount})
-              </button>
-              <button
-                className="inline-action danger"
+              </ActionButton>
+              <ActionButton
                 disabled={!selectedLibraryCount}
                 onClick={() => {
                   const deletedIds = Array.from(selectedLibraryIds);
@@ -3334,9 +3323,10 @@ export function Sidebar({
                   );
                 }}
                 type="button"
+                variant="danger"
               >
                 Delete Selected ({selectedLibraryCount})
-              </button>
+              </ActionButton>
             </div>
             {showAddLibraryForm ? (
               <div className="library-editor">
@@ -3395,9 +3385,9 @@ export function Sidebar({
                       type="number"
                       value={newLibraryGroundM}
                     />
-                    <button className="inline-action field-inline-btn" disabled={isEditorTerrainFetching} onClick={fetchNewLibraryGroundFromTerrain} type="button">
+                    <ActionButton className="field-inline-btn" disabled={isEditorTerrainFetching} onClick={fetchNewLibraryGroundFromTerrain} type="button">
                       {isEditorTerrainFetching ? "Loading…" : "Fetch"}
-                    </button>
+                    </ActionButton>
                   </div>
                 </label>
                 <label className="field-grid">
@@ -3449,22 +3439,21 @@ export function Sidebar({
                     value={librarySearchQuery}
                   />
                 </label>
-                <button className="inline-action" disabled={librarySearchBusy} onClick={() => void runLibrarySearch()} type="button">
+                <ActionButton disabled={librarySearchBusy} onClick={() => void runLibrarySearch()} type="button">
                   {librarySearchBusy ? "Searching…" : "Search"}
-                </button>
+                </ActionButton>
                 {librarySearchStatus ? <p className="field-help">{librarySearchStatus}</p> : null}
                 {librarySearchResults.length ? (
                   <div className="asset-list">
                     {librarySearchResults.map((result) => (
-                      <button
-                        className="inline-action"
+                      <ActionButton
                         disabled={librarySearchPickBusyId !== null}
                         key={result.id}
                         onClick={() => void selectLibrarySearchResult(result)}
                         type="button"
                       >
                         {librarySearchPickBusyId === result.id ? "Loading..." : `Use: ${result.label}`}
-                      </button>
+                      </ActionButton>
                     ))}
                   </div>
                 ) : null}
@@ -3484,16 +3473,15 @@ export function Sidebar({
                     />
                   </label>
                   <div className="chip-group">
-                    <button className="inline-action" disabled={meshmapLoading} onClick={() => void loadMeshmapFeed()} type="button">
+                    <ActionButton disabled={meshmapLoading} onClick={() => void loadMeshmapFeed()} type="button">
                       {meshmapLoading ? "Loading..." : "Load Feed"}
-                    </button>
-                    <button
-                      className="inline-action"
+                    </ActionButton>
+                    <ActionButton
                       onClick={() => setShowMeshtasticBrowser((current) => !current)}
                       type="button"
                     >
                       {showMeshtasticBrowser ? "Hide Browser" : "Show Browser"}
-                    </button>
+                    </ActionButton>
                   </div>
                   {meshmapLoading ? (
                     <div className="map-progress-track" style={{ marginTop: 8 }}>
@@ -3510,16 +3498,15 @@ export function Sidebar({
                     <p className="field-help">
                       {meshmapStatus}
                       {meshmapStatus.includes("failed") ? (
-                        <button
+                        <ActionButton
                           aria-label="Retry loading Meshtastic feed"
-                          className="inline-action"
                           onClick={() => void loadMeshmapFeed()}
                           style={{ marginLeft: 8 }}
                           type="button"
                         >
                           <RefreshCw aria-hidden="true" size={12} strokeWidth={2} />
                           <span>Retry</span>
-                        </button>
+                        </ActionButton>
                       ) : null}
                     </p>
                   ) : null}
@@ -3562,9 +3549,9 @@ export function Sidebar({
                             Short: {selectedMeshmapNode.shortName ?? "n/a"} | Node ID: {selectedMeshmapNode.nodeId}
                             {selectedMeshmapNode.hwModel ? ` | HW: ${selectedMeshmapNode.hwModel}` : ""}
                           </p>
-                          <button className="inline-action" onClick={() => void addSelectedMeshmapNodeToLibrary()} type="button">
+                          <ActionButton onClick={() => void addSelectedMeshmapNodeToLibrary()} type="button">
                             Add Selected MQTT Node To Library
-                          </button>
+                          </ActionButton>
                         </div>
                       ) : (
                         <p className="field-help">Click a node in the map to select it.</p>

--- a/src/components/UiGalleryPage.tsx
+++ b/src/components/UiGalleryPage.tsx
@@ -1,10 +1,20 @@
-import { useEffect, type ReactNode } from "react";
-import { Layers, Maximize2, PanelRightClose, RefreshCw } from "lucide-react";
+import { useEffect, useState, type ReactNode } from "react";
+import { Layers, Maximize2, Minus, PanelRightClose, Plus, RefreshCw } from "lucide-react";
 import { ActionButton } from "./ActionButton";
 import { useThemeVariant } from "../hooks/useThemeVariant";
 import { useAppStore } from "../store/appStore";
 
-type GalleryStatus = "standard" | "exception" | "legacy" | "under migration";
+type GalleryStatus = "standard" | "exception" | "legacy" | "under migration" | "mapped only";
+type GalleryTab = "actions" | "panels" | "forms" | "notifications" | "states" | "meta-map-ui";
+
+const GALLERY_TABS: Array<{ id: GalleryTab; label: string }> = [
+  { id: "actions", label: "Actions" },
+  { id: "panels", label: "Panels" },
+  { id: "forms", label: "Forms" },
+  { id: "notifications", label: "Notifications" },
+  { id: "states", label: "States" },
+  { id: "meta-map-ui", label: "Meta/Map UI" },
+];
 
 const statusClassName = (status: GalleryStatus) => status.replace(/\s+/g, "-");
 
@@ -32,6 +42,7 @@ const PatternCard = ({
 
 export function UiGalleryPage() {
   const { theme, variant } = useThemeVariant();
+  const [activeTab, setActiveTab] = useState<GalleryTab>("actions");
   const uiThemePreference = useAppStore((state) => state.uiThemePreference);
   const setUiThemePreference = useAppStore((state) => state.setUiThemePreference);
 
@@ -52,192 +63,286 @@ export function UiGalleryPage() {
           <h2>LinkSim UI Gallery</h2>
           <StatusPill status="under migration" />
         </div>
-        <p className="field-help">Live pattern dictionary using real app classes/components. Route: /ui-gallery</p>
+        <p className="field-help">Live UI inventory grounded in real app classes/components. Route: /ui-gallery</p>
         <div className="chip-group ui-gallery-theme-toggle">
-          <ActionButton
-            aria-pressed={uiThemePreference === "system"}
-            onClick={() => setUiThemePreference("system")}
-            type="button"
-          >
+          <ActionButton aria-pressed={uiThemePreference === "system"} onClick={() => setUiThemePreference("system")} type="button">
             System
           </ActionButton>
-          <ActionButton
-            aria-pressed={uiThemePreference === "light"}
-            onClick={() => setUiThemePreference("light")}
-            type="button"
-          >
+          <ActionButton aria-pressed={uiThemePreference === "light"} onClick={() => setUiThemePreference("light")} type="button">
             Light
           </ActionButton>
           <ActionButton aria-pressed={uiThemePreference === "dark"} onClick={() => setUiThemePreference("dark")} type="button">
             Dark
           </ActionButton>
         </div>
+        <nav className="ui-gallery-tabs" aria-label="UI gallery tabs">
+          {GALLERY_TABS.map((tab) => (
+            <ActionButton
+              aria-pressed={activeTab === tab.id}
+              className="ui-gallery-tab-btn"
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              type="button"
+            >
+              {tab.label}
+            </ActionButton>
+          ))}
+        </nav>
       </header>
 
-      <section className="ui-gallery-section">
-        <h3>PanelShell + PanelHeader</h3>
-        <div className="ui-pattern-grid ui-pattern-grid-shells">
-          <PatternCard name="PanelShell.LeftSidePanel" status="under migration">
-            <aside className="sidebar-panel">
-              <header>
-                <div className="section-heading">
-                  <h2>Simulation</h2>
-                  <span className="field-help">left shell</span>
+      {activeTab === "actions" ? (
+        <section className="ui-gallery-section">
+          <h3>Actions</h3>
+          <div className="ui-pattern-grid">
+            <PatternCard name="ActionButton" status="under migration">
+              <div className="chip-group">
+                <ActionButton>Save Selected Path</ActionButton>
+                <ActionButton>Details</ActionButton>
+                <ActionButton variant="danger">Remove From Simulation</ActionButton>
+              </div>
+            </PatternCard>
+            <PatternCard name="ToolButton (true overlay controls only)" status="standard">
+              <div className="chip-group">
+                <button className="map-control-btn" type="button">
+                  Pass/Fail
+                </button>
+                <button className="map-control-btn is-selected" type="button">
+                  Heatmap
+                </button>
+                <button className="map-control-btn" type="button">
+                  Fit
+                </button>
+              </div>
+            </PatternCard>
+            <PatternCard name="LinkButton" status="exception">
+              <button className="inline-link-button" type="button">
+                Open change log
+              </button>
+            </PatternCard>
+            <PatternCard name="Icon-only utility controls" status="mapped only">
+              <div className="chip-group">
+                <button className="map-control-btn map-control-btn-icon" title="Zoom out" type="button">
+                  <Minus aria-hidden="true" size={16} strokeWidth={1.8} />
+                </button>
+                <button className="map-control-btn map-control-btn-icon" title="Zoom in" type="button">
+                  <Plus aria-hidden="true" size={16} strokeWidth={1.8} />
+                </button>
+                <button className="inline-action inline-action-icon" title="Close" type="button">
+                  <PanelRightClose aria-hidden="true" size={16} strokeWidth={1.8} />
+                </button>
+              </div>
+            </PatternCard>
+          </div>
+        </section>
+      ) : null}
+
+      {activeTab === "panels" ? (
+        <section className="ui-gallery-section">
+          <h3>Panels</h3>
+          <div className="ui-pattern-grid ui-pattern-grid-shells">
+            <PatternCard name="PanelShell.LeftSidePanel + PanelHeader" status="under migration">
+              <aside className="sidebar-panel">
+                <header>
+                  <div className="section-heading">
+                    <h2>Simulation</h2>
+                    <span className="field-help">left shell</span>
+                  </div>
+                </header>
+                <section className="panel-section">
+                  <div className="section-heading">
+                    <h2>Sites</h2>
+                    <span className="field-help">header rhythm</span>
+                  </div>
+                  <div className="chip-group">
+                    <ActionButton>Library</ActionButton>
+                    <ActionButton>New</ActionButton>
+                  </div>
+                </section>
+              </aside>
+            </PatternCard>
+            <PatternCard name="PanelShell.RightSidePanel + PanelHeader" status="under migration">
+              <aside className="map-inspector">
+                <div className="map-inspector-header-row">
+                  <div className="map-inspector-header-actions">
+                    <strong>Inspector</strong>
+                    <div className="map-inspector-header-actions-right">
+                      <button className="map-control-btn map-control-btn-icon" title="Hide panel" type="button">
+                        <PanelRightClose aria-hidden="true" size={16} strokeWidth={1.8} />
+                      </button>
+                    </div>
+                  </div>
                 </div>
-              </header>
-              <section className="panel-section">
-                <div className="section-heading">
-                  <h2>Sites</h2>
-                  <span className="field-help">PanelHeader</span>
+                <div className="map-inspector-section">
+                  <p className="map-inspector-line">Section/divider cadence shared with panel shell family.</p>
                 </div>
-                <div className="chip-group">
-                  <ActionButton>Library</ActionButton>
-                  <ActionButton>New</ActionButton>
-                </div>
-              </section>
-            </aside>
-          </PatternCard>
-          <PatternCard name="PanelShell.RightSidePanel" status="under migration">
-            <aside className="map-inspector">
-              <div className="map-inspector-header-row">
-                <div className="map-inspector-header-actions">
-                  <strong>Inspector</strong>
-                  <div className="map-inspector-header-actions-right">
-                    <button className="map-control-btn map-control-btn-icon" title="Hide panel" type="button">
-                      <PanelRightClose aria-hidden="true" size={16} strokeWidth={1.8} />
+              </aside>
+            </PatternCard>
+            <PatternCard name="PanelShell.BottomPanel + header/action rows" status="under migration">
+              <section className="chart-panel">
+                <div className="chart-top-row">
+                  <div className="chart-hover-state">
+                    <span>Path Profile</span>
+                  </div>
+                  <div className="chart-action-row-controls">
+                    <button className="chart-endpoint-swap chart-endpoint-icon" title="Full size" type="button">
+                      <Maximize2 aria-hidden="true" size={16} strokeWidth={1.8} />
                     </button>
                   </div>
                 </div>
-              </div>
-              <div className="map-inspector-section">
-                <p className="map-inspector-line">Header/action cluster rhythm aligned with shell family.</p>
+                <div className="chart-action-row">
+                  <div className="chart-hover-state">
+                    <span>Action row cadence aligned with shell family.</span>
+                  </div>
+                  <div className="chart-action-row-controls">
+                    <ActionButton>Save</ActionButton>
+                  </div>
+                </div>
+              </section>
+            </PatternCard>
+          </div>
+        </section>
+      ) : null}
+
+      {activeTab === "forms" ? (
+        <section className="ui-gallery-section">
+          <h3>Forms</h3>
+          <div className="ui-pattern-grid">
+            <PatternCard name="FormActionRow" status="under migration">
+              <div className="panel-section">
                 <div className="chip-group">
-                  <ActionButton>Details</ActionButton>
-                  <ActionButton variant="danger">Remove</ActionButton>
+                  <ActionButton>Apply</ActionButton>
+                  <ActionButton>Reset</ActionButton>
+                  <ActionButton variant="danger">Delete</ActionButton>
                 </div>
               </div>
-            </aside>
-          </PatternCard>
-          <PatternCard name="PanelShell.BottomPanel" status="under migration">
-            <section className="chart-panel">
-              <div className="chart-top-row">
-                <div className="chart-hover-state">
-                  <span>Path Profile</span>
+            </PatternCard>
+            <PatternCard name="Input + Select + FieldGroup" status="standard">
+              <label className="field-grid">
+                <span>Simulation Name</span>
+                <input defaultValue="Mountain Relay Net" type="text" />
+              </label>
+              <label className="field-grid">
+                <span>Frequency Plan</span>
+                <select className="locale-select" defaultValue="oslo">
+                  <option value="oslo">Oslo Local 869.618</option>
+                  <option value="eu">EU 868</option>
+                </select>
+              </label>
+              <label className="field-grid">
+                <span>Clutter Height (m)</span>
+                <input defaultValue={7} type="number" />
+              </label>
+            </PatternCard>
+            <PatternCard name="Badges/Chips/Pills" status="standard">
+              <div className="chip-group">
+                <span className="access-badge">shared</span>
+                <span className="access-badge mqtt-source-badge">MQTT</span>
+                <span className="ui-pattern-status is-standard">standard</span>
+              </div>
+            </PatternCard>
+          </div>
+        </section>
+      ) : null}
+
+      {activeTab === "notifications" ? (
+        <section className="ui-gallery-section">
+          <h3>Notifications</h3>
+          <div className="ui-pattern-grid">
+            <PatternCard name="Map inline notice" status="under migration">
+              <div className="map-inline-notice map-inline-notice-warning" role="status">
+                <span>Offline mode active. Changes will sync later.</span>
+                <ActionButton>Dismiss</ActionButton>
+              </div>
+            </PatternCard>
+            <PatternCard name="Banner notice" status="under migration">
+              <div className="notification-banner" role="status">
+                <strong>2 moderator notifications</strong> need review.
+              </div>
+              <div className="notification-banner" role="status">
+                <strong>Schema warning:</strong> missing optional index metadata.
+              </div>
+            </PatternCard>
+            <PatternCard name="Offline banner" status="under migration">
+              <div className="offline-banner" role="status">
+                <span>Offline. Changes are saved locally and will sync when connection returns.</span>
+                <div className="chip-group">
+                  <ActionButton>Open Sync Status</ActionButton>
+                  <ActionButton>Dismiss</ActionButton>
                 </div>
-                <div className="chart-action-row-controls">
-                  <button className="chart-endpoint-swap chart-endpoint-icon" title="Full size" type="button">
-                    <Maximize2 aria-hidden="true" size={16} strokeWidth={1.8} />
+              </div>
+            </PatternCard>
+            <PatternCard name="Notification bell + badge" status="exception">
+              <div className="chip-group">
+                <button className="notification-bell" type="button">
+                  🔔
+                  <span className="notification-badge">3</span>
+                </button>
+              </div>
+            </PatternCard>
+          </div>
+        </section>
+      ) : null}
+
+      {activeTab === "states" ? (
+        <section className="ui-gallery-section">
+          <h3>States</h3>
+          <div className="ui-pattern-grid">
+            <PatternCard name="Empty state" status="standard">
+              <div className="chart-empty">No profile available for current selection.</div>
+            </PatternCard>
+            <PatternCard name="Loading state" status="standard">
+              <div className="map-progress-track">
+                <div className="map-progress-fill map-progress-fill-indeterminate" />
+              </div>
+              <p className="field-help">Loading terrain and profile data…</p>
+            </PatternCard>
+            <PatternCard name="Error/helper states" status="under migration">
+              <p className="field-help field-help-error">Name must be at least 3 characters.</p>
+              <div className="terrain-alert">
+                <p>Terrain fetch failed for one tile. Retry when network is stable.</p>
+              </div>
+            </PatternCard>
+          </div>
+        </section>
+      ) : null}
+
+      {activeTab === "meta-map-ui" ? (
+        <section className="ui-gallery-section">
+          <h3>Meta / Map UI</h3>
+          <div className="ui-pattern-grid">
+            <PatternCard name="Map control cluster (overlay family)" status="standard">
+              <div className="map-controls map-controls-unified">
+                <div className="map-controls-group">
+                  <button className="map-control-btn map-control-btn-icon" title="Layers" type="button">
+                    <Layers aria-hidden="true" size={16} strokeWidth={1.8} />
+                  </button>
+                  <button className="map-control-btn map-control-btn-icon" title="Refresh" type="button">
+                    <RefreshCw aria-hidden="true" size={16} strokeWidth={1.8} />
                   </button>
                 </div>
               </div>
-              <div className="chart-action-row">
-                <div className="chart-hover-state">
-                  <span>Section/divider cadence aligned with right shell.</span>
+            </PatternCard>
+            <PatternCard name="Attribution / low-priority meta UI" status="standard">
+              <footer className="sidebar-footer">
+                <div className="sidebar-footer-links">
+                  <span>©</span>
+                  <a href="https://maplibre.org" rel="noreferrer" target="_blank">
+                    MapLibre
+                  </a>
+                  <span>©</span>
+                  <a href="https://www.openstreetmap.org" rel="noreferrer" target="_blank">
+                    OpenStreetMap
+                  </a>
                 </div>
-                <div className="chart-action-row-controls">
-                  <ActionButton>Save</ActionButton>
-                </div>
-              </div>
-            </section>
-          </PatternCard>
-        </div>
-      </section>
-
-      <section className="ui-gallery-section">
-        <h3>ActionButton + ToolButton + FormActionRow</h3>
-        <div className="ui-pattern-grid">
-          <PatternCard name="ActionButton" status="under migration">
-            <div className="chip-group">
-              <ActionButton>Save Selected Path</ActionButton>
-              <ActionButton>Details</ActionButton>
-              <ActionButton variant="danger">Remove From Simulation</ActionButton>
-            </div>
-          </PatternCard>
-          <PatternCard name="ToolButton" status="standard">
-            <div className="chip-group">
-              <button className="map-control-btn map-control-btn-icon" title="Layers" type="button">
-                <Layers aria-hidden="true" size={16} strokeWidth={1.8} />
-              </button>
-              <button className="map-control-btn map-control-btn-icon" title="Refresh" type="button">
-                <RefreshCw aria-hidden="true" size={16} strokeWidth={1.8} />
-              </button>
-              <button className="map-control-btn is-selected" type="button">
-                Pass/Fail
-              </button>
-            </div>
-          </PatternCard>
-          <PatternCard name="FormActionRow" status="under migration">
-            <div className="panel-section">
-              <div className="chip-group">
-                <ActionButton>Apply</ActionButton>
-                <ActionButton>Reset</ActionButton>
-                <ActionButton variant="danger">Delete</ActionButton>
-              </div>
-            </div>
-          </PatternCard>
-        </div>
-      </section>
-
-      <section className="ui-gallery-section">
-        <h3>Section/Divider + Inputs/Chips/Notices</h3>
-        <div className="ui-pattern-grid">
-          <PatternCard name="Section/Divider" status="standard">
-            <div className="map-inspector-section">
-              <p className="field-help">First section block</p>
-            </div>
-            <div className="map-inspector-section">
-              <p className="field-help">Second section block (divider above)</p>
-            </div>
-          </PatternCard>
-          <PatternCard name="Input + Select + Chip" status="standard">
-            <label className="field-grid">
-              <span>Simulation Name</span>
-              <input defaultValue="Mountain Relay Net" type="text" />
-            </label>
-            <label className="field-grid">
-              <span>Frequency Preset</span>
-              <select className="locale-select" defaultValue="oslo">
-                <option value="oslo">Oslo Local 869.618</option>
-                <option value="eu">EU 868</option>
-              </select>
-            </label>
-            <div className="chip-group">
-              <span className="access-badge">shared</span>
-              <span className="access-badge mqtt-source-badge">MQTT</span>
-            </div>
-          </PatternCard>
-          <PatternCard name="Notice Pattern" status="standard">
-            <div className="notification-banner" role="status">
-              Access pending approval. You can edit profile while waiting.
-            </div>
-            <p className="field-help">Notice styles are kept in the shell language family.</p>
-          </PatternCard>
-        </div>
-      </section>
-
-      <section className="ui-gallery-section">
-        <h3>Exceptions / Legacy Comparison</h3>
-        <div className="ui-pattern-grid">
-          <PatternCard name="LinkButton (exception)" status="exception">
-            <button className="inline-link-button" type="button">
-              Open changelog details
-            </button>
-          </PatternCard>
-          <PatternCard name="Compact Welcome Action (exception)" status="exception">
-            <button className="inline-action welcome-compact-button" type="button">
-              Start with sample simulation
-            </button>
-          </PatternCard>
-          <PatternCard name="Legacy inline-action specimen" status="legacy">
-            <div className="chip-group">
-              <button className="inline-action" type="button">
-                Legacy Inline Action
-              </button>
-            </div>
-            <p className="field-help">Kept only as comparison reference while migration remains incomplete.</p>
-          </PatternCard>
-        </div>
-      </section>
+                <div className="sidebar-footer-version">Build: v0.14.0-beta+fc9813a</div>
+              </footer>
+            </PatternCard>
+            <PatternCard name="Icon-only controls policy" status="mapped only">
+              <p className="field-help">Mapped for taxonomy coverage only in this pass. No visual convergence applied.</p>
+            </PatternCard>
+          </div>
+        </section>
+      ) : null}
     </main>
   );
 }

--- a/src/components/WelcomeModal.tsx
+++ b/src/components/WelcomeModal.tsx
@@ -1,4 +1,5 @@
 import { ModalOverlay } from "./ModalOverlay";
+import { ActionButton } from "./ActionButton";
 
 type WelcomeModalProps = {
   open: boolean;
@@ -26,27 +27,15 @@ export default function WelcomeModal({
           an existing simulation, creating a new one, or reading the getting started guide.
         </p>
         <div className="welcome-compact-actions">
-          <button
-            className="inline-action welcome-compact-button"
-            onClick={onOpenLibrary}
-            type="button"
-          >
+          <ActionButton onClick={onOpenLibrary} type="button">
             Open Simulation Library
-          </button>
-          <button
-            className="inline-action welcome-compact-button"
-            onClick={onCreateNewSimulation}
-            type="button"
-          >
+          </ActionButton>
+          <ActionButton onClick={onCreateNewSimulation} type="button">
             Create New Simulation
-          </button>
-          <button
-            className="inline-action welcome-compact-button"
-            onClick={onOpenOnboarding}
-            type="button"
-          >
+          </ActionButton>
+          <ActionButton onClick={onOpenOnboarding} type="button">
             Read Getting Started
-          </button>
+          </ActionButton>
         </div>
       </div>
     </ModalOverlay>

--- a/src/index.css
+++ b/src/index.css
@@ -3113,19 +3113,6 @@ input {
   gap: 8px;
 }
 
-.welcome-compact-button {
-  padding: 10px 16px;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: var(--surface);
-  text-align: left;
-  font-size: 0.92rem;
-}
-
-.welcome-compact-button:hover {
-  background: color-mix(in srgb, var(--accent) 12%, var(--surface));
-}
-
 .welcome-modal-new-simulation-backdrop {
   position: fixed;
   inset: 0;
@@ -3496,6 +3483,17 @@ input {
   z-index: 4;
 }
 
+.ui-gallery-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.ui-gallery-tab-btn[aria-pressed="true"] {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
 .ui-gallery-section {
   display: grid;
   gap: 10px;
@@ -3564,6 +3562,10 @@ input {
   background: color-mix(in srgb, var(--danger) 16%, transparent);
 }
 
+.ui-pattern-status.is-mapped-only {
+  background: color-mix(in srgb, var(--muted) 18%, transparent);
+}
+
 .ui-gallery-theme-toggle .action-button[aria-pressed="true"] {
   border-color: var(--accent);
   background: var(--accent-soft);
@@ -3594,4 +3596,24 @@ input {
 .ui-gallery-page .chart-panel {
   padding: 12px;
   gap: 10px;
+}
+
+.ui-gallery-page .map-inline-notice {
+  position: relative;
+  top: auto;
+  left: auto;
+  transform: none;
+  max-width: 100%;
+}
+
+.ui-gallery-page .offline-banner {
+  position: relative;
+}
+
+.ui-gallery-page .map-controls {
+  position: relative;
+  top: auto;
+  left: auto;
+  right: auto;
+  bottom: auto;
 }


### PR DESCRIPTION
## Summary
- broad text-bearing action convergence to ActionButton in remaining Sidebar/Welcome/Onboarding flows
- kept true overlay controls, LinkButton, tabs/selection surfaces separate
- icon-only controls mapped-only (no visual convergence)
- expanded  into tabbed inventory: Actions, Panels, Forms, Notifications, States, Meta/Map UI
- added  gallery status and updated glossary taxonomy + notification inventory/classification

## Verification
- npm test
- npm run build

## Notes
- no backend/data API changes