### PR TITLE
Issue #539: Mini-bar notification redesign + dismiss-all

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,5 +1,5 @@
 import { type CSSProperties, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { CircleUserRound, CloudAlert, Copy, Globe, Maximize2, PanelBottom, PanelBottomClose, PanelLeft, PanelLeftClose, PanelRight, PanelRightClose, Share, UserRoundPlus, UserRoundSearch, Users } from "lucide-react";
+import { CircleAlert, CircleCheck, CircleUserRound, CircleX, CloudAlert, Copy, Globe, Info, Maximize2, PanelBottom, PanelBottomClose, PanelLeft, PanelLeftClose, PanelRight, PanelRightClose, Share, UserRoundPlus, UserRoundSearch, Users, X } from "lucide-react";
 import { type CollaboratorDirectoryUser, fetchCollaboratorDirectory, fetchDeepLinkStatus, fetchMe, setLocalDevRole } from "../lib/cloudUser";
 import { fetchCloudLibrary, fetchPublicSimulationLibrary, pushCloudLibrary } from "../lib/cloudLibrary";
 import { buildDeepLinkPathname, buildDeepLinkUrl, canonicalizeDeepLinkKey, parseDeepLinkFromLocation, slugifyName } from "../lib/deepLink";
@@ -68,7 +68,7 @@ type NotificationDebugWindow = Window & {
     list: () => UiNotification[];
   };
 };
