### PR TITLE
Issue #539: Notification animations + mobile spacing + icon cleanup

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -69,6 +69,8 @@ type NotificationDebugWindow = Window & {
   };
 };
 const DISMISS_ALL_THRESHOLD = 4;
+const MANUAL_DISMISS_EXIT_MS = 220;
+const AUTO_DISMISS_EXIT_MS = 1000;
 
 const UI_PANEL_KEYS = {
   // Storage keys keep legacy names to avoid migration churn.
@@ -190,6 +192,7 @@ export function AppShell() {
   const [uiNotifications, setUiNotifications] = useState<UiNotification[]>([]);
   const uiNotificationsRef = useRef<UiNotification[]>([]);
   const [pausedNotificationIds, setPausedNotificationIds] = useState<string[]>([]);
+  const [dismissingNotificationIds, setDismissingNotificationIds] = useState<Record<string, "manual" | "auto">>({});
   const [isMobileViewport, setIsMobileViewport] = useState(false);
   const [mobileActivePanel, setMobileActivePanel] = useState<MobileWorkspacePanel>("navigator");
   const [mobileBottomPanelMode, setMobileBottomPanelMode] = useState<MobileBottomPanelMode>("normal");
@@ -251,12 +254,33 @@ export function AppShell() {
       return next;
     });
     setPausedNotificationIds((current) => current.filter((entry) => entry !== id));
+    setDismissingNotificationIds((current) => {
+      if (!current[id]) return current;
+      const next = { ...current };
+      delete next[id];
+      return next;
+    });
   }, []);
