### PR TITLE
Prevent notification shadow clipping at stack boundary

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -968,7 +968,7 @@ input {
   gap: 6px;
   max-height: min(52vh, 460px);
   overflow-y: auto;
-  padding: 10px;
+  padding: 26px 18px;
   margin: 0;
   scrollbar-gutter: stable;
 }


### PR DESCRIPTION
## Summary\n- increase notification stack list inset to fit mini-bar shadow extents\n- keep behavior/motion unchanged\n\n## Validation\n- npm test\n- npm run build\n- follow-up inspection confirmed previous inset was smaller than shadow spread