### PR TITLE
Issue #176: clamp simulation to 1x while terrain is loading

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1539,6 +1539,8 @@ export function MapView({
   const effectiveGridSize =
     isDraggingSite || !Number.isFinite(selectedGridSize) || selectedGridSize < 24
       ? 24
+      : isTerrainFetching
+        ? 24
       : isSimulationRecomputing
         ? lastCompletedGridSize
         : selectedGridSize;

--- a/src/store/coverageStore.test.ts
+++ b/src/store/coverageStore.test.ts
@@ -106,4 +106,29 @@ describe("coverageStore simulation progress phases", () => {
     expect(useCoverageStore.getState().isSimulationRecomputing).toBe(false);
     expect(useCoverageStore.getState().coverageSamples).toHaveLength(1);
   });
+
+  it("forces 1x simulation resolution while terrain is fetching", async () => {
+    let capturedGridSize = 0;
+    setAppStoreBridge({
+      getState: () =>
+        ({
+          ...bridgeState,
+          selectedCoverageResolution: "168",
+          isTerrainFetching: true,
+        }) as unknown as Record<string, unknown>,
+      setState: vi.fn(),
+    });
+    vi.spyOn(coverageLib, "buildCoverageAsync").mockImplementation((gridSize) => {
+      capturedGridSize = Number(gridSize);
+      return Promise.resolve([]);
+    });
+
+    useCoverageStore.getState().recomputeCoverage();
+    vi.advanceTimersByTime(220);
+    await Promise.resolve();
+    vi.advanceTimersByTime(700);
+    await Promise.resolve();
+
+    expect(capturedGridSize).toBe(24);
+  });
 });

--- a/src/store/coverageStore.ts
+++ b/src/store/coverageStore.ts
@@ -88,7 +88,6 @@ export const useCoverageStore = create<CoverageState>((set, get) => ({
             : selectedCoverageResolutionRaw === "high"
               ? "42"
               : "24";
-        const gridSize = Number(selectedCoverageResolution);
         const networks = appState.networks as Array<{ id: string; [key: string]: unknown }>;
         const selectedNetworkId = appState.selectedNetworkId as string;
         const sites = appState.sites as Site[];
@@ -104,6 +103,8 @@ export const useCoverageStore = create<CoverageState>((set, get) => ({
         const selectedSiteIds = (appState.selectedSiteIds as string[]) ?? [];
         const isTerrainFetching = Boolean(appState.isTerrainFetching);
         const selectedOverlayRadiusOptionRaw = appState.selectedOverlayRadiusOption;
+        const effectiveCoverageResolution = isTerrainFetching ? "24" : selectedCoverageResolution;
+        const gridSize = Number(effectiveCoverageResolution);
 
         const network = networks.find((n) => n.id === selectedNetworkId);
         if (!network) {
@@ -225,7 +226,7 @@ export const useCoverageStore = create<CoverageState>((set, get) => ({
                 simulationSamplesTotal: total,
               });
             },
-            terrainCacheKey: `${selectedCoverageResolution}|${selectedNetworkId}|${propagationModel}|${terrainLoadEpoch}`,
+            terrainCacheKey: `${effectiveCoverageResolution}|${selectedNetworkId}|${propagationModel}|${terrainLoadEpoch}`,
           },
         );
         if (get().simulationRunToken !== runId) return;


### PR DESCRIPTION
## Summary
- Force simulation coverage compute to `1x` while `isTerrainFetching` is true
- Force overlay render grid to `1x` while terrain fetch is active
- Preserve selected higher resolution and resume it automatically when terrain loading finishes
- Add regression test that high selected resolution is clamped to `1x` during fetch

## Verification
- npm test -- --run src/store/coverageStore.test.ts
- npm test
- npm run build