### PR TITLE
#176: radius context reset, fit guardrails, and mobile inspector/insets fixes

### DIFF
--- a/functions/_lib/buildInfo.ts
+++ b/functions/_lib/buildInfo.ts
@@ -1,5 +1,5 @@
 export const APP_VERSION = "0.15.0";
-export const APP_COMMIT = "a0b10428";
+export const APP_COMMIT = "f4286d73";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -199,6 +199,9 @@ export function AppShell() {
   const [mobileActivePanel, setMobileActivePanel] = useState<MobileWorkspacePanel>("navigator");
   const [mobileBottomPanelMode, setMobileBottomPanelMode] = useState<MobileBottomPanelMode>("normal");
   const [mobileControlsOccupied, setMobileControlsOccupied] = useState(0);
+  const [mobileBottomOccupied, setMobileBottomOccupied] = useState(0);
+  const [measuredSidebarWidth, setMeasuredSidebarWidth] = useState(0);
+  const [measuredInspectorWidth, setMeasuredInspectorWidth] = useState(0);
   const [localDevStatus, setLocalDevStatus] = useState<string | null>(null);
   const [offlineBannerDismissed, setOfflineBannerDismissed] = useState(false);
   const [showLibraryFromRequest, setShowLibraryFromRequest] = useState(false);
@@ -878,6 +881,71 @@ export function AppShell() {
   }, [isMobileViewport, isMapExpanded, isProfileExpanded, mobileActivePanel, mobileBottomPanelMode]);
 
   useEffect(() => {
+    const shell = appShellRef.current;
+    if (!shell) return;
+
+    let frameId = 0;
+    const measureVisibleRect = (selector: string) => {
+      const element = shell.querySelector<HTMLElement>(selector);
+      if (!element) return null;
+      const style = window.getComputedStyle(element);
+      if (style.display === "none" || style.visibility === "hidden") return null;
+      return element.getBoundingClientRect();
+    };
+
+    const recompute = () => {
+      const sidebarRect = measureVisibleRect(".sidebar-panel");
+      const inspectorRect = measureVisibleRect(".map-inspector");
+      const tabsRect = measureVisibleRect(".mobile-workspace-tabs");
+      const mobilePanelRect = measureVisibleRect(".mobile-workspace-panel");
+
+      setMeasuredSidebarWidth((current) => {
+        const next = Math.round(sidebarRect?.width ?? 0);
+        return current === next ? current : next;
+      });
+      setMeasuredInspectorWidth((current) => {
+        const next = Math.round(inspectorRect?.width ?? 0);
+        return current === next ? current : next;
+      });
+
+      if (!isMobileViewport) {
+        setMobileBottomOccupied((current) => (current === 0 ? current : 0));
+        return;
+      }
+
+      const bottomCoverages = [tabsRect, mobilePanelRect, inspectorRect]
+        .filter((rect): rect is DOMRect => Boolean(rect))
+        .map((rect) => Math.max(0, Math.round(window.innerHeight - rect.top)));
+      const nextBottomOccupied = bottomCoverages.length ? Math.max(...bottomCoverages) : 0;
+      setMobileBottomOccupied((current) => (current === nextBottomOccupied ? current : nextBottomOccupied));
+    };
+
+    const schedule = () => {
+      if (frameId) window.cancelAnimationFrame(frameId);
+      frameId = window.requestAnimationFrame(recompute);
+    };
+
+    schedule();
+    const followUpTimerA = window.setTimeout(schedule, 120);
+    const followUpTimerB = window.setTimeout(schedule, 280);
+    const observer = new ResizeObserver(schedule);
+    observer.observe(shell);
+    shell.querySelectorAll<HTMLElement>(".sidebar-panel, .map-inspector, .mobile-workspace-tabs, .mobile-workspace-panel").forEach((element) => {
+      observer.observe(element);
+    });
+    window.addEventListener("resize", schedule);
+    window.addEventListener("orientationchange", schedule);
+    return () => {
+      if (frameId) window.cancelAnimationFrame(frameId);
+      window.clearTimeout(followUpTimerA);
+      window.clearTimeout(followUpTimerB);
+      observer.disconnect();
+      window.removeEventListener("resize", schedule);
+      window.removeEventListener("orientationchange", schedule);
+    };
+  }, [isMobileViewport, isMapExpanded, isProfileExpanded, mobileActivePanel, mobileBottomPanelMode]);
+
+  useEffect(() => {
     if (isInitializing) {
       cloudInitSeenRef.current = true;
       return;
@@ -1403,6 +1471,30 @@ export function AppShell() {
     isProfileExpanded,
     mobileControlsOccupied,
   ]);
+  const mapFitChromePadding = useMemo(
+    () => ({
+      top: 30,
+      left: !isMobileViewport && !isMapExpanded ? Math.max(20, measuredSidebarWidth + 20) : 20,
+      right:
+        !isMobileViewport && !isMapExpanded && !isProfileExpanded && !isInspectorHidden
+          ? Math.max(70, measuredInspectorWidth + 20)
+          : 70,
+      bottom: 30,
+    }),
+    [
+      isInspectorHidden,
+      isMapExpanded,
+      isMobileViewport,
+      isProfileExpanded,
+      measuredInspectorWidth,
+      measuredSidebarWidth,
+    ],
+  );
+  const mapFitBottomInset = useMemo(() => {
+    if (isMobileViewport) return Math.max(30, mobileBottomOccupied + 18);
+    if (isMapExpanded || isProfileExpanded || isProfileHidden) return 30;
+    return Math.max(220, typeof window !== "undefined" ? window.innerHeight * 0.32 : 220) + 18 + 18;
+  }, [isMapExpanded, isMobileViewport, isProfileExpanded, isProfileHidden, mobileBottomOccupied]);
   const isAnonymousBootstrapShell = accessState === "checking";
   const isReadOnlyShell = isAnonymousGuestReadonly || isAnonymousBootstrapShell;
   const emitProfileLayoutPulse = useCallback(() => {
@@ -1746,9 +1838,10 @@ export function AppShell() {
           isMapExpanded={isMapExpanded}
           showInspector={
             !isMapExpanded &&
-            !isProfileExpanded &&
             !isInspectorHidden &&
-            (!isMobileViewport || (mobileActivePanel === "inspector" && mobileBottomPanelMode !== "hidden"))
+            (isMobileViewport
+              ? mobileActivePanel === "inspector" && mobileBottomPanelMode !== "hidden"
+              : !isProfileExpanded)
           }
           showMultiSelectToggle={isMobileViewport}
           canPersist={canPersistWorkspace}
@@ -1793,11 +1886,8 @@ export function AppShell() {
             setIsMapExpanded((prev) => !prev);
             emitProfileLayoutPulse();
           }}
-          fitBottomInset={
-            isMobileViewport || isMapExpanded || isProfileExpanded || isProfileHidden
-              ? 30
-              : Math.max(220, typeof window !== "undefined" ? window.innerHeight * 0.32 : 220) + 18 + 18
-          }
+          fitBottomInset={mapFitBottomInset}
+          fitChromePadding={mapFitChromePadding}
         />
         {isMobileViewport ? (
           <MobileWorkspaceTabs

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1570,7 +1570,7 @@ export function MapView({
     return options.map((gridSize) => {
       const fallbackSamples = gridSize * gridSize;
       const samples = overlayBounds ? computeCoverageGridDimensions(gridSize, overlayBounds, 1).totalSamples : fallbackSamples;
-      const isDefault = gridSize === 42;
+      const isDefault = gridSize === 24;
       return {
         value: String(gridSize) as "24" | "42" | "84" | "168",
         label: `${gridSize} (${samples} samples)${isDefault ? " - Default" : ""}`,
@@ -1751,8 +1751,10 @@ export function MapView({
     : isTerrainRecommending
       ? terrainFetchStatus || "Checking terrain dataset coverage..."
       : "") + keepWorkingSuffix;
+  const showLocalTerrainDiagnostics =
+    import.meta.env.DEV || (typeof window !== "undefined" && window.location.hostname === "localhost");
   useEffect(() => {
-    if (!import.meta.env.DEV) return;
+    if (!showLocalTerrainDiagnostics) return;
     const rawThresholdMb = localStorage.getItem("linksim-dev-terrain-memory-warn-mb");
     const thresholdMb = Number(rawThresholdMb ?? "4096");
     if (!Number.isFinite(thresholdMb) || thresholdMb <= 0) return;
@@ -1762,7 +1764,7 @@ export function MapView({
       `[terrain-memory] retained decoded terrain is ${retainedMb.toFixed(1)} MB (threshold ${thresholdMb} MB)`,
       terrainMemoryDiagnostics,
     );
-  }, [terrainMemoryDiagnostics]);
+  }, [showLocalTerrainDiagnostics, terrainMemoryDiagnostics]);
   const activeViewState = interactionViewState ?? {
     longitude: viewport.center.lon,
     latitude: viewport.center.lat,
@@ -2273,10 +2275,12 @@ export function MapView({
           {inspectorHeaderActions ? (
             <div className="map-inspector-header-row">{inspectorHeaderActions}</div>
           ) : null}
-          {(isSimulationRecomputing || isBackgroundBusy) && backgroundBusyLabel ? (
+          {isSimulationRecomputing || (isBackgroundBusy && backgroundBusyLabel) ? (
             <div className="map-inspector-section">
               <p className="map-inspector-line">
-                {isSimulationRecomputing ? `Recalculating simulation... ${simulationProgress}%` : backgroundBusyLabel}
+                {isSimulationRecomputing
+                  ? `Recalculating simulation... ${simulationProgress}%`
+                  : (backgroundBusyLabel ?? "Working in background...")}
               </p>
               <div className="map-progress-track">
                 {isSimulationRecomputing ? (
@@ -2770,7 +2774,7 @@ export function MapView({
             <p>Site elevations: Simulation values</p>
             <p>Resolution: Auto ({overlayDimensions.width}x{overlayDimensions.height})</p>
             <p>Overlay area diagonal: {analysisBoundsDiagonalKm.toFixed(0)} km</p>
-            {import.meta.env.DEV ? (
+            {showLocalTerrainDiagnostics ? (
               <>
                 <p>
                   Terrain memory (retained decoded): {formatMb(terrainMemoryDiagnostics.retainedBytesTotal)} [

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -28,10 +28,10 @@ import type { Link, PropagationEnvironment, Site } from "../types/radio";
 import { fetchMeshmapNodes, type MeshmapNode } from "../lib/meshtasticMqtt";
 import { canShowSaveSelectedLinkAction } from "../lib/selectedPairActions";
 import {
-  normalizeOverlayRadiusOptionForSelectionCount,
   optionsForSelectionCount,
   resolveEffectiveOverlayRadiusKm,
   resolveLoadedOverlayRadiusCapKm,
+  resolveOverlayRadiusOptionForSelectionTransition,
   resolveTargetOverlayRadiusKm,
   type SimulationOverlayRadiusOption,
 } from "../lib/simulationOverlayRadius";
@@ -989,6 +989,8 @@ type MapViewProps = {
   };
   /** Pixel inset for the bottom edge when computing fitBounds, to avoid UI chrome. */
   fitBottomInset?: number;
+  /** Pixel insets reserved for map-internal chrome when fitting bounds. */
+  fitChromePadding?: { top: number; right: number; bottom: number; left: number };
 };
 
 type MarkerActionButtonProps = {
@@ -1059,6 +1061,7 @@ export function MapView({
   inspectorHeaderActions,
   notice,
   fitBottomInset = 30,
+  fitChromePadding = FIT_CHROME_PADDING,
 }: MapViewProps) {
   const sites = useAppStore((state) => state.sites);
   const siteLibrary = useAppStore((state) => state.siteLibrary);
@@ -1196,21 +1199,6 @@ export function MapView({
     };
   }, []);
 
-  // When a scenario or simulation loads (fitSitesEpoch increments), fit the map to
-  // all sites with a ~20 km geographic margin and insets for UI chrome.
-  useEffect(() => {
-    if (!fitSitesEpoch || !isMapLoaded || !mapRef.current) return;
-    const bounds = computeSiteFitBounds(sites);
-    if (!bounds) return;
-    mapRef.current.fitBounds(bounds, {
-      padding: { ...FIT_CHROME_PADDING, bottom: fitBottomInset },
-      animate: false,
-      maxZoom: 14,
-    });
-    setInteractionViewState(null);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fitSitesEpoch, isMapLoaded, fitBottomInset]);
-
   const hasNonAutoLinks = useMemo(
     () => links.some((link) => (link.name ?? "").trim().toLowerCase() !== "auto link"),
     [links],
@@ -1238,6 +1226,7 @@ export function MapView({
   );
   const selectedSiteSet = useMemo(() => new Set(selectedSites.map((site) => site.id)), [selectedSites]);
   const selectionCount = selectedSites.length;
+  const previousSelectionCountRef = useRef(selectionCount);
   const selectedFromSite = selectedSites[0] ?? (selectedFromSiteId ? sites.find((site) => site.id === selectedFromSiteId) ?? null : null);
   const selectedToSite =
     selectedSites.length >= 2
@@ -1305,9 +1294,15 @@ export function MapView({
     };
   }, [showDiscoveryMqtt, mqttNodes.length]);
   useEffect(() => {
-    const normalized = normalizeOverlayRadiusOptionForSelectionCount(selectionCount, selectedOverlayRadiusOption);
-    if (normalized !== selectedOverlayRadiusOption) {
-      setSelectedOverlayRadiusOption(normalized);
+    const previousSelectionCount = previousSelectionCountRef.current;
+    previousSelectionCountRef.current = selectionCount;
+    const nextOption = resolveOverlayRadiusOptionForSelectionTransition({
+      previousSelectionCount,
+      selectionCount,
+      option: selectedOverlayRadiusOption,
+    });
+    if (nextOption !== selectedOverlayRadiusOption) {
+      setSelectedOverlayRadiusOption(nextOption);
     }
   }, [selectionCount, selectedOverlayRadiusOption, setSelectedOverlayRadiusOption]);
 
@@ -1315,7 +1310,11 @@ export function MapView({
   const hasRelayTopology = selectionCount >= 2;
   const hasMinimumTopology = sites.length >= 1;
   const analysisTargetSites = selectionCount === 1 ? selectedSites : sites;
-  const normalizedOverlayRadiusOption = normalizeOverlayRadiusOptionForSelectionCount(selectionCount, selectedOverlayRadiusOption);
+  const normalizedOverlayRadiusOption = resolveOverlayRadiusOptionForSelectionTransition({
+    previousSelectionCount: selectionCount,
+    selectionCount,
+    option: selectedOverlayRadiusOption,
+  });
   const targetRadiusKm = useMemo(
     () => resolveTargetOverlayRadiusKm(selectionCount, normalizedOverlayRadiusOption),
     [selectionCount, normalizedOverlayRadiusOption],
@@ -2121,11 +2120,35 @@ export function MapView({
     providerMaxZoom,
     sites,
     computeSiteFitBounds: (fitSites) => computeSiteFitBounds(fitSites, overlayRadiusKm),
-    fitChromePadding: FIT_CHROME_PADDING,
+    fitChromePadding,
     clamp,
     setInteractionViewState,
     updateMapViewport,
   });
+  useEffect(() => {
+    if (!fitControlActive || !fitSitesEpoch || !isMapLoaded || !mapRef.current) return;
+    const bounds = computeSiteFitBounds(sites, overlayRadiusKm);
+    if (!bounds) return;
+    mapRef.current.fitBounds(bounds, {
+      padding: { ...fitChromePadding, bottom: fitBottomInset },
+      animate: true,
+      linear: false,
+      duration: 900,
+      maxZoom: 14,
+    });
+    setInteractionViewState(null);
+  }, [
+    fitControlActive,
+    fitSitesEpoch,
+    isMapLoaded,
+    sites,
+    overlayRadiusKm,
+    fitBottomInset,
+    fitChromePadding.left,
+    fitChromePadding.right,
+    fitChromePadding.top,
+    fitChromePadding.bottom,
+  ]);
   const allowedOverlayModes = useMemo<Array<"none" | "heatmap" | "contours" | "passfail" | "relay">>(() => {
     if (selectionCount <= 0) return ["none", "heatmap", "contours"];
     if (selectionCount === 1) return ["none", "passfail", "heatmap", "contours"];

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1094,6 +1094,13 @@ export function MapView({
   const terrainProgressTilesTotal = useAppStore((state) => state.terrainProgressTilesTotal);
   const terrainProgressBytesLoaded = useAppStore((state) => state.terrainProgressBytesLoaded);
   const terrainProgressBytesEstimated = useAppStore((state) => state.terrainProgressBytesEstimated);
+  const terrainProgressTransientDecodeBytesEstimated = useAppStore(
+    (state) => state.terrainProgressTransientDecodeBytesEstimated,
+  );
+  const terrainProgressPhaseLabel = useAppStore((state) => state.terrainProgressPhaseLabel);
+  const terrainProgressPhaseIndex = useAppStore((state) => state.terrainProgressPhaseIndex);
+  const terrainProgressPhaseTotal = useAppStore((state) => state.terrainProgressPhaseTotal);
+  const terrainMemoryDiagnostics = useAppStore((state) => state.terrainMemoryDiagnostics);
   const propagationModel = useAppStore((state) => state.propagationModel);
   const selectedNetworkId = useAppStore((state) => state.selectedNetworkId);
   const networks = useAppStore((state) => state.networks);
@@ -1715,16 +1722,24 @@ export function MapView({
   const hasTerrainDownloadProgress =
     terrainProgressTilesLoaded > 0 || terrainProgressBytesLoaded > 0 || terrainProgressBytesEstimated > 0;
   const formatMb = (bytes: number) => `${(Math.max(0, bytes) / (1024 * 1024)).toFixed(1)} MB`;
+  const terrainPhasePrefix =
+    isTerrainFetching && terrainProgressPhaseTotal > 0
+      ? `Phase ${Math.max(1, terrainProgressPhaseIndex)}/${terrainProgressPhaseTotal}${
+          terrainProgressPhaseLabel ? `: ${terrainProgressPhaseLabel}` : ""
+        }`
+      : null;
   const terrainProgressLabel =
     isTerrainFetching && hasTerrainDownloadProgress && terrainProgressTilesTotal > 0
-      ? `Loading terrain ${terrainProgressPercent}% — ${formatMb(terrainProgressBytesLoaded)} of ~${formatMb(
+      ? `${terrainPhasePrefix ? `${terrainPhasePrefix} — ` : ""}Loading terrain ${terrainProgressPercent}% — ${formatMb(
+          terrainProgressBytesLoaded,
+        )} of ~${formatMb(
           terrainProgressBytesEstimated || terrainProgressBytesLoaded,
         )} (${terrainProgressTilesLoaded}/${terrainProgressTilesTotal} tiles)`
       : null;
   const terrainPreparingLabel =
     isTerrainFetching && !hasTerrainDownloadProgress
       ? terrainProgressTilesTotal > 0
-        ? `Preparing terrain download... (${terrainProgressTilesLoaded}/${terrainProgressTilesTotal} tiles queued)`
+        ? `${terrainPhasePrefix ? `${terrainPhasePrefix} — ` : ""}Preparing terrain download... (${terrainProgressTilesLoaded}/${terrainProgressTilesTotal} tiles queued)`
         : "Preparing terrain download..."
       : null;
   const backgroundBusyLabel = (isTerrainFetching
@@ -1732,6 +1747,18 @@ export function MapView({
     : isTerrainRecommending
       ? terrainFetchStatus || "Checking terrain dataset coverage..."
       : "") + keepWorkingSuffix;
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    const rawThresholdMb = localStorage.getItem("linksim-dev-terrain-memory-warn-mb");
+    const thresholdMb = Number(rawThresholdMb ?? "4096");
+    if (!Number.isFinite(thresholdMb) || thresholdMb <= 0) return;
+    const retainedMb = terrainMemoryDiagnostics.retainedBytesTotal / (1024 * 1024);
+    if (retainedMb < thresholdMb) return;
+    console.warn(
+      `[terrain-memory] retained decoded terrain is ${retainedMb.toFixed(1)} MB (threshold ${thresholdMb} MB)`,
+      terrainMemoryDiagnostics,
+    );
+  }, [terrainMemoryDiagnostics]);
   const activeViewState = interactionViewState ?? {
     longitude: viewport.center.lon,
     latitude: viewport.center.lat,
@@ -2736,6 +2763,26 @@ export function MapView({
             <p>Site elevations: Simulation values</p>
             <p>Resolution: Auto ({overlayDimensions.width}x{overlayDimensions.height})</p>
             <p>Overlay area diagonal: {analysisBoundsDiagonalKm.toFixed(0)} km</p>
+            {import.meta.env.DEV ? (
+              <>
+                <p>
+                  Terrain memory (retained decoded): {formatMb(terrainMemoryDiagnostics.retainedBytesTotal)} [
+                  30m {formatMb(terrainMemoryDiagnostics.retainedBytesByDataset.copernicus30)}, 90m{" "}
+                  {formatMb(terrainMemoryDiagnostics.retainedBytesByDataset.copernicus90)}, manual{" "}
+                  {formatMb(terrainMemoryDiagnostics.retainedBytesByDataset.manual)}]
+                </p>
+                <p>
+                  Terrain tiles by dataset: 30m {terrainMemoryDiagnostics.tileCountsByDataset.copernicus30}, 90m{" "}
+                  {terrainMemoryDiagnostics.tileCountsByDataset.copernicus90}, manual{" "}
+                  {terrainMemoryDiagnostics.tileCountsByDataset.manual}, other{" "}
+                  {terrainMemoryDiagnostics.tileCountsByDataset.other}
+                </p>
+                <p>
+                  Terrain decode overhead (in-flight estimate):{" "}
+                  {formatMb(terrainProgressTransientDecodeBytesEstimated)}
+                </p>
+              </>
+            ) : null}
             <p>Optimization thresholds (by simulation area): &gt;250 km, &gt;400 km, &gt;600 km.</p>
             {largeAreaOptimizationActive ? (
               <p>

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -46,7 +46,6 @@ const UI_SECTION_KEYS = {
   mapViewSimSummary: "linksim-ui-mapview-sim-summary-v1",
   mapViewOverlayGuide: "linksim-ui-mapview-overlay-guide-v1",
 } as const;
-const SINGLE_SITE_BONUS_DEBOUNCE_MS = 220;
 
 const readSectionBool = (key: string, fallback: boolean): boolean => {
   try {
@@ -946,8 +945,7 @@ const buildTerrainShadeOverlay = (
   };
 };
 
-/** ~20 km geographic margin added around sites before fitting. */
-const FIT_PAD_DEG = 0.18;
+const kmToLatDegrees = (km: number): number => km / 111.32;
 /**
  * Pixel insets reserved for UI chrome inside the map container.
  * Right accounts for the map controls pill; others are minimal breathing room.
@@ -960,16 +958,18 @@ const FIT_CHROME_PADDING = { top: 30, right: 70, bottom: 30, left: 20 } as const
  */
 const computeSiteFitBounds = (
   sites: { position: { lat: number; lon: number } }[],
+  fitRadiusKm = 20,
 ): [[number, number], [number, number]] | null => {
   if (!sites.length) return null;
   const lats = sites.map((s) => s.position.lat);
   const lons = sites.map((s) => s.position.lon);
   const centerLat = (Math.min(...lats) + Math.max(...lats)) / 2;
+  const latPad = kmToLatDegrees(Math.max(1, fitRadiusKm));
   // Scale lon padding by 1/cos(lat) so the geographic margin is uniform in km.
-  const lonPad = FIT_PAD_DEG / Math.max(0.1, Math.cos((centerLat * Math.PI) / 180));
+  const lonPad = latPad / Math.max(0.1, Math.cos((centerLat * Math.PI) / 180));
   return [
-    [Math.min(...lons) - lonPad, Math.min(...lats) - FIT_PAD_DEG],
-    [Math.max(...lons) + lonPad, Math.max(...lats) + FIT_PAD_DEG],
+    [Math.min(...lons) - lonPad, Math.min(...lats) - latPad],
+    [Math.max(...lons) + lonPad, Math.max(...lats) + latPad],
   ];
 };
 
@@ -1169,7 +1169,6 @@ export function MapView({
   const [mqttNodes, setMqttNodes] = useState<MeshmapNode[]>([]);
   const [mqttLoadStatus, setMqttLoadStatus] = useState<string | null>(null);
   const [overlayHoverInfo, setOverlayHoverInfo] = useState<MapInspectorHoverInfo | null>(null);
-  const [singleSiteBonusRadiusKm, setSingleSiteBonusRadiusKm] = useState(20);
   const [selectedDiscoveryLibraryEntryId, setSelectedDiscoveryLibraryEntryId] = useState<string | null>(null);
   const [mqttDuplicatePrompt, setMqttDuplicatePrompt] = useState<{
     node: MeshmapNode;
@@ -1312,26 +1311,6 @@ export function MapView({
     }
   }, [selectionCount, selectedOverlayRadiusOption, setSelectedOverlayRadiusOption]);
 
-  useEffect(() => {
-    const normalizedOption = normalizeOverlayRadiusOptionForSelectionCount(selectionCount, selectedOverlayRadiusOption);
-    if (selectionCount !== 1 || normalizedOption !== "auto" || isTerrainFetching) {
-      setSingleSiteBonusRadiusKm(20);
-      return;
-    }
-    const timer = window.setTimeout(() => {
-      const nextRadius = resolveEffectiveOverlayRadiusKm({
-        selectionCount: 1,
-        option: "auto",
-        selectedSingleSite: selectedSites[0],
-        srtmTiles,
-        isTerrainFetching: false,
-      });
-      setSingleSiteBonusRadiusKm((current) => (current === nextRadius ? current : nextRadius));
-    }, SINGLE_SITE_BONUS_DEBOUNCE_MS);
-    return () => {
-      window.clearTimeout(timer);
-    };
-  }, [selectionCount, selectedSites, srtmTiles, isTerrainFetching, selectedOverlayRadiusOption]);
   const hasPassFailTopology = selectionCount >= 1;
   const hasRelayTopology = selectionCount >= 2;
   const hasMinimumTopology = sites.length >= 1;
@@ -1349,23 +1328,20 @@ export function MapView({
     () =>
       Math.min(
         targetRadiusKm,
-        normalizedOverlayRadiusOption === "auto"
-          ? singleSiteBonusRadiusKm
-          : Math.min(
-              loadedRadiusCapKm,
-              resolveEffectiveOverlayRadiusKm({
-                selectionCount,
-                option: normalizedOverlayRadiusOption,
-                selectedSingleSite: selectionCount === 1 ? selectedSites[0] ?? null : null,
-                srtmTiles,
-                isTerrainFetching,
-              }),
-            ),
+        Math.min(
+          loadedRadiusCapKm,
+          resolveEffectiveOverlayRadiusKm({
+            selectionCount,
+            option: normalizedOverlayRadiusOption,
+            selectedSingleSite: selectionCount === 1 ? selectedSites[0] ?? null : null,
+            srtmTiles,
+            isTerrainFetching,
+          }),
+        ),
       ),
     [
       targetRadiusKm,
       normalizedOverlayRadiusOption,
-      singleSiteBonusRadiusKm,
       loadedRadiusCapKm,
       selectionCount,
       selectedSites,
@@ -1402,10 +1378,6 @@ export function MapView({
   const targetRadiusFetchAttemptRef = useRef("");
   useEffect(() => {
     if (coverageVizMode === "none") {
-      targetRadiusFetchAttemptRef.current = "";
-      return;
-    }
-    if (normalizedOverlayRadiusOption === "auto") {
       targetRadiusFetchAttemptRef.current = "";
       return;
     }
@@ -1566,14 +1538,19 @@ export function MapView({
 
   const overlayBounds = useMemo(() => analysisBounds ?? computeCoverageBounds(samplesForOverlay), [analysisBounds, samplesForOverlay]);
   const resolutionOptionLabels = useMemo(() => {
-    const options = [24, 42, 84, 168] as const;
-    return options.map((gridSize) => {
-      const fallbackSamples = gridSize * gridSize;
-      const samples = overlayBounds ? computeCoverageGridDimensions(gridSize, overlayBounds, 1).totalSamples : fallbackSamples;
+    const options = [
+      { gridSize: 24, name: "1x" },
+      { gridSize: 42, name: "2x" },
+      { gridSize: 84, name: "4x" },
+      { gridSize: 168, name: "8x" },
+    ] as const;
+    return options.map(({ gridSize, name }) => {
+      const fallback = { rows: gridSize, cols: gridSize, totalSamples: gridSize * gridSize };
+      const dims = overlayBounds ? computeCoverageGridDimensions(gridSize, overlayBounds, 1) : fallback;
       const isDefault = gridSize === 24;
       return {
         value: String(gridSize) as "24" | "42" | "84" | "168",
-        label: `${gridSize} (${samples} samples)${isDefault ? " - Default" : ""}`,
+        label: `${name} (${dims.rows}x${dims.cols}, ${dims.totalSamples} samples)${isDefault ? " - Default" : ""}`,
       };
     });
   }, [overlayBounds]);
@@ -1595,10 +1572,21 @@ export function MapView({
     );
   }, [overlayBounds, samplesForOverlay, baseOverlayMode, effectiveBandStepDb, overlayDimensions, overlayPointMask, srtmTiles]);
   // During a site drag, force low-res (24) to keep overlay recomputations cheap.
-  // On mouse release (isDraggingSite → false) the configured resolution is restored.
+  // During simulation recompute, keep using the last completed grid size to avoid
+  // blocking the UI while a higher-resolution recompute is still preparing.
   const selectedGridSize = Number(selectedCoverageResolution);
+  const [lastCompletedGridSize, setLastCompletedGridSize] = useState(24);
+  useEffect(() => {
+    if (isSimulationRecomputing) return;
+    if (!Number.isFinite(selectedGridSize) || selectedGridSize < 24) return;
+    setLastCompletedGridSize(selectedGridSize);
+  }, [isSimulationRecomputing, selectedGridSize]);
   const effectiveGridSize =
-    isDraggingSite || !Number.isFinite(selectedGridSize) || selectedGridSize < 24 ? 24 : selectedGridSize;
+    isDraggingSite || !Number.isFinite(selectedGridSize) || selectedGridSize < 24
+      ? 24
+      : isSimulationRecomputing
+        ? lastCompletedGridSize
+        : selectedGridSize;
   const passFailCoverageOverlay = useMemo<(OverlayRaster & { minDbm?: number; maxDbm?: number }) | null>(() => {
     if (coverageVizMode !== "passfail") return null;
     if (!overlayBounds || !activeSelectionLink || !selectedFromSite || !hasPassFailTopology) return null;
@@ -2132,7 +2120,7 @@ export function MapView({
     mapRef,
     providerMaxZoom,
     sites,
-    computeSiteFitBounds,
+    computeSiteFitBounds: (fitSites) => computeSiteFitBounds(fitSites, overlayRadiusKm),
     fitChromePadding: FIT_CHROME_PADDING,
     clamp,
     setInteractionViewState,
@@ -2567,7 +2555,7 @@ export function MapView({
                   >
                     {overlayRadiusOptions.map((option) => (
                       <option key={option} value={option}>
-                        {option === "auto" ? "Auto (current behavior)" : `${option} km`}
+                        {option === "200" ? "200 km (Slow)" : `${option} km`}
                       </option>
                     ))}
                   </select>

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -11,6 +11,7 @@ import Map, {
 } from "react-map-gl/maplibre";
 import type { LayerProps } from "react-map-gl/maplibre";
 import { classifyPassFailState, computeSourceCentricRxMetrics } from "../lib/passFailState";
+import { computeCoverageGridDimensions } from "../lib/coverage";
 import { STANDARD_SITE_RADIO } from "../lib/linkRadio";
 import { sampleSrtmElevation } from "../lib/srtm";
 import { getUiErrorMessage } from "../lib/uiError";
@@ -30,8 +31,12 @@ import {
   normalizeOverlayRadiusOptionForSelectionCount,
   optionsForSelectionCount,
   resolveEffectiveOverlayRadiusKm,
+  resolveLoadedOverlayRadiusCapKm,
+  resolveTargetOverlayRadiusKm,
   type SimulationOverlayRadiusOption,
 } from "../lib/simulationOverlayRadius";
+import { simulationAreaBoundsForSites } from "../lib/simulationArea";
+import { tilesForBounds } from "../lib/terrainTiles";
 import { SimulationResultsSection } from "./SimulationResultsSection";
 import { ActionButton } from "./ActionButton";
 import { useMapControls } from "./map/useMapControls";
@@ -1136,6 +1141,7 @@ export function MapView({
   const setCoverageVizMode = useAppStore((state) => state.setMapOverlayMode);
   const selectedCoverageResolution = useAppStore((state) => state.selectedCoverageResolution);
   const setSelectedCoverageResolution = useAppStore((state) => state.setSelectedCoverageResolution);
+  const recommendAndFetchTerrainForCurrentArea = useAppStore((state) => state.recommendAndFetchTerrainForCurrentArea);
   const selectedOverlayRadiusOption = useAppStore((state) => state.selectedOverlayRadiusOption);
   const setSelectedOverlayRadiusOption = useAppStore((state) => state.setSelectedOverlayRadiusOption);
   const [bandStepMode, setBandStepMode] = useState<BandStepMode>("auto");
@@ -1324,20 +1330,36 @@ export function MapView({
   const hasMinimumTopology = sites.length >= 1;
   const analysisTargetSites = selectionCount === 1 ? selectedSites : sites;
   const normalizedOverlayRadiusOption = normalizeOverlayRadiusOptionForSelectionCount(selectionCount, selectedOverlayRadiusOption);
+  const targetRadiusKm = useMemo(
+    () => resolveTargetOverlayRadiusKm(selectionCount, normalizedOverlayRadiusOption),
+    [selectionCount, normalizedOverlayRadiusOption],
+  );
+  const loadedRadiusCapKm = useMemo(
+    () => resolveLoadedOverlayRadiusCapKm(analysisTargetSites, targetRadiusKm, srtmTiles, 20),
+    [analysisTargetSites, targetRadiusKm, srtmTiles],
+  );
   const overlayRadiusKm = useMemo(
     () =>
-      normalizedOverlayRadiusOption === "auto"
-        ? singleSiteBonusRadiusKm
-        : resolveEffectiveOverlayRadiusKm({
-            selectionCount,
-            option: normalizedOverlayRadiusOption,
-            selectedSingleSite: selectionCount === 1 ? selectedSites[0] ?? null : null,
-            srtmTiles,
-            isTerrainFetching,
-          }),
+      Math.min(
+        targetRadiusKm,
+        normalizedOverlayRadiusOption === "auto"
+          ? singleSiteBonusRadiusKm
+          : Math.min(
+              loadedRadiusCapKm,
+              resolveEffectiveOverlayRadiusKm({
+                selectionCount,
+                option: normalizedOverlayRadiusOption,
+                selectedSingleSite: selectionCount === 1 ? selectedSites[0] ?? null : null,
+                srtmTiles,
+                isTerrainFetching,
+              }),
+            ),
+      ),
     [
+      targetRadiusKm,
       normalizedOverlayRadiusOption,
       singleSiteBonusRadiusKm,
+      loadedRadiusCapKm,
       selectionCount,
       selectedSites,
       srtmTiles,
@@ -1345,6 +1367,60 @@ export function MapView({
     ],
   );
   const overlayRadiusOptions = optionsForSelectionCount(selectionCount);
+  const loaded30mTileKeys = useMemo(
+    () => new Set(srtmTiles.filter((tile) => tile.sourceId === "copernicus30").map((tile) => tile.key)),
+    [srtmTiles],
+  );
+  const targetRadiusBounds = useMemo(
+    () => simulationAreaBoundsForSites(analysisTargetSites, { overlayRadiusKm: targetRadiusKm }),
+    [analysisTargetSites, targetRadiusKm],
+  );
+  const requiredTargetRadiusTileKeys = useMemo(
+    () =>
+      targetRadiusBounds
+        ? tilesForBounds(
+            targetRadiusBounds.minLat,
+            targetRadiusBounds.maxLat,
+            targetRadiusBounds.minLon,
+            targetRadiusBounds.maxLon,
+          )
+        : [],
+    [targetRadiusBounds],
+  );
+  const missingTargetRadiusTileCount = useMemo(
+    () => requiredTargetRadiusTileKeys.filter((key) => !loaded30mTileKeys.has(key)).length,
+    [requiredTargetRadiusTileKeys, loaded30mTileKeys],
+  );
+  const targetRadiusTerrainSignature = `${targetRadiusKm}|${requiredTargetRadiusTileKeys.join(",")}`;
+  const targetRadiusFetchAttemptRef = useRef("");
+  useEffect(() => {
+    if (coverageVizMode === "none") {
+      targetRadiusFetchAttemptRef.current = "";
+      return;
+    }
+    if (normalizedOverlayRadiusOption === "auto") {
+      targetRadiusFetchAttemptRef.current = "";
+      return;
+    }
+    if (!analysisTargetSites.length || missingTargetRadiusTileCount <= 0) {
+      targetRadiusFetchAttemptRef.current = "";
+      return;
+    }
+    if (isTerrainFetching || isTerrainRecommending) return;
+    if (targetRadiusFetchAttemptRef.current === targetRadiusTerrainSignature) return;
+    targetRadiusFetchAttemptRef.current = targetRadiusTerrainSignature;
+    void recommendAndFetchTerrainForCurrentArea(targetRadiusKm);
+  }, [
+    coverageVizMode,
+    analysisTargetSites.length,
+    missingTargetRadiusTileCount,
+    isTerrainFetching,
+    isTerrainRecommending,
+    normalizedOverlayRadiusOption,
+    targetRadiusTerrainSignature,
+    recommendAndFetchTerrainForCurrentArea,
+    targetRadiusKm,
+  ]);
   const overlayMaskArea = useMemo(
     () => buildBufferedSelectionArea(analysisTargetSites, overlayRadiusKm),
     [analysisTargetSites, overlayRadiusKm],
@@ -1386,7 +1462,6 @@ export function MapView({
     () => (boundedCoverageSamples.length >= 6 ? boundedCoverageSamples : coverageSamples),
     [boundedCoverageSamples, coverageSamples],
   );
-
   const lineFeatures = useMemo(
     () => {
       const showSelectionHighlights = !armAddSiteOnNextEmptyMapClick;
@@ -1483,6 +1558,16 @@ export function MapView({
   }, [analysisBounds, samplesForOverlay, overlayResolutionScale]);
 
   const overlayBounds = useMemo(() => analysisBounds ?? computeCoverageBounds(samplesForOverlay), [analysisBounds, samplesForOverlay]);
+  const normalResolutionLabel = useMemo(() => {
+    if (!overlayBounds) return "Normal (576 samples)";
+    const dims = computeCoverageGridDimensions(24, overlayBounds, 1);
+    return `Normal (${dims.totalSamples} samples)`;
+  }, [overlayBounds]);
+  const highResolutionLabel = useMemo(() => {
+    if (!overlayBounds) return "High (1764 samples, slower)";
+    const dims = computeCoverageGridDimensions(42, overlayBounds, 1);
+    return `High (${dims.totalSamples} samples, slower)`;
+  }, [overlayBounds]);
   const effectiveBandStepDb = useMemo(() => {
     if (!overlayBounds) return 5;
     return bandStepMode === "auto" ? autoBandStepDb(samplesForOverlay, overlayBounds) : bandStepMode;
@@ -2422,14 +2507,14 @@ export function MapView({
               </label>
               {coverageVizMode !== "none" && (
                 <label className="map-inspector-map-setting">
-                  <span>Coverage Detail</span>
+                  <span>Simulation Resolution</span>
                   <select
                     className="locale-select"
                     onChange={(event) => setSelectedCoverageResolution(event.target.value as "normal" | "high")}
                     value={selectedCoverageResolution}
                   >
-                    <option value="normal">Normal</option>
-                    <option value="high">High (slower)</option>
+                    <option value="normal">{normalResolutionLabel}</option>
+                    <option value="high">{highResolutionLabel}</option>
                   </select>
                 </label>
               )}

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1565,15 +1565,17 @@ export function MapView({
   }, [analysisBounds, samplesForOverlay, overlayResolutionScale]);
 
   const overlayBounds = useMemo(() => analysisBounds ?? computeCoverageBounds(samplesForOverlay), [analysisBounds, samplesForOverlay]);
-  const normalResolutionLabel = useMemo(() => {
-    if (!overlayBounds) return "Normal (576 samples)";
-    const dims = computeCoverageGridDimensions(24, overlayBounds, 1);
-    return `Normal (${dims.totalSamples} samples)`;
-  }, [overlayBounds]);
-  const highResolutionLabel = useMemo(() => {
-    if (!overlayBounds) return "High (1764 samples, slower)";
-    const dims = computeCoverageGridDimensions(42, overlayBounds, 1);
-    return `High (${dims.totalSamples} samples, slower)`;
+  const resolutionOptionLabels = useMemo(() => {
+    const options = [24, 42, 84, 168] as const;
+    return options.map((gridSize) => {
+      const fallbackSamples = gridSize * gridSize;
+      const samples = overlayBounds ? computeCoverageGridDimensions(gridSize, overlayBounds, 1).totalSamples : fallbackSamples;
+      const isDefault = gridSize === 42;
+      return {
+        value: String(gridSize) as "24" | "42" | "84" | "168",
+        label: `${gridSize} (${samples} samples)${isDefault ? " - Default" : ""}`,
+      };
+    });
   }, [overlayBounds]);
   const effectiveBandStepDb = useMemo(() => {
     if (!overlayBounds) return 5;
@@ -1594,7 +1596,9 @@ export function MapView({
   }, [overlayBounds, samplesForOverlay, baseOverlayMode, effectiveBandStepDb, overlayDimensions, overlayPointMask, srtmTiles]);
   // During a site drag, force low-res (24) to keep overlay recomputations cheap.
   // On mouse release (isDraggingSite → false) the configured resolution is restored.
-  const effectiveGridSize = isDraggingSite || selectedCoverageResolution !== "high" ? 24 : 42;
+  const selectedGridSize = Number(selectedCoverageResolution);
+  const effectiveGridSize =
+    isDraggingSite || !Number.isFinite(selectedGridSize) || selectedGridSize < 24 ? 24 : selectedGridSize;
   const passFailCoverageOverlay = useMemo<(OverlayRaster & { minDbm?: number; maxDbm?: number }) | null>(() => {
     if (coverageVizMode !== "passfail") return null;
     if (!overlayBounds || !activeSelectionLink || !selectedFromSite || !hasPassFailTopology) return null;
@@ -2537,11 +2541,14 @@ export function MapView({
                   <span>Simulation Resolution</span>
                   <select
                     className="locale-select"
-                    onChange={(event) => setSelectedCoverageResolution(event.target.value as "normal" | "high")}
+                    onChange={(event) => setSelectedCoverageResolution(event.target.value as "24" | "42" | "84" | "168")}
                     value={selectedCoverageResolution}
                   >
-                    <option value="normal">{normalResolutionLabel}</option>
-                    <option value="high">{highResolutionLabel}</option>
+                    {resolutionOptionLabels.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
                   </select>
                 </label>
               )}

--- a/src/components/map/useMapControls.test.ts
+++ b/src/components/map/useMapControls.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { computeNextZoom } from "./useMapControls";
+import {
+  computeNextAutoFitEnabledAfterFitToggle,
+  computeNextAutoFitEnabledAfterInteraction,
+  computeNextZoom,
+} from "./useMapControls";
 
 const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
 
@@ -14,5 +18,16 @@ describe("computeNextZoom", () => {
 
   it("clamps to provider max zoom", () => {
     expect(computeNextZoom(14.5, 2, 15, clamp)).toBe(15);
+  });
+});
+
+describe("auto-fit control state helpers", () => {
+  it("disables auto-fit on direct user interaction", () => {
+    expect(computeNextAutoFitEnabledAfterInteraction()).toBe(false);
+  });
+
+  it("toggles auto-fit when pressing the fit control", () => {
+    expect(computeNextAutoFitEnabledAfterFitToggle(true)).toBe(false);
+    expect(computeNextAutoFitEnabledAfterFitToggle(false)).toBe(true);
   });
 });

--- a/src/components/map/useMapControls.ts
+++ b/src/components/map/useMapControls.ts
@@ -26,6 +26,10 @@ export const computeNextZoom = (
   clamp: (value: number, min: number, max: number) => number,
 ) => clamp(currentZoom + delta, 2, providerMaxZoom);
 
+export const computeNextAutoFitEnabledAfterInteraction = (): boolean => false;
+
+export const computeNextAutoFitEnabledAfterFitToggle = (current: boolean): boolean => !current;
+
 export function useMapControls({
   activeViewState,
   fitBottomInset,
@@ -39,20 +43,22 @@ export function useMapControls({
   updateMapViewport,
 }: UseMapControlsParams) {
   const [isMultiSelectMode, setIsMultiSelectMode] = useState(false);
-  const [fitControlActive, setFitControlActive] = useState(false);
+  const [fitControlActive, setFitControlActive] = useState(true);
 
   const zoomBy = (delta: number) => {
-    setFitControlActive(false);
+    setFitControlActive(computeNextAutoFitEnabledAfterInteraction());
     const nextZoom = computeNextZoom(activeViewState.zoom, delta, providerMaxZoom, clamp);
     setInteractionViewState(null);
     updateMapViewport({ zoom: nextZoom });
   };
 
   const fitToNodes = () => {
+    const nextEnabled = computeNextAutoFitEnabledAfterFitToggle(fitControlActive);
+    setFitControlActive(nextEnabled);
+    if (!nextEnabled) return;
     if (!mapRef.current) return;
     const bounds = computeSiteFitBounds(sites);
     if (!bounds) return;
-    setFitControlActive(true);
     setInteractionViewState(null);
     mapRef.current.fitBounds(bounds, {
       padding: { ...fitChromePadding, bottom: fitBottomInset },
@@ -65,7 +71,7 @@ export function useMapControls({
     isMultiSelectMode,
     setIsMultiSelectMode,
     fitControlActive,
-    clearFitControlActive: () => setFitControlActive(false),
+    clearFitControlActive: () => setFitControlActive(computeNextAutoFitEnabledAfterInteraction()),
     zoomBy,
     fitToNodes,
   };

--- a/src/lib/buildInfo.ts
+++ b/src/lib/buildInfo.ts
@@ -1,5 +1,5 @@
 export const APP_VERSION = "0.15.0";
-export const APP_COMMIT = "a0b10428";
+export const APP_COMMIT = "f4286d73";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {

--- a/src/lib/coverage.test.ts
+++ b/src/lib/coverage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildCoverage, buildCoverageAsync } from "./coverage";
+import { buildCoverage, buildCoverageAsync, computeCoverageGridDimensions } from "./coverage";
 import { haversineDistanceKm } from "./geo";
 import { defaultPropagationEnvironment } from "./propagationEnvironment";
 import type { Network, RadioSystem, Site } from "../types/radio";
@@ -58,13 +58,13 @@ const NORMAL_GRID = 24;
 const HIGH_GRID = 42;
 
 describe("buildCoverage", () => {
-  it("creates non-empty coverage at normal resolution (24x24 grid)", () => {
+  it("creates non-empty coverage at normal resolution", () => {
     const result = buildCoverage(NORMAL_GRID, network, sites, systems, defaultPropagationEnvironment());
     expect(result.length).toBeGreaterThan(100);
     expect(Number.isFinite(result[0].valueDbm)).toBe(true);
   });
 
-  it("creates more samples at high resolution (42x42 grid)", () => {
+  it("creates more samples at high resolution", () => {
     const normal = buildCoverage(NORMAL_GRID, network, sites, systems, defaultPropagationEnvironment());
     const high = buildCoverage(HIGH_GRID, network, sites, systems, defaultPropagationEnvironment());
     expect(high.length).toBeGreaterThan(normal.length);
@@ -104,5 +104,18 @@ describe("buildCoverage", () => {
     const farthestBase = Math.max(...base.map((sample) => haversineDistanceKm(sample, center)));
     const farthestExpanded = Math.max(...expanded.map((sample) => haversineDistanceKm(sample, center)));
     expect(farthestExpanded).toBeGreaterThan(farthestBase + 30);
+  });
+
+  it("computes aspect-ratio adjusted grid dimensions", () => {
+    const dims = computeCoverageGridDimensions(24, {
+      minLat: 59.8,
+      maxLat: 60.1,
+      minLon: 10.7,
+      maxLon: 10.8,
+    });
+    expect(dims.totalSamples).toBe(dims.rows * dims.cols);
+    expect(dims.targetSamples).toBe(576);
+    expect(dims.rows).toBeGreaterThan(0);
+    expect(dims.cols).toBeGreaterThan(0);
   });
 });

--- a/src/lib/coverage.ts
+++ b/src/lib/coverage.ts
@@ -20,6 +20,41 @@ export type BuildCoverageOptions = {
   singleSiteRadiusKm?: number;
 };
 
+export type CoverageGridBounds = {
+  minLat: number;
+  maxLat: number;
+  minLon: number;
+  maxLon: number;
+};
+
+export type CoverageGridDimensions = {
+  rows: number;
+  cols: number;
+  totalSamples: number;
+  targetSamples: number;
+};
+
+export const computeCoverageGridDimensions = (
+  gridSize: number,
+  bounds: CoverageGridBounds,
+  sampleMultiplier = 1,
+): CoverageGridDimensions => {
+  const targetSamples = Math.max(64, Math.round(gridSize * gridSize * sampleMultiplier * sampleMultiplier));
+  const centerLat = (bounds.minLat + bounds.maxLat) / 2;
+  const latSpanKm = Math.max(0.001, (bounds.maxLat - bounds.minLat) * 111.32);
+  const lonScale = Math.max(0.1, Math.cos((centerLat * Math.PI) / 180));
+  const lonSpanKm = Math.max(0.001, (bounds.maxLon - bounds.minLon) * 111.32 * lonScale);
+  const aspect = latSpanKm / lonSpanKm;
+  const cols = Math.max(6, Math.round(Math.sqrt(targetSamples / Math.max(0.2, Math.min(5, aspect)))));
+  const rows = Math.max(6, Math.round(targetSamples / cols));
+  return {
+    rows,
+    cols,
+    totalSamples: rows * cols,
+    targetSamples,
+  };
+};
+
 const nUnitsToKFactor = (nUnits: number): number => {
   const n = Math.max(250, Math.min(400, nUnits));
   return Math.max(1, Math.min(2, 1 + (n - 250) / 153));
@@ -161,20 +196,13 @@ export const buildCoverage = (
       : sites.map((site) => ({ siteId: site.id, systemId: fallbackSystemId }));
 
   const samples: { lat: number; lon: number }[] = [];
-  const targetSamples = Math.max(64, Math.round(gridSize * gridSize * sampleMultiplier * sampleMultiplier));
   const bounds = simulationAreaBoundsForSites(sites, {
     overlayRadiusKm: options?.overlayRadiusKm,
     singleSiteRadiusKm: options?.singleSiteRadiusKm,
   });
   if (!bounds) return [];
 
-  const centerLat = (bounds.minLat + bounds.maxLat) / 2;
-  const latSpanKm = Math.max(0.001, (bounds.maxLat - bounds.minLat) * 111.32);
-  const lonScale = Math.max(0.1, Math.cos((centerLat * Math.PI) / 180));
-  const lonSpanKm = Math.max(0.001, (bounds.maxLon - bounds.minLon) * 111.32 * lonScale);
-  const aspect = latSpanKm / lonSpanKm;
-  const cols = Math.max(6, Math.round(Math.sqrt(targetSamples / Math.max(0.2, Math.min(5, aspect)))));
-  const rows = Math.max(6, Math.round(targetSamples / cols));
+  const { rows, cols } = computeCoverageGridDimensions(gridSize, bounds, sampleMultiplier);
 
   for (let y = 0; y < rows; y += 1) {
     const ty = rows <= 1 ? 0 : y / (rows - 1);
@@ -250,20 +278,13 @@ export const buildCoverageAsync = async (
       : sites.map((site) => ({ siteId: site.id, systemId: fallbackSystemId }));
 
   const samples: { lat: number; lon: number }[] = [];
-  const targetSamples = Math.max(64, Math.round(gridSize * gridSize * sampleMultiplier * sampleMultiplier));
   const bounds = simulationAreaBoundsForSites(sites, {
     overlayRadiusKm: options?.overlayRadiusKm,
     singleSiteRadiusKm: options?.singleSiteRadiusKm,
   });
   if (!bounds) return [];
 
-  const centerLat = (bounds.minLat + bounds.maxLat) / 2;
-  const latSpanKm = Math.max(0.001, (bounds.maxLat - bounds.minLat) * 111.32);
-  const lonScale = Math.max(0.1, Math.cos((centerLat * Math.PI) / 180));
-  const lonSpanKm = Math.max(0.001, (bounds.maxLon - bounds.minLon) * 111.32 * lonScale);
-  const aspect = latSpanKm / lonSpanKm;
-  const cols = Math.max(6, Math.round(Math.sqrt(targetSamples / Math.max(0.2, Math.min(5, aspect)))));
-  const rows = Math.max(6, Math.round(targetSamples / cols));
+  const { rows, cols } = computeCoverageGridDimensions(gridSize, bounds, sampleMultiplier);
 
   for (let y = 0; y < rows; y += 1) {
     const ty = rows <= 1 ? 0 : y / (rows - 1);

--- a/src/lib/simulationOverlayRadius.test.ts
+++ b/src/lib/simulationOverlayRadius.test.ts
@@ -22,36 +22,26 @@ const mkTile = (key: string, sourceId = "copernicus30"): SrtmTile => ({
 
 describe("simulationOverlayRadius", () => {
   it("exposes expected options by selection context", () => {
-    expect(optionsForSelectionCount(1)).toEqual(["auto", "100", "200"]);
-    expect(optionsForSelectionCount(2)).toEqual(["20", "50", "100"]);
-    expect(defaultOptionForSelectionCount(1)).toBe("auto");
+    expect(optionsForSelectionCount(1)).toEqual(["20", "50", "100", "200"]);
+    expect(optionsForSelectionCount(2)).toEqual(["20", "50", "100", "200"]);
+    expect(defaultOptionForSelectionCount(1)).toBe("20");
     expect(defaultOptionForSelectionCount(3)).toBe("20");
   });
 
   it("normalizes invalid option to context default", () => {
-    expect(normalizeOverlayRadiusOptionForSelectionCount(1, "50")).toBe("auto");
+    expect(normalizeOverlayRadiusOptionForSelectionCount(1, "50")).toBe("50");
     expect(normalizeOverlayRadiusOptionForSelectionCount(2, "auto")).toBe("20");
   });
 
-  it("uses tile-aware auto radius in single-site mode", () => {
+  it("uses fixed values in single-site mode", () => {
     const radius = resolveEffectiveOverlayRadiusKm({
       selectionCount: 1,
-      option: "auto",
+      option: "100",
       selectedSingleSite: site,
-      srtmTiles: [
-        mkTile("N59E010"),
-        mkTile("N60E010"),
-        mkTile("N58E010"),
-        mkTile("N59E009"),
-        mkTile("N59E011"),
-        mkTile("N60E009"),
-        mkTile("N60E011"),
-        mkTile("N58E009"),
-        mkTile("N58E011"),
-      ],
+      srtmTiles: [mkTile("N59E010")],
       isTerrainFetching: false,
     });
-    expect(radius).toBeGreaterThan(50);
+    expect(radius).toBe(100);
   });
 
   it("uses fixed values outside single-site mode", () => {
@@ -66,7 +56,7 @@ describe("simulationOverlayRadius", () => {
   });
 
   it("resolves target radius by context and option", () => {
-    expect(resolveTargetOverlayRadiusKm(1, "auto")).toBe(100);
+    expect(resolveTargetOverlayRadiusKm(1, "20")).toBe(20);
     expect(resolveTargetOverlayRadiusKm(1, "200")).toBe(200);
     expect(resolveTargetOverlayRadiusKm(3, "100")).toBe(100);
   });

--- a/src/lib/simulationOverlayRadius.test.ts
+++ b/src/lib/simulationOverlayRadius.test.ts
@@ -4,6 +4,8 @@ import {
   normalizeOverlayRadiusOptionForSelectionCount,
   optionsForSelectionCount,
   resolveEffectiveOverlayRadiusKm,
+  resolveLoadedOverlayRadiusCapKm,
+  resolveTargetOverlayRadiusKm,
 } from "./simulationOverlayRadius";
 import type { Site, SrtmTile } from "../types/radio";
 
@@ -62,5 +64,15 @@ describe("simulationOverlayRadius", () => {
     });
     expect(radius).toBe(100);
   });
-});
 
+  it("resolves target radius by context and option", () => {
+    expect(resolveTargetOverlayRadiusKm(1, "auto")).toBe(100);
+    expect(resolveTargetOverlayRadiusKm(1, "500")).toBe(500);
+    expect(resolveTargetOverlayRadiusKm(3, "100")).toBe(100);
+  });
+
+  it("caps loaded radius conservatively to available 30m tiles", () => {
+    const capped = resolveLoadedOverlayRadiusCapKm([site], 500, [mkTile("N59E010")], 20);
+    expect(capped).toBe(20);
+  });
+});

--- a/src/lib/simulationOverlayRadius.test.ts
+++ b/src/lib/simulationOverlayRadius.test.ts
@@ -22,7 +22,7 @@ const mkTile = (key: string, sourceId = "copernicus30"): SrtmTile => ({
 
 describe("simulationOverlayRadius", () => {
   it("exposes expected options by selection context", () => {
-    expect(optionsForSelectionCount(1)).toEqual(["auto", "100", "200", "500"]);
+    expect(optionsForSelectionCount(1)).toEqual(["auto", "100", "200"]);
     expect(optionsForSelectionCount(2)).toEqual(["20", "50", "100"]);
     expect(defaultOptionForSelectionCount(1)).toBe("auto");
     expect(defaultOptionForSelectionCount(3)).toBe("20");
@@ -67,12 +67,12 @@ describe("simulationOverlayRadius", () => {
 
   it("resolves target radius by context and option", () => {
     expect(resolveTargetOverlayRadiusKm(1, "auto")).toBe(100);
-    expect(resolveTargetOverlayRadiusKm(1, "500")).toBe(500);
+    expect(resolveTargetOverlayRadiusKm(1, "200")).toBe(200);
     expect(resolveTargetOverlayRadiusKm(3, "100")).toBe(100);
   });
 
   it("caps loaded radius conservatively to available 30m tiles", () => {
-    const capped = resolveLoadedOverlayRadiusCapKm([site], 500, [mkTile("N59E010")], 20);
+    const capped = resolveLoadedOverlayRadiusCapKm([site], 200, [mkTile("N59E010")], 20);
     expect(capped).toBe(20);
   });
 });

--- a/src/lib/simulationOverlayRadius.test.ts
+++ b/src/lib/simulationOverlayRadius.test.ts
@@ -5,6 +5,7 @@ import {
   optionsForSelectionCount,
   resolveEffectiveOverlayRadiusKm,
   resolveLoadedOverlayRadiusCapKm,
+  resolveOverlayRadiusOptionForSelectionTransition,
   resolveTargetOverlayRadiusKm,
 } from "./simulationOverlayRadius";
 import type { Site, SrtmTile } from "../types/radio";
@@ -24,13 +25,31 @@ describe("simulationOverlayRadius", () => {
   it("exposes expected options by selection context", () => {
     expect(optionsForSelectionCount(1)).toEqual(["20", "50", "100", "200"]);
     expect(optionsForSelectionCount(2)).toEqual(["20", "50", "100", "200"]);
-    expect(defaultOptionForSelectionCount(1)).toBe("20");
+    expect(defaultOptionForSelectionCount(1)).toBe("50");
     expect(defaultOptionForSelectionCount(3)).toBe("20");
   });
 
   it("normalizes invalid option to context default", () => {
     expect(normalizeOverlayRadiusOptionForSelectionCount(1, "50")).toBe("50");
     expect(normalizeOverlayRadiusOptionForSelectionCount(2, "auto")).toBe("20");
+    expect(normalizeOverlayRadiusOptionForSelectionCount(1, "auto")).toBe("50");
+  });
+
+  it("resets to context defaults when switching between single and non-single selection", () => {
+    expect(
+      resolveOverlayRadiusOptionForSelectionTransition({
+        previousSelectionCount: 1,
+        selectionCount: 2,
+        option: "50",
+      }),
+    ).toBe("20");
+    expect(
+      resolveOverlayRadiusOptionForSelectionTransition({
+        previousSelectionCount: 2,
+        selectionCount: 1,
+        option: "20",
+      }),
+    ).toBe("50");
   });
 
   it("uses fixed values in single-site mode", () => {

--- a/src/lib/simulationOverlayRadius.ts
+++ b/src/lib/simulationOverlayRadius.ts
@@ -1,18 +1,16 @@
-import { resolveSingleSiteBonusRadiusKm } from "./singleSiteBonusRadius";
 import { simulationAreaBoundsForSites } from "./simulationArea";
 import { tilesForBounds } from "./terrainTiles";
 import type { Site, SrtmTile } from "../types/radio";
 
-export type SimulationOverlayRadiusOption = "auto" | "20" | "50" | "100" | "200";
+export type SimulationOverlayRadiusOption = "20" | "50" | "100" | "200";
 
-const SINGLE_SITE_OPTIONS: SimulationOverlayRadiusOption[] = ["auto", "100", "200"];
-const MULTI_SITE_OPTIONS: SimulationOverlayRadiusOption[] = ["20", "50", "100"];
+const SHARED_OPTIONS: SimulationOverlayRadiusOption[] = ["20", "50", "100", "200"];
 
 export const optionsForSelectionCount = (selectionCount: number): SimulationOverlayRadiusOption[] =>
-  selectionCount === 1 ? SINGLE_SITE_OPTIONS : MULTI_SITE_OPTIONS;
+  selectionCount >= 0 ? SHARED_OPTIONS : SHARED_OPTIONS;
 
 export const defaultOptionForSelectionCount = (selectionCount: number): SimulationOverlayRadiusOption =>
-  selectionCount === 1 ? "auto" : "20";
+  selectionCount >= 0 ? "20" : "20";
 
 export const normalizeOverlayRadiusOptionForSelectionCount = (
   selectionCount: number,
@@ -26,7 +24,7 @@ export const normalizeOverlayRadiusOptionForSelectionCount = (
 
 export const isOverlayRadiusOption = (value: unknown): value is SimulationOverlayRadiusOption =>
   typeof value === "string" &&
-  (["auto", "20", "50", "100", "200"] as const).includes(value as SimulationOverlayRadiusOption);
+  (["20", "50", "100", "200"] as const).includes(value as SimulationOverlayRadiusOption);
 
 export const resolveEffectiveOverlayRadiusKm = (params: {
   selectionCount: number;
@@ -35,16 +33,8 @@ export const resolveEffectiveOverlayRadiusKm = (params: {
   srtmTiles: ReadonlyArray<SrtmTile>;
   isTerrainFetching: boolean;
 }): number => {
-  const { selectionCount, option, selectedSingleSite, srtmTiles, isTerrainFetching } = params;
-  if (selectionCount === 1) {
-    if (option === "auto") {
-      if (!selectedSingleSite || isTerrainFetching) return 20;
-      return resolveSingleSiteBonusRadiusKm(selectedSingleSite, srtmTiles, { baseRadiusKm: 20, maxRadiusKm: 100 });
-    }
-    const fixed = Number(option);
-    return Number.isFinite(fixed) ? Math.max(20, fixed) : 20;
-  }
-  const fixed = option === "20" || option === "50" || option === "100" ? Number(option) : 20;
+  const { option } = params;
+  const fixed = option === "20" || option === "50" || option === "100" || option === "200" ? Number(option) : 20;
   return fixed;
 };
 
@@ -52,13 +42,9 @@ export const resolveTargetOverlayRadiusKm = (
   selectionCount: number,
   option: SimulationOverlayRadiusOption,
 ): number =>
-  selectionCount === 1
-    ? option === "auto"
-      ? 100
-      : Number(option)
-    : option === "20" || option === "50" || option === "100"
-      ? Number(option)
-      : 20;
+  selectionCount >= 0 && (option === "20" || option === "50" || option === "100" || option === "200")
+    ? Number(option)
+    : 20;
 
 export const resolveLoadedOverlayRadiusCapKm = (
   sites: Pick<Site, "position">[],

--- a/src/lib/simulationOverlayRadius.ts
+++ b/src/lib/simulationOverlayRadius.ts
@@ -1,4 +1,6 @@
 import { resolveSingleSiteBonusRadiusKm } from "./singleSiteBonusRadius";
+import { simulationAreaBoundsForSites } from "./simulationArea";
+import { tilesForBounds } from "./terrainTiles";
 import type { Site, SrtmTile } from "../types/radio";
 
 export type SimulationOverlayRadiusOption = "auto" | "20" | "50" | "100" | "200" | "500";
@@ -46,3 +48,48 @@ export const resolveEffectiveOverlayRadiusKm = (params: {
   return fixed;
 };
 
+export const resolveTargetOverlayRadiusKm = (
+  selectionCount: number,
+  option: SimulationOverlayRadiusOption,
+): number =>
+  selectionCount === 1
+    ? option === "auto"
+      ? 100
+      : Number(option)
+    : option === "20" || option === "50" || option === "100"
+      ? Number(option)
+      : 20;
+
+export const resolveLoadedOverlayRadiusCapKm = (
+  sites: Pick<Site, "position">[],
+  targetRadiusKm: number,
+  srtmTiles: ReadonlyArray<SrtmTile>,
+  minimumRadiusKm = 20,
+): number => {
+  if (!sites.length) return minimumRadiusKm;
+  const loaded30m = new Set(srtmTiles.filter((tile) => tile.sourceId === "copernicus30").map((tile) => tile.key));
+  if (!loaded30m.size) return minimumRadiusKm;
+
+  const minRadiusKm = Math.max(1, minimumRadiusKm);
+  const maxRadiusKm = Math.max(minRadiusKm, Math.round(targetRadiusKm));
+  const hasCoverageForRadius = (radiusKm: number): boolean => {
+    const bounds = simulationAreaBoundsForSites(sites, { overlayRadiusKm: radiusKm });
+    if (!bounds) return false;
+    const needed = tilesForBounds(bounds.minLat, bounds.maxLat, bounds.minLon, bounds.maxLon);
+    if (!needed.length) return false;
+    return needed.every((key) => loaded30m.has(key));
+  };
+
+  if (!hasCoverageForRadius(minRadiusKm)) return minRadiusKm;
+  let low = minRadiusKm;
+  let high = maxRadiusKm;
+  while (low < high) {
+    const mid = Math.ceil((low + high + 1) / 2);
+    if (hasCoverageForRadius(mid)) {
+      low = mid;
+    } else {
+      high = mid - 1;
+    }
+  }
+  return low;
+};

--- a/src/lib/simulationOverlayRadius.ts
+++ b/src/lib/simulationOverlayRadius.ts
@@ -10,7 +10,7 @@ export const optionsForSelectionCount = (selectionCount: number): SimulationOver
   selectionCount >= 0 ? SHARED_OPTIONS : SHARED_OPTIONS;
 
 export const defaultOptionForSelectionCount = (selectionCount: number): SimulationOverlayRadiusOption =>
-  selectionCount >= 0 ? "20" : "20";
+  selectionCount === 1 ? "50" : "20";
 
 export const normalizeOverlayRadiusOptionForSelectionCount = (
   selectionCount: number,
@@ -20,6 +20,20 @@ export const normalizeOverlayRadiusOptionForSelectionCount = (
   const allowed = optionsForSelectionCount(selectionCount);
   if (candidate && allowed.includes(candidate)) return candidate;
   return defaultOptionForSelectionCount(selectionCount);
+};
+
+export const resolveOverlayRadiusOptionForSelectionTransition = (params: {
+  previousSelectionCount: number;
+  selectionCount: number;
+  option: unknown;
+}): SimulationOverlayRadiusOption => {
+  const normalized = normalizeOverlayRadiusOptionForSelectionCount(params.selectionCount, params.option);
+  const previousWasSingle = params.previousSelectionCount === 1;
+  const currentIsSingle = params.selectionCount === 1;
+  if (previousWasSingle !== currentIsSingle) {
+    return defaultOptionForSelectionCount(params.selectionCount);
+  }
+  return normalized;
 };
 
 export const isOverlayRadiusOption = (value: unknown): value is SimulationOverlayRadiusOption =>

--- a/src/lib/simulationOverlayRadius.ts
+++ b/src/lib/simulationOverlayRadius.ts
@@ -3,9 +3,9 @@ import { simulationAreaBoundsForSites } from "./simulationArea";
 import { tilesForBounds } from "./terrainTiles";
 import type { Site, SrtmTile } from "../types/radio";
 
-export type SimulationOverlayRadiusOption = "auto" | "20" | "50" | "100" | "200" | "500";
+export type SimulationOverlayRadiusOption = "auto" | "20" | "50" | "100" | "200";
 
-const SINGLE_SITE_OPTIONS: SimulationOverlayRadiusOption[] = ["auto", "100", "200", "500"];
+const SINGLE_SITE_OPTIONS: SimulationOverlayRadiusOption[] = ["auto", "100", "200"];
 const MULTI_SITE_OPTIONS: SimulationOverlayRadiusOption[] = ["20", "50", "100"];
 
 export const optionsForSelectionCount = (selectionCount: number): SimulationOverlayRadiusOption[] =>
@@ -26,7 +26,7 @@ export const normalizeOverlayRadiusOptionForSelectionCount = (
 
 export const isOverlayRadiusOption = (value: unknown): value is SimulationOverlayRadiusOption =>
   typeof value === "string" &&
-  (["auto", "20", "50", "100", "200", "500"] as const).includes(value as SimulationOverlayRadiusOption);
+  (["auto", "20", "50", "100", "200"] as const).includes(value as SimulationOverlayRadiusOption);
 
 export const resolveEffectiveOverlayRadiusKm = (params: {
   selectionCount: number;

--- a/src/lib/terrainMemory.test.ts
+++ b/src/lib/terrainMemory.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import type { SrtmTile } from "../types/radio";
+import {
+  COPERNICUS_30_TILE_DECODED_BYTES,
+  COPERNICUS_90_TILE_DECODED_BYTES,
+  estimateTerrainMemoryDiagnostics,
+  estimateTransientDecodeBytes,
+} from "./terrainMemory";
+
+const makeTile = (
+  key: string,
+  sourceId: SrtmTile["sourceId"],
+  sourceKind: SrtmTile["sourceKind"],
+  size: number,
+): SrtmTile => ({
+  key,
+  latStart: 60,
+  lonStart: 10,
+  size,
+  width: size,
+  height: size,
+  arcSecondSpacing: sourceId === "copernicus30" ? 1 : 3,
+  elevations: new Int16Array(size * size),
+  sourceId,
+  sourceKind,
+  sourceLabel: "test",
+});
+
+describe("terrainMemory", () => {
+  it("estimates retained decoded bytes by dataset", () => {
+    const tiles: SrtmTile[] = [
+      makeTile("N60E010", "copernicus30", "auto-fetch", 3601),
+      makeTile("N60E011", "copernicus90", "auto-fetch", 1201),
+      makeTile("N60E012", "manual", "manual-upload", 1201),
+      makeTile("N60E013", "other", "auto-fetch", 1201),
+    ];
+
+    const diagnostics = estimateTerrainMemoryDiagnostics(tiles);
+
+    expect(diagnostics.tileCountsByDataset).toEqual({
+      copernicus30: 1,
+      copernicus90: 1,
+      manual: 1,
+      other: 1,
+    });
+    expect(diagnostics.retainedBytesByDataset.copernicus30).toBe(COPERNICUS_30_TILE_DECODED_BYTES);
+    expect(diagnostics.retainedBytesByDataset.copernicus90).toBe(COPERNICUS_90_TILE_DECODED_BYTES);
+    expect(diagnostics.retainedBytesByDataset.manual).toBe(COPERNICUS_90_TILE_DECODED_BYTES);
+    expect(diagnostics.retainedBytesByDataset.other).toBe(COPERNICUS_90_TILE_DECODED_BYTES);
+    expect(diagnostics.retainedBytesTotal).toBe(
+      COPERNICUS_30_TILE_DECODED_BYTES + COPERNICUS_90_TILE_DECODED_BYTES * 3,
+    );
+  });
+
+  it("estimates transient decode bytes from in-flight tile counts", () => {
+    expect(estimateTransientDecodeBytes({ copernicus30: 2, copernicus90: 3 })).toBe(
+      COPERNICUS_30_TILE_DECODED_BYTES * 2 + COPERNICUS_90_TILE_DECODED_BYTES * 3,
+    );
+  });
+});

--- a/src/lib/terrainMemory.ts
+++ b/src/lib/terrainMemory.ts
@@ -1,0 +1,68 @@
+import type { SrtmTile } from "../types/radio";
+
+export const COPERNICUS_30_TILE_DECODED_BYTES = 3601 * 3601 * 2;
+export const COPERNICUS_90_TILE_DECODED_BYTES = 1201 * 1201 * 2;
+
+export type TerrainMemoryDiagnostics = {
+  retainedBytesTotal: number;
+  retainedBytesByDataset: {
+    copernicus30: number;
+    copernicus90: number;
+    manual: number;
+    other: number;
+  };
+  tileCountsByDataset: {
+    copernicus30: number;
+    copernicus90: number;
+    manual: number;
+    other: number;
+  };
+};
+
+const datasetBucketForTile = (tile: SrtmTile): keyof TerrainMemoryDiagnostics["retainedBytesByDataset"] => {
+  if (tile.sourceKind === "manual-upload") return "manual";
+  if (tile.sourceId === "copernicus30") return "copernicus30";
+  if (tile.sourceId === "copernicus90") return "copernicus90";
+  return "other";
+};
+
+const tileDecodedBytes = (tile: SrtmTile): number => {
+  const width = Math.max(1, tile.width ?? tile.size);
+  const height = Math.max(1, tile.height ?? tile.size);
+  return width * height * 2;
+};
+
+export const estimateTerrainMemoryDiagnostics = (tiles: ReadonlyArray<SrtmTile>): TerrainMemoryDiagnostics => {
+  const diagnostics: TerrainMemoryDiagnostics = {
+    retainedBytesTotal: 0,
+    retainedBytesByDataset: {
+      copernicus30: 0,
+      copernicus90: 0,
+      manual: 0,
+      other: 0,
+    },
+    tileCountsByDataset: {
+      copernicus30: 0,
+      copernicus90: 0,
+      manual: 0,
+      other: 0,
+    },
+  };
+
+  for (const tile of tiles) {
+    const bucket = datasetBucketForTile(tile);
+    const bytes = tileDecodedBytes(tile);
+    diagnostics.retainedBytesTotal += bytes;
+    diagnostics.retainedBytesByDataset[bucket] += bytes;
+    diagnostics.tileCountsByDataset[bucket] += 1;
+  }
+
+  return diagnostics;
+};
+
+export const estimateTransientDecodeBytes = (datasetTileCounts: {
+  copernicus30: number;
+  copernicus90: number;
+}): number =>
+  datasetTileCounts.copernicus30 * COPERNICUS_30_TILE_DECODED_BYTES +
+  datasetTileCounts.copernicus90 * COPERNICUS_90_TILE_DECODED_BYTES;

--- a/src/lib/terrainMerge.test.ts
+++ b/src/lib/terrainMerge.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { SrtmTile } from "../types/radio";
 import { mergeSrtmTiles } from "./terrainMerge";
 
-const makeTile = (key: string, lat: number, lon: number): SrtmTile => ({
+const makeTile = (key: string, lat: number, lon: number, sourceId = "copernicus30"): SrtmTile => ({
   key,
   latStart: lat,
   lonStart: lon,
@@ -12,8 +12,8 @@ const makeTile = (key: string, lat: number, lon: number): SrtmTile => ({
   arcSecondSpacing: 1,
   elevations: new Int16Array(3601 * 3601),
   sourceKind: "auto-fetch",
-  sourceId: "copernicus30",
-  sourceLabel: "Copernicus GLO-30",
+  sourceId,
+  sourceLabel: sourceId === "copernicus90" ? "Copernicus GLO-90" : "Copernicus GLO-30",
   sourceDetail: "test",
 });
 
@@ -39,9 +39,9 @@ describe("mergeSrtmTiles", () => {
     expect(result.map((t) => t.key).sort()).toEqual(["N60E009", "N60E010", "N61E009"]);
   });
 
-  it("incoming tile overwrites existing tile with same key", () => {
-    const existing = [makeTile("N60E009", 60, 9)];
-    const incoming = [{ ...makeTile("N60E009", 99, 99) }];
+  it("incoming same-rank tile overwrites existing tile with same key", () => {
+    const existing = [makeTile("N60E009", 60, 9, "copernicus30")];
+    const incoming = [makeTile("N60E009", 99, 99, "copernicus30")];
     const result = mergeSrtmTiles(existing, incoming);
     expect(result).toHaveLength(1);
     expect(result[0].latStart).toBe(99);
@@ -54,11 +54,21 @@ describe("mergeSrtmTiles", () => {
     expect(result.map((t) => t.key)).toEqual(["N60E009", "N61E009", "N60E010"]);
   });
 
-  it("incoming overwrites existing (not vice versa) for same key", () => {
-    const existing = [makeTile("N60E009", 60, 9)];
-    const incoming = [makeTile("N60E009", 99, 99)];
+  it("keeps existing 30m tile when incoming tile is 90m for same key", () => {
+    const existing = [makeTile("N60E009", 60, 9, "copernicus30")];
+    const incoming = [makeTile("N60E009", 99, 99, "copernicus90")];
+    const result = mergeSrtmTiles(existing, incoming);
+    expect(result).toHaveLength(1);
+    expect(result[0].latStart).toBe(60);
+    expect(result[0].sourceId).toBe("copernicus30");
+  });
+
+  it("promotes 90m tile to 30m tile when incoming 30m arrives", () => {
+    const existing = [makeTile("N60E009", 60, 9, "copernicus90")];
+    const incoming = [makeTile("N60E009", 99, 99, "copernicus30")];
     const result = mergeSrtmTiles(existing, incoming);
     expect(result).toHaveLength(1);
     expect(result[0].latStart).toBe(99);
+    expect(result[0].sourceId).toBe("copernicus30");
   });
 });

--- a/src/lib/terrainMerge.ts
+++ b/src/lib/terrainMerge.ts
@@ -1,8 +1,26 @@
 import type { SrtmTile } from "../types/radio";
 
+const tileQualityRank = (tile: SrtmTile): number => {
+  if (tile.sourceKind === "manual-upload") return 4;
+  if (tile.sourceId === "copernicus30") return 3;
+  if (tile.sourceId === "copernicus90") return 2;
+  return 1;
+};
+
 export const mergeSrtmTiles = (existing: SrtmTile[], incoming: SrtmTile[]): SrtmTile[] => {
   const dedup = new Map<string, SrtmTile>();
   for (const tile of existing) dedup.set(tile.key, tile);
-  for (const tile of incoming) dedup.set(tile.key, tile);
+  for (const tile of incoming) {
+    const previous = dedup.get(tile.key);
+    if (!previous) {
+      dedup.set(tile.key, tile);
+      continue;
+    }
+    const incomingRank = tileQualityRank(tile);
+    const previousRank = tileQualityRank(previous);
+    if (incomingRank >= previousRank) {
+      dedup.set(tile.key, tile);
+    }
+  }
   return Array.from(dedup.values());
 };

--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -195,7 +195,7 @@ describe("appStore auth guards", () => {
             selectedSiteId: "",
             selectedLinkId: "",
             selectedNetworkId: "",
-            selectedCoverageResolution: "normal",
+            selectedCoverageResolution: "24",
             propagationModel: "ITM",
             selectedFrequencyPresetId: "custom",
             rxSensitivityTargetDbm: -120,

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -574,9 +574,9 @@ type AppState = {
   updateMapViewport: (patch: Partial<MapViewport>) => void;
   ingestSrtmFiles: (files: FileList | File[]) => Promise<void>;
   recommendTerrainDatasetForCurrentArea: () => Promise<void>;
-  fetchTerrainForCurrentArea: () => Promise<void>;
-  recommendAndFetchTerrainForCurrentArea: () => Promise<void>;
-  loadTerrainForCurrentArea: () => Promise<void>;
+  fetchTerrainForCurrentArea: (targetRadiusKm?: number) => Promise<void>;
+  recommendAndFetchTerrainForCurrentArea: (targetRadiusKm?: number) => Promise<void>;
+  loadTerrainForCurrentArea: (targetRadiusKm?: number) => Promise<void>;
   loadTerrainForCoordinate: (lat: number, lon: number) => Promise<void>;
   clearTerrainCache: () => Promise<void>;
   getSelectedLink: () => Link;
@@ -3331,13 +3331,14 @@ export const useAppStore = create<AppState>((set, get) => ({
       set({ terrainRecommendation: `Recommendation failed: ${message}`, isTerrainRecommending: false });
     }
   },
-  fetchTerrainForCurrentArea: async () => {
+  fetchTerrainForCurrentArea: async (targetRadiusKm = 20) => {
     const { sites, srtmTiles, isTerrainFetching } = get();
     if (isTerrainFetching) return;
     if (!sites.length) return;
 
-    const coreBounds = bufferedBoundsForSites(sites, 20);
-    const extendedBounds = bufferedBoundsForSites(sites, 40);
+    const radiusKm = Math.max(20, Math.min(500, Math.round(targetRadiusKm)));
+    const coreBounds = bufferedBoundsForSites(sites, radiusKm);
+    const extendedBounds = bufferedBoundsForSites(sites, radiusKm);
     if (!coreBounds || !extendedBounds) return;
 
     const requiredTileKeys = new Set(
@@ -3367,7 +3368,9 @@ export const useAppStore = create<AppState>((set, get) => ({
     }
 
     set({
-      terrainFetchStatus: isSmallArea ? "Loading terrain (30m, small area)..." : "Loading terrain (90m, broad coverage)...",
+      terrainFetchStatus:
+        (isSmallArea ? "Loading terrain (30m, small area)" : "Loading terrain (90m, broad coverage)") +
+        ` for ${radiusKm} km...`,
       isTerrainFetching: true,
       isHighResTerrainLoaded: alreadyHasHighRes,
       terrainLoadingStartedAtMs: Date.now(),
@@ -3479,7 +3482,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       }
 
       if (isSmallArea) {
-        set({ terrainFetchStatus: "Loading terrain (30m, small area)...", isHighResTerrainLoaded: false });
+        set({ terrainFetchStatus: `Loading terrain (30m, small area) for ${radiusKm} km...`, isHighResTerrainLoaded: false });
         const phased = await loadPhased("copernicus30", coreBounds);
         applyTiles(phased.priority);
         applyTiles(phased.remaining);
@@ -3497,7 +3500,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 
       const ninetyPhased = await loadPhased("copernicus90", coreBounds, endpointKeys);
       applyTiles(ninetyPhased.priority);
-      set({ terrainFetchStatus: "Loading terrain (90m, broad coverage refinement)..." });
+      set({ terrainFetchStatus: `Loading terrain (90m, broad coverage refinement) for ${radiusKm} km...` });
       applyTiles(ninetyPhased.remaining);
       const ninetyResult = mergeLoadResults(ninetyPhased.priority, ninetyPhased.remaining);
 
@@ -3516,7 +3519,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       }
 
       extendTerrainProgressTotal(requiredTileKeys.size);
-      set({ terrainFetchStatus: "Loading terrain (30m, high-res refinement)...", isHighResTerrainLoaded: false });
+      set({ terrainFetchStatus: `Loading terrain (30m, high-res refinement) for ${radiusKm} km...`, isHighResTerrainLoaded: false });
       const thirtyPhased = await loadPhased("copernicus30", coreBounds, endpointKeys);
       applyTiles(thirtyPhased.priority);
       applyTiles(thirtyPhased.remaining);
@@ -3524,7 +3527,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 
       if (extendedOnlyKeys.size > 0) {
         extendTerrainProgressTotal(extendedOnlyKeys.size);
-        set({ terrainFetchStatus: "Loading terrain (30m, extended radial area)..." });
+        set({ terrainFetchStatus: `Loading terrain (30m, extended radial area) for ${radiusKm} km...` });
         const extendedPhased = await loadPhased("copernicus30", extendedBounds, extendedOnlyKeys, true);
         applyTiles(extendedPhased.priority);
       }
@@ -3541,7 +3544,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       set({ terrainFetchStatus: `Terrain fetch failed: ${message}`, isTerrainFetching: false, terrainLoadingStartedAtMs: 0 });
     }
   },
-  recommendAndFetchTerrainForCurrentArea: () => get().loadTerrainForCurrentArea(),
+  recommendAndFetchTerrainForCurrentArea: (targetRadiusKm) => get().loadTerrainForCurrentArea(targetRadiusKm),
   loadTerrainForCoordinate: async (lat: number, lon: number) => {
     const { isEditorTerrainFetching, srtmTiles, terrainDataset } = get();
     if (isEditorTerrainFetching) return;
@@ -3565,13 +3568,14 @@ export const useAppStore = create<AppState>((set, get) => ({
       set({ isEditorTerrainFetching: false });
     }
   },
-  loadTerrainForCurrentArea: async () => {
+  loadTerrainForCurrentArea: async (targetRadiusKm = 20) => {
     if (get().isTerrainFetching) return;
     const { sites } = get();
     if (!sites.length) return;
 
-    const coreBounds = bufferedBoundsForSites(sites, 20);
-    const extendedBounds = bufferedBoundsForSites(sites, 40);
+    const radiusKm = Math.max(20, Math.min(500, Math.round(targetRadiusKm)));
+    const coreBounds = bufferedBoundsForSites(sites, radiusKm);
+    const extendedBounds = bufferedBoundsForSites(sites, radiusKm);
     if (!coreBounds || !extendedBounds) return;
 
     const { terrainLoadEpoch: currentEpoch } = get();
@@ -3582,7 +3586,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       isTerrainRecommending: true,
       isTerrainFetching: true,
       terrainRecommendation: "Evaluating terrain dataset coverage...",
-      terrainFetchStatus: "Loading terrain (90m)...",
+      terrainFetchStatus: `Loading terrain (90m) for ${radiusKm} km...`,
       terrainLoadingStartedAtMs: Date.now(),
       terrainProgressPercent: 0,
       terrainProgressTilesLoaded: 0,
@@ -3650,7 +3654,9 @@ export const useAppStore = create<AppState>((set, get) => ({
     }
 
     set({
-      terrainFetchStatus: isSmallArea ? "Loading terrain (30m, small area)..." : "Loading terrain (90m, broad coverage)...",
+      terrainFetchStatus:
+        (isSmallArea ? "Loading terrain (30m, small area)" : "Loading terrain (90m, broad coverage)") +
+        ` for ${radiusKm} km...`,
       isHighResTerrainLoaded: alreadyHasHighRes,
     });
 
@@ -3756,7 +3762,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       }
 
       if (isSmallArea) {
-        set({ terrainFetchStatus: "Loading terrain (30m, small area)...", isHighResTerrainLoaded: false });
+        set({ terrainFetchStatus: `Loading terrain (30m, small area) for ${radiusKm} km...`, isHighResTerrainLoaded: false });
         const phased = await loadPhased("copernicus30", coreBounds);
         if (get().terrainLoadEpoch !== epoch) return;
         applyTiles(phased.priority);
@@ -3793,7 +3799,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       }
 
       extendTerrainProgressTotal(requiredTileKeys.size);
-      set({ terrainFetchStatus: "Loading terrain (30m, high-res refinement)...", isHighResTerrainLoaded: false });
+      set({ terrainFetchStatus: `Loading terrain (30m, high-res refinement) for ${radiusKm} km...`, isHighResTerrainLoaded: false });
       const thirtyPhased = await loadPhased("copernicus30", coreBounds, endpointKeys);
       if (get().terrainLoadEpoch !== epoch) return;
       applyTiles(thirtyPhased.priority);
@@ -3802,7 +3808,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 
       if (extendedOnlyKeys.size > 0) {
         extendTerrainProgressTotal(extendedOnlyKeys.size);
-        set({ terrainFetchStatus: "Loading terrain (30m, extended radial area)..." });
+        set({ terrainFetchStatus: `Loading terrain (30m, extended radial area) for ${radiusKm} km...` });
         const extendedPhased = await loadPhased("copernicus30", extendedBounds, extendedOnlyKeys, true);
         if (get().terrainLoadEpoch !== epoch) return;
         applyTiles(extendedPhased.priority);

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -40,6 +40,11 @@ import {
 } from "../lib/terrainDataset";
 import { atmosphericBendingNUnitsToKFactor } from "../lib/terrainLoss";
 import {
+  estimateTerrainMemoryDiagnostics,
+  estimateTransientDecodeBytes,
+  type TerrainMemoryDiagnostics,
+} from "../lib/terrainMemory";
+import {
   defaultOptionForSelectionCount,
   isOverlayRadiusOption,
   type SimulationOverlayRadiusOption,
@@ -407,6 +412,11 @@ type AppState = {
   terrainProgressTilesTotal: number;
   terrainProgressBytesLoaded: number;
   terrainProgressBytesEstimated: number;
+  terrainProgressTransientDecodeBytesEstimated: number;
+  terrainProgressPhaseLabel: string;
+  terrainProgressPhaseIndex: number;
+  terrainProgressPhaseTotal: number;
+  terrainMemoryDiagnostics: TerrainMemoryDiagnostics;
   siteLibrary: SiteLibraryEntry[];
   simulationPresets: SimulationPreset[];
   siteDragPreview: Record<string, { position: { lat: number; lon: number }; groundElevationM: number }>;
@@ -1211,6 +1221,11 @@ export const useAppStore = create<AppState>((set, get) => ({
   terrainProgressTilesTotal: 0,
   terrainProgressBytesLoaded: 0,
   terrainProgressBytesEstimated: 0,
+  terrainProgressTransientDecodeBytesEstimated: 0,
+  terrainProgressPhaseLabel: "",
+  terrainProgressPhaseIndex: 0,
+  terrainProgressPhaseTotal: 0,
+  terrainMemoryDiagnostics: estimateTerrainMemoryDiagnostics([]),
   siteLibrary: initialSiteLibrary,
   simulationPresets: initialSimulationPresets,
   siteDragPreview: {},
@@ -3293,11 +3308,15 @@ export const useAppStore = create<AppState>((set, get) => ({
         }),
       );
 
-      set((state) => ({
-        srtmTiles: mergeSrtmTiles(state.srtmTiles, parsed),
-        isTerrainFetching: false,
-        terrainProgressPercent: 0,
-      }));
+      set((state) => {
+        const nextTiles = mergeSrtmTiles(state.srtmTiles, parsed);
+        return {
+          srtmTiles: nextTiles,
+          terrainMemoryDiagnostics: estimateTerrainMemoryDiagnostics(nextTiles),
+          isTerrainFetching: false,
+          terrainProgressPercent: 0,
+        };
+      });
       clearTerrainLossCache();
       useCoverageStore.getState().recomputeCoverage();
     } finally {
@@ -3440,9 +3459,13 @@ export const useAppStore = create<AppState>((set, get) => ({
 
     const applyTiles = (result: CopernicusLoadResult) => {
       if (!result.tiles.length) return;
-      set((state) => ({
-        srtmTiles: mergeSrtmTiles(state.srtmTiles, result.tiles),
-      }));
+      set((state) => {
+        const nextTiles = mergeSrtmTiles(state.srtmTiles, result.tiles);
+        return {
+          srtmTiles: nextTiles,
+          terrainMemoryDiagnostics: estimateTerrainMemoryDiagnostics(nextTiles),
+        };
+      });
       useCoverageStore.getState().recomputeCoverage();
     };
 
@@ -3562,7 +3585,13 @@ export const useAppStore = create<AppState>((set, get) => ({
       );
       const incoming = [...result.priority.tiles, ...result.remaining.tiles];
       if (incoming.length > 0) {
-        set((s) => ({ srtmTiles: mergeSrtmTiles(s.srtmTiles, incoming) }));
+        set((state) => {
+          const nextTiles = mergeSrtmTiles(state.srtmTiles, incoming);
+          return {
+            srtmTiles: nextTiles,
+            terrainMemoryDiagnostics: estimateTerrainMemoryDiagnostics(nextTiles),
+          };
+        });
       }
     } finally {
       set({ isEditorTerrainFetching: false });
@@ -3593,6 +3622,10 @@ export const useAppStore = create<AppState>((set, get) => ({
       terrainProgressTilesTotal: 0,
       terrainProgressBytesLoaded: 0,
       terrainProgressBytesEstimated: 0,
+      terrainProgressTransientDecodeBytesEstimated: 0,
+      terrainProgressPhaseLabel: "",
+      terrainProgressPhaseIndex: 0,
+      terrainProgressPhaseTotal: 0,
     });
 
     try {
@@ -3620,6 +3653,10 @@ export const useAppStore = create<AppState>((set, get) => ({
         isTerrainFetching: false,
         terrainLoadingStartedAtMs: 0,
         terrainProgressPercent: 0,
+        terrainProgressTransientDecodeBytesEstimated: 0,
+        terrainProgressPhaseLabel: "",
+        terrainProgressPhaseIndex: 0,
+        terrainProgressPhaseTotal: 0,
       });
       return;
     }
@@ -3653,17 +3690,22 @@ export const useAppStore = create<AppState>((set, get) => ({
       }
     }
 
+    const terrainPhaseTotal = isSmallArea ? 1 : extendedOnlyKeys.size > 0 ? 3 : 2;
     set({
       terrainFetchStatus:
         (isSmallArea ? "Loading terrain (30m, small area)" : "Loading terrain (90m, broad coverage)") +
         ` for ${radiusKm} km...`,
       isHighResTerrainLoaded: alreadyHasHighRes,
+      terrainProgressPhaseTotal: terrainPhaseTotal,
     });
 
     let terrainProgressTilesLoaded = 0;
     let terrainProgressTilesTotal = isSmallArea ? requiredTileKeys.size : requiredTileKeys.size;
     let terrainProgressBytesLoaded = 0;
     let terrainProgressMeasuredTiles = 0;
+    let terrainProgressPhaseIndex = 0;
+    let terrainProgressPhaseLabel = "";
+    let terrainPhaseTileCounts: { copernicus30: number; copernicus90: number } = { copernicus30: 0, copernicus90: 0 };
     const syncTerrainProgress = () => {
       const estimatedBytes =
         terrainProgressMeasuredTiles > 0
@@ -3679,12 +3721,26 @@ export const useAppStore = create<AppState>((set, get) => ({
         terrainProgressTilesTotal,
         terrainProgressBytesLoaded,
         terrainProgressBytesEstimated: estimatedBytes,
+        terrainProgressTransientDecodeBytesEstimated: estimateTransientDecodeBytes(terrainPhaseTileCounts),
+        terrainProgressPhaseLabel,
+        terrainProgressPhaseIndex,
+        terrainProgressPhaseTotal: terrainPhaseTotal,
       });
     };
-    syncTerrainProgress();
-    const extendTerrainProgressTotal = (byTiles: number) => {
-      if (byTiles <= 0) return;
-      terrainProgressTilesTotal += byTiles;
+    const startTerrainPhase = (phaseLabel: string, totalTiles: number, statusText: string) => {
+      terrainProgressPhaseIndex += 1;
+      terrainProgressPhaseLabel = phaseLabel;
+      terrainProgressTilesLoaded = 0;
+      terrainProgressTilesTotal = Math.max(0, totalTiles);
+      terrainProgressBytesLoaded = 0;
+      terrainProgressMeasuredTiles = 0;
+      terrainPhaseTileCounts = { copernicus30: 0, copernicus90: 0 };
+      set({
+        terrainFetchStatus: statusText,
+        terrainProgressPhaseIndex,
+        terrainProgressPhaseLabel,
+        terrainProgressPhaseTotal: terrainPhaseTotal,
+      });
       syncTerrainProgress();
     };
     const makeTileProgressHandler = () => {
@@ -3694,6 +3750,8 @@ export const useAppStore = create<AppState>((set, get) => ({
         if (seen.has(key)) return;
         seen.add(key);
         terrainProgressTilesLoaded += 1;
+        if (progress.dataset === "copernicus30") terrainPhaseTileCounts.copernicus30 += 1;
+        if (progress.dataset === "copernicus90") terrainPhaseTileCounts.copernicus90 += 1;
         if (progress.bytes > 0) {
           terrainProgressBytesLoaded += progress.bytes;
           terrainProgressMeasuredTiles += 1;
@@ -3720,9 +3778,13 @@ export const useAppStore = create<AppState>((set, get) => ({
 
     const applyTiles = (result: CopernicusLoadResult) => {
       if (!result.tiles.length) return;
-      set((state) => ({
-        srtmTiles: mergeSrtmTiles(state.srtmTiles, result.tiles),
-      }));
+      set((state) => {
+        const nextTiles = mergeSrtmTiles(state.srtmTiles, result.tiles);
+        return {
+          srtmTiles: nextTiles,
+          terrainMemoryDiagnostics: estimateTerrainMemoryDiagnostics(nextTiles),
+        };
+      });
       useCoverageStore.getState().recomputeCoverage();
     };
 
@@ -3757,12 +3819,17 @@ export const useAppStore = create<AppState>((set, get) => ({
           isTerrainFetching: false,
           terrainLoadingStartedAtMs: 0,
           terrainProgressPercent: 100,
+          terrainProgressTransientDecodeBytesEstimated: 0,
+          terrainProgressPhaseLabel: "",
+          terrainProgressPhaseIndex: 0,
+          terrainProgressPhaseTotal: 0,
         });
         return;
       }
 
       if (isSmallArea) {
-        set({ terrainFetchStatus: `Loading terrain (30m, small area) for ${radiusKm} km...`, isHighResTerrainLoaded: false });
+        set({ isHighResTerrainLoaded: false });
+        startTerrainPhase("30m small area", requiredTileKeys.size, `Loading terrain (30m, small area) for ${radiusKm} km...`);
         const phased = await loadPhased("copernicus30", coreBounds);
         if (get().terrainLoadEpoch !== epoch) return;
         applyTiles(phased.priority);
@@ -3774,10 +3841,15 @@ export const useAppStore = create<AppState>((set, get) => ({
           isHighResTerrainLoaded: true,
           terrainLoadingStartedAtMs: 0,
           terrainProgressPercent: 100,
+          terrainProgressTransientDecodeBytesEstimated: 0,
+          terrainProgressPhaseLabel: "",
+          terrainProgressPhaseIndex: 0,
+          terrainProgressPhaseTotal: 0,
         });
         return;
       }
 
+      startTerrainPhase("90m broad coverage", requiredTileKeys.size, `Loading terrain (90m, broad coverage) for ${radiusKm} km...`);
       const ninetyPhased = await loadPhased("copernicus90", coreBounds, endpointKeys);
       if (get().terrainLoadEpoch !== epoch) return;
       applyTiles(ninetyPhased.priority);
@@ -3794,12 +3866,20 @@ export const useAppStore = create<AppState>((set, get) => ({
           isHighResTerrainLoaded: true,
           terrainLoadingStartedAtMs: 0,
           terrainProgressPercent: 100,
+          terrainProgressTransientDecodeBytesEstimated: 0,
+          terrainProgressPhaseLabel: "",
+          terrainProgressPhaseIndex: 0,
+          terrainProgressPhaseTotal: 0,
         });
         return;
       }
 
-      extendTerrainProgressTotal(requiredTileKeys.size);
-      set({ terrainFetchStatus: `Loading terrain (30m, high-res refinement) for ${radiusKm} km...`, isHighResTerrainLoaded: false });
+      set({ isHighResTerrainLoaded: false });
+      startTerrainPhase(
+        "30m high-res refinement",
+        requiredTileKeys.size,
+        `Loading terrain (30m, high-res refinement) for ${radiusKm} km...`,
+      );
       const thirtyPhased = await loadPhased("copernicus30", coreBounds, endpointKeys);
       if (get().terrainLoadEpoch !== epoch) return;
       applyTiles(thirtyPhased.priority);
@@ -3807,8 +3887,11 @@ export const useAppStore = create<AppState>((set, get) => ({
       const thirtyResult = mergeLoadResults(thirtyPhased.priority, thirtyPhased.remaining);
 
       if (extendedOnlyKeys.size > 0) {
-        extendTerrainProgressTotal(extendedOnlyKeys.size);
-        set({ terrainFetchStatus: `Loading terrain (30m, extended radial area) for ${radiusKm} km...` });
+        startTerrainPhase(
+          "30m radial extension",
+          extendedOnlyKeys.size,
+          `Loading terrain (30m, extended radial area) for ${radiusKm} km...`,
+        );
         const extendedPhased = await loadPhased("copernicus30", extendedBounds, extendedOnlyKeys, true);
         if (get().terrainLoadEpoch !== epoch) return;
         applyTiles(extendedPhased.priority);
@@ -3819,6 +3902,10 @@ export const useAppStore = create<AppState>((set, get) => ({
         isHighResTerrainLoaded: true,
         terrainLoadingStartedAtMs: 0,
         terrainProgressPercent: 100,
+        terrainProgressTransientDecodeBytesEstimated: 0,
+        terrainProgressPhaseLabel: "",
+        terrainProgressPhaseIndex: 0,
+        terrainProgressPhaseTotal: 0,
       });
     } catch (error) {
       if (get().terrainLoadEpoch !== epoch) return;
@@ -3826,6 +3913,10 @@ export const useAppStore = create<AppState>((set, get) => ({
         terrainFetchStatus: `Terrain fetch failed: ${getUiErrorMessage(error)}`,
         isTerrainFetching: false,
         terrainLoadingStartedAtMs: 0,
+        terrainProgressTransientDecodeBytesEstimated: 0,
+        terrainProgressPhaseLabel: "",
+        terrainProgressPhaseIndex: 0,
+        terrainProgressPhaseTotal: 0,
       });
     }
   },
@@ -3833,19 +3924,27 @@ export const useAppStore = create<AppState>((set, get) => ({
     set({ isTerrainFetching: true, terrainProgressPercent: 0 });
     await clearCopernicusCache();
     clearTerrainLossCache();
-    set((state) => ({
-      srtmTiles: state.srtmTiles.filter((tile) => tile.sourceKind === "manual-upload"),
-      isTerrainFetching: false,
-      isHighResTerrainLoaded: false,
-      terrainLoadingStartedAtMs: 0,
-      terrainLoadEpoch: 0,
-      terrainProgressPercent: 0,
-      terrainProgressTilesLoaded: 0,
-      terrainProgressTilesTotal: 0,
-      terrainProgressBytesLoaded: 0,
-      terrainProgressBytesEstimated: 0,
-      terrainFetchStatus: "Terrain source caches cleared.",
-    }));
+    set((state) => {
+      const nextTiles = state.srtmTiles.filter((tile) => tile.sourceKind === "manual-upload");
+      return {
+        srtmTiles: nextTiles,
+        terrainMemoryDiagnostics: estimateTerrainMemoryDiagnostics(nextTiles),
+        isTerrainFetching: false,
+        isHighResTerrainLoaded: false,
+        terrainLoadingStartedAtMs: 0,
+        terrainLoadEpoch: 0,
+        terrainProgressPercent: 0,
+        terrainProgressTilesLoaded: 0,
+        terrainProgressTilesTotal: 0,
+        terrainProgressBytesLoaded: 0,
+        terrainProgressBytesEstimated: 0,
+        terrainProgressTransientDecodeBytesEstimated: 0,
+        terrainProgressPhaseLabel: "",
+        terrainProgressPhaseIndex: 0,
+        terrainProgressPhaseTotal: 0,
+        terrainFetchStatus: "Terrain source caches cleared.",
+      };
+    });
     useCoverageStore.getState().recomputeCoverage();
   },
   getSelectedLink: () => {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1177,6 +1177,13 @@ const initialBasemapStylePreset = normalizeBasemapStylePreset(
   readStorage<string>(BASEMAP_STYLE_PRESET_KEY, "normal-themed"),
 );
 
+const normalizeCoverageResolution = (value: unknown): CoverageResolution => {
+  if (value === "24" || value === "42" || value === "84" || value === "168") return value;
+  if (value === "high") return "42";
+  if (value === "normal") return "24";
+  return "24";
+};
+
 export const useAppStore = create<AppState>((set, get) => ({
   sites: [],
   links: [],
@@ -1193,7 +1200,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   selectedSiteId: "",
   selectedSiteIds: [],
   selectedNetworkId: "",
-  selectedCoverageResolution: "normal",
+  selectedCoverageResolution: "24",
   selectedOverlayRadiusOption: "20",
   propagationModel: "ITM",
   mapViewport: undefined,
@@ -2850,10 +2857,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         selectedLinkId: "",
         temporaryDirectionReversed: false,
         selectedNetworkId: "",
-        selectedCoverageResolution:
-          snap.selectedCoverageResolution === "normal" || snap.selectedCoverageResolution === "high"
-            ? snap.selectedCoverageResolution
-            : "normal",
+        selectedCoverageResolution: normalizeCoverageResolution(snap.selectedCoverageResolution),
         selectedOverlayRadiusOption: isOverlayRadiusOption(snap.selectedOverlayRadiusOption)
           ? snap.selectedOverlayRadiusOption
           : defaultOptionForSelectionCount(0),
@@ -2907,10 +2911,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       selectedLinkId,
       temporaryDirectionReversed: false,
       selectedNetworkId,
-      selectedCoverageResolution:
-        snap.selectedCoverageResolution === "normal" || snap.selectedCoverageResolution === "high"
-          ? snap.selectedCoverageResolution
-          : "normal",
+      selectedCoverageResolution: normalizeCoverageResolution(snap.selectedCoverageResolution),
       selectedOverlayRadiusOption: isOverlayRadiusOption(snap.selectedOverlayRadiusOption)
         ? snap.selectedOverlayRadiusOption
         : defaultOptionForSelectionCount(selectedSiteId ? 1 : 0),

--- a/src/store/coverageStore.ts
+++ b/src/store/coverageStore.ts
@@ -5,7 +5,9 @@ import {
 } from "../lib/propagationEnvironment";
 import {
   normalizeOverlayRadiusOptionForSelectionCount,
+  resolveLoadedOverlayRadiusCapKm,
   resolveEffectiveOverlayRadiusKm,
+  resolveTargetOverlayRadiusKm,
 } from "../lib/simulationOverlayRadius";
 import { sampleSrtmElevation } from "../lib/srtm";
 import type { Site, SrtmTile } from "../types/radio";
@@ -148,6 +150,14 @@ export const useCoverageStore = create<CoverageState>((set, get) => ({
           srtmTiles,
           isTerrainFetching,
         });
+        const targetRadiusKm = resolveTargetOverlayRadiusKm(selectionCount, selectedOverlayRadiusOption);
+        const loadedRadiusCapKm = resolveLoadedOverlayRadiusCapKm(
+          selectionCount === 1 && selectedSingleSite ? [selectedSingleSite] : sites,
+          targetRadiusKm,
+          srtmTiles,
+          20,
+        );
+        const effectiveOverlayRadiusKm = Math.min(targetRadiusKm, overlayRadiusKm, loadedRadiusCapKm);
 
         set({ simulationProgress: 8 });
         let lastProgress = 8;
@@ -162,7 +172,7 @@ export const useCoverageStore = create<CoverageState>((set, get) => ({
           {
             sampleMultiplier: 1,
             terrainSamples: 20,
-            overlayRadiusKm,
+            overlayRadiusKm: effectiveOverlayRadiusKm,
             onProgress: (progress: number) => {
               if (get().simulationRunToken !== runId) return;
               const next = Math.round(8 + progress * 84);

--- a/src/store/coverageStore.ts
+++ b/src/store/coverageStore.ts
@@ -65,8 +65,17 @@ export const useCoverageStore = create<CoverageState>((set, get) => ({
         if (get().simulationRunToken !== runId) return;
 
         const appState = appStoreBridge!.getState();
-        const selectedCoverageResolution = (appState.selectedCoverageResolution as string) === "high" ? "high" : "normal";
-        const gridSize = selectedCoverageResolution === "high" ? 42 : 24;
+        const selectedCoverageResolutionRaw = appState.selectedCoverageResolution as string;
+        const selectedCoverageResolution =
+          selectedCoverageResolutionRaw === "24" ||
+          selectedCoverageResolutionRaw === "42" ||
+          selectedCoverageResolutionRaw === "84" ||
+          selectedCoverageResolutionRaw === "168"
+            ? selectedCoverageResolutionRaw
+            : selectedCoverageResolutionRaw === "high"
+              ? "42"
+              : "24";
+        const gridSize = Number(selectedCoverageResolution);
         const networks = appState.networks as Array<{ id: string; [key: string]: unknown }>;
         const selectedNetworkId = appState.selectedNetworkId as string;
         const sites = appState.sites as Site[];

--- a/src/types/radio.ts
+++ b/src/types/radio.ts
@@ -30,7 +30,7 @@ export type Link = {
 
 export type PropagationModel = "ITM";
 export type CoverageMode = "BestSite";
-export type CoverageResolution = "normal" | "high";
+export type CoverageResolution = "24" | "42" | "84" | "168";
 export type Polarization = "Vertical" | "Horizontal";
 export type RadioClimate =
   | "Equatorial"


### PR DESCRIPTION
## Summary
- reset simulation radius by context transition (single-site=50, non-single-site=20)
- restore auto-fit guardrails and fit-toggle behavior
- make fit insets panel-aware including mobile bottom occupancy
- fix mobile inspector tab rendering gate
- restore smooth animated fit transitions

## Verification
- npm test
- npm run build