### PR TITLE
#176: Tile-aware + manual simulation overlay radius controls

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -26,7 +26,12 @@ import { TERRAIN_DATASET_LABEL } from "../lib/terrainDataset";
 import type { Link, PropagationEnvironment, Site } from "../types/radio";
 import { fetchMeshmapNodes, type MeshmapNode } from "../lib/meshtasticMqtt";
 import { canShowSaveSelectedLinkAction } from "../lib/selectedPairActions";
-import { resolveSingleSiteBonusRadiusKm } from "../lib/singleSiteBonusRadius";
+import {
+  normalizeOverlayRadiusOptionForSelectionCount,
+  optionsForSelectionCount,
+  resolveEffectiveOverlayRadiusKm,
+  type SimulationOverlayRadiusOption,
+} from "../lib/simulationOverlayRadius";
 import { SimulationResultsSection } from "./SimulationResultsSection";
 import { ActionButton } from "./ActionButton";
 import { useMapControls } from "./map/useMapControls";
@@ -1131,6 +1136,8 @@ export function MapView({
   const setCoverageVizMode = useAppStore((state) => state.setMapOverlayMode);
   const selectedCoverageResolution = useAppStore((state) => state.selectedCoverageResolution);
   const setSelectedCoverageResolution = useAppStore((state) => state.setSelectedCoverageResolution);
+  const selectedOverlayRadiusOption = useAppStore((state) => state.selectedOverlayRadiusOption);
+  const setSelectedOverlayRadiusOption = useAppStore((state) => state.setSelectedOverlayRadiusOption);
   const [bandStepMode, setBandStepMode] = useState<BandStepMode>("auto");
   const [showTerrainOverlay, setShowTerrainOverlay] = useState(false);
   const [showResultsSummary, setShowResultsSummary] = useState(() => readSectionBool(UI_SECTION_KEYS.mapViewResults, true));
@@ -1286,26 +1293,58 @@ export function MapView({
     };
   }, [showDiscoveryMqtt, mqttNodes.length]);
   useEffect(() => {
-    if (selectedSites.length !== 1 || isTerrainFetching) {
+    const normalized = normalizeOverlayRadiusOptionForSelectionCount(selectionCount, selectedOverlayRadiusOption);
+    if (normalized !== selectedOverlayRadiusOption) {
+      setSelectedOverlayRadiusOption(normalized);
+    }
+  }, [selectionCount, selectedOverlayRadiusOption, setSelectedOverlayRadiusOption]);
+
+  useEffect(() => {
+    const normalizedOption = normalizeOverlayRadiusOptionForSelectionCount(selectionCount, selectedOverlayRadiusOption);
+    if (selectionCount !== 1 || normalizedOption !== "auto" || isTerrainFetching) {
       setSingleSiteBonusRadiusKm(20);
       return;
     }
     const timer = window.setTimeout(() => {
-      const nextRadius = resolveSingleSiteBonusRadiusKm(selectedSites[0], srtmTiles, {
-        baseRadiusKm: 20,
-        maxRadiusKm: 100,
+      const nextRadius = resolveEffectiveOverlayRadiusKm({
+        selectionCount: 1,
+        option: "auto",
+        selectedSingleSite: selectedSites[0],
+        srtmTiles,
+        isTerrainFetching: false,
       });
       setSingleSiteBonusRadiusKm((current) => (current === nextRadius ? current : nextRadius));
     }, SINGLE_SITE_BONUS_DEBOUNCE_MS);
     return () => {
       window.clearTimeout(timer);
     };
-  }, [selectedSites, srtmTiles, isTerrainFetching]);
+  }, [selectionCount, selectedSites, srtmTiles, isTerrainFetching, selectedOverlayRadiusOption]);
   const hasPassFailTopology = selectionCount >= 1;
   const hasRelayTopology = selectionCount >= 2;
   const hasMinimumTopology = sites.length >= 1;
   const analysisTargetSites = selectionCount === 1 ? selectedSites : sites;
-  const overlayRadiusKm = selectionCount === 1 ? singleSiteBonusRadiusKm : 20;
+  const normalizedOverlayRadiusOption = normalizeOverlayRadiusOptionForSelectionCount(selectionCount, selectedOverlayRadiusOption);
+  const overlayRadiusKm = useMemo(
+    () =>
+      normalizedOverlayRadiusOption === "auto"
+        ? singleSiteBonusRadiusKm
+        : resolveEffectiveOverlayRadiusKm({
+            selectionCount,
+            option: normalizedOverlayRadiusOption,
+            selectedSingleSite: selectionCount === 1 ? selectedSites[0] ?? null : null,
+            srtmTiles,
+            isTerrainFetching,
+          }),
+    [
+      normalizedOverlayRadiusOption,
+      singleSiteBonusRadiusKm,
+      selectionCount,
+      selectedSites,
+      srtmTiles,
+      isTerrainFetching,
+    ],
+  );
+  const overlayRadiusOptions = optionsForSelectionCount(selectionCount);
   const overlayMaskArea = useMemo(
     () => buildBufferedSelectionArea(analysisTargetSites, overlayRadiusKm),
     [analysisTargetSites, overlayRadiusKm],
@@ -2391,6 +2430,23 @@ export function MapView({
                   >
                     <option value="normal">Normal</option>
                     <option value="high">High (slower)</option>
+                  </select>
+                </label>
+              )}
+              {coverageVizMode !== "none" && (
+                <label className="map-inspector-map-setting">
+                  <span>Simulation Radius</span>
+                  <select
+                    className="locale-select"
+                    onChange={(event) =>
+                      setSelectedOverlayRadiusOption(event.target.value as SimulationOverlayRadiusOption)}
+                    value={normalizedOverlayRadiusOption}
+                  >
+                    {overlayRadiusOptions.map((option) => (
+                      <option key={option} value={option}>
+                        {option === "auto" ? "Auto (current behavior)" : `${option} km`}
+                      </option>
+                    ))}
                   </select>
                 </label>
               )}

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -26,6 +26,7 @@ import { TERRAIN_DATASET_LABEL } from "../lib/terrainDataset";
 import type { Link, PropagationEnvironment, Site } from "../types/radio";
 import { fetchMeshmapNodes, type MeshmapNode } from "../lib/meshtasticMqtt";
 import { canShowSaveSelectedLinkAction } from "../lib/selectedPairActions";
+import { resolveSingleSiteBonusRadiusKm } from "../lib/singleSiteBonusRadius";
 import { SimulationResultsSection } from "./SimulationResultsSection";
 import { ActionButton } from "./ActionButton";
 import { useMapControls } from "./map/useMapControls";
@@ -35,6 +36,7 @@ const UI_SECTION_KEYS = {
   mapViewSimSummary: "linksim-ui-mapview-sim-summary-v1",
   mapViewOverlayGuide: "linksim-ui-mapview-overlay-guide-v1",
 } as const;
+const SINGLE_SITE_BONUS_DEBOUNCE_MS = 220;
 
 const readSectionBool = (key: string, fallback: boolean): boolean => {
   try {
@@ -1147,6 +1149,7 @@ export function MapView({
   const [mqttNodes, setMqttNodes] = useState<MeshmapNode[]>([]);
   const [mqttLoadStatus, setMqttLoadStatus] = useState<string | null>(null);
   const [overlayHoverInfo, setOverlayHoverInfo] = useState<MapInspectorHoverInfo | null>(null);
+  const [singleSiteBonusRadiusKm, setSingleSiteBonusRadiusKm] = useState(20);
   const [selectedDiscoveryLibraryEntryId, setSelectedDiscoveryLibraryEntryId] = useState<string | null>(null);
   const [mqttDuplicatePrompt, setMqttDuplicatePrompt] = useState<{
     node: MeshmapNode;
@@ -1282,11 +1285,31 @@ export function MapView({
       canceled = true;
     };
   }, [showDiscoveryMqtt, mqttNodes.length]);
+  useEffect(() => {
+    if (selectedSites.length !== 1 || isTerrainFetching) {
+      setSingleSiteBonusRadiusKm(20);
+      return;
+    }
+    const timer = window.setTimeout(() => {
+      const nextRadius = resolveSingleSiteBonusRadiusKm(selectedSites[0], srtmTiles, {
+        baseRadiusKm: 20,
+        maxRadiusKm: 100,
+      });
+      setSingleSiteBonusRadiusKm((current) => (current === nextRadius ? current : nextRadius));
+    }, SINGLE_SITE_BONUS_DEBOUNCE_MS);
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [selectedSites, srtmTiles, isTerrainFetching]);
   const hasPassFailTopology = selectionCount >= 1;
   const hasRelayTopology = selectionCount >= 2;
   const hasMinimumTopology = sites.length >= 1;
-  const analysisTargetSites = sites;
-  const overlayMaskArea = useMemo(() => buildBufferedSelectionArea(analysisTargetSites, 20), [analysisTargetSites]);
+  const analysisTargetSites = selectionCount === 1 ? selectedSites : sites;
+  const overlayRadiusKm = selectionCount === 1 ? singleSiteBonusRadiusKm : 20;
+  const overlayMaskArea = useMemo(
+    () => buildBufferedSelectionArea(analysisTargetSites, overlayRadiusKm),
+    [analysisTargetSites, overlayRadiusKm],
+  );
   const overlayPointMask = overlayMaskArea?.contains;
   const analysisBounds = useMemo(() => {
     if (overlayMaskArea) return overlayMaskArea.bounds;

--- a/src/lib/coverage.test.ts
+++ b/src/lib/coverage.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { buildCoverage, buildCoverageAsync } from "./coverage";
+import { haversineDistanceKm } from "./geo";
 import { defaultPropagationEnvironment } from "./propagationEnvironment";
 import type { Network, RadioSystem, Site } from "../types/radio";
 
@@ -74,5 +75,20 @@ describe("buildCoverage", () => {
     const asyncResult = await buildCoverageAsync(NORMAL_GRID, network, sites, systems, defaultPropagationEnvironment());
     expect(asyncResult).toHaveLength(sync.length);
     expect(Math.abs(asyncResult[0].valueDbm - sync[0].valueDbm)).toBeLessThan(0.0001);
+  });
+
+  it("uses single-site radius override for sampling bounds", () => {
+    const singleSite = [sites[0]];
+    const base = buildCoverage(NORMAL_GRID, network, singleSite, systems, defaultPropagationEnvironment());
+    const expanded = buildCoverage(NORMAL_GRID, network, singleSite, systems, defaultPropagationEnvironment(), undefined, {
+      singleSiteRadiusKm: 60,
+    });
+    const farthestBase = Math.max(
+      ...base.map((sample) => haversineDistanceKm(sample, singleSite[0].position)),
+    );
+    const farthestExpanded = Math.max(
+      ...expanded.map((sample) => haversineDistanceKm(sample, singleSite[0].position)),
+    );
+    expect(farthestExpanded).toBeGreaterThan(farthestBase + 20);
   });
 });

--- a/src/lib/coverage.test.ts
+++ b/src/lib/coverage.test.ts
@@ -91,4 +91,18 @@ describe("buildCoverage", () => {
     );
     expect(farthestExpanded).toBeGreaterThan(farthestBase + 20);
   });
+
+  it("uses overlay radius override for multi-site sampling bounds", () => {
+    const base = buildCoverage(NORMAL_GRID, network, sites, systems, defaultPropagationEnvironment());
+    const expanded = buildCoverage(NORMAL_GRID, network, sites, systems, defaultPropagationEnvironment(), undefined, {
+      overlayRadiusKm: 100,
+    });
+    const center = {
+      lat: (sites[0].position.lat + sites[1].position.lat) / 2,
+      lon: (sites[0].position.lon + sites[1].position.lon) / 2,
+    };
+    const farthestBase = Math.max(...base.map((sample) => haversineDistanceKm(sample, center)));
+    const farthestExpanded = Math.max(...expanded.map((sample) => haversineDistanceKm(sample, center)));
+    expect(farthestExpanded).toBeGreaterThan(farthestBase + 30);
+  });
 });

--- a/src/lib/coverage.ts
+++ b/src/lib/coverage.ts
@@ -16,6 +16,7 @@ export type BuildCoverageOptions = {
   terrainSamples?: number;
   onProgress?: (progress: number) => void;
   terrainCacheKey?: string;
+  overlayRadiusKm?: number;
   singleSiteRadiusKm?: number;
 };
 
@@ -161,7 +162,10 @@ export const buildCoverage = (
 
   const samples: { lat: number; lon: number }[] = [];
   const targetSamples = Math.max(64, Math.round(gridSize * gridSize * sampleMultiplier * sampleMultiplier));
-  const bounds = simulationAreaBoundsForSites(sites, { singleSiteRadiusKm: options?.singleSiteRadiusKm });
+  const bounds = simulationAreaBoundsForSites(sites, {
+    overlayRadiusKm: options?.overlayRadiusKm,
+    singleSiteRadiusKm: options?.singleSiteRadiusKm,
+  });
   if (!bounds) return [];
 
   const centerLat = (bounds.minLat + bounds.maxLat) / 2;
@@ -247,7 +251,10 @@ export const buildCoverageAsync = async (
 
   const samples: { lat: number; lon: number }[] = [];
   const targetSamples = Math.max(64, Math.round(gridSize * gridSize * sampleMultiplier * sampleMultiplier));
-  const bounds = simulationAreaBoundsForSites(sites, { singleSiteRadiusKm: options?.singleSiteRadiusKm });
+  const bounds = simulationAreaBoundsForSites(sites, {
+    overlayRadiusKm: options?.overlayRadiusKm,
+    singleSiteRadiusKm: options?.singleSiteRadiusKm,
+  });
   if (!bounds) return [];
 
   const centerLat = (bounds.minLat + bounds.maxLat) / 2;

--- a/src/lib/coverage.ts
+++ b/src/lib/coverage.ts
@@ -16,6 +16,7 @@ export type BuildCoverageOptions = {
   terrainSamples?: number;
   onProgress?: (progress: number) => void;
   terrainCacheKey?: string;
+  singleSiteRadiusKm?: number;
 };
 
 const nUnitsToKFactor = (nUnits: number): number => {
@@ -160,7 +161,7 @@ export const buildCoverage = (
 
   const samples: { lat: number; lon: number }[] = [];
   const targetSamples = Math.max(64, Math.round(gridSize * gridSize * sampleMultiplier * sampleMultiplier));
-  const bounds = simulationAreaBoundsForSites(sites);
+  const bounds = simulationAreaBoundsForSites(sites, { singleSiteRadiusKm: options?.singleSiteRadiusKm });
   if (!bounds) return [];
 
   const centerLat = (bounds.minLat + bounds.maxLat) / 2;
@@ -246,7 +247,7 @@ export const buildCoverageAsync = async (
 
   const samples: { lat: number; lon: number }[] = [];
   const targetSamples = Math.max(64, Math.round(gridSize * gridSize * sampleMultiplier * sampleMultiplier));
-  const bounds = simulationAreaBoundsForSites(sites);
+  const bounds = simulationAreaBoundsForSites(sites, { singleSiteRadiusKm: options?.singleSiteRadiusKm });
   if (!bounds) return [];
 
   const centerLat = (bounds.minLat + bounds.maxLat) / 2;

--- a/src/lib/simulationArea.test.ts
+++ b/src/lib/simulationArea.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { simulationAreaBoundsForSites } from "./simulationArea";
+
+describe("simulationAreaBoundsForSites", () => {
+  it("uses explicit single-site radius override when provided", () => {
+    const bounds = simulationAreaBoundsForSites([{ position: { lat: 59.9, lon: 10.7 } }], {
+      singleSiteRadiusKm: 60,
+    });
+    expect(bounds).not.toBeNull();
+    expect((bounds?.latSpanDeg ?? 0) * 111.32).toBeGreaterThan(100);
+  });
+
+  it("keeps default behavior for multi-site selections", () => {
+    const bounds = simulationAreaBoundsForSites(
+      [
+        { position: { lat: 59.9, lon: 10.7 } },
+        { position: { lat: 60.0, lon: 10.8 } },
+      ],
+      { singleSiteRadiusKm: 100 },
+    );
+    expect(bounds).not.toBeNull();
+    expect((bounds?.latSpanDeg ?? 0) * 111.32).toBeLessThan(70);
+  });
+});
+

--- a/src/lib/simulationArea.test.ts
+++ b/src/lib/simulationArea.test.ts
@@ -21,5 +21,16 @@ describe("simulationAreaBoundsForSites", () => {
     expect(bounds).not.toBeNull();
     expect((bounds?.latSpanDeg ?? 0) * 111.32).toBeLessThan(70);
   });
-});
 
+  it("applies overlayRadiusKm buffer for multi-site selections", () => {
+    const bounds = simulationAreaBoundsForSites(
+      [
+        { position: { lat: 59.9, lon: 10.7 } },
+        { position: { lat: 60.0, lon: 10.8 } },
+      ],
+      { overlayRadiusKm: 100 },
+    );
+    expect(bounds).not.toBeNull();
+    expect((bounds?.latSpanDeg ?? 0) * 111.32).toBeGreaterThan(200);
+  });
+});

--- a/src/lib/simulationArea.ts
+++ b/src/lib/simulationArea.ts
@@ -14,10 +14,31 @@ const LAT_PAD_DEG = 0.15;
 const LON_PAD_DEG = 0.15;
 const MAX_SPAN_DEG = 5;
 
+export type SimulationAreaOptions = {
+  singleSiteRadiusKm?: number;
+};
+
 export const simulationAreaBoundsForSites = (
   sites: Pick<Site, "position">[],
+  options?: SimulationAreaOptions,
 ): SimulationAreaBounds | null => {
   if (!sites.length) return null;
+  if (sites.length === 1 && typeof options?.singleSiteRadiusKm === "number") {
+    const radiusKm = Math.max(1, options.singleSiteRadiusKm);
+    const centerLat = sites[0].position.lat;
+    const centerLon = sites[0].position.lon;
+    const latDelta = Math.max(0.01, radiusKm / 111.32);
+    const lonDelta = Math.max(0.01, radiusKm / (111.32 * Math.max(0.1, Math.cos((centerLat * Math.PI) / 180))));
+    return {
+      minLat: centerLat - latDelta,
+      maxLat: centerLat + latDelta,
+      minLon: centerLon - lonDelta,
+      maxLon: centerLon + lonDelta,
+      latSpanDeg: latDelta * 2,
+      lonSpanDeg: lonDelta * 2,
+      isCapped: false,
+    };
+  }
   const lats = sites.map((site) => site.position.lat);
   const lons = sites.map((site) => site.position.lon);
   const minLatRaw = Math.min(...lats);

--- a/src/lib/simulationArea.ts
+++ b/src/lib/simulationArea.ts
@@ -15,6 +15,7 @@ const LON_PAD_DEG = 0.15;
 const MAX_SPAN_DEG = 5;
 
 export type SimulationAreaOptions = {
+  overlayRadiusKm?: number;
   singleSiteRadiusKm?: number;
 };
 
@@ -23,19 +24,34 @@ export const simulationAreaBoundsForSites = (
   options?: SimulationAreaOptions,
 ): SimulationAreaBounds | null => {
   if (!sites.length) return null;
-  if (sites.length === 1 && typeof options?.singleSiteRadiusKm === "number") {
-    const radiusKm = Math.max(1, options.singleSiteRadiusKm);
-    const centerLat = sites[0].position.lat;
-    const centerLon = sites[0].position.lon;
+  const radiusOverrideKm =
+    typeof options?.overlayRadiusKm === "number"
+      ? options.overlayRadiusKm
+      : sites.length === 1 && typeof options?.singleSiteRadiusKm === "number"
+        ? options.singleSiteRadiusKm
+        : undefined;
+  if (typeof radiusOverrideKm === "number") {
+    const radiusKm = Math.max(1, radiusOverrideKm);
+    const lats = sites.map((site) => site.position.lat);
+    const lons = sites.map((site) => site.position.lon);
+    const minLat = Math.min(...lats);
+    const maxLat = Math.max(...lats);
+    const minLon = Math.min(...lons);
+    const maxLon = Math.max(...lons);
+    const centerLat = (minLat + maxLat) / 2;
     const latDelta = Math.max(0.01, radiusKm / 111.32);
     const lonDelta = Math.max(0.01, radiusKm / (111.32 * Math.max(0.1, Math.cos((centerLat * Math.PI) / 180))));
+    const outMinLat = minLat - latDelta;
+    const outMaxLat = maxLat + latDelta;
+    const outMinLon = minLon - lonDelta;
+    const outMaxLon = maxLon + lonDelta;
     return {
-      minLat: centerLat - latDelta,
-      maxLat: centerLat + latDelta,
-      minLon: centerLon - lonDelta,
-      maxLon: centerLon + lonDelta,
-      latSpanDeg: latDelta * 2,
-      lonSpanDeg: lonDelta * 2,
+      minLat: outMinLat,
+      maxLat: outMaxLat,
+      minLon: outMinLon,
+      maxLon: outMaxLon,
+      latSpanDeg: outMaxLat - outMinLat,
+      lonSpanDeg: outMaxLon - outMinLon,
       isCapped: false,
     };
   }

--- a/src/lib/simulationOverlayRadius.test.ts
+++ b/src/lib/simulationOverlayRadius.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  defaultOptionForSelectionCount,
+  normalizeOverlayRadiusOptionForSelectionCount,
+  optionsForSelectionCount,
+  resolveEffectiveOverlayRadiusKm,
+} from "./simulationOverlayRadius";
+import type { Site, SrtmTile } from "../types/radio";
+
+const site: Pick<Site, "position"> = { position: { lat: 59.9, lon: 10.7 } };
+const mkTile = (key: string, sourceId = "copernicus30"): SrtmTile => ({
+  key,
+  latStart: 59,
+  lonStart: 10,
+  size: 1201,
+  arcSecondSpacing: 3,
+  elevations: new Int16Array(1201 * 1201),
+  sourceId,
+});
+
+describe("simulationOverlayRadius", () => {
+  it("exposes expected options by selection context", () => {
+    expect(optionsForSelectionCount(1)).toEqual(["auto", "100", "200", "500"]);
+    expect(optionsForSelectionCount(2)).toEqual(["20", "50", "100"]);
+    expect(defaultOptionForSelectionCount(1)).toBe("auto");
+    expect(defaultOptionForSelectionCount(3)).toBe("20");
+  });
+
+  it("normalizes invalid option to context default", () => {
+    expect(normalizeOverlayRadiusOptionForSelectionCount(1, "50")).toBe("auto");
+    expect(normalizeOverlayRadiusOptionForSelectionCount(2, "auto")).toBe("20");
+  });
+
+  it("uses tile-aware auto radius in single-site mode", () => {
+    const radius = resolveEffectiveOverlayRadiusKm({
+      selectionCount: 1,
+      option: "auto",
+      selectedSingleSite: site,
+      srtmTiles: [
+        mkTile("N59E010"),
+        mkTile("N60E010"),
+        mkTile("N58E010"),
+        mkTile("N59E009"),
+        mkTile("N59E011"),
+        mkTile("N60E009"),
+        mkTile("N60E011"),
+        mkTile("N58E009"),
+        mkTile("N58E011"),
+      ],
+      isTerrainFetching: false,
+    });
+    expect(radius).toBeGreaterThan(50);
+  });
+
+  it("uses fixed values outside single-site mode", () => {
+    const radius = resolveEffectiveOverlayRadiusKm({
+      selectionCount: 2,
+      option: "100",
+      selectedSingleSite: null,
+      srtmTiles: [],
+      isTerrainFetching: false,
+    });
+    expect(radius).toBe(100);
+  });
+});
+

--- a/src/lib/simulationOverlayRadius.ts
+++ b/src/lib/simulationOverlayRadius.ts
@@ -1,0 +1,48 @@
+import { resolveSingleSiteBonusRadiusKm } from "./singleSiteBonusRadius";
+import type { Site, SrtmTile } from "../types/radio";
+
+export type SimulationOverlayRadiusOption = "auto" | "20" | "50" | "100" | "200" | "500";
+
+const SINGLE_SITE_OPTIONS: SimulationOverlayRadiusOption[] = ["auto", "100", "200", "500"];
+const MULTI_SITE_OPTIONS: SimulationOverlayRadiusOption[] = ["20", "50", "100"];
+
+export const optionsForSelectionCount = (selectionCount: number): SimulationOverlayRadiusOption[] =>
+  selectionCount === 1 ? SINGLE_SITE_OPTIONS : MULTI_SITE_OPTIONS;
+
+export const defaultOptionForSelectionCount = (selectionCount: number): SimulationOverlayRadiusOption =>
+  selectionCount === 1 ? "auto" : "20";
+
+export const normalizeOverlayRadiusOptionForSelectionCount = (
+  selectionCount: number,
+  option: unknown,
+): SimulationOverlayRadiusOption => {
+  const candidate = typeof option === "string" ? (option as SimulationOverlayRadiusOption) : null;
+  const allowed = optionsForSelectionCount(selectionCount);
+  if (candidate && allowed.includes(candidate)) return candidate;
+  return defaultOptionForSelectionCount(selectionCount);
+};
+
+export const isOverlayRadiusOption = (value: unknown): value is SimulationOverlayRadiusOption =>
+  typeof value === "string" &&
+  (["auto", "20", "50", "100", "200", "500"] as const).includes(value as SimulationOverlayRadiusOption);
+
+export const resolveEffectiveOverlayRadiusKm = (params: {
+  selectionCount: number;
+  option: SimulationOverlayRadiusOption;
+  selectedSingleSite: Pick<Site, "position"> | null;
+  srtmTiles: ReadonlyArray<SrtmTile>;
+  isTerrainFetching: boolean;
+}): number => {
+  const { selectionCount, option, selectedSingleSite, srtmTiles, isTerrainFetching } = params;
+  if (selectionCount === 1) {
+    if (option === "auto") {
+      if (!selectedSingleSite || isTerrainFetching) return 20;
+      return resolveSingleSiteBonusRadiusKm(selectedSingleSite, srtmTiles, { baseRadiusKm: 20, maxRadiusKm: 100 });
+    }
+    const fixed = Number(option);
+    return Number.isFinite(fixed) ? Math.max(20, fixed) : 20;
+  }
+  const fixed = option === "20" || option === "50" || option === "100" ? Number(option) : 20;
+  return fixed;
+};
+

--- a/src/lib/singleSiteBonusRadius.test.ts
+++ b/src/lib/singleSiteBonusRadius.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { resolveSingleSiteBonusRadiusKm } from "./singleSiteBonusRadius";
+import type { Site, SrtmTile } from "../types/radio";
+
+const site: Pick<Site, "position"> = {
+  position: { lat: 59.9, lon: 10.7 },
+};
+
+const mkTile = (key: string, sourceId = "copernicus30"): SrtmTile => ({
+  key,
+  latStart: 59,
+  lonStart: 10,
+  size: 1201,
+  arcSecondSpacing: 3,
+  elevations: new Int16Array(1201 * 1201),
+  sourceId,
+});
+
+describe("resolveSingleSiteBonusRadiusKm", () => {
+  it("keeps base radius when no 30m tiles are loaded", () => {
+    const radius = resolveSingleSiteBonusRadiusKm(site, [], { baseRadiusKm: 20, maxRadiusKm: 100 });
+    expect(radius).toBe(20);
+  });
+
+  it("ignores non-30m loaded tiles for bonus expansion", () => {
+    const radius = resolveSingleSiteBonusRadiusKm(site, [mkTile("N59E010", "copernicus90")], {
+      baseRadiusKm: 20,
+      maxRadiusKm: 100,
+    });
+    expect(radius).toBe(20);
+  });
+
+  it("stays conservative when surrounding 30m coverage is not full-circle", () => {
+    const radius = resolveSingleSiteBonusRadiusKm(
+      site,
+      [mkTile("N59E010"), mkTile("N60E010"), mkTile("N59E011")],
+      { baseRadiusKm: 20, maxRadiusKm: 100 },
+    );
+    expect(radius).toBe(20);
+  });
+
+  it("expands and respects the maximum cap when fully covered around the site", () => {
+    const tiles = [
+      mkTile("N59E010"),
+      mkTile("N60E010"),
+      mkTile("N58E010"),
+      mkTile("N59E009"),
+      mkTile("N59E011"),
+      mkTile("N60E009"),
+      mkTile("N60E011"),
+      mkTile("N58E009"),
+      mkTile("N58E011"),
+    ];
+    const radius = resolveSingleSiteBonusRadiusKm(site, tiles, { baseRadiusKm: 20, maxRadiusKm: 100 });
+    expect(radius).toBeGreaterThan(50);
+    expect(radius).toBeLessThanOrEqual(100);
+  });
+});
+

--- a/src/lib/singleSiteBonusRadius.ts
+++ b/src/lib/singleSiteBonusRadius.ts
@@ -1,0 +1,81 @@
+import type { Site, SrtmTile } from "../types/radio";
+
+const EARTH_RADIUS_KM = 6_371;
+
+export type SingleSiteBonusRadiusOptions = {
+  baseRadiusKm?: number;
+  maxRadiusKm?: number;
+  azimuthStepDeg?: number;
+  radialStepKm?: number;
+};
+
+const toRadians = (deg: number): number => (deg * Math.PI) / 180;
+const toDegrees = (rad: number): number => (rad * 180) / Math.PI;
+
+const tileKeyForCoordinate = (lat: number, lon: number): string => {
+  const latBase = Math.floor(Math.abs(lat));
+  const lonBase = Math.floor(Math.abs(lon));
+  const ns = lat >= 0 ? "N" : "S";
+  const ew = lon >= 0 ? "E" : "W";
+  return `${ns}${String(latBase).padStart(2, "0")}${ew}${String(lonBase).padStart(3, "0")}`;
+};
+
+const destinationForDistanceKm = (
+  origin: { lat: number; lon: number },
+  bearingDeg: number,
+  distanceKm: number,
+): { lat: number; lon: number } => {
+  const delta = distanceKm / EARTH_RADIUS_KM;
+  const theta = toRadians(bearingDeg);
+  const phi1 = toRadians(origin.lat);
+  const lambda1 = toRadians(origin.lon);
+
+  const sinPhi2 = Math.sin(phi1) * Math.cos(delta) + Math.cos(phi1) * Math.sin(delta) * Math.cos(theta);
+  const phi2 = Math.asin(Math.max(-1, Math.min(1, sinPhi2)));
+  const y = Math.sin(theta) * Math.sin(delta) * Math.cos(phi1);
+  const x = Math.cos(delta) - Math.sin(phi1) * Math.sin(phi2);
+  const lambda2 = lambda1 + Math.atan2(y, x);
+
+  return {
+    lat: toDegrees(phi2),
+    lon: ((toDegrees(lambda2) + 540) % 360) - 180,
+  };
+};
+
+const loadedThirtyMeterTileKeys = (tiles: ReadonlyArray<SrtmTile>): Set<string> =>
+  new Set(tiles.filter((tile) => tile.sourceId === "copernicus30").map((tile) => tile.key));
+
+export const resolveSingleSiteBonusRadiusKm = (
+  site: Pick<Site, "position"> | null,
+  tiles: ReadonlyArray<SrtmTile>,
+  options?: SingleSiteBonusRadiusOptions,
+): number => {
+  const baseRadiusKm = Math.max(1, options?.baseRadiusKm ?? 20);
+  const maxRadiusKm = Math.max(baseRadiusKm, options?.maxRadiusKm ?? 100);
+  const azimuthStepDeg = Math.max(1, Math.min(45, options?.azimuthStepDeg ?? 5));
+  const radialStepKm = Math.max(0.5, Math.min(5, options?.radialStepKm ?? 1));
+
+  if (!site) return baseRadiusKm;
+
+  const tileKeys = loadedThirtyMeterTileKeys(tiles);
+  if (!tileKeys.size) return baseRadiusKm;
+
+  const centerKey = tileKeyForCoordinate(site.position.lat, site.position.lon);
+  if (!tileKeys.has(centerKey)) return baseRadiusKm;
+
+  let minContinuousRadiusKm = maxRadiusKm;
+  for (let azimuth = 0; azimuth < 360; azimuth += azimuthStepDeg) {
+    let radialCoverageKm = 0;
+    for (let distanceKm = radialStepKm; distanceKm <= maxRadiusKm; distanceKm += radialStepKm) {
+      const point = destinationForDistanceKm(site.position, azimuth, distanceKm);
+      const key = tileKeyForCoordinate(point.lat, point.lon);
+      if (!tileKeys.has(key)) break;
+      radialCoverageKm = distanceKm;
+    }
+    minContinuousRadiusKm = Math.min(minContinuousRadiusKm, radialCoverageKm);
+    if (minContinuousRadiusKm <= baseRadiusKm) return baseRadiusKm;
+  }
+
+  return Math.max(baseRadiusKm, Math.min(maxRadiusKm, Math.floor(minContinuousRadiusKm)));
+};
+

--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -316,6 +316,31 @@ describe("appStore auth guards", () => {
     expect(state.simulationPresets[0]?.snapshot.sites.some((site) => site.id === "site-1")).toBe(false);
   });
 
+  it("persists selected overlay radius option to active simulation snapshot", () => {
+    useAppStore.getState().setCurrentUser({
+      id: "owner-1",
+      username: "owner",
+      avatarUrl: "",
+      role: "user",
+      accountState: "approved",
+      isApproved: true,
+      isAdmin: false,
+      isModerator: false,
+      createdAt: "",
+      updatedAt: null,
+      approvedAt: null,
+      approvedByUserId: null,
+      email: undefined,
+      emailPublic: true,
+      bio: "",
+    });
+
+    useAppStore.getState().setSelectedOverlayRadiusOption("100");
+
+    expect(useAppStore.getState().selectedOverlayRadiusOption).toBe("100");
+    expect(useAppStore.getState().simulationPresets[0]?.snapshot.selectedOverlayRadiusOption).toBe("100");
+  });
+
   it("blocks deleteSite when current user cannot edit selected simulation", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     useAppStore.getState().setCurrentUser({

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -39,6 +39,11 @@ import {
   type TerrainDataset,
 } from "../lib/terrainDataset";
 import { atmosphericBendingNUnitsToKFactor } from "../lib/terrainLoss";
+import {
+  defaultOptionForSelectionCount,
+  isOverlayRadiusOption,
+  type SimulationOverlayRadiusOption,
+} from "../lib/simulationOverlayRadius";
 import type { LocaleCode } from "../i18n/locales";
 import type { UiColorTheme } from "../themes/types";
 import { getActiveHolidayTheme } from "../themes/holidayThemes";
@@ -296,6 +301,7 @@ type SimulationPreset = {
     selectedLinkId: string;
     selectedNetworkId: string;
     selectedCoverageResolution?: CoverageResolution;
+    selectedOverlayRadiusOption?: SimulationOverlayRadiusOption;
     propagationModel: PropagationModel;
     selectedFrequencyPresetId: string;
     rxSensitivityTargetDbm: number;
@@ -374,6 +380,7 @@ type AppState = {
   selectedSiteIds: string[];
   selectedNetworkId: string;
   selectedCoverageResolution: CoverageResolution;
+  selectedOverlayRadiusOption: SimulationOverlayRadiusOption;
   propagationModel: PropagationModel;
   mapViewport?: MapViewport;
   locale: LocaleCode;
@@ -457,6 +464,7 @@ type AppState = {
   getSelectedSiteIds: () => string[];
   setSelectedNetworkId: (id: string) => void;
   setSelectedCoverageResolution: (resolution: CoverageResolution) => void;
+  setSelectedOverlayRadiusOption: (value: SimulationOverlayRadiusOption) => void;
   setSelectedFrequencyPresetId: (id: string) => void;
   setRxSensitivityTargetDbm: (value: number) => void;
   setEnvironmentLossDb: (value: number) => void;
@@ -1176,6 +1184,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   selectedSiteIds: [],
   selectedNetworkId: "",
   selectedCoverageResolution: "normal",
+  selectedOverlayRadiusOption: "20",
   propagationModel: "ITM",
   mapViewport: undefined,
   locale: "eng",
@@ -1985,6 +1994,11 @@ export const useAppStore = create<AppState>((set, get) => ({
     useCoverageStore.getState().recomputeCoverage();
     get().updateCurrentSimulationSnapshot();
   },
+  setSelectedOverlayRadiusOption: (value) => {
+    set({ selectedOverlayRadiusOption: value });
+    useCoverageStore.getState().recomputeCoverage();
+    get().updateCurrentSimulationSnapshot();
+  },
   setSelectedFrequencyPresetId: (id) => {
     set({ selectedFrequencyPresetId: id });
     get().updateCurrentSimulationSnapshot();
@@ -2539,6 +2553,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       selectedLinkId: state.selectedLinkId,
       selectedNetworkId: state.selectedNetworkId,
       selectedCoverageResolution: state.selectedCoverageResolution,
+      selectedOverlayRadiusOption: state.selectedOverlayRadiusOption,
       propagationModel: state.propagationModel,
       selectedFrequencyPresetId: state.selectedFrequencyPresetId,
       rxSensitivityTargetDbm: state.rxSensitivityTargetDbm,
@@ -2621,6 +2636,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         selectedLinkId: "",
         selectedNetworkId: "",
         selectedCoverageResolution: current.selectedCoverageResolution,
+        selectedOverlayRadiusOption: current.selectedOverlayRadiusOption,
         propagationModel: current.propagationModel,
         selectedFrequencyPresetId: selectedPresetId,
         rxSensitivityTargetDbm: current.rxSensitivityTargetDbm,
@@ -2681,6 +2697,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       selectedLinkId: state.selectedLinkId,
       selectedNetworkId: state.selectedNetworkId,
       selectedCoverageResolution: state.selectedCoverageResolution,
+      selectedOverlayRadiusOption: state.selectedOverlayRadiusOption,
       propagationModel: state.propagationModel,
       selectedFrequencyPresetId: state.selectedFrequencyPresetId,
       rxSensitivityTargetDbm: state.rxSensitivityTargetDbm,
@@ -2765,6 +2782,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         selectedLinkId: get().selectedLinkId,
         selectedNetworkId: get().selectedNetworkId,
         selectedCoverageResolution: get().selectedCoverageResolution,
+        selectedOverlayRadiusOption: get().selectedOverlayRadiusOption,
         propagationModel: get().propagationModel,
         selectedFrequencyPresetId: get().selectedFrequencyPresetId,
         rxSensitivityTargetDbm: get().rxSensitivityTargetDbm,
@@ -2821,6 +2839,9 @@ export const useAppStore = create<AppState>((set, get) => ({
           snap.selectedCoverageResolution === "normal" || snap.selectedCoverageResolution === "high"
             ? snap.selectedCoverageResolution
             : "normal",
+        selectedOverlayRadiusOption: isOverlayRadiusOption(snap.selectedOverlayRadiusOption)
+          ? snap.selectedOverlayRadiusOption
+          : defaultOptionForSelectionCount(0),
         propagationModel: "ITM" as const,
         selectedFrequencyPresetId: typeof snap.selectedFrequencyPresetId === "string" ? snap.selectedFrequencyPresetId : "custom",
         rxSensitivityTargetDbm: typeof snap.rxSensitivityTargetDbm === "number" ? snap.rxSensitivityTargetDbm : -120,
@@ -2875,6 +2896,9 @@ export const useAppStore = create<AppState>((set, get) => ({
         snap.selectedCoverageResolution === "normal" || snap.selectedCoverageResolution === "high"
           ? snap.selectedCoverageResolution
           : "normal",
+      selectedOverlayRadiusOption: isOverlayRadiusOption(snap.selectedOverlayRadiusOption)
+        ? snap.selectedOverlayRadiusOption
+        : defaultOptionForSelectionCount(selectedSiteId ? 1 : 0),
       propagationModel: "ITM" as const,
       selectedFrequencyPresetId: typeof snap.selectedFrequencyPresetId === "string" ? snap.selectedFrequencyPresetId : "custom",
       rxSensitivityTargetDbm:

--- a/src/store/coverageStore.ts
+++ b/src/store/coverageStore.ts
@@ -3,7 +3,10 @@ import { buildCoverageAsync } from "../lib/coverage";
 import {
   deriveDynamicPropagationEnvironment,
 } from "../lib/propagationEnvironment";
-import { resolveSingleSiteBonusRadiusKm } from "../lib/singleSiteBonusRadius";
+import {
+  normalizeOverlayRadiusOptionForSelectionCount,
+  resolveEffectiveOverlayRadiusKm,
+} from "../lib/simulationOverlayRadius";
 import { sampleSrtmElevation } from "../lib/srtm";
 import type { Site, SrtmTile } from "../types/radio";
 import type { CoverageSample } from "../types/radio";
@@ -76,6 +79,7 @@ export const useCoverageStore = create<CoverageState>((set, get) => ({
         const terrainLoadEpoch = appState.terrainLoadEpoch as number;
         const selectedSiteIds = (appState.selectedSiteIds as string[]) ?? [];
         const isTerrainFetching = Boolean(appState.isTerrainFetching);
+        const selectedOverlayRadiusOptionRaw = appState.selectedOverlayRadiusOption;
 
         const network = networks.find((n) => n.id === selectedNetworkId);
         if (!network) {
@@ -129,17 +133,21 @@ export const useCoverageStore = create<CoverageState>((set, get) => ({
           }
         }
 
-        const singleSelectedSite =
-          selectedSiteIds.length === 1
-            ? sites.find((site) => site.id === selectedSiteIds[0]) ?? null
-            : null;
-        const singleSiteRadiusKm =
-          singleSelectedSite && !isTerrainFetching
-            ? resolveSingleSiteBonusRadiusKm(singleSelectedSite, srtmTiles, {
-                baseRadiusKm: 20,
-                maxRadiusKm: 100,
-              })
-            : undefined;
+        const selectionCount = selectedSiteIds.length;
+        const selectedSingleSite = selectionCount === 1
+          ? sites.find((site) => site.id === selectedSiteIds[0]) ?? null
+          : null;
+        const selectedOverlayRadiusOption = normalizeOverlayRadiusOptionForSelectionCount(
+          selectionCount,
+          selectedOverlayRadiusOptionRaw,
+        );
+        const overlayRadiusKm = resolveEffectiveOverlayRadiusKm({
+          selectionCount,
+          option: selectedOverlayRadiusOption,
+          selectedSingleSite,
+          srtmTiles,
+          isTerrainFetching,
+        });
 
         set({ simulationProgress: 8 });
         let lastProgress = 8;
@@ -154,7 +162,7 @@ export const useCoverageStore = create<CoverageState>((set, get) => ({
           {
             sampleMultiplier: 1,
             terrainSamples: 20,
-            singleSiteRadiusKm,
+            overlayRadiusKm,
             onProgress: (progress: number) => {
               if (get().simulationRunToken !== runId) return;
               const next = Math.round(8 + progress * 84);

--- a/src/store/coverageStore.ts
+++ b/src/store/coverageStore.ts
@@ -3,7 +3,9 @@ import { buildCoverageAsync } from "../lib/coverage";
 import {
   deriveDynamicPropagationEnvironment,
 } from "../lib/propagationEnvironment";
+import { resolveSingleSiteBonusRadiusKm } from "../lib/singleSiteBonusRadius";
 import { sampleSrtmElevation } from "../lib/srtm";
+import type { Site, SrtmTile } from "../types/radio";
 import type { CoverageSample } from "../types/radio";
 
 const COVERAGE_RECOMPUTE_DEBOUNCE_MS = 140;
@@ -62,16 +64,18 @@ export const useCoverageStore = create<CoverageState>((set, get) => ({
         const gridSize = selectedCoverageResolution === "high" ? 42 : 24;
         const networks = appState.networks as Array<{ id: string; [key: string]: unknown }>;
         const selectedNetworkId = appState.selectedNetworkId as string;
-        const sites = appState.sites as Array<{ id: string; [key: string]: unknown }>;
+        const sites = appState.sites as Site[];
         const systems = appState.systems as unknown[];
         const propagationModel = appState.propagationModel as string;
-        const srtmTiles = appState.srtmTiles as Parameters<typeof sampleSrtmElevation>[0];
+        const srtmTiles = appState.srtmTiles as SrtmTile[];
         const links = appState.links as Array<{ id: string; fromSiteId: string; toSiteId: string; [key: string]: unknown }>;
         const selectedLinkId = appState.selectedLinkId as string;
         const autoPropagationEnvironment = appState.autoPropagationEnvironment as boolean;
         const propagationEnvironment = appState.propagationEnvironment as Record<string, unknown>;
         const propagationEnvironmentReason = appState.propagationEnvironmentReason as string;
         const terrainLoadEpoch = appState.terrainLoadEpoch as number;
+        const selectedSiteIds = (appState.selectedSiteIds as string[]) ?? [];
+        const isTerrainFetching = Boolean(appState.isTerrainFetching);
 
         const network = networks.find((n) => n.id === selectedNetworkId);
         if (!network) {
@@ -125,6 +129,18 @@ export const useCoverageStore = create<CoverageState>((set, get) => ({
           }
         }
 
+        const singleSelectedSite =
+          selectedSiteIds.length === 1
+            ? sites.find((site) => site.id === selectedSiteIds[0]) ?? null
+            : null;
+        const singleSiteRadiusKm =
+          singleSelectedSite && !isTerrainFetching
+            ? resolveSingleSiteBonusRadiusKm(singleSelectedSite, srtmTiles, {
+                baseRadiusKm: 20,
+                maxRadiusKm: 100,
+              })
+            : undefined;
+
         set({ simulationProgress: 8 });
         let lastProgress = 8;
         const coverageSamples = await buildCoverageAsync(
@@ -138,6 +154,7 @@ export const useCoverageStore = create<CoverageState>((set, get) => ({
           {
             sampleMultiplier: 1,
             terrainSamples: 20,
+            singleSiteRadiusKm,
             onProgress: (progress: number) => {
               if (get().simulationRunToken !== runId) return;
               const next = Math.round(8 + progress * 84);


### PR DESCRIPTION
## Summary
Implements issue #176 follow-up behavior for simulation overlay radius controls.

### Included
- Single-site radius options: `Auto (current behavior)`, `100 km`, `200 km`, `500 km`
- Non-single-site radius options: `20 km`, `50 km`, `100 km`
- Persisted radius option in simulation snapshot state
- Shared resolver used by both coverage sampling bounds and overlay mask radius
- Context normalization when switching selection mode
- Keep auto path debounced/background-safe

## Verification
- `npm test` passed (`58` files, `271` tests)
- `npm run build` passed

## Notes
- This PR includes commits:
  - `08f27c3` feat(coverage): expand single-site radius from loaded 30m tiles
  - `911c6e2` feat(overlay): add manual simulation radius modes by context