### PR TITLE
Fix notification mini-bar shadow clipping

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -968,8 +968,8 @@ input {
   gap: 6px;
   max-height: min(52vh, 460px);
   overflow-y: auto;
-  padding: 6px;
-  margin: -6px;
+  padding: 10px;
+  margin: 0;
   scrollbar-gutter: stable;
 }
 


### PR DESCRIPTION
## Summary\n- remove negative-margin clipping hack on notification stack list\n- provide real inset breathing room so mini-bar shadows render fully\n- keep scroll overflow behavior intact\n\n## Verification\n- npm test\n- npm run build\n- playwright inspection on staging/local to trace clipping containers