### PR TITLE
#176: calibrate overlay rendering to 24x24 historical baseline

### DIFF
--- a/functions/_lib/buildInfo.ts
+++ b/functions/_lib/buildInfo.ts
@@ -1,5 +1,5 @@
 export const APP_VERSION = "0.15.0";
-export const APP_COMMIT = "168ce760";
+export const APP_COMMIT = "c6140f35";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -514,9 +514,10 @@ const computeOverlayDimensions = (
   resolutionScale = 1,
 ): { width: number; height: number } => {
   const { rows, cols } = computeCoverageGridDimensions(targetGridSize, bounds, 1);
-  // Keep display raster proportional to simulation sample grid, but supersample
-  // for smoother visual output while preserving relative resolution differences.
-  const displaySupersample = 2;
+  // Match the historical visual baseline (~100k display pixels at 24x24 samples)
+  // while keeping display density proportional to simulation sample density.
+  const targetDisplayPixelsPerSample = 174;
+  const displaySupersample = Math.sqrt(targetDisplayPixelsPerSample);
   const scaledWidth = Math.round(cols * resolutionScale * displaySupersample);
   const scaledHeight = Math.round(rows * resolutionScale * displaySupersample);
   return {

--- a/src/lib/buildInfo.ts
+++ b/src/lib/buildInfo.ts
@@ -1,5 +1,5 @@
 export const APP_VERSION = "0.15.0";
-export const APP_COMMIT = "168ce760";
+export const APP_COMMIT = "c6140f35";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {


### PR DESCRIPTION
## Summary
- calibrate overlay display density to historical baseline (~100k display pixels at 24x24)
- keep density proportional to simulation sample grid and current optimization scale

## Verification
- npm test
- npm run build