### PR TITLE
Issue #539: Converge notice surfaces into mini-bar system

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -44,8 +44,10 @@ initializeMigrations();
 const LAST_SIMULATION_REF_KEY = "rmw-last-simulation-ref-v1";
 const ONBOARDING_SEEN_KEY_PREFIX = "linksim:onboarding-seen:v1:";
 const LOCAL_FORCE_READONLY_KEY = "linksim:local-force-readonly:v1";
-const OPEN_SYNC_MODAL_EVENT = "linksim:open-sync-modal";
 const ACCESS_CHECK_TIMEOUT_MS = 10_000;
+const ACCESS_CHECKING_NOTICE_ID = "access-checking";
+const OFFLINE_SYNC_NOTICE_ID = "offline-sync";
+const BLANK_SIM_NOTICE_ID = "blank-simulation-guidance";
 // Shell vocabulary mapping for cleanup work:
 // - navigator => LeftSidePanel
 // - inspector => RightSidePanel (legacy term retained in code for stability)
@@ -281,6 +283,20 @@ export function AppShell() {
     uiNotificationsRef.current = next;
     setPausedNotificationIds([]);
     setDismissingNotificationIds({});
+  }, []);
+  const removeNotificationImmediately = useCallback((id: string) => {
+    setUiNotifications((current) => {
+      const next = dismissUiNotification(current, id);
+      uiNotificationsRef.current = next;
+      return next;
+    });
+    setPausedNotificationIds((current) => current.filter((entry) => entry !== id));
+    setDismissingNotificationIds((current) => {
+      if (!current[id]) return current;
+      const next = { ...current };
+      delete next[id];
+      return next;
+    });
   }, []);
   const setNotificationPaused = useCallback((id: string, isPaused: boolean) => {
     setPausedNotificationIds((current) => {
@@ -712,6 +728,48 @@ export function AppShell() {
       }
     };
   }, [pausedNotificationIds, requestDismissNotification, uiNotifications]);
+
+  useEffect(() => {
+    if (accessState === "checking") {
+      pushNotification({
+        id: ACCESS_CHECKING_NOTICE_ID,
+        message: "Checking access in the background. Anonymous mode is available while this resolves.",
+        tone: "info",
+        dismissMode: "manual",
+      });
+      return;
+    }
+    removeNotificationImmediately(ACCESS_CHECKING_NOTICE_ID);
+  }, [accessState, pushNotification, removeNotificationImmediately]);
+
+  useEffect(() => {
+    if (!isOnline && !offlineBannerDismissed) {
+      pushNotification({
+        id: OFFLINE_SYNC_NOTICE_ID,
+        message: "Offline. Changes are saved locally and will sync when connection returns.",
+        tone: "warning",
+        dismissMode: "manual",
+      });
+      return;
+    }
+    removeNotificationImmediately(OFFLINE_SYNC_NOTICE_ID);
+    if (isOnline && offlineBannerDismissed) {
+      setOfflineBannerDismissed(false);
+    }
+  }, [isOnline, offlineBannerDismissed, pushNotification, removeNotificationImmediately]);
+
+  useEffect(() => {
+    if (workspaceState === "blank-simulation" && !(isAnonymousGuestReadonly || accessState === "checking")) {
+      pushNotification({
+        id: BLANK_SIM_NOTICE_ID,
+        message: "This Simulation is blank. Add sites from the map or Site Library to continue.",
+        tone: "info",
+        dismissMode: "manual",
+      });
+      return;
+    }
+    removeNotificationImmediately(BLANK_SIM_NOTICE_ID);
+  }, [accessState, isAnonymousGuestReadonly, pushNotification, removeNotificationImmediately, workspaceState]);
 
   useEffect(() => {
     if (runtimeEnvironment === "production") return;
@@ -1654,29 +1712,6 @@ export function AppShell() {
         id={isMobileViewport ? mobileInspectorPanelId : undefined}
         role={isMobileViewport ? "tabpanel" : undefined}
       >
-        {accessState === "checking" ? (
-          <div className="workspace-header-actions">
-            <span className="field-help">Checking access in the background. Anonymous mode is available while this resolves.</span>
-          </div>
-        ) : null}
-        {!isOnline && !offlineBannerDismissed ? (
-          <div className="offline-banner" role="status">
-            <span>Offline. Changes are saved locally and will sync when connection returns.</span>
-            <div className="chip-group">
-              <ActionButton
-                onClick={() => {
-                  window.dispatchEvent(new CustomEvent(OPEN_SYNC_MODAL_EVENT));
-                }}
-                type="button"
-              >
-                Open Sync Status
-              </ActionButton>
-              <ActionButton onClick={() => setOfflineBannerDismissed(true)} type="button">
-                Dismiss
-              </ActionButton>
-            </div>
-          </div>
-        ) : null}
         {workspaceState === "no-simulation" && !isReadOnlyShell ? (
           <div className="empty-workspace-overlay">
             <div className="empty-workspace-message">
@@ -1688,11 +1723,6 @@ export function AppShell() {
                 Open Library
               </ActionButton>
             </div>
-          </div>
-        ) : null}
-        {workspaceState === "blank-simulation" && uiNotifications.length === 0 ? (
-          <div className="workspace-header-actions">
-            <span className="field-help">This Simulation is blank. Add sites from the map or Site Library to continue.</span>
           </div>
         ) : null}
         <div className="workspace-header-actions">
@@ -1873,7 +1903,12 @@ export function AppShell() {
                 <button
                   aria-label="Dismiss notification"
                   className="app-notification-dismiss"
-                  onClick={() => requestDismissNotification(notification.id, "manual")}
+                  onClick={() => {
+                    if (notification.id === OFFLINE_SYNC_NOTICE_ID) {
+                      setOfflineBannerDismissed(true);
+                    }
+                    requestDismissNotification(notification.id, "manual");
+                  }}
                   title="Dismiss"
                   type="button"
                 >

--- a/src/components/NotificationsPanel.tsx
+++ b/src/components/NotificationsPanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { CircleAlert } from "lucide-react";
 import { fetchNotifications, type NotificationFeed, type PendingApprovalUser } from "../lib/cloudNotifications";
 import { getUiErrorMessage } from "../lib/uiError";
 import { formatDate } from "../lib/locale";
@@ -44,8 +45,15 @@ export function NotificationsPanel() {
   return (
     <div className="notifications-panel">
       {feed.unreadCount > 0 ? (
-        <div className="notification-banner" role="status">
-          <strong>{feed.unreadCount} pending user(s)</strong> need moderator/admin review.
+        <div className="app-notification-item app-notification-item-warning app-notification-item-static" role="status">
+          <span className="app-notification-glyph" aria-hidden="true">
+            <CircleAlert size={14} strokeWidth={2} />
+          </span>
+          <div className="app-notification-copy">
+            <span>
+              <strong>{feed.unreadCount} pending user(s)</strong> need moderator/admin review.
+            </span>
+          </div>
         </div>
       ) : null}
 

--- a/src/components/UserAdminPanel.tsx
+++ b/src/components/UserAdminPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState, type ChangeEvent, type ReactNode } from "react";
-import { CircleQuestionMark, CircleUserRound } from "lucide-react";
+import { CircleAlert, CircleQuestionMark, CircleUserRound } from "lucide-react";
 import {
   bulkReassignOwnership,
   fetchAdminAuditEvents,
@@ -1038,15 +1038,29 @@ export function UserAdminPanel({ onOpenHelp, authBootstrapPending = false, extra
                   </div>
                 </div>
                 {authWarnings.length ? (
-                  <div className="notification-banner" role="status">
-                    <strong>Auth warnings:</strong> {authWarnings.join(" | ")}
+                  <div className="app-notification-item app-notification-item-warning app-notification-item-static" role="status">
+                    <span className="app-notification-glyph" aria-hidden="true">
+                      <CircleAlert size={14} strokeWidth={2} />
+                    </span>
+                    <div className="app-notification-copy">
+                      <span>
+                        <strong>Auth warnings:</strong> {authWarnings.join(" | ")}
+                      </span>
+                    </div>
                   </div>
                 ) : (
                   <p className="field-help">Auth configuration checks passed.</p>
                 )}
                 {schemaWarnings.length ? (
-                  <div className="notification-banner" role="status">
-                    <strong>Schema warnings:</strong> {schemaWarnings.join(" | ")}
+                  <div className="app-notification-item app-notification-item-warning app-notification-item-static" role="status">
+                    <span className="app-notification-glyph" aria-hidden="true">
+                      <CircleAlert size={14} strokeWidth={2} />
+                    </span>
+                    <div className="app-notification-copy">
+                      <span>
+                        <strong>Schema warnings:</strong> {schemaWarnings.join(" | ")}
+                      </span>
+                    </div>
                   </div>
                 ) : (
                   <p className="field-help">Schema diagnostics passed.</p>
@@ -1157,8 +1171,15 @@ export function UserAdminPanel({ onOpenHelp, authBootstrapPending = false, extra
             {canModerate ? (
               <div className="user-manager-list notifications-center">
                 {unreadNotifications.length > 0 ? (
-                  <div className="notification-banner" role="status">
-                    <strong>{unreadNotifications.length} moderator/admin notification(s)</strong> need your review.
+                  <div className="app-notification-item app-notification-item-warning app-notification-item-static" role="status">
+                    <span className="app-notification-glyph" aria-hidden="true">
+                      <CircleAlert size={14} strokeWidth={2} />
+                    </span>
+                    <div className="app-notification-copy">
+                      <span>
+                        <strong>{unreadNotifications.length} moderator/admin notification(s)</strong> need your review.
+                      </span>
+                    </div>
                   </div>
                 ) : null}
                 <div className="section-heading">

--- a/src/index.css
+++ b/src/index.css
@@ -968,7 +968,9 @@ input {
   gap: 6px;
   max-height: min(52vh, 460px);
   overflow-y: auto;
-  padding-right: 1px;
+  padding: 6px;
+  margin: -6px;
+  scrollbar-gutter: stable;
 }
 
 .app-notification-item {
@@ -998,6 +1000,17 @@ input {
 
 .app-notification-item.is-dismissing[data-dismiss-kind="auto"] {
   animation: notification-exit-slow 1000ms ease forwards;
+}
+
+.app-notification-item-static {
+  grid-template-columns: auto minmax(0, 1fr);
+  padding-right: 10px;
+}
+
+.app-notification-item-static .app-notification-copy span {
+  white-space: normal;
+  overflow: visible;
+  text-overflow: clip;
 }
 
 .app-notification-item-warning {
@@ -1086,36 +1099,30 @@ input {
 @keyframes notification-enter {
   from {
     opacity: 0;
-    transform: translateY(8px) scale(0.985);
   }
 
   to {
     opacity: 1;
-    transform: translateY(0) scale(1);
   }
 }
 
 @keyframes notification-exit-fast {
   from {
     opacity: 1;
-    transform: translateY(0) scale(1);
   }
 
   to {
     opacity: 0;
-    transform: translateY(-5px) scale(0.985);
   }
 }
 
 @keyframes notification-exit-slow {
   from {
     opacity: 1;
-    transform: translateY(0) scale(1);
   }
 
   to {
     opacity: 0;
-    transform: translateY(-10px) scale(0.975);
   }
 }
 


### PR DESCRIPTION
Summary:
- migrate AppShell startup/offline/blank transient notices into queue-based mini-bar notifications
- migrate app notification-banner usages in NotificationsPanel and UserAdminPanel to mini-bar notice rows
- lock notification motion to fade-only enter/exit (manual fast, auto slow)
- preserve natural sibling reflow and fix shadow clipping with stack-list overflow/padding adjustments

Validation:
- npm test
- npm run build