-const MAX_VISIBLE_NOTIFICATIONS = 3;
+const DISMISS_ALL_THRESHOLD = 4;
 
 const UI_PANEL_KEYS = {
   // Storage keys keep legacy names to avoid migration churn.
@@ -188,7 +188,6 @@ export function AppShell() {
   const [shareSpecificBusy, setShareSpecificBusy] = useState(false);
   const [shareSpecificStatus, setShareSpecificStatus] = useState("");
   const [uiNotifications, setUiNotifications] = useState<UiNotification[]>([]);
-  const [notificationsExpanded, setNotificationsExpanded] = useState(false);
   const [pausedNotificationIds, setPausedNotificationIds] = useState<string[]>([]);
   const [isMobileViewport, setIsMobileViewport] = useState(false);
   const [mobileActivePanel, setMobileActivePanel] = useState<MobileWorkspacePanel>("navigator");
@@ -247,7 +246,6 @@ export function AppShell() {
   const clearNotifications = useCallback(() => {
     setUiNotifications(clearUiNotifications());
     setPausedNotificationIds([]);
-    setNotificationsExpanded(false);
   }, []);
   const setNotificationPaused = useCallback((id: string, isPaused: boolean) => {
     setPausedNotificationIds((current) => {
@@ -679,12 +677,6 @@ export function AppShell() {
       }
     };
   }, [dismissNotification, pausedNotificationIds, uiNotifications]);
-
-  useEffect(() => {
-    if (uiNotifications.length <= MAX_VISIBLE_NOTIFICATIONS) {
-      setNotificationsExpanded(false);
-    }
-  }, [uiNotifications.length]);
 
   useEffect(() => {
     if (runtimeEnvironment === "production") return;
@@ -1805,7 +1797,7 @@ export function AppShell() {
       {uiNotifications.length ? (
         <section aria-label="App notifications" className="app-notification-stack">
           <div className="app-notification-stack-list">
-            {(notificationsExpanded ? uiNotifications : uiNotifications.slice(0, MAX_VISIBLE_NOTIFICATIONS)).map((notification) => (
+            {uiNotifications.map((notification) => (
               <div
                 className={`app-notification-item app-notification-item-${notification.tone}`}
                 key={notification.id}
@@ -1815,32 +1807,31 @@ export function AppShell() {
                 onMouseLeave={() => setNotificationPaused(notification.id, false)}
                 role={notification.tone === "error" ? "alert" : "status"}
               >
+                <span className="app-notification-glyph" aria-hidden="true">
+                  {notification.tone === "warning" ? <CircleAlert size={14} strokeWidth={2} /> : null}
+                  {notification.tone === "error" ? <CircleX size={14} strokeWidth={2} /> : null}
+                  {notification.tone === "success" ? <CircleCheck size={14} strokeWidth={2} /> : null}
+                  {notification.tone === "info" ? <Info size={14} strokeWidth={2} /> : null}
+                </span>
                 <div className="app-notification-copy">
-                  {notification.title ? <strong>{notification.title}</strong> : null}
                   <span>{notification.message}</span>
                 </div>
-                <div className="chip-group app-notification-actions">
-                  {notification.actions?.map((action) => (
-                    <ActionButton key={action.label} onClick={action.onClick} type="button">
-                      {action.label}
-                    </ActionButton>
-                  ))}
-                  {notification.dismissMode === "manual" ? (
-                    <ActionButton onClick={() => dismissNotification(notification.id)} type="button">
-                      Dismiss
-                    </ActionButton>
-                  ) : null}
-                </div>
+                <button
+                  aria-label="Dismiss notification"
+                  className="app-notification-dismiss"
+                  onClick={() => dismissNotification(notification.id)}
+                  title="Dismiss"
+                  type="button"
+                >
+                  <X aria-hidden="true" size={14} strokeWidth={2} />
+                </button>
               </div>
             ))}
           </div>
-          {uiNotifications.length > MAX_VISIBLE_NOTIFICATIONS ? (
+          {uiNotifications.length >= DISMISS_ALL_THRESHOLD ? (
             <div className="app-notification-stack-controls">
-              <ActionButton onClick={() => setNotificationsExpanded((current) => !current)} type="button">
-                {notificationsExpanded ? "Show Less" : `Show More (${uiNotifications.length - MAX_VISIBLE_NOTIFICATIONS})`}
-              </ActionButton>
               <ActionButton onClick={clearNotifications} type="button">
-                Clear All
+                Dismiss all
               </ActionButton>
             </div>
           ) : null}

--- a/src/components/UiGalleryPage.tsx
+++ b/src/components/UiGalleryPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type ReactNode } from "react";
-import { Layers, Maximize2, Minus, PanelRightClose, Plus, RefreshCw } from "lucide-react";
+import { CircleAlert, CircleCheck, CircleX, Info, Layers, Maximize2, Minus, PanelRightClose, Plus, RefreshCw, X } from "lucide-react";
 import { ActionButton } from "./ActionButton";
 import { useThemeVariant } from "../hooks/useThemeVariant";
 import { useAppStore } from "../store/appStore";
@@ -273,34 +273,52 @@ export function UiGalleryPage() {
               <div className="app-notification-stack app-notification-stack-gallery">
                 <div className="app-notification-stack-list">
                   <div className="app-notification-item app-notification-item-info" role="status">
+                    <span className="app-notification-glyph" aria-hidden="true">
+                      <Info size={14} strokeWidth={2} />
+                    </span>
                     <div className="app-notification-copy">
                       <span>Share link copied.</span>
                     </div>
+                    <button aria-label="Dismiss notification" className="app-notification-dismiss" type="button">
+                      <X aria-hidden="true" size={14} strokeWidth={2} />
+                    </button>
                   </div>
                   <div className="app-notification-item app-notification-item-warning" role="status">
+                    <span className="app-notification-glyph" aria-hidden="true">
+                      <CircleAlert size={14} strokeWidth={2} />
+                    </span>
                     <div className="app-notification-copy">
-                      <strong>Offline mode</strong>
-                      <span>Changes are stored locally until sync resumes.</span>
+                      <span>Retrying tile 12/41.</span>
                     </div>
-                    <div className="chip-group app-notification-actions">
-                      <ActionButton>Open Sync Status</ActionButton>
-                      <ActionButton>Dismiss</ActionButton>
-                    </div>
+                    <button aria-label="Dismiss notification" className="app-notification-dismiss" type="button">
+                      <X aria-hidden="true" size={14} strokeWidth={2} />
+                    </button>
                   </div>
                   <div className="app-notification-item app-notification-item-error" role="alert">
+                    <span className="app-notification-glyph" aria-hidden="true">
+                      <CircleX size={14} strokeWidth={2} />
+                    </span>
                     <div className="app-notification-copy">
-                      <span>Failed to copy link. Try again.</span>
+                      <span>Elevation API slow.</span>
                     </div>
+                    <button aria-label="Dismiss notification" className="app-notification-dismiss" type="button">
+                      <X aria-hidden="true" size={14} strokeWidth={2} />
+                    </button>
                   </div>
-                  <div className="app-notification-item app-notification-item-info" role="status">
+                  <div className="app-notification-item app-notification-item-success" role="status">
+                    <span className="app-notification-glyph" aria-hidden="true">
+                      <CircleCheck size={14} strokeWidth={2} />
+                    </span>
                     <div className="app-notification-copy">
-                      <span>Additional queued notice (overflow example).</span>
+                      <span>Profile updated.</span>
                     </div>
+                    <button aria-label="Dismiss notification" className="app-notification-dismiss" type="button">
+                      <X aria-hidden="true" size={14} strokeWidth={2} />
+                    </button>
                   </div>
                 </div>
                 <div className="app-notification-stack-controls">
-                  <ActionButton>Show More (1)</ActionButton>
-                  <ActionButton>Clear All</ActionButton>
+                  <ActionButton>Dismiss all</ActionButton>
                 </div>
               </div>
             </PatternCard>

--- a/src/index.css
+++ b/src/index.css
@@ -965,21 +965,26 @@ input {
 
 .app-notification-stack-list {
   display: grid;
-  gap: 8px;
+  gap: 6px;
   max-height: min(52vh, 460px);
   overflow-y: auto;
-  padding-right: 2px;
+  padding-right: 1px;
 }
 
 .app-notification-item {
   pointer-events: auto;
   display: grid;
-  gap: 8px;
-  border: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
-  border-radius: 12px;
-  background: color-mix(in srgb, var(--surface-2) 94%, transparent);
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  min-height: 36px;
+  border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--surface-2) 88%, transparent);
   box-shadow: var(--shadow-elev-3);
-  padding: 10px 12px;
+  -webkit-backdrop-filter: blur(var(--glass-panel-blur));
+  backdrop-filter: blur(var(--glass-panel-blur));
+  padding: 5px 8px;
 }
 
 .app-notification-item-warning {
@@ -994,30 +999,74 @@ input {
   border-color: color-mix(in srgb, var(--success) 55%, var(--border));
 }
 
-.app-notification-copy {
-  display: grid;
-  gap: 2px;
-  font-size: 0.84rem;
+.app-notification-glyph {
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  display: inline-grid;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--accent) 46%, var(--border));
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+  color: var(--text);
 }
 
-.app-notification-copy strong {
-  font-size: 0.83rem;
+.app-notification-item-warning .app-notification-glyph {
+  border-color: color-mix(in srgb, var(--warning) 46%, var(--border));
+  background: color-mix(in srgb, var(--warning) 18%, transparent);
+}
+
+.app-notification-item-error .app-notification-glyph {
+  border-color: color-mix(in srgb, var(--danger) 46%, var(--border));
+  background: color-mix(in srgb, var(--danger) 18%, transparent);
+}
+
+.app-notification-item-success .app-notification-glyph {
+  border-color: color-mix(in srgb, var(--success) 46%, var(--border));
+  background: color-mix(in srgb, var(--success) 18%, transparent);
+}
+
+.app-notification-copy {
+  min-width: 0;
+  font-size: 0.78rem;
 }
 
 .app-notification-copy span {
-  line-height: 1.3;
+  display: block;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.2;
 }
 
-.app-notification-actions {
-  align-items: center;
+.app-notification-dismiss {
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  width: 24px;
+  height: 24px;
+  border-radius: 999px;
+  display: inline-grid;
+  place-items: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+.app-notification-dismiss:hover {
+  background: color-mix(in srgb, var(--text) 8%, transparent);
+  color: var(--text);
+}
+
+.app-notification-dismiss:focus-visible {
+  outline: 2px solid var(--focus-outline);
+  outline-offset: 1px;
 }
 
 .app-notification-stack-controls {
   pointer-events: auto;
   display: flex;
-  flex-wrap: wrap;
   justify-content: flex-end;
-  gap: 8px;
+  margin-top: 2px;
 }
 
 .app-notification-stack-gallery {

--- a/src/lib/uiNotifications.ts
+++ b/src/lib/uiNotifications.ts
@@ -8,8 +8,6 @@ export type UiNotification = {
   dismissMode: UiNotificationDismissMode;
   durationMs: number;
   createdAt: number;
-  title?: string;
-  actions?: Array<{ label: string; onClick: () => void }>;
 };
 
 export type UiNotificationInput = {
@@ -18,8 +16,6 @@ export type UiNotificationInput = {
   tone?: UiNotificationTone;
   dismissMode?: UiNotificationDismissMode;
   durationMs?: number;
-  title?: string;
-  actions?: Array<{ label: string; onClick: () => void }>;
 };
 
 const DEFAULT_DURATION_MS = 5_000;
@@ -31,8 +27,6 @@ export const createUiNotification = (input: UiNotificationInput, now = Date.now(
   dismissMode: input.dismissMode ?? "auto",
   durationMs: Math.max(0, input.durationMs ?? DEFAULT_DURATION_MS),
   createdAt: now,
-  title: input.title,
-  actions: input.actions,
 });
 
 export const upsertUiNotification = (


### PR DESCRIPTION
## Summary
- redesign app notification stack to compact mini-bars with theme-adapted styling
- use Lucide tone glyphs: CircleAlert, CircleX, CircleCheck, Info
- always show per-row dismiss icon button
- simplify notification model to message-only by removing title/actions fields
- replace show-more controls with Dismiss all action shown when queue size >= 4
- keep stack anchored below map controls cluster and preserve local/staging debug API
- update UI gallery notification specimen to match new mini-bar family

## Validation
- npm test
- npm run build
