### PR TITLE
Issue #176 follow-up: truthful progress + basemap no-recompute guards

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1108,6 +1108,8 @@ export function MapView({
   const propagationEnvironment = useAppStore((state) => state.propagationEnvironment);
   const isSimulationRecomputing = useCoverageStore((state) => state.isSimulationRecomputing);
   const simulationProgress = useCoverageStore((state) => state.simulationProgress);
+  const simulationProgressMode = useCoverageStore((state) => state.simulationProgressMode);
+  const simulationStepLabel = useCoverageStore((state) => state.simulationStepLabel);
   const isTerrainFetching = useAppStore((state) => state.isTerrainFetching);
   const isTerrainRecommending = useAppStore((state) => state.isTerrainRecommending);
   const basemapProvider = useAppStore((state) => state.basemapProvider);
@@ -1681,7 +1683,7 @@ export function MapView({
           : "Relay";
 
   const simulationTerrainOverlay = useMemo(() => {
-    if (!hasSimulationTerrain || !analysisBounds) return null;
+    if (!showTerrainOverlay || !hasSimulationTerrain || !analysisBounds) return null;
     const bounds = analysisBounds;
     return buildTerrainShadeOverlay(
       bounds,
@@ -1689,7 +1691,7 @@ export function MapView({
       overlayDimensions,
       overlayPointMask,
     );
-  }, [hasSimulationTerrain, analysisBounds, srtmTiles, overlayDimensions, overlayPointMask]);
+  }, [showTerrainOverlay, hasSimulationTerrain, analysisBounds, srtmTiles, overlayDimensions, overlayPointMask]);
 
   const webglAvailable = useMemo(() => supportsWebgl(), []);
   const isBackgroundBusy = isTerrainFetching || isTerrainRecommending;
@@ -2286,12 +2288,18 @@ export function MapView({
             <div className="map-inspector-section">
               <p className="map-inspector-line">
                 {isSimulationRecomputing
-                  ? `Recalculating simulation... ${simulationProgress}%`
+                  ? simulationProgressMode === "determinate"
+                    ? `${simulationStepLabel || "Sampling simulation grid..."} ${simulationProgress}%`
+                    : simulationStepLabel || "Recalculating simulation..."
                   : (backgroundBusyLabel ?? "Working in background...")}
               </p>
               <div className="map-progress-track">
                 {isSimulationRecomputing ? (
-                  <div className="map-progress-fill" style={{ width: `${simulationProgress}%` }} />
+                  simulationProgressMode === "determinate" ? (
+                    <div className="map-progress-fill" style={{ width: `${simulationProgress}%` }} />
+                  ) : (
+                    <div className="map-progress-fill map-progress-fill-indeterminate" />
+                  )
                 ) : isTerrainFetching && hasTerrainDownloadProgress && terrainProgressTilesTotal > 0 ? (
                   <div className="map-progress-fill" style={{ width: `${terrainProgressPercent}%` }} />
                 ) : (

--- a/src/lib/coverage.ts
+++ b/src/lib/coverage.ts
@@ -15,6 +15,7 @@ export type BuildCoverageOptions = {
   sampleMultiplier?: number;
   terrainSamples?: number;
   onProgress?: (progress: number) => void;
+  onSampleProgress?: (processed: number, total: number) => void;
   terrainCacheKey?: string;
   overlayRadiusKm?: number;
   singleSiteRadiusKm?: number;
@@ -214,7 +215,7 @@ export const buildCoverage = (
     }
   }
 
-  onProgress?.(0.1);
+  onProgress?.(0);
   const total = Math.max(1, samples.length);
   const notifyEvery = Math.max(1, Math.floor(total / 40));
   const results: CoverageSample[] = [];
@@ -243,7 +244,7 @@ export const buildCoverage = (
 
     results.push({ ...sample, valueDbm });
     if ((i + 1) % notifyEvery === 0 || i === samples.length - 1) {
-      onProgress?.(0.1 + ((i + 1) / total) * 0.9);
+      onProgress?.((i + 1) / total);
     }
   }
   return results;
@@ -296,11 +297,12 @@ export const buildCoverageAsync = async (
     }
   }
 
-  onProgress?.(0.1);
+  onProgress?.(0);
   const total = Math.max(1, samples.length);
   const notifyEvery = Math.max(1, Math.floor(total / 40));
   const results: CoverageSample[] = [];
-  const chunkSize = 48;
+  const chunkSize = 8;
+  let chunkStartedAt = performance.now();
 
   for (let i = 0; i < samples.length; i += 1) {
     const sample = samples[i];
@@ -327,9 +329,10 @@ export const buildCoverageAsync = async (
 
     results.push({ ...sample, valueDbm });
     if ((i + 1) % notifyEvery === 0 || i === samples.length - 1) {
-      onProgress?.(0.1 + ((i + 1) / total) * 0.9);
+      onProgress?.((i + 1) / total);
     }
-    if ((i + 1) % chunkSize === 0) {
+    options?.onSampleProgress?.(i + 1, total);
+    if ((i + 1) % chunkSize === 0 || performance.now() - chunkStartedAt > 7) {
       await new Promise<void>((resolve) => {
         if (typeof window !== "undefined" && typeof window.requestAnimationFrame === "function") {
           window.requestAnimationFrame(() => resolve());
@@ -337,6 +340,7 @@ export const buildCoverageAsync = async (
         }
         setTimeout(resolve, 0);
       });
+      chunkStartedAt = performance.now();
     }
   }
   return results;

--- a/src/store/appStore.basemapRecompute.test.ts
+++ b/src/store/appStore.basemapRecompute.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const storage = vi.hoisted(() => {
+  const data = new Map<string, string>();
+  const mock = {
+    getItem: (key: string) => data.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      data.set(key, String(value));
+    },
+    removeItem: (key: string) => {
+      data.delete(key);
+    },
+    clear: () => {
+      data.clear();
+    },
+    key: (index: number) => Array.from(data.keys())[index] ?? null,
+    get length() {
+      return data.size;
+    },
+  };
+  vi.stubGlobal("localStorage", mock);
+  vi.stubGlobal("window", {
+    localStorage: mock,
+    setTimeout,
+    clearTimeout,
+  });
+  return { mock };
+});
+
+vi.mock("../lib/coverage", () => ({
+  buildCoverage: vi.fn(() => []),
+}));
+
+vi.mock("../lib/elevationService", () => ({
+  fetchElevations: vi.fn(async () => [123]),
+}));
+
+describe("appStore basemap changes", () => {
+  beforeEach(() => {
+    storage.mock.clear();
+    vi.resetModules();
+  });
+
+  it("does not trigger simulation recompute when basemap provider/style changes", async () => {
+    const recomputeCoverage = vi.fn();
+    vi.doMock("./coverageStore", () => ({
+      useCoverageStore: {
+        getState: () => ({ recomputeCoverage }),
+      },
+      setAppStoreBridge: vi.fn(),
+    }));
+
+    const { useAppStore } = await import("./appStore");
+    const state = useAppStore.getState();
+    state.setBasemapProvider("carto");
+    state.setBasemapStylePreset("normal");
+
+    expect(recomputeCoverage).not.toHaveBeenCalled();
+  });
+});

--- a/src/store/coverageStore.test.ts
+++ b/src/store/coverageStore.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setAppStoreBridge, useCoverageStore } from "./coverageStore";
+import * as coverageLib from "../lib/coverage";
+import type { CoverageSample, Site } from "../types/radio";
+
+const site: Site = {
+  id: "site-1",
+  name: "Alpha",
+  position: { lat: 59.91, lon: 10.75 },
+  groundElevationM: 100,
+  antennaHeightM: 10,
+  txPowerDbm: 20,
+  txGainDbi: 2,
+  rxGainDbi: 2,
+  cableLossDb: 1,
+};
+
+const bridgeState = {
+  selectedCoverageResolution: "24",
+  networks: [{ id: "net-1", memberships: [], frequencyMHz: 869.5 }],
+  selectedNetworkId: "net-1",
+  sites: [site],
+  systems: [],
+  propagationModel: "ITM",
+  srtmTiles: [],
+  links: [],
+  selectedLinkId: "",
+  autoPropagationEnvironment: false,
+  propagationEnvironment: {
+    radioClimate: "Continental Temperate",
+    polarization: "Vertical",
+    clutterHeightM: 10,
+    groundDielectric: 15,
+    groundConductivity: 0.005,
+    atmosphericBendingNUnits: 301,
+  },
+  propagationEnvironmentReason: "",
+  terrainLoadEpoch: 0,
+  selectedSiteIds: ["site-1"],
+  isTerrainFetching: false,
+  selectedOverlayRadiusOption: "50",
+};
+
+describe("coverageStore simulation progress phases", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal("window", {
+      setTimeout,
+      clearTimeout,
+      requestAnimationFrame: (cb: FrameRequestCallback) => {
+        cb(0);
+        return 1;
+      },
+    });
+    useCoverageStore.setState({
+      coverageSamples: [],
+      isSimulationRecomputing: false,
+      simulationProgress: 0,
+      simulationProgressMode: "indeterminate",
+      simulationStepLabel: "",
+      simulationSamplesDone: 0,
+      simulationSamplesTotal: 0,
+      simulationRunToken: "",
+    });
+    setAppStoreBridge({
+      getState: () => bridgeState as unknown as Record<string, unknown>,
+      setState: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("uses indeterminate prep/finalizing phases and determinate sampling percent", async () => {
+    let resolveBuild!: (value: CoverageSample[]) => void;
+    vi.spyOn(coverageLib, "buildCoverageAsync").mockImplementation((...args) => {
+      const options = args[6];
+      options?.onProgress?.(0.5);
+      options?.onSampleProgress?.(7, 14);
+      return new Promise<CoverageSample[]>((resolve) => {
+        resolveBuild = resolve;
+      });
+    });
+
+    useCoverageStore.getState().recomputeCoverage();
+    expect(useCoverageStore.getState().simulationProgressMode).toBe("indeterminate");
+    expect(useCoverageStore.getState().simulationStepLabel).toBe("Preparing simulation bounds...");
+
+    vi.advanceTimersByTime(180);
+    await Promise.resolve();
+
+    expect(useCoverageStore.getState().simulationProgressMode).toBe("determinate");
+    expect(useCoverageStore.getState().simulationProgress).toBe(50);
+    expect(useCoverageStore.getState().simulationStepLabel).toBe("Sampling simulation grid (7/14)");
+
+    resolveBuild([{ lat: site.position.lat, lon: site.position.lon, valueDbm: -90 }]);
+    await Promise.resolve();
+    expect(useCoverageStore.getState().simulationProgressMode).toBe("indeterminate");
+    expect(useCoverageStore.getState().simulationStepLabel).toBe("Finalizing simulation overlay...");
+
+    vi.advanceTimersByTime(700);
+    await Promise.resolve();
+
+    expect(useCoverageStore.getState().isSimulationRecomputing).toBe(false);
+    expect(useCoverageStore.getState().coverageSamples).toHaveLength(1);
+  });
+});

--- a/src/store/coverageStore.ts
+++ b/src/store/coverageStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
-import { buildCoverageAsync } from "../lib/coverage";
+import { buildCoverageAsync, computeCoverageGridDimensions } from "../lib/coverage";
+import { simulationAreaBoundsForSites } from "../lib/simulationArea";
 import {
   deriveDynamicPropagationEnvironment,
 } from "../lib/propagationEnvironment";
@@ -32,6 +33,10 @@ export type CoverageState = {
   coverageSamples: CoverageSample[];
   isSimulationRecomputing: boolean;
   simulationProgress: number;
+  simulationProgressMode: "determinate" | "indeterminate";
+  simulationStepLabel: string;
+  simulationSamplesDone: number;
+  simulationSamplesTotal: number;
   simulationRunToken: string;
   recomputeCoverage: () => void;
 };
@@ -40,6 +45,10 @@ export const useCoverageStore = create<CoverageState>((set, get) => ({
   coverageSamples: [],
   isSimulationRecomputing: false,
   simulationProgress: 0,
+  simulationProgressMode: "indeterminate",
+  simulationStepLabel: "",
+  simulationSamplesDone: 0,
+  simulationSamplesTotal: 0,
   simulationRunToken: "",
   recomputeCoverage: () => {
     if (!appStoreBridge) return;
@@ -48,7 +57,11 @@ export const useCoverageStore = create<CoverageState>((set, get) => ({
     set({
       simulationRunToken: runId,
       isSimulationRecomputing: true,
-      simulationProgress: 3,
+      simulationProgress: 0,
+      simulationProgressMode: "indeterminate",
+      simulationStepLabel: "Preparing simulation bounds...",
+      simulationSamplesDone: 0,
+      simulationSamplesTotal: 0,
     });
 
     if (coverageRecomputeTimer !== null) {
@@ -100,6 +113,10 @@ export const useCoverageStore = create<CoverageState>((set, get) => ({
               coverageSamples: [],
               isSimulationRecomputing: false,
               simulationProgress: 100,
+              simulationProgressMode: "determinate",
+              simulationStepLabel: "",
+              simulationSamplesDone: 0,
+              simulationSamplesTotal: 0,
             });
             window.setTimeout(() => {
               if (get().simulationRunToken === runId) {
@@ -168,8 +185,18 @@ export const useCoverageStore = create<CoverageState>((set, get) => ({
         );
         const effectiveOverlayRadiusKm = Math.min(targetRadiusKm, overlayRadiusKm, loadedRadiusCapKm);
 
-        set({ simulationProgress: 8 });
-        let lastProgress = 8;
+        const boundsForCount = simulationAreaBoundsForSites(sites, { overlayRadiusKm: effectiveOverlayRadiusKm });
+        const sampleCount = boundsForCount
+          ? computeCoverageGridDimensions(gridSize, boundsForCount, 1).totalSamples
+          : 0;
+        set({
+          simulationProgress: 0,
+          simulationProgressMode: "determinate",
+          simulationStepLabel: "Sampling simulation grid...",
+          simulationSamplesDone: 0,
+          simulationSamplesTotal: sampleCount,
+        });
+        let lastProgress = 0;
         const coverageSamples = await buildCoverageAsync(
           gridSize,
           network as Parameters<typeof buildCoverageAsync>[1],
@@ -184,22 +211,38 @@ export const useCoverageStore = create<CoverageState>((set, get) => ({
             overlayRadiusKm: effectiveOverlayRadiusKm,
             onProgress: (progress: number) => {
               if (get().simulationRunToken !== runId) return;
-              const next = Math.round(8 + progress * 84);
+              const next = Math.round(progress * 100);
               if (next - lastProgress >= 2 || next >= 99) {
                 lastProgress = next;
                 set({ simulationProgress: next });
               }
             },
+            onSampleProgress: (processed, total) => {
+              if (get().simulationRunToken !== runId) return;
+              set({
+                simulationStepLabel: `Sampling simulation grid (${processed}/${total})`,
+                simulationSamplesDone: processed,
+                simulationSamplesTotal: total,
+              });
+            },
             terrainCacheKey: `${selectedCoverageResolution}|${selectedNetworkId}|${propagationModel}|${terrainLoadEpoch}`,
           },
         );
         if (get().simulationRunToken !== runId) return;
+        set({
+          simulationProgressMode: "indeterminate",
+          simulationStepLabel: "Finalizing simulation overlay...",
+        });
         const finalize = () => {
           if (get().simulationRunToken === runId) {
             set({
               coverageSamples,
               isSimulationRecomputing: false,
               simulationProgress: 100,
+              simulationProgressMode: "determinate",
+              simulationStepLabel: "",
+              simulationSamplesDone: 0,
+              simulationSamplesTotal: 0,
             });
             window.setTimeout(() => {
               if (get().simulationRunToken === runId) {


### PR DESCRIPTION
## Summary
- Wire simulation progress UI to truthful phase semantics using existing progress bar modes
- Show determinate progress only during measurable sampling
- Show indeterminate progress during preparation/finalization phases
- Avoid terrain shade overlay computation when terrain overlay is hidden
- Add regression tests for basemap provider/style changes not triggering recompute
- Add coverageStore phase/progress regression test

## Verification
- npm test
- npm run build