### PR TITLE
Issue #539: Unified notifications + gallery taxonomy/specimen fixes

### DIFF
--- a/docs/ui-pattern-glossary.md
+++ b/docs/ui-pattern-glossary.md
@@ -11,8 +11,9 @@ Status labels:
 
 Current snapshot (after tabbed gallery and broad action convergence pass):
 - Normal text-bearing app actions continue converging into one shared `ActionButton` family.
-- `ToolButton` is restricted to true map/workspace overlay controls.
-- Icon-only controls are mapped and tracked (`mapped only`) but not visually converged in this run.
+- `ToolButton` currently maps to icon-only map/workspace overlay controls in production UI.
+- No active text-bearing ToolButton family is in use.
+- Icon-only controls outside true overlay controls are mapped and tracked (`mapped only`) but not visually converged in this run.
 
 ## Proposed Outline
 1. Standard patterns
@@ -67,12 +68,10 @@ Boundary (simplified):
 
 ### ToolButton
 - Role: map/workspace overlay controls and view tools.
-- Use when: zooming, fitting, panel show/hide, map mode toggles, and map-side helper actions tied to overlay/tool context.
+- Use when: zooming, fitting, panel show/hide, and map-side helper actions tied to overlay/tool context.
 - Do not use when: action belongs to standard app action family (ActionButton) in forms/modals/normal panel flows.
 - Variants:
-  - `map-control-btn`
   - `map-control-btn map-control-btn-icon`
-  - selected state via `is-selected`
 - Known examples/files:
   - `src/components/MapView.tsx`
   - `src/components/AppShell.tsx`
@@ -182,14 +181,13 @@ Exception policy:
 Policy:
 - Mapped and tracked in gallery for coverage.
 - Out of scope for visual convergence in the current pass.
+- True map/workspace overlay icon controls are standardized under `ToolButton`; non-overlay icon controls remain mapped-only.
 
 ## Notification / Notice Inventory
 
-### Should converge next
-- `map-inline-notice`
-- `offline-banner`
-- `notification-banner`
-- shared helper/error container rhythm around sync/status messaging blocks
+### Converged now
+- AppShell transient/persistent notices now use one unified app-level notification stack (always visible, multi-item, auto/manual dismiss, overflow expand/collapse).
+- Existing `publishAppNotice` publication points now route into this unified system.
 
 ### Intentional exceptions
 - `notification-bell` + `notification-badge` (trigger/badge behavior pattern)
@@ -200,7 +198,7 @@ Policy:
 - domain-specific status tiles (`margin-status`, `terrain-alert`) that encode simulation semantics
 
 Recommended next cleanup pass:
-- Introduce one shared notice container baseline (surface/border/padding/title-row/action-slot) and migrate `map-inline-notice`, `offline-banner`, and `notification-banner` to it while keeping bell/badge and domain tiles as exceptions.
+- Migrate remaining standalone notice surfaces (`notification-banner`, selected offline/status blocks) onto the same notification container language where semantics match, while keeping bell/badge and domain tiles as exceptions.
 
 ### Specialized Triggers
 - Role: controls with distinct meaning and visual behavior that should not be forced into generic button taxonomy.

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -15,6 +15,13 @@ import { handleSimulationLibraryLoad } from "../lib/simulationLibraryLoad";
 import { emptyWorkspaceState } from "../lib/emptyWorkspaceState";
 import { getCurrentRuntimeEnvironment } from "../lib/environment";
 import { getUiErrorMessage } from "../lib/uiError";
+import {
+  clearUiNotifications,
+  dismissUiNotification,
+  type UiNotification,
+  type UiNotificationInput,
+  upsertUiNotification,
+} from "../lib/uiNotifications";
 import { initializeMigrations, runMigrations } from "../lib/migrations";
 import { resolveBasemapSelection } from "../lib/basemaps";
 import { useThemeVariant } from "../hooks/useThemeVariant";
@@ -51,6 +58,7 @@ type AppNotice = {
   tone: "info" | "warning" | "error";
   persistent: boolean;
 };
