### PR TITLE
#176: improve overlay crispness with proportional supersampling

### DIFF
--- a/functions/_lib/buildInfo.ts
+++ b/functions/_lib/buildInfo.ts
@@ -1,5 +1,5 @@
 export const APP_VERSION = "0.15.0";
-export const APP_COMMIT = "57fc3f70";
+export const APP_COMMIT = "168ce760";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -514,8 +514,11 @@ const computeOverlayDimensions = (
   resolutionScale = 1,
 ): { width: number; height: number } => {
   const { rows, cols } = computeCoverageGridDimensions(targetGridSize, bounds, 1);
-  const scaledWidth = Math.round(cols * resolutionScale);
-  const scaledHeight = Math.round(rows * resolutionScale);
+  // Keep display raster proportional to simulation sample grid, but supersample
+  // for smoother visual output while preserving relative resolution differences.
+  const displaySupersample = 2;
+  const scaledWidth = Math.round(cols * resolutionScale * displaySupersample);
+  const scaledHeight = Math.round(rows * resolutionScale * displaySupersample);
   return {
     width: clamp(scaledWidth, 8, 1400),
     height: clamp(scaledHeight, 8, 1400),

--- a/src/lib/buildInfo.ts
+++ b/src/lib/buildInfo.ts
@@ -1,5 +1,5 @@
 export const APP_VERSION = "0.15.0";
-export const APP_COMMIT = "57fc3f70";
+export const APP_COMMIT = "168ce760";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {


### PR DESCRIPTION
## Summary
- add 2x proportional display supersampling to overlay raster dimensions
- keep dimensions tied to simulation grid + large-area scale so quality differences remain visible

## Verification
- npm test
- npm run build