+  const requestDismissNotification = useCallback(
+    (id: string, reason: "manual" | "auto") => {
+      if (dismissingNotificationIds[id]) return;
+      setDismissingNotificationIds((current) => {
+        if (current[id]) return current;
+        return { ...current, [id]: reason };
+      });
+      window.setTimeout(
+        () => dismissNotification(id),
+        reason === "auto" ? AUTO_DISMISS_EXIT_MS : MANUAL_DISMISS_EXIT_MS,
+      );
+    },
+    [dismissNotification, dismissingNotificationIds],
+  );
   const clearNotifications = useCallback(() => {
     const next = clearUiNotifications();
     setUiNotifications(next);
     uiNotificationsRef.current = next;
     setPausedNotificationIds([]);
+    setDismissingNotificationIds({});
   }, []);
   const setNotificationPaused = useCallback((id: string, isPaused: boolean) => {
     setPausedNotificationIds((current) => {
@@ -680,14 +704,14 @@ export function AppShell() {
     for (const notification of uiNotifications) {
       if (notification.dismissMode !== "auto") continue;
       if (pausedNotificationIds.includes(notification.id)) continue;
-      timers.push(window.setTimeout(() => dismissNotification(notification.id), notification.durationMs));
+      timers.push(window.setTimeout(() => requestDismissNotification(notification.id, "auto"), notification.durationMs));
     }
     return () => {
       for (const timer of timers) {
         window.clearTimeout(timer);
       }
     };
-  }, [dismissNotification, pausedNotificationIds, uiNotifications]);
+  }, [pausedNotificationIds, requestDismissNotification, uiNotifications]);
 
   useEffect(() => {
     if (runtimeEnvironment === "production") return;
@@ -707,9 +731,7 @@ export function AppShell() {
         setUiNotifications(next);
       },
       dismiss: (id) => {
-        const next = dismissUiNotification(uiNotificationsRef.current, id);
-        uiNotificationsRef.current = next;
-        setUiNotifications(next);
+        requestDismissNotification(id, "manual");
       },
       clear: () => {
         uiNotificationsRef.current = [];
@@ -720,7 +742,7 @@ export function AppShell() {
     return () => {
       delete target.linksimNotifications;
     };
-  }, [runtimeEnvironment]);
+  }, [requestDismissNotification, runtimeEnvironment]);
 
   useEffect(() => {
     try { localStorage.setItem(UI_PANEL_KEYS.navigatorHidden, String(isNavigatorHidden)); } catch {}
@@ -1826,13 +1848,18 @@ export function AppShell() {
           <div className="app-notification-stack-list">
             {uiNotifications.map((notification) => (
               <div
-                className={`app-notification-item app-notification-item-${notification.tone}`}
+                data-dismiss-kind={dismissingNotificationIds[notification.id] ?? undefined}
                 key={notification.id}
                 onBlurCapture={() => setNotificationPaused(notification.id, false)}
                 onFocusCapture={() => setNotificationPaused(notification.id, true)}
                 onMouseEnter={() => setNotificationPaused(notification.id, true)}
                 onMouseLeave={() => setNotificationPaused(notification.id, false)}
                 role={notification.tone === "error" ? "alert" : "status"}
+                aria-live={notification.tone === "error" ? "assertive" : "polite"}
+                aria-atomic="true"
+                className={`app-notification-item app-notification-item-${notification.tone} ${
+                  dismissingNotificationIds[notification.id] ? "is-dismissing" : ""
+                }`}
               >
                 <span className="app-notification-glyph" aria-hidden="true">
                   {notification.tone === "warning" ? <CircleAlert size={14} strokeWidth={2} /> : null}
@@ -1846,7 +1873,7 @@ export function AppShell() {
                 <button
                   aria-label="Dismiss notification"
                   className="app-notification-dismiss"
-                  onClick={() => dismissNotification(notification.id)}
+                  onClick={() => requestDismissNotification(notification.id, "manual")}
                   title="Dismiss"
                   type="button"
                 >

--- a/src/index.css
+++ b/src/index.css
@@ -985,6 +985,19 @@ input {
   -webkit-backdrop-filter: blur(var(--glass-panel-blur));
   backdrop-filter: blur(var(--glass-panel-blur));
   padding: 5px 8px;
+  animation: notification-enter 240ms ease both;
+}
+
+.app-notification-item.is-dismissing {
+  pointer-events: none;
+}
+
+.app-notification-item.is-dismissing[data-dismiss-kind="manual"] {
+  animation: notification-exit-fast 220ms ease forwards;
+}
+
+.app-notification-item.is-dismissing[data-dismiss-kind="auto"] {
+  animation: notification-exit-slow 1000ms ease forwards;
 }
 
 .app-notification-item-warning {
@@ -1000,29 +1013,22 @@ input {
 }
 
 .app-notification-glyph {
-  width: 18px;
-  height: 18px;
-  border-radius: 999px;
-  display: inline-grid;
-  place-items: center;
-  border: 1px solid color-mix(in srgb, var(--accent) 46%, var(--border));
-  background: color-mix(in srgb, var(--accent) 18%, transparent);
-  color: var(--text);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent);
 }
 
 .app-notification-item-warning .app-notification-glyph {
-  border-color: color-mix(in srgb, var(--warning) 46%, var(--border));
-  background: color-mix(in srgb, var(--warning) 18%, transparent);
+  color: var(--warning);
 }
 
 .app-notification-item-error .app-notification-glyph {
-  border-color: color-mix(in srgb, var(--danger) 46%, var(--border));
-  background: color-mix(in srgb, var(--danger) 18%, transparent);
+  color: var(--danger);
 }
 
 .app-notification-item-success .app-notification-glyph {
-  border-color: color-mix(in srgb, var(--success) 46%, var(--border));
-  background: color-mix(in srgb, var(--success) 18%, transparent);
+  color: var(--success);
 }
 
 .app-notification-copy {
@@ -1075,6 +1081,42 @@ input {
   right: auto;
   width: 100%;
   max-width: none;
+}
+
+@keyframes notification-enter {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.985);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes notification-exit-fast {
+  from {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+
+  to {
+    opacity: 0;
+    transform: translateY(-5px) scale(0.985);
+  }
+}
+
+@keyframes notification-exit-slow {
+  from {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+
+  to {
+    opacity: 0;
+    transform: translateY(-10px) scale(0.975);
+  }
 }
 
 .map-controls-icon-only {
@@ -3766,7 +3808,7 @@ input {
 
 @media (max-width: 980px) {
   .app-notification-stack {
-    top: calc(var(--mobile-controls-top) + 52px);
+    top: calc(var(--mobile-controls-top) + 68px);
     width: min(460px, calc(100% - 16px));
   }
 }


### PR DESCRIPTION
Summary:
- add enter/exit motion for app notifications
- manual dismiss exits fast, auto-expire exits slower
- increase mobile offset so stack has clear spacing below map controls
- remove glyph chip backgrounds and color Lucide icons directly by tone

Validation:
- npm test
- npm run build