+const MAX_VISIBLE_NOTIFICATIONS = 3;
 
 const UI_PANEL_KEYS = {
   // Storage keys keep legacy names to avoid migration churn.
@@ -169,7 +177,9 @@ export function AppShell() {
   const [shareUserQuery, setShareUserQuery] = useState("");
   const [shareSpecificBusy, setShareSpecificBusy] = useState(false);
   const [shareSpecificStatus, setShareSpecificStatus] = useState("");
-  const [appNotice, setAppNotice] = useState<AppNotice | null>(null);
+  const [uiNotifications, setUiNotifications] = useState<UiNotification[]>([]);
+  const [notificationsExpanded, setNotificationsExpanded] = useState(false);
+  const [pausedNotificationIds, setPausedNotificationIds] = useState<string[]>([]);
   const [isMobileViewport, setIsMobileViewport] = useState(false);
   const [mobileActivePanel, setMobileActivePanel] = useState<MobileWorkspacePanel>("navigator");
   const [mobileBottomPanelMode, setMobileBottomPanelMode] = useState<MobileBottomPanelMode>("normal");
@@ -217,14 +227,34 @@ export function AppShell() {
     () => simulationPresets.find((preset) => preset.id === selectedScenarioId) ?? null,
     [simulationPresets, selectedScenarioId],
   );
-  const publishAppNotice = useCallback((notice: AppNotice) => {
-    setAppNotice((current) => {
-      if (current && current.id === notice.id && current.message === notice.message) {
-        return current;
-      }
-      return notice;
+  const pushNotification = useCallback((notice: UiNotificationInput) => {
+    setUiNotifications((current) => upsertUiNotification(current, notice));
+  }, []);
+  const dismissNotification = useCallback((id: string) => {
+    setUiNotifications((current) => dismissUiNotification(current, id));
+    setPausedNotificationIds((current) => current.filter((entry) => entry !== id));
+  }, []);
+  const clearNotifications = useCallback(() => {
+    setUiNotifications(clearUiNotifications());
+    setPausedNotificationIds([]);
+    setNotificationsExpanded(false);
+  }, []);
+  const setNotificationPaused = useCallback((id: string, isPaused: boolean) => {
+    setPausedNotificationIds((current) => {
+      const hasId = current.includes(id);
+      if (isPaused && !hasId) return [...current, id];
+      if (!isPaused && hasId) return current.filter((entry) => entry !== id);
+      return current;
     });
   }, []);
+  const publishAppNotice = useCallback((notice: AppNotice) => {
+    pushNotification({
+      id: notice.id,
+      message: notice.message,
+      tone: notice.tone,
+      dismissMode: notice.persistent ? "manual" : "auto",
+    });
+  }, [pushNotification]);
   const publishTransientNotice = useCallback(
     (id: string, message: string, tone: AppNotice["tone"] = "info") => {
       publishAppNotice({ id, message, tone, persistent: false });
@@ -627,10 +657,24 @@ export function AppShell() {
   );
 
   useEffect(() => {
-    if (!appNotice || appNotice.persistent) return;
-    const timer = window.setTimeout(() => setAppNotice(null), 5000);
-    return () => window.clearTimeout(timer);
-  }, [appNotice]);
+    const timers: number[] = [];
+    for (const notification of uiNotifications) {
+      if (notification.dismissMode !== "auto") continue;
+      if (pausedNotificationIds.includes(notification.id)) continue;
+      timers.push(window.setTimeout(() => dismissNotification(notification.id), notification.durationMs));
+    }
+    return () => {
+      for (const timer of timers) {
+        window.clearTimeout(timer);
+      }
+    };
+  }, [dismissNotification, pausedNotificationIds, uiNotifications]);
+
+  useEffect(() => {
+    if (uiNotifications.length <= MAX_VISIBLE_NOTIFICATIONS) {
+      setNotificationsExpanded(false);
+    }
+  }, [uiNotifications.length]);
 
   useEffect(() => {
     try { localStorage.setItem(UI_PANEL_KEYS.navigatorHidden, String(isNavigatorHidden)); } catch {}
@@ -1263,7 +1307,7 @@ export function AppShell() {
   }, []);
 
   const openShareModalOrCopy = useCallback(() => {
-    setAppNotice(null);
+    clearNotifications();
     if (!activeSimulation) {
       publishAppNotice({
         id: "share-open-simulation-first",
@@ -1295,7 +1339,7 @@ export function AppShell() {
         persistent: true,
       });
     });
-  }, [activeSimulation, copyCurrentLink, publishAppNotice]);
+  }, [activeSimulation, clearNotifications, copyCurrentLink, publishAppNotice]);
 
   const panelSizeControls = useCallback(
     (labelPrefix: string, variant: "map" | "chart" = "map") => (
@@ -1578,7 +1622,7 @@ export function AppShell() {
             </div>
           </div>
         ) : null}
-        {workspaceState === "blank-simulation" && !appNotice ? (
+        {workspaceState === "blank-simulation" && uiNotifications.length === 0 ? (
           <div className="workspace-header-actions">
             <span className="field-help">This Simulation is blank. Add sites from the map or Site Library to continue.</span>
           </div>
@@ -1651,15 +1695,6 @@ export function AppShell() {
             setIsMapExpanded((prev) => !prev);
             emitProfileLayoutPulse();
           }}
-          notice={
-            appNotice
-              ? {
-                  message: appNotice.message,
-                  tone: appNotice.tone,
-                  onDismiss: appNotice.persistent ? () => setAppNotice(null) : undefined,
-                }
-              : undefined
-          }
           fitBottomInset={
             isMobileViewport || isMapExpanded || isProfileExpanded || isProfileHidden
               ? 30
@@ -1740,6 +1775,50 @@ export function AppShell() {
           </div>
         ) : null}
       </section>
+      {uiNotifications.length ? (
+        <section aria-label="App notifications" className="app-notification-stack">
+          <div className="app-notification-stack-list">
+            {(notificationsExpanded ? uiNotifications : uiNotifications.slice(0, MAX_VISIBLE_NOTIFICATIONS)).map((notification) => (
+              <div
+                className={`app-notification-item app-notification-item-${notification.tone}`}
+                key={notification.id}
+                onBlurCapture={() => setNotificationPaused(notification.id, false)}
+                onFocusCapture={() => setNotificationPaused(notification.id, true)}
+                onMouseEnter={() => setNotificationPaused(notification.id, true)}
+                onMouseLeave={() => setNotificationPaused(notification.id, false)}
+                role={notification.tone === "error" ? "alert" : "status"}
+              >
+                <div className="app-notification-copy">
+                  {notification.title ? <strong>{notification.title}</strong> : null}
+                  <span>{notification.message}</span>
+                </div>
+                <div className="chip-group app-notification-actions">
+                  {notification.actions?.map((action) => (
+                    <ActionButton key={action.label} onClick={action.onClick} type="button">
+                      {action.label}
+                    </ActionButton>
+                  ))}
+                  {notification.dismissMode === "manual" ? (
+                    <ActionButton onClick={() => dismissNotification(notification.id)} type="button">
+                      Dismiss
+                    </ActionButton>
+                  ) : null}
+                </div>
+              </div>
+            ))}
+          </div>
+          {uiNotifications.length > MAX_VISIBLE_NOTIFICATIONS ? (
+            <div className="app-notification-stack-controls">
+              <ActionButton onClick={() => setNotificationsExpanded((current) => !current)} type="button">
+                {notificationsExpanded ? "Show Less" : `Show More (${uiNotifications.length - MAX_VISIBLE_NOTIFICATIONS})`}
+              </ActionButton>
+              <ActionButton onClick={clearNotifications} type="button">
+                Clear All
+              </ActionButton>
+            </div>
+          ) : null}
+        </section>
+      ) : null}
       {isMapExpanded || isProfileExpanded || (!isMobileViewport && (isNavigatorHidden || isInspectorHidden || isProfileHidden)) ? (
         <div className="floating-attribution-pill">
           <span>&copy;</span>

--- a/src/components/UiGalleryPage.tsx
+++ b/src/components/UiGalleryPage.tsx
@@ -3,6 +3,7 @@ import { Layers, Maximize2, Minus, PanelRightClose, Plus, RefreshCw } from "luci
 import { ActionButton } from "./ActionButton";
 import { useThemeVariant } from "../hooks/useThemeVariant";
 import { useAppStore } from "../store/appStore";
+import type { UiColorTheme } from "../themes/types";
 
 type GalleryStatus = "standard" | "exception" | "legacy" | "under migration" | "mapped only";
 type GalleryTab = "actions" | "panels" | "forms" | "notifications" | "states" | "meta-map-ui";
@@ -41,10 +42,12 @@ const PatternCard = ({
 );
 
 export function UiGalleryPage() {
-  const { theme, variant } = useThemeVariant();
+  const { theme, variant, colorTheme, activeHolidayTheme } = useThemeVariant();
   const [activeTab, setActiveTab] = useState<GalleryTab>("actions");
   const uiThemePreference = useAppStore((state) => state.uiThemePreference);
+  const setUiColorTheme = useAppStore((state) => state.setUiColorTheme);
   const setUiThemePreference = useAppStore((state) => state.setUiThemePreference);
+  const colorThemes: UiColorTheme[] = ["blue", "pink", "red", "green", "yellow"];
 
   useEffect(() => {
     const root = document.documentElement;
@@ -75,6 +78,24 @@ export function UiGalleryPage() {
             Dark
           </ActionButton>
         </div>
+        <div className="chip-group ui-gallery-theme-toggle">
+          {colorThemes.map((entry) => (
+            <ActionButton
+              aria-pressed={colorTheme === entry}
+              key={entry}
+              onClick={() => setUiColorTheme(entry)}
+              type="button"
+            >
+              {entry[0].toUpperCase()}
+              {entry.slice(1)}
+            </ActionButton>
+          ))}
+          {activeHolidayTheme ? (
+            <span className="access-badge" title="Holiday palette is active and may override your selected color theme">
+              Holiday: {activeHolidayTheme.title}
+            </span>
+          ) : null}
+        </div>
         <nav className="ui-gallery-tabs" aria-label="UI gallery tabs">
           {GALLERY_TABS.map((tab) => (
             <ActionButton
@@ -101,16 +122,16 @@ export function UiGalleryPage() {
                 <ActionButton variant="danger">Remove From Simulation</ActionButton>
               </div>
             </PatternCard>
-            <PatternCard name="ToolButton (true overlay controls only)" status="standard">
+            <PatternCard name="OverlayIconControl (map controls pill)" status="standard">
               <div className="chip-group">
-                <button className="map-control-btn" type="button">
-                  Pass/Fail
+                <button aria-label="Zoom out" className="map-control-btn map-control-btn-icon" title="Zoom out" type="button">
+                  <Minus aria-hidden="true" size={16} strokeWidth={1.8} />
                 </button>
-                <button className="map-control-btn is-selected" type="button">
-                  Heatmap
+                <button aria-label="Zoom in" className="map-control-btn map-control-btn-icon" title="Zoom in" type="button">
+                  <Plus aria-hidden="true" size={16} strokeWidth={1.8} />
                 </button>
-                <button className="map-control-btn" type="button">
-                  Fit
+                <button aria-label="Fit bounds" className="map-control-btn map-control-btn-icon" title="Fit bounds" type="button">
+                  <Maximize2 aria-hidden="true" size={16} strokeWidth={1.8} />
                 </button>
               </div>
             </PatternCard>
@@ -119,7 +140,7 @@ export function UiGalleryPage() {
                 Open change log
               </button>
             </PatternCard>
-            <PatternCard name="Icon-only utility controls" status="mapped only">
+            <PatternCard name="Overlay icon controls (mapped inventory)" status="mapped only">
               <div className="chip-group">
                 <button className="map-control-btn map-control-btn-icon" title="Zoom out" type="button">
                   <Minus aria-hidden="true" size={16} strokeWidth={1.8} />
@@ -234,10 +255,10 @@ export function UiGalleryPage() {
               </label>
             </PatternCard>
             <PatternCard name="Badges/Chips/Pills" status="standard">
-              <div className="chip-group">
+              <div className="chip-group ui-gallery-chip-specimen">
                 <span className="access-badge">shared</span>
                 <span className="access-badge mqtt-source-badge">MQTT</span>
-                <span className="ui-pattern-status is-standard">standard</span>
+                <span className="map-band-chip">Mesh</span>
               </div>
             </PatternCard>
           </div>
@@ -248,13 +269,42 @@ export function UiGalleryPage() {
         <section className="ui-gallery-section">
           <h3>Notifications</h3>
           <div className="ui-pattern-grid">
-            <PatternCard name="Map inline notice" status="under migration">
-              <div className="map-inline-notice map-inline-notice-warning" role="status">
-                <span>Offline mode active. Changes will sync later.</span>
-                <ActionButton>Dismiss</ActionButton>
+            <PatternCard name="Unified app notification stack (auto/manual + overflow)" status="under migration">
+              <div className="app-notification-stack app-notification-stack-gallery">
+                <div className="app-notification-stack-list">
+                  <div className="app-notification-item app-notification-item-info" role="status">
+                    <div className="app-notification-copy">
+                      <span>Share link copied.</span>
+                    </div>
+                  </div>
+                  <div className="app-notification-item app-notification-item-warning" role="status">
+                    <div className="app-notification-copy">
+                      <strong>Offline mode</strong>
+                      <span>Changes are stored locally until sync resumes.</span>
+                    </div>
+                    <div className="chip-group app-notification-actions">
+                      <ActionButton>Open Sync Status</ActionButton>
+                      <ActionButton>Dismiss</ActionButton>
+                    </div>
+                  </div>
+                  <div className="app-notification-item app-notification-item-error" role="alert">
+                    <div className="app-notification-copy">
+                      <span>Failed to copy link. Try again.</span>
+                    </div>
+                  </div>
+                  <div className="app-notification-item app-notification-item-info" role="status">
+                    <div className="app-notification-copy">
+                      <span>Additional queued notice (overflow example).</span>
+                    </div>
+                  </div>
+                </div>
+                <div className="app-notification-stack-controls">
+                  <ActionButton>Show More (1)</ActionButton>
+                  <ActionButton>Clear All</ActionButton>
+                </div>
               </div>
             </PatternCard>
-            <PatternCard name="Banner notice" status="under migration">
+            <PatternCard name="Notification banner (legacy)" status="legacy">
               <div className="notification-banner" role="status">
                 <strong>2 moderator notifications</strong> need review.
               </div>
@@ -262,7 +312,15 @@ export function UiGalleryPage() {
                 <strong>Schema warning:</strong> missing optional index metadata.
               </div>
             </PatternCard>
-            <PatternCard name="Offline banner" status="under migration">
+            <PatternCard name="Map inline notice baseline" status="exception">
+              <div className="ui-gallery-map-notice-stage">
+                <div className="map-inline-notice map-inline-notice-warning" role="status">
+                  <span>Offline mode active. Changes will sync later.</span>
+                  <ActionButton>Dismiss</ActionButton>
+                </div>
+              </div>
+            </PatternCard>
+            <PatternCard name="Offline banner (legacy)" status="legacy">
               <div className="offline-banner" role="status">
                 <span>Offline. Changes are saved locally and will sync when connection returns.</span>
                 <div className="chip-group">
@@ -338,7 +396,7 @@ export function UiGalleryPage() {
               </footer>
             </PatternCard>
             <PatternCard name="Icon-only controls policy" status="mapped only">
-              <p className="field-help">Mapped for taxonomy coverage only in this pass. No visual convergence applied.</p>
+              <p className="field-help">Mapped for taxonomy coverage only in this pass. No visual convergence or restyling is applied.</p>
             </PatternCard>
           </div>
         </section>

--- a/src/index.css
+++ b/src/index.css
@@ -944,6 +944,82 @@ input {
   padding: 4px 10px;
 }
 
+.app-notification-stack {
+  position: fixed;
+  top: max(14px, env(safe-area-inset-top, 0px) + 8px);
+  right: max(14px, env(safe-area-inset-right, 0px) + 8px);
+  width: min(440px, calc(100vw - 28px));
+  z-index: 980;
+  display: grid;
+  gap: 8px;
+  pointer-events: none;
+}
+
+.app-notification-stack-list {
+  display: grid;
+  gap: 8px;
+  max-height: min(52vh, 460px);
+  overflow-y: auto;
+  padding-right: 2px;
+}
+
+.app-notification-item {
+  pointer-events: auto;
+  display: grid;
+  gap: 8px;
+  border: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--surface-2) 94%, transparent);
+  box-shadow: var(--shadow-elev-3);
+  padding: 10px 12px;
+}
+
+.app-notification-item-warning {
+  border-color: color-mix(in srgb, var(--warning) 56%, var(--border));
+}
+
+.app-notification-item-error {
+  border-color: color-mix(in srgb, var(--danger) 62%, var(--border));
+}
+
+.app-notification-item-success {
+  border-color: color-mix(in srgb, var(--success) 55%, var(--border));
+}
+
+.app-notification-copy {
+  display: grid;
+  gap: 2px;
+  font-size: 0.84rem;
+}
+
+.app-notification-copy strong {
+  font-size: 0.83rem;
+}
+
+.app-notification-copy span {
+  line-height: 1.3;
+}
+
+.app-notification-actions {
+  align-items: center;
+}
+
+.app-notification-stack-controls {
+  pointer-events: auto;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.app-notification-stack-gallery {
+  position: relative;
+  top: auto;
+  right: auto;
+  width: 100%;
+  max-width: none;
+}
+
 .map-controls-icon-only {
   justify-content: center;
   overflow: visible;
@@ -3598,14 +3674,6 @@ input {
   gap: 10px;
 }
 
-.ui-gallery-page .map-inline-notice {
-  position: relative;
-  top: auto;
-  left: auto;
-  transform: none;
-  max-width: 100%;
-}
-
 .ui-gallery-page .offline-banner {
   position: relative;
 }
@@ -3616,4 +3684,34 @@ input {
   left: auto;
   right: auto;
   bottom: auto;
+}
+
+.ui-gallery-chip-specimen {
+  align-items: center;
+}
+
+.ui-gallery-map-notice-stage {
+  position: relative;
+  min-height: 86px;
+  border-radius: 12px;
+  border: 1px solid color-mix(in srgb, var(--border) 68%, transparent);
+  background: color-mix(in srgb, var(--surface) 84%, transparent);
+  overflow: hidden;
+}
+
+.ui-gallery-map-notice-stage .map-inline-notice {
+  left: 12px;
+  right: 12px;
+  top: 12px;
+  transform: none;
+  max-width: calc(100% - 24px);
+}
+
+@media (max-width: 980px) {
+  .app-notification-stack {
+    top: calc(var(--mobile-controls-top) + 46px);
+    right: 8px;
+    left: 8px;
+    width: auto;
+  }
 }

--- a/src/lib/uiNotifications.test.ts
+++ b/src/lib/uiNotifications.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  clearUiNotifications,
+  createUiNotification,
+  dismissUiNotification,
+  upsertUiNotification,
+} from "./uiNotifications";
+
+describe("createUiNotification", () => {
+  it("applies defaults", () => {
+    expect(
+      createUiNotification(
+        {
+          id: "alpha",
+          message: "Saved",
+        },
+        100,
+      ),
+    ).toMatchObject({
+      id: "alpha",
+      message: "Saved",
+      tone: "info",
+      dismissMode: "auto",
+      durationMs: 5000,
+      createdAt: 100,
+    });
+  });
+});
+
+describe("upsertUiNotification", () => {
+  it("adds notifications when id does not exist", () => {
+    const next = upsertUiNotification([], { id: "alpha", message: "Saved" }, 100);
+    expect(next).toHaveLength(1);
+    expect(next[0]).toMatchObject({ id: "alpha", createdAt: 100 });
+  });
+
+  it("replaces notifications with the same id", () => {
+    const initial = upsertUiNotification([], { id: "alpha", message: "Saved" }, 100);
+    const next = upsertUiNotification(initial, { id: "alpha", message: "Updated", tone: "warning" }, 200);
+    expect(next).toHaveLength(1);
+    expect(next[0]).toMatchObject({ id: "alpha", message: "Updated", tone: "warning", createdAt: 200 });
+  });
+});
+
+describe("dismissUiNotification", () => {
+  it("removes only the selected notification", () => {
+    const seeded = [
+      createUiNotification({ id: "alpha", message: "A" }, 100),
+      createUiNotification({ id: "beta", message: "B" }, 200),
+    ];
+    const next = dismissUiNotification(seeded, "alpha");
+    expect(next).toHaveLength(1);
+    expect(next[0].id).toBe("beta");
+  });
+});
+
+describe("clearUiNotifications", () => {
+  it("returns an empty list", () => {
+    expect(clearUiNotifications()).toEqual([]);
+  });
+});

--- a/src/lib/uiNotifications.ts
+++ b/src/lib/uiNotifications.ts
@@ -1,0 +1,52 @@
+export type UiNotificationTone = "info" | "warning" | "error" | "success";
+export type UiNotificationDismissMode = "auto" | "manual";
+
+export type UiNotification = {
+  id: string;
+  message: string;
+  tone: UiNotificationTone;
+  dismissMode: UiNotificationDismissMode;
+  durationMs: number;
+  createdAt: number;
+  title?: string;
+  actions?: Array<{ label: string; onClick: () => void }>;
+};
+
+export type UiNotificationInput = {
+  id: string;
+  message: string;
+  tone?: UiNotificationTone;
+  dismissMode?: UiNotificationDismissMode;
+  durationMs?: number;
+  title?: string;
+  actions?: Array<{ label: string; onClick: () => void }>;
+};
+
+const DEFAULT_DURATION_MS = 5_000;
+
+export const createUiNotification = (input: UiNotificationInput, now = Date.now()): UiNotification => ({
+  id: input.id,
+  message: input.message,
+  tone: input.tone ?? "info",
+  dismissMode: input.dismissMode ?? "auto",
+  durationMs: Math.max(0, input.durationMs ?? DEFAULT_DURATION_MS),
+  createdAt: now,
+  title: input.title,
+  actions: input.actions,
+});
+
+export const upsertUiNotification = (
+  notifications: UiNotification[],
+  input: UiNotificationInput,
+  now = Date.now(),
+): UiNotification[] => {
+  const next = createUiNotification(input, now);
+  const index = notifications.findIndex((item) => item.id === next.id);
+  if (index === -1) return [...notifications, next];
+  return notifications.map((item, itemIndex) => (itemIndex === index ? next : item));
+};
+
+export const dismissUiNotification = (notifications: UiNotification[], id: string): UiNotification[] =>
+  notifications.filter((item) => item.id !== id);
+
+export const clearUiNotifications = (): UiNotification[] => [];


### PR DESCRIPTION
## Summary
- correct tool-control taxonomy labeling and gallery naming for overlay icon controls
- add gallery color-theme selector using real app theme state, alongside system/light/dark
- fix gallery specimen drift for chips/badges/pills and map-inline-notice wrappers
- introduce unified AppShell notification stack with queue, auto/manual dismiss, pause-on-hover/focus, and overflow expand/collapse
- route existing AppShell publishAppNotice calls into unified notifications
- update UI glossary snapshot for tool-control boundary and notification convergence state

## Validation
- npm test
- npm run build
- npm run deploy:staging (to run after merge from staging branch)
