### PR TITLE
Fix 0.15.0 changelog scope and codify release-note coverage rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,8 @@
 - Follow and maintain `docs/release-flow.md` as the source of truth for release promotion steps.
 - Follow `docs/release-flow.md` versioning policy (SemVer + explicit bump rules) for all releases.
 - Maintain a human-readable `CHANGELOG.md` for every release; do not use raw commit dumps as release notes.
+- `CHANGELOG.md` entries must cover the full shipped release scope (all milestone issues labeled `released` for that version), not only the most recent implementation batch.
+- Before production promotion, cross-check changelog coverage against the milestone issue list and close any notable gaps.
 - Before each production release, verify whether any issues closed since the previous release are missing a milestone and report/fix that metadata drift.
 - Version/channel labeling rule:
   - Local must display `vX.Y.Z-alpha+<commit>`.
@@ -84,6 +86,7 @@
   - Confirm build label matches intended SemVer channel rules
   - Confirm no unresolved issue/project status drift for items in the current pass
   - Confirm `CHANGELOG.md` is updated with user-readable highlights for the target release
+  - Confirm changelog highlights represent the full release/milestone scope (not only latest batch work)
 - Token-efficient execution:
   - Lock scope for each pass before implementation.
   - Define done criteria and no-touch areas at pass start.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,22 @@ All notable changes to this project are documented here in a human-readable form
 
 ### Added
 - Added an in-app `/ui-gallery` visual inventory with tabbed families (Actions, Panels, Forms, Notifications, States, Meta/Map UI), status labeling, and gallery-local theme controls aligned with real app styling. (#539)
-- Added a unified app-level notification queue with debug hooks for local/staging (`window.linksimNotifications`) to support iterative UI verification without code edits. (#539)
+- Added reusable UI primitives and helpers used across app chrome cleanup, including shared formatting/filter helpers, avatar/close button primitives, and ActionButton baseline components. (#493, #506, #508, #512, #521)
+- Added mobile workspace tab semantics and reusable map-control accessibility coverage for cross-surface interaction parity. (#430, #431)
 
 ### Changed
-- Converged standard text-bearing app actions toward the shared `ActionButton` family across Simulation Library and inspector surfaces, reducing mixed legacy button language. (#521, #523, #525, #529)
-- Aligned panel shell language across left/right/bottom surfaces and improved shell/header rhythm consistency while preserving intentional structural differences. (#529)
-- Updated UI taxonomy and glossary coverage to better map real production families and migration status for future cleanup passes. (#527, #529, #539)
+- Converged standard text-bearing app actions toward shared `ActionButton` language across Simulation Library, inspector, and panel action surfaces, reducing mixed legacy inline-action usage. (#521, #523, #525, #529)
+- Normalized panel shell and app-chrome vocabulary/rhythm through glossary-driven cleanup (left/right/bottom shell alignment, section cadence, action-row consistency, and role boundaries). (#527, #529, #539)
+- Improved simulation and path workflows in core UI flows, including frequency plan controls, simulation/library wording consistency, and path profile visibility behavior. (#409, #410, #411, #222)
 
 ### Fixed
-- Unified banner-like transient notices into the mini-bar notification system and removed remaining duplicate notice styles in app shell/admin contexts. (#539)
-- Fixed staging/prod shell visibility regression where `.app-shell` could remain at `opacity: 0` after animation path mismatch. (#539)
+- Unified banner-like transient notices into the mini-bar notification system and removed duplicate notice styles in app shell/admin contexts; fixed startup/access/offline notice inconsistencies. (#539)
+- Fixed app-shell visibility regression where `.app-shell` could remain at `opacity: 0` after animation path mismatch. (#539)
 - Fixed notification mini-bar clipping regressions (shadow clipping and mobile spacing under controls) and refined fade/reflow behavior for manual vs timed dismissals. (#539)
+- Fixed modal and panel interaction regressions, including duplicate modal opens, stacked resource/site modal conflicts, and profile/UI slowdown side effects from merge drift. (#500, #502, #504, #514, #517)
+- Fixed path profile rendering/interaction regressions, including initial SVG scaling issues, temporary-hover override behavior, and saved-link radio override handling. (#108, #221, #392, #415)
+- Fixed simulation/library reliability regressions around close-after-load behavior, duplicate-name/sync error handling, and private-site reference auto-push sharing failures. (#252, #283, #391)
+- Resolved staging drift and stabilization chores required to keep promotion flow reliable during the release train. (#420, #497)
 
 ## [0.14.0] - 2026-04-05
 

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -99,6 +99,7 @@
   - `npm test` passes
   - `npm run build` passes
   - `CHANGELOG.md` includes a human-readable entry for the release
+  - changelog entry reflects the full shipped milestone scope (not only the latest implementation batch), cross-checked against milestone `released` issues
   - `docs/milestone-release-checklist.md` is completed
 - PR body requirement for normal promotion (`staging` -> `main`):
   - include the checked line:


### PR DESCRIPTION
## Summary\n- ensure 0.15.0 changelog reflects full release scope\n- add explicit rule in AGENTS.md and release-flow: changelog must cover full milestone/released scope, not just latest batch\n\n## Validation\n- doc-only change