### PR TITLE
Issue #539: Notification debug trigger + anchored stack position

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -58,6 +58,16 @@ type AppNotice = {
   tone: "info" | "warning" | "error";
   persistent: boolean;
 };
+
+type NotificationDebugWindow = Window & {
+  linksimNotifications?: {
+    push: (notice: UiNotificationInput) => void;
+    pushMany: (notices: UiNotificationInput[]) => void;
+    dismiss: (id: string) => void;
+    clear: () => void;
+    list: () => UiNotification[];
+  };
+};
 const MAX_VISIBLE_NOTIFICATIONS = 3;
 
 const UI_PANEL_KEYS = {
@@ -675,6 +685,23 @@ export function AppShell() {
       setNotificationsExpanded(false);
     }
   }, [uiNotifications.length]);
+
+  useEffect(() => {
+    if (import.meta.env.PROD) return;
+    const target = window as NotificationDebugWindow;
+    target.linksimNotifications = {
+      push: (notice) => pushNotification(notice),
+      pushMany: (notices) => {
+        for (const notice of notices) pushNotification(notice);
+      },
+      dismiss: (id) => dismissNotification(id),
+      clear: () => clearNotifications(),
+      list: () => [...uiNotifications],
+    };
+    return () => {
+      delete target.linksimNotifications;
+    };
+  }, [clearNotifications, dismissNotification, pushNotification, uiNotifications]);
 
   useEffect(() => {
     try { localStorage.setItem(UI_PANEL_KEYS.navigatorHidden, String(isNavigatorHidden)); } catch {}

--- a/src/index.css
+++ b/src/index.css
@@ -947,14 +947,20 @@ input {
 }
 
 .app-notification-stack {
-  position: fixed;
-  top: max(14px, env(safe-area-inset-top, 0px) + 8px);
-  right: max(14px, env(safe-area-inset-right, 0px) + 8px);
-  width: min(440px, calc(100vw - 28px));
-  z-index: 980;
+  position: absolute;
+  top: calc(18px + 36px + (var(--workspace-panel-gap) * 2));
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(520px, calc(100% - 36px), calc(100% - (var(--sidebar-overlay-width) * 2) - 60px));
+  z-index: 58;
   display: grid;
   gap: 8px;
   pointer-events: none;
+}
+
+.app-shell.is-map-expanded .app-notification-stack,
+.app-shell.is-profile-expanded .app-notification-stack {
+  width: min(520px, calc(100% - 36px));
 }
 
 .app-notification-stack-list {
@@ -3711,9 +3717,7 @@ input {
 
 @media (max-width: 980px) {
   .app-notification-stack {
-    top: calc(var(--mobile-controls-top) + 46px);
-    right: 8px;
-    left: 8px;
-    width: auto;
+    top: calc(var(--mobile-controls-top) + 52px);
+    width: min(460px, calc(100% - 16px));
   }
 }


### PR DESCRIPTION
## Summary
- add non-production window debug API for notifications ()
- supports push, pushMany, dismiss, clear, and list for console-driven iteration
- reposition app notification stack to anchor below map controls cluster instead of top-right panel area
- keep mobile spacing/panel collision handling with viewport-specific offset

## Validation
- npm test
- npm run build
