### PR TITLE
Issue #539: Fix app shell fade-in visibility

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -122,7 +122,9 @@ input {
   height: 100dvh;
   min-height: 100dvh;
   overflow: hidden;
+  opacity: 1;
   animation: fade-in 260ms ease;
+  animation-fill-mode: both;
 }
 
 .app-shell.is-map-expanded,


### PR DESCRIPTION
## Summary
- keep app shell visible by default with opacity: 1
- set animation-fill-mode: both on fade-in animation so final visible state is retained

## Why
- staging observed main app shell remaining at opacity 0 even though fade-in keyframes exist
- this guarantees visible end state regardless of animation timing edge cases

## Validation
- npm test
- npm run build
