### PR TITLE
#176: fix overlay min-size clamp flattening resolution levels

### DIFF
--- a/functions/_lib/buildInfo.ts
+++ b/functions/_lib/buildInfo.ts
@@ -1,5 +1,5 @@
 export const APP_VERSION = "0.15.0";
-export const APP_COMMIT = "ab68ce2b";
+export const APP_COMMIT = "57fc3f70";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -517,8 +517,8 @@ const computeOverlayDimensions = (
   const scaledWidth = Math.round(cols * resolutionScale);
   const scaledHeight = Math.round(rows * resolutionScale);
   return {
-    width: clamp(scaledWidth, 64, 1400),
-    height: clamp(scaledHeight, 64, 1400),
+    width: clamp(scaledWidth, 8, 1400),
+    height: clamp(scaledHeight, 8, 1400),
   };
 };
 
@@ -1539,7 +1539,7 @@ export function MapView({
 
   const overlayDimensions = useMemo(() => {
     const bounds = analysisBounds ?? computeCoverageBounds(samplesForOverlay);
-    if (!bounds) return { width: 64, height: 64 };
+    if (!bounds) return { width: 24, height: 24 };
     return computeOverlayDimensions(bounds, effectiveGridSize, overlayResolutionScale);
   }, [analysisBounds, samplesForOverlay, effectiveGridSize, overlayResolutionScale]);
 

--- a/src/lib/buildInfo.ts
+++ b/src/lib/buildInfo.ts
@@ -1,5 +1,5 @@
 export const APP_VERSION = "0.15.0";
-export const APP_COMMIT = "ab68ce2b";
+export const APP_COMMIT = "57fc3f70";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {


### PR DESCRIPTION
## Summary
- remove aggressive minimum overlay raster clamp that collapsed multiple simulation resolutions to same rendered size
- keep grid-derived dimensions + large-area scale, but allow lower bounded sizes to stay distinct by mode

## Verification
- npm test
- npm run build