### PR TITLE
Prepare 0.15.0 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project are documented here in a human-readable format.
 
+## [0.15.0] - 2026-04-08
+
+### Added
+- Added an in-app `/ui-gallery` visual inventory with tabbed families (Actions, Panels, Forms, Notifications, States, Meta/Map UI), status labeling, and gallery-local theme controls aligned with real app styling. (#539)
+- Added a unified app-level notification queue with debug hooks for local/staging (`window.linksimNotifications`) to support iterative UI verification without code edits. (#539)
+
+### Changed
+- Converged standard text-bearing app actions toward the shared `ActionButton` family across Simulation Library and inspector surfaces, reducing mixed legacy button language. (#521, #523, #525, #529)
+- Aligned panel shell language across left/right/bottom surfaces and improved shell/header rhythm consistency while preserving intentional structural differences. (#529)
+- Updated UI taxonomy and glossary coverage to better map real production families and migration status for future cleanup passes. (#527, #529, #539)
+
+### Fixed
+- Unified banner-like transient notices into the mini-bar notification system and removed remaining duplicate notice styles in app shell/admin contexts. (#539)
+- Fixed staging/prod shell visibility regression where `.app-shell` could remain at `opacity: 0` after animation path mismatch. (#539)
+- Fixed notification mini-bar clipping regressions (shadow clipping and mobile spacing under controls) and refined fade/reflow behavior for manual vs timed dismissals. (#539)
+
 ## [0.14.0] - 2026-04-05
 
 ### Added

--- a/functions/_lib/buildInfo.ts
+++ b/functions/_lib/buildInfo.ts
@@ -1,5 +1,5 @@
-export const APP_VERSION = "0.14.0";
-export const APP_COMMIT = "b387b27e";
+export const APP_VERSION = "0.15.0";
+export const APP_COMMIT = "a0b10428";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "linksim",
   "private": true,
-  "version": "0.14.0",
+  "version": "0.15.0",
   "license": "GPL-3.0-only",
   "type": "module",
   "scripts": {

--- a/src/lib/buildInfo.ts
+++ b/src/lib/buildInfo.ts
@@ -1,5 +1,5 @@
-export const APP_VERSION = "0.14.0";
-export const APP_COMMIT = "b387b27e";
+export const APP_VERSION = "0.15.0";
+export const APP_COMMIT = "a0b10428";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {


### PR DESCRIPTION
## Summary\n- bump app version to 0.15.0\n- update build info base version to 0.15.0\n- add human-readable CHANGELOG entry for 0.15.0\n\n## Verification\n- npm run test\n- npm run build:bundle