### PR TITLE
Issue #574: Non-blocking simulation pipeline

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -10,7 +10,6 @@ import Map, {
   type ViewStateChangeEvent,
 } from "react-map-gl/maplibre";
 import type { LayerProps } from "react-map-gl/maplibre";
-import { classifyPassFailState, computeSourceCentricRxMetrics } from "../lib/passFailState";
 import { computeCoverageGridDimensions } from "../lib/coverage";
 import { STANDARD_SITE_RADIO } from "../lib/linkRadio";
 import { sampleSrtmElevation } from "../lib/srtm";
@@ -24,7 +23,7 @@ import {
 import { useAppStore } from "../store/appStore";
 import { useCoverageStore } from "../store/coverageStore";
 import { TERRAIN_DATASET_LABEL } from "../lib/terrainDataset";
-import type { Link, PropagationEnvironment, Site } from "../types/radio";
+import type { Link, Site } from "../types/radio";
 import { fetchMeshmapNodes, type MeshmapNode } from "../lib/meshtasticMqtt";
 import { canShowSaveSelectedLinkAction } from "../lib/selectedPairActions";
 import {
@@ -37,6 +36,15 @@ import {
 } from "../lib/simulationOverlayRadius";
 import { simulationAreaBoundsForSites } from "../lib/simulationArea";
 import { tilesForBounds } from "../lib/terrainTiles";
+import {
+  buildCoverageOverlayPixelsAsync,
+  buildRelayCandidateOverlayPixelsAsync,
+  buildSourcePassFailOverlayPixelsAsync,
+  buildTerrainShadeOverlayPixelsAsync,
+  overlayPixelsToDataUrl,
+  OverlayTaskCancelledError,
+  type OverlayRasterPixels,
+} from "../lib/overlayRaster";
 import { SimulationResultsSection } from "./SimulationResultsSection";
 import { ActionButton } from "./ActionButton";
 import { useMapControls } from "./map/useMapControls";
@@ -354,46 +362,6 @@ const boundsDiagonalKm = (bounds: TerrainBounds): number => {
   return Math.hypot(latSpanKm, lonSpanKm);
 };
 
-const coverageColorForDbm = (valueDbm: number): [number, number, number] => {
-  const stops: Array<{ v: number; c: [number, number, number] }> = [
-    { v: -125, c: [105, 42, 45] },
-    { v: -114, c: [156, 63, 49] },
-    { v: -104, c: [201, 92, 45] },
-    { v: -95, c: [226, 127, 45] },
-    { v: -86, c: [218, 175, 55] },
-    { v: -78, c: [164, 193, 68] },
-    { v: -70, c: [95, 178, 95] },
-    { v: -62, c: [64, 150, 178] },
-  ];
-  if (valueDbm <= stops[0].v) return stops[0].c;
-  if (valueDbm >= stops[stops.length - 1].v) return stops[stops.length - 1].c;
-  for (let i = 0; i < stops.length - 1; i += 1) {
-    const a = stops[i];
-    const b = stops[i + 1];
-    if (valueDbm < a.v || valueDbm > b.v) continue;
-    const t = (valueDbm - a.v) / (b.v - a.v);
-    return [
-      Math.round(a.c[0] + (b.c[0] - a.c[0]) * t),
-      Math.round(a.c[1] + (b.c[1] - a.c[1]) * t),
-      Math.round(a.c[2] + (b.c[2] - a.c[2]) * t),
-    ];
-  }
-  return [255, 255, 255];
-};
-
-const coverageColorAdaptive = (valueDbm: number, samples: CoverageSampleLite[]): [number, number, number] => {
-  if (samples.length < 2) return coverageColorForDbm(valueDbm);
-  let min = Number.POSITIVE_INFINITY;
-  let max = Number.NEGATIVE_INFINITY;
-  for (const sample of samples) {
-    min = Math.min(min, sample.valueDbm);
-    max = Math.max(max, sample.valueDbm);
-  }
-  const range = Math.max(6, max - min);
-  const normalized = -125 + ((valueDbm - min) / range) * 63;
-  return coverageColorForDbm(clamp(normalized, -125, -62));
-};
-
 const autoBandStepDb = (samples: CoverageSampleLite[], bounds: TerrainBounds): 3 | 5 | 8 | 10 => {
   if (samples.length < 2) return 5;
   let min = Number.POSITIVE_INFINITY;
@@ -417,97 +385,6 @@ const autoBandStepDb = (samples: CoverageSampleLite[], bounds: TerrainBounds): 3
   return 3;
 };
 
-const interpolateCoverageDbm = (samples: CoverageSampleLite[], lat: number, lon: number): number | null => {
-  if (!samples.length) return null;
-  let weightSum = 0;
-  let valueSum = 0;
-  for (const sample of samples) {
-    const dLat = sample.lat - lat;
-    const dLon = sample.lon - lon;
-    const d2 = dLat * dLat + dLon * dLon;
-    if (d2 < 1e-12) return sample.valueDbm;
-    const weight = 1 / d2;
-    weightSum += weight;
-    valueSum += sample.valueDbm * weight;
-  }
-  if (weightSum <= 0) return null;
-  return valueSum / weightSum;
-};
-
-const binarySearchFloor = (values: number[], target: number): number => {
-  let lo = 0;
-  let hi = values.length - 1;
-  while (lo <= hi) {
-    const mid = (lo + hi) >> 1;
-    const value = values[mid];
-    if (value <= target) {
-      lo = mid + 1;
-    } else {
-      hi = mid - 1;
-    }
-  }
-  return clamp(hi, 0, values.length - 1);
-};
-
-const makeGridInterpolator = (
-  samples: CoverageSampleLite[],
-): ((lat: number, lon: number) => number | null) | null => {
-  if (samples.length < 4) return null;
-  const latSet = new Set<number>();
-  const lonSet = new Set<number>();
-  for (const sample of samples) {
-    latSet.add(sample.lat);
-    lonSet.add(sample.lon);
-  }
-  const lats = Array.from(latSet).sort((a, b) => a - b);
-  const lons = Array.from(lonSet).sort((a, b) => a - b);
-  if (lats.length < 2 || lons.length < 2) return null;
-  if (lats.length * lons.length !== samples.length) return null;
-
-  const latIndex = new globalThis.Map<number, number>();
-  const lonIndex = new globalThis.Map<number, number>();
-  lats.forEach((value, index) => latIndex.set(value, index));
-  lons.forEach((value, index) => lonIndex.set(value, index));
-
-  const values = new Float64Array(lats.length * lons.length);
-  const seen = new Uint8Array(lats.length * lons.length);
-  for (const sample of samples) {
-    const yi = latIndex.get(sample.lat);
-    const xi = lonIndex.get(sample.lon);
-    if (yi === undefined || xi === undefined) return null;
-    const idx = yi * lons.length + xi;
-    values[idx] = sample.valueDbm;
-    seen[idx] = 1;
-  }
-  for (const mark of seen) {
-    if (mark !== 1) return null;
-  }
-
-  return (lat, lon) => {
-    const latClamped = clamp(lat, lats[0], lats[lats.length - 1]);
-    const lonClamped = clamp(lon, lons[0], lons[lons.length - 1]);
-    const y0 = binarySearchFloor(lats, latClamped);
-    const x0 = binarySearchFloor(lons, lonClamped);
-    const y1 = Math.min(y0 + 1, lats.length - 1);
-    const x1 = Math.min(x0 + 1, lons.length - 1);
-
-    const lat0 = lats[y0];
-    const lat1 = lats[y1];
-    const lon0 = lons[x0];
-    const lon1 = lons[x1];
-    const ty = lat1 === lat0 ? 0 : (latClamped - lat0) / (lat1 - lat0);
-    const tx = lon1 === lon0 ? 0 : (lonClamped - lon0) / (lon1 - lon0);
-
-    const q00 = values[y0 * lons.length + x0];
-    const q10 = values[y0 * lons.length + x1];
-    const q01 = values[y1 * lons.length + x0];
-    const q11 = values[y1 * lons.length + x1];
-    const a = q00 + (q10 - q00) * tx;
-    const b = q01 + (q11 - q01) * tx;
-    return a + (b - a) * ty;
-  };
-};
-
 const computeOverlayDimensions = (
   bounds: TerrainBounds,
   targetGridSize: number,
@@ -523,420 +400,6 @@ const computeOverlayDimensions = (
   return {
     width: clamp(scaledWidth, 8, 1400),
     height: clamp(scaledHeight, 8, 1400),
-  };
-};
-
-const computeSourceCentricRxDbm = (
-  lat: number,
-  lon: number,
-  fromSite: Site,
-  effectiveLink: Link,
-  receiverAntennaHeightM: number,
-  receiverRxGainDbi: number,
-  terrainSampler: (lat: number, lon: number) => number | null,
-  terrainSamples: number,
-  propagationEnvironment: PropagationEnvironment,
-): number =>
-  computeSourceCentricRxMetrics(
-    lat,
-    lon,
-    fromSite,
-    effectiveLink,
-    receiverAntennaHeightM,
-    receiverRxGainDbi,
-    terrainSampler,
-    terrainSamples,
-    propagationEnvironment,
-  ).rxDbm;
-
-const buildCoverageOverlay = (
-  bounds: TerrainBounds,
-  samples: CoverageSampleLite[],
-  mode: "heatmap" | "contours",
-  bandStepDb: number,
-  dimensions: { width: number; height: number },
-  pointMask?: (lat: number, lon: number) => boolean,
-  terrainSampler?: (lat: number, lon: number) => number | null,
-): OverlayRaster | null => {
-  if (!samples.length) return null;
-  const gridInterpolator = makeGridInterpolator(samples);
-  const width = dimensions.width;
-  const height = dimensions.height;
-  const canvas = document.createElement("canvas");
-  canvas.width = width;
-  canvas.height = height;
-  const ctx = canvas.getContext("2d");
-  if (!ctx) return null;
-  const image = ctx.createImageData(width, height);
-
-  for (let y = 0; y < height; y += 1) {
-    const tY = y / Math.max(1, height - 1);
-    const lat = bounds.maxLat - (bounds.maxLat - bounds.minLat) * tY;
-    for (let x = 0; x < width; x += 1) {
-      const tX = x / Math.max(1, width - 1);
-      const lon = bounds.minLon + (bounds.maxLon - bounds.minLon) * tX;
-      if (pointMask && !pointMask(lat, lon)) continue;
-      if (terrainSampler && terrainSampler(lat, lon) === null) continue;
-      const valueDbm = gridInterpolator
-        ? gridInterpolator(lat, lon)
-        : interpolateCoverageDbm(samples, lat, lon);
-      if (valueDbm === null) continue;
-      let r = 0;
-      let g = 0;
-      let b = 0;
-      let a = 180;
-      if (mode === "heatmap") {
-        [r, g, b] = coverageColorAdaptive(valueDbm, samples);
-      } else if (mode === "contours") {
-        const banded = Math.round(valueDbm / Math.max(1, bandStepDb)) * Math.max(1, bandStepDb);
-        [r, g, b] = coverageColorAdaptive(banded, samples);
-        a = 170;
-      }
-      const px = (y * width + x) * 4;
-      image.data[px] = r;
-      image.data[px + 1] = g;
-      image.data[px + 2] = b;
-      image.data[px + 3] = a;
-    }
-  }
-  ctx.putImageData(image, 0, 0);
-  return {
-    url: canvas.toDataURL("image/png"),
-    coordinates: [
-      [bounds.minLon, bounds.maxLat],
-      [bounds.maxLon, bounds.maxLat],
-      [bounds.maxLon, bounds.minLat],
-      [bounds.minLon, bounds.minLat],
-    ],
-  };
-};
-
-const buildSourcePassFailOverlay = (
-  bounds: TerrainBounds,
-  fromSite: Site,
-  effectiveLink: Link,
-  receiverAntennaHeightM: number,
-  receiverRxGainDbi: number,
-  propagationEnvironment: PropagationEnvironment,
-  rxTargetDbm: number,
-  environmentLossDb: number,
-  terrainSampler: (lat: number, lon: number) => number | null,
-  dimensions: { width: number; height: number },
-  terrainSamples: number,
-  pointMask?: (lat: number, lon: number) => boolean,
-): OverlayRaster | null => {
-  const width = dimensions.width;
-  const height = dimensions.height;
-  const canvas = document.createElement("canvas");
-  canvas.width = width;
-  canvas.height = height;
-  const ctx = canvas.getContext("2d");
-  if (!ctx) return null;
-  const image = ctx.createImageData(width, height);
-
-  for (let y = 0; y < height; y += 1) {
-    const tY = y / Math.max(1, height - 1);
-    const lat = bounds.maxLat - (bounds.maxLat - bounds.minLat) * tY;
-    for (let x = 0; x < width; x += 1) {
-      const tX = x / Math.max(1, width - 1);
-      const lon = bounds.minLon + (bounds.maxLon - bounds.minLon) * tX;
-      if (pointMask && !pointMask(lat, lon)) {
-        continue;
-      }
-      if (terrainSampler(lat, lon) === null) {
-        continue;
-      }
-      const metrics = computeSourceCentricRxMetrics(
-        lat,
-        lon,
-        fromSite,
-        effectiveLink,
-        receiverAntennaHeightM,
-        receiverRxGainDbi,
-        terrainSampler,
-        terrainSamples,
-        propagationEnvironment,
-      );
-      const pass = metrics.rxDbm - environmentLossDb >= rxTargetDbm;
-      const losBlocked = metrics.terrainObstructed;
-      const state = classifyPassFailState(pass, losBlocked);
-      const px = (y * width + x) * 4;
-      if (state === "pass_clear") {
-        image.data[px] = 82;
-        image.data[px + 1] = 181;
-        image.data[px + 2] = 96;
-      } else if (state === "pass_blocked") {
-        image.data[px] = 232;
-        image.data[px + 1] = 170;
-        image.data[px + 2] = 72;
-      } else if (state === "fail_clear") {
-        image.data[px] = 235;
-        image.data[px + 1] = 120;
-        image.data[px + 2] = 70;
-      } else {
-        image.data[px] = 205;
-        image.data[px + 1] = 87;
-        image.data[px + 2] = 79;
-      }
-      image.data[px + 3] = 162;
-    }
-  }
-
-  ctx.putImageData(image, 0, 0);
-  return {
-    url: canvas.toDataURL("image/png"),
-    coordinates: [
-      [bounds.minLon, bounds.maxLat],
-      [bounds.maxLon, bounds.maxLat],
-      [bounds.maxLon, bounds.minLat],
-      [bounds.minLon, bounds.minLat],
-    ],
-  };
-};
-
-const buildRelayCandidateOverlay = (
-  bounds: TerrainBounds,
-  fromSite: Site,
-  toSite: Site,
-  effectiveLink: Link,
-  propagationEnvironment: PropagationEnvironment,
-  environmentLossDb: number,
-  terrainSampler: (lat: number, lon: number) => number | null,
-  dimensions: { width: number; height: number },
-  terrainSamples: number,
-  pointMask?: (lat: number, lon: number) => boolean,
-): (OverlayRaster & { minDbm: number; maxDbm: number }) | null => {
-  const width = dimensions.width;
-  const height = dimensions.height;
-  const relayAntennaHeightM = Math.max(2, (fromSite.antennaHeightM + toSite.antennaHeightM) / 2);
-  const fallbackRelayGround = (fromSite.groundElevationM + toSite.groundElevationM) / 2;
-  const canvas = document.createElement("canvas");
-  canvas.width = width;
-  canvas.height = height;
-  const ctx = canvas.getContext("2d");
-  if (!ctx) return null;
-  const image = ctx.createImageData(width, height);
-  const bottleneck = new Float32Array(width * height).fill(-Infinity);
-  let minDbm = Number.POSITIVE_INFINITY;
-  let maxDbm = Number.NEGATIVE_INFINITY;
-
-  for (let y = 0; y < height; y += 1) {
-    const tY = y / Math.max(1, height - 1);
-    const lat = bounds.maxLat - (bounds.maxLat - bounds.minLat) * tY;
-    for (let x = 0; x < width; x += 1) {
-      const tX = x / Math.max(1, width - 1);
-      const lon = bounds.minLon + (bounds.maxLon - bounds.minLon) * tX;
-      if (pointMask && !pointMask(lat, lon)) {
-        continue;
-      }
-
-      const sampledGround = terrainSampler(lat, lon);
-      if (sampledGround === null) {
-        continue;
-      }
-      const relayGround = sampledGround ?? fallbackRelayGround;
-      const relaySite: Site = {
-        id: "__relay_candidate__",
-        name: "Relay candidate",
-        position: { lat, lon },
-        antennaHeightM: relayAntennaHeightM,
-        groundElevationM: relayGround,
-        txPowerDbm: STANDARD_SITE_RADIO.txPowerDbm,
-        txGainDbi: STANDARD_SITE_RADIO.txGainDbi,
-        rxGainDbi: STANDARD_SITE_RADIO.rxGainDbi,
-        cableLossDb: STANDARD_SITE_RADIO.cableLossDb,
-      };
-      const fromToRelayRx = computeSourceCentricRxDbm(
-        lat,
-        lon,
-        fromSite,
-        effectiveLink,
-        relayAntennaHeightM,
-        relaySite.rxGainDbi,
-        terrainSampler,
-        terrainSamples,
-        propagationEnvironment,
-      );
-      const relayToTargetRx = computeSourceCentricRxDbm(
-        toSite.position.lat,
-        toSite.position.lon,
-        relaySite,
-        effectiveLink,
-        toSite.antennaHeightM,
-        toSite.rxGainDbi,
-        terrainSampler,
-        terrainSamples,
-        propagationEnvironment,
-      );
-      const bottleneckDbm = Math.min(fromToRelayRx, relayToTargetRx) - environmentLossDb;
-      const i = y * width + x;
-      bottleneck[i] = bottleneckDbm;
-      minDbm = Math.min(minDbm, bottleneckDbm);
-      maxDbm = Math.max(maxDbm, bottleneckDbm);
-    }
-  }
-  if (!Number.isFinite(minDbm) || !Number.isFinite(maxDbm)) return null;
-  const dynamicRange = Math.max(6, maxDbm - minDbm);
-
-  for (let y = 0; y < height; y += 1) {
-    for (let x = 0; x < width; x += 1) {
-      const i = y * width + x;
-      if (!Number.isFinite(bottleneck[i])) continue;
-      const px = i * 4;
-      const normalized = -125 + ((bottleneck[i] - minDbm) / dynamicRange) * 63;
-      const [r, g, b] = coverageColorForDbm(clamp(normalized, -125, -62));
-      image.data[px] = r;
-      image.data[px + 1] = g;
-      image.data[px + 2] = b;
-      image.data[px + 3] = 172;
-    }
-  }
-
-  ctx.putImageData(image, 0, 0);
-  return {
-    url: canvas.toDataURL("image/png"),
-    coordinates: [
-      [bounds.minLon, bounds.maxLat],
-      [bounds.maxLon, bounds.maxLat],
-      [bounds.maxLon, bounds.minLat],
-      [bounds.minLon, bounds.minLat],
-    ],
-    minDbm,
-    maxDbm,
-  };
-};
-
-const buildTerrainShadeOverlay = (
-  bounds: TerrainBounds,
-  sampler: (lat: number, lon: number) => number | null,
-  dimensions: { width: number; height: number },
-  pointMask?: (lat: number, lon: number) => boolean,
-): OverlayRaster | null => {
-  const width = dimensions.width;
-  const height = dimensions.height;
-  const elevations = new Float32Array(width * height);
-  const valid = new Uint8Array(width * height);
-  const allowed = new Uint8Array(width * height);
-
-  let minElevation = Number.POSITIVE_INFINITY;
-  let maxElevation = Number.NEGATIVE_INFINITY;
-
-  for (let y = 0; y < height; y += 1) {
-    const tY = y / Math.max(1, height - 1);
-    const lat = bounds.maxLat - (bounds.maxLat - bounds.minLat) * tY;
-    for (let x = 0; x < width; x += 1) {
-      const tX = x / Math.max(1, width - 1);
-      const lon = bounds.minLon + (bounds.maxLon - bounds.minLon) * tX;
-      const isAllowed = pointMask ? pointMask(lat, lon) : true;
-      const elevation = sampler(lat, lon);
-      const i = y * width + x;
-      if (isAllowed) {
-        allowed[i] = 1;
-      }
-      if (!isAllowed) continue;
-      if (elevation === null) continue;
-      elevations[i] = elevation;
-      valid[i] = 1;
-      minElevation = Math.min(minElevation, elevation);
-      maxElevation = Math.max(maxElevation, elevation);
-    }
-  }
-
-  if (!Number.isFinite(minElevation) || !Number.isFinite(maxElevation)) return null;
-
-  for (let pass = 0; pass < 3; pass += 1) {
-    for (let y = 1; y < height - 1; y += 1) {
-      for (let x = 1; x < width - 1; x += 1) {
-        const i = y * width + x;
-        if (!allowed[i]) continue;
-        if (valid[i]) continue;
-        const neighbors = [i - 1, i + 1, i - width, i + width];
-        let sum = 0;
-        let count = 0;
-        for (const n of neighbors) {
-          if (!allowed[n]) continue;
-          if (!valid[n]) continue;
-          sum += elevations[n];
-          count += 1;
-        }
-        if (!count) continue;
-        elevations[i] = sum / count;
-        valid[i] = 1;
-      }
-    }
-  }
-
-  const lightAzimuthRad = (315 * Math.PI) / 180;
-  const lightAltitudeRad = (45 * Math.PI) / 180;
-  const lx = Math.cos(lightAltitudeRad) * Math.sin(lightAzimuthRad);
-  const ly = Math.cos(lightAltitudeRad) * Math.cos(lightAzimuthRad);
-  const lz = Math.sin(lightAltitudeRad);
-  const centerLat = (bounds.minLat + bounds.maxLat) / 2;
-  const metersPerLon =
-    ((bounds.maxLon - bounds.minLon) * 111_320 * Math.max(0.1, Math.cos((centerLat * Math.PI) / 180))) /
-    Math.max(1, width - 1);
-  const metersPerLat = ((bounds.maxLat - bounds.minLat) * 111_320) / Math.max(1, height - 1);
-
-  const canvas = document.createElement("canvas");
-  canvas.width = width;
-  canvas.height = height;
-  const ctx = canvas.getContext("2d");
-  if (!ctx) return null;
-  const image = ctx.createImageData(width, height);
-  const range = Math.max(1, maxElevation - minElevation);
-
-  for (let y = 0; y < height; y += 1) {
-    for (let x = 0; x < width; x += 1) {
-      const i = y * width + x;
-      const px = i * 4;
-      if (!allowed[i]) {
-        image.data[px + 3] = 0;
-        continue;
-      }
-      if (!valid[i]) {
-        image.data[px + 3] = 0;
-        continue;
-      }
-
-      const x0 = Math.max(0, x - 1);
-      const x1 = Math.min(width - 1, x + 1);
-      const y0 = Math.max(0, y - 1);
-      const y1 = Math.min(height - 1, y + 1);
-      const left = elevations[y * width + x0];
-      const right = elevations[y * width + x1];
-      const top = elevations[y0 * width + x];
-      const bottom = elevations[y1 * width + x];
-
-      const dzdx = (right - left) / Math.max(1, (x1 - x0) * metersPerLon);
-      const dzdy = (bottom - top) / Math.max(1, (y1 - y0) * metersPerLat);
-
-      const nx = -dzdx;
-      const ny = -dzdy;
-      const nz = 1;
-      const norm = Math.hypot(nx, ny, nz) || 1;
-      const shade = Math.max(0, (nx * lx + ny * ly + nz * lz) / norm);
-
-      const elevationNorm = (elevations[i] - minElevation) / range;
-      const base = 58 + elevationNorm * 112;
-      const lit = clamp(base * 0.65 + shade * 145, 0, 255);
-
-      image.data[px] = lit * 0.95;
-      image.data[px + 1] = lit;
-      image.data[px + 2] = lit * 1.04;
-      image.data[px + 3] = 210;
-    }
-  }
-
-  ctx.putImageData(image, 0, 0);
-
-  return {
-    url: canvas.toDataURL("image/png"),
-    coordinates: [
-      [bounds.minLon, bounds.maxLat],
-      [bounds.maxLon, bounds.maxLat],
-      [bounds.maxLon, bounds.minLat],
-      [bounds.minLon, bounds.minLat],
-    ],
   };
 };
 
@@ -1573,38 +1036,146 @@ export function MapView({
     if (!overlayBounds) return 5;
     return bandStepMode === "auto" ? autoBandStepDb(samplesForOverlay, overlayBounds) : bandStepMode;
   }, [overlayBounds, samplesForOverlay, bandStepMode]);
-  const baseOverlayMode = coverageVizMode === "contours" ? "contours" : coverageVizMode === "heatmap" ? "heatmap" : null;
-  const baseCoverageOverlay = useMemo<(OverlayRaster & { minDbm?: number; maxDbm?: number }) | null>(() => {
-    if (!overlayBounds || !baseOverlayMode) return null;
-    return buildCoverageOverlay(
-      overlayBounds,
-      samplesForOverlay,
-      baseOverlayMode,
+  const overlayLongTaskWarnedRef = useRef<Set<string>>(new Set());
+  const showOverlayDiagnostics =
+    import.meta.env.DEV || (typeof window !== "undefined" && window.location.hostname === "localhost");
+  const coverageOverlayTaskTokenRef = useRef(0);
+  const terrainOverlayTaskTokenRef = useRef(0);
+  const [coverageOverlay, setCoverageOverlay] = useState<(OverlayRaster & { minDbm?: number; maxDbm?: number }) | null>(null);
+  const [simulationTerrainOverlay, setSimulationTerrainOverlay] = useState<OverlayRaster | null>(null);
+
+  useEffect(() => {
+    if (coverageVizMode === "none") {
+      coverageOverlayTaskTokenRef.current += 1;
+      setCoverageOverlay(null);
+      return;
+    }
+    if (!overlayBounds) {
+      coverageOverlayTaskTokenRef.current += 1;
+      setCoverageOverlay(null);
+      return;
+    }
+
+    const mode = coverageVizMode;
+    if (mode === "passfail" && (!activeSelectionLink || !selectedFromSite || !hasPassFailTopology)) {
+      coverageOverlayTaskTokenRef.current += 1;
+      setCoverageOverlay(null);
+      return;
+    }
+    if (mode === "relay" && (!activeSelectionLink || !selectedFromSite || !selectedToSite || !hasRelayTopology)) {
+      coverageOverlayTaskTokenRef.current += 1;
+      setCoverageOverlay(null);
+      return;
+    }
+
+    coverageOverlayTaskTokenRef.current += 1;
+    const token = coverageOverlayTaskTokenRef.current;
+    const signature = [
+      mode,
+      overlayBounds.minLat.toFixed(5),
+      overlayBounds.maxLat.toFixed(5),
+      overlayBounds.minLon.toFixed(5),
+      overlayBounds.maxLon.toFixed(5),
+      overlayDimensions.width,
+      overlayDimensions.height,
       effectiveBandStepDb,
-      overlayDimensions,
-      overlayPointMask,
-      (lat, lon) => sampleSrtmElevation(srtmTiles, lat, lon),
-    );
-  }, [overlayBounds, samplesForOverlay, baseOverlayMode, effectiveBandStepDb, overlayDimensions, overlayPointMask, srtmTiles]);
-  const passFailCoverageOverlay = useMemo<(OverlayRaster & { minDbm?: number; maxDbm?: number }) | null>(() => {
-    if (coverageVizMode !== "passfail") return null;
-    if (!overlayBounds || !activeSelectionLink || !selectedFromSite || !hasPassFailTopology) return null;
-    const receiverAntennaHeightM = selectedToSite?.antennaHeightM ?? selectedFromSite.antennaHeightM ?? 2;
-    const receiverRxGainDbi = selectedToSite?.rxGainDbi ?? selectedFromSite.rxGainDbi ?? STANDARD_SITE_RADIO.rxGainDbi;
-    return buildSourcePassFailOverlay(
-      overlayBounds,
-      selectedFromSite,
-      activeSelectionLink,
-      receiverAntennaHeightM,
-      receiverRxGainDbi,
-      propagationEnvironment,
-      rxSensitivityTargetDbm,
-      environmentLossDb,
-      (lat, lon) => sampleSrtmElevation(srtmTiles, lat, lon),
-      overlayDimensions,
+      samplesForOverlay.length,
+      srtmTiles.length,
       effectiveGridSize,
-      overlayPointMask,
-    );
+    ].join("|");
+
+    const onLongTask = (payload: {
+      phase: string;
+      signature: string;
+      durationMs: number;
+      processed: number;
+      total: number;
+    }) => {
+      if (!showOverlayDiagnostics) return;
+      const warnKey = `${payload.phase}|${payload.signature}`;
+      const warned = overlayLongTaskWarnedRef.current;
+      if (warned.has(warnKey)) return;
+      warned.add(warnKey);
+      if (warned.size > 80) warned.clear();
+      console.warn("[simulation-long-task]", {
+        scope: "overlay",
+        ...payload,
+      });
+    };
+
+    const shouldCancel = () => coverageOverlayTaskTokenRef.current !== token;
+    const terrainSampler = (lat: number, lon: number) => sampleSrtmElevation(srtmTiles, lat, lon);
+
+    void (async () => {
+      try {
+        const context = {
+          phase: mode,
+          signature,
+          shouldCancel,
+          onLongTask,
+        } as const;
+        let rasterPixels: OverlayRasterPixels | null = null;
+        if (mode === "heatmap" || mode === "contours") {
+          rasterPixels = await buildCoverageOverlayPixelsAsync(
+            overlayBounds,
+            samplesForOverlay,
+            mode,
+            effectiveBandStepDb,
+            overlayDimensions,
+            overlayPointMask,
+            terrainSampler,
+            context,
+          );
+        } else if (mode === "passfail") {
+          const receiverAntennaHeightM = selectedToSite?.antennaHeightM ?? selectedFromSite!.antennaHeightM ?? 2;
+          const receiverRxGainDbi = selectedToSite?.rxGainDbi ?? selectedFromSite!.rxGainDbi ?? STANDARD_SITE_RADIO.rxGainDbi;
+          rasterPixels = await buildSourcePassFailOverlayPixelsAsync(
+            overlayBounds,
+            selectedFromSite!,
+            activeSelectionLink!,
+            receiverAntennaHeightM,
+            receiverRxGainDbi,
+            propagationEnvironment,
+            rxSensitivityTargetDbm,
+            environmentLossDb,
+            terrainSampler,
+            overlayDimensions,
+            effectiveGridSize,
+            overlayPointMask,
+            context,
+          );
+        } else if (mode === "relay") {
+          rasterPixels = await buildRelayCandidateOverlayPixelsAsync(
+            overlayBounds,
+            selectedFromSite!,
+            selectedToSite!,
+            activeSelectionLink!,
+            propagationEnvironment,
+            environmentLossDb,
+            terrainSampler,
+            overlayDimensions,
+            effectiveGridSize,
+            overlayPointMask,
+            context,
+          );
+        }
+
+        if (shouldCancel()) return;
+        if (!rasterPixels) {
+          setCoverageOverlay(null);
+          return;
+        }
+        const raster = overlayPixelsToDataUrl(rasterPixels);
+        if (shouldCancel()) return;
+        setCoverageOverlay(raster ? { ...raster } : null);
+      } catch (error) {
+        if (error instanceof OverlayTaskCancelledError) return;
+        console.error("Failed to render simulation overlay", error);
+      }
+    })();
+    return () => {
+      coverageOverlayTaskTokenRef.current += 1;
+    };
   }, [
     coverageVizMode,
     overlayBounds,
@@ -1612,49 +1183,18 @@ export function MapView({
     selectedFromSite,
     selectedToSite,
     hasPassFailTopology,
+    hasRelayTopology,
+    overlayDimensions,
+    overlayPointMask,
+    srtmTiles,
+    effectiveBandStepDb,
+    samplesForOverlay,
     propagationEnvironment,
     rxSensitivityTargetDbm,
     environmentLossDb,
-    srtmTiles,
-    overlayDimensions,
-    overlayPointMask,
     effectiveGridSize,
+    showOverlayDiagnostics,
   ]);
-  const relayCoverageOverlay = useMemo<(OverlayRaster & { minDbm?: number; maxDbm?: number }) | null>(() => {
-    if (coverageVizMode !== "relay") return null;
-    if (!overlayBounds || !activeSelectionLink || !selectedFromSite || !selectedToSite || !hasRelayTopology) return null;
-    return buildRelayCandidateOverlay(
-      overlayBounds,
-      selectedFromSite,
-      selectedToSite,
-      activeSelectionLink,
-      propagationEnvironment,
-      environmentLossDb,
-      (lat, lon) => sampleSrtmElevation(srtmTiles, lat, lon),
-      overlayDimensions,
-      effectiveGridSize,
-      overlayPointMask,
-    );
-  }, [
-    coverageVizMode,
-    overlayBounds,
-    activeSelectionLink,
-    selectedFromSite,
-    selectedToSite,
-    hasRelayTopology,
-    propagationEnvironment,
-    environmentLossDb,
-    srtmTiles,
-    overlayDimensions,
-    overlayPointMask,
-    effectiveGridSize,
-  ]);
-  const coverageOverlay = useMemo<(OverlayRaster & { minDbm?: number; maxDbm?: number }) | null>(() => {
-    if (coverageVizMode === "none") return null;
-    if (coverageVizMode === "relay") return relayCoverageOverlay;
-    if (coverageVizMode === "passfail") return passFailCoverageOverlay;
-    return baseCoverageOverlay;
-  }, [coverageVizMode, relayCoverageOverlay, passFailCoverageOverlay, baseCoverageOverlay]);
   const currentBandStepDb = effectiveBandStepDb;
 
   const signalRange = useMemo(() => {
@@ -1684,16 +1224,85 @@ export function MapView({
           ? "Pass/Fail"
           : "Relay";
 
-  const simulationTerrainOverlay = useMemo(() => {
-    if (!showTerrainOverlay || !hasSimulationTerrain || !analysisBounds) return null;
-    const bounds = analysisBounds;
-    return buildTerrainShadeOverlay(
-      bounds,
-      (lat, lon) => sampleSrtmElevation(srtmTiles, lat, lon),
-      overlayDimensions,
-      overlayPointMask,
-    );
-  }, [showTerrainOverlay, hasSimulationTerrain, analysisBounds, srtmTiles, overlayDimensions, overlayPointMask]);
+  useEffect(() => {
+    if (!showTerrainOverlay || !hasSimulationTerrain || !analysisBounds) {
+      terrainOverlayTaskTokenRef.current += 1;
+      setSimulationTerrainOverlay(null);
+      return;
+    }
+
+    terrainOverlayTaskTokenRef.current += 1;
+    const token = terrainOverlayTaskTokenRef.current;
+    const signature = [
+      "terrain",
+      analysisBounds.minLat.toFixed(5),
+      analysisBounds.maxLat.toFixed(5),
+      analysisBounds.minLon.toFixed(5),
+      analysisBounds.maxLon.toFixed(5),
+      overlayDimensions.width,
+      overlayDimensions.height,
+      srtmTiles.length,
+    ].join("|");
+
+    const shouldCancel = () => terrainOverlayTaskTokenRef.current !== token;
+    const onLongTask = (payload: {
+      phase: string;
+      signature: string;
+      durationMs: number;
+      processed: number;
+      total: number;
+    }) => {
+      if (!showOverlayDiagnostics) return;
+      const warnKey = `${payload.phase}|${payload.signature}`;
+      const warned = overlayLongTaskWarnedRef.current;
+      if (warned.has(warnKey)) return;
+      warned.add(warnKey);
+      if (warned.size > 80) warned.clear();
+      console.warn("[simulation-long-task]", {
+        scope: "overlay",
+        ...payload,
+      });
+    };
+
+    void (async () => {
+      try {
+        const rasterPixels = await buildTerrainShadeOverlayPixelsAsync(
+          analysisBounds,
+          (lat, lon) => sampleSrtmElevation(srtmTiles, lat, lon),
+          overlayDimensions,
+          overlayPointMask,
+          {
+            phase: "terrain-shade",
+            signature,
+            shouldCancel,
+            onLongTask,
+          },
+        );
+        if (shouldCancel()) return;
+        if (!rasterPixels) {
+          setSimulationTerrainOverlay(null);
+          return;
+        }
+        const raster = overlayPixelsToDataUrl(rasterPixels);
+        if (shouldCancel()) return;
+        setSimulationTerrainOverlay(raster ? { url: raster.url, coordinates: raster.coordinates } : null);
+      } catch (error) {
+        if (error instanceof OverlayTaskCancelledError) return;
+        console.error("Failed to render terrain overlay", error);
+      }
+    })();
+    return () => {
+      terrainOverlayTaskTokenRef.current += 1;
+    };
+  }, [
+    showTerrainOverlay,
+    hasSimulationTerrain,
+    analysisBounds,
+    srtmTiles,
+    overlayDimensions,
+    overlayPointMask,
+    showOverlayDiagnostics,
+  ]);
 
   const webglAvailable = useMemo(() => supportsWebgl(), []);
   const isBackgroundBusy = isTerrainFetching || isTerrainRecommending;

--- a/src/lib/overlayRaster.test.ts
+++ b/src/lib/overlayRaster.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCoverageOverlayPixelsAsync,
+  buildRelayCandidateOverlayPixelsAsync,
+  buildSourcePassFailOverlayPixelsAsync,
+  buildTerrainShadeOverlayPixelsAsync,
+  OverlayTaskCancelledError,
+  type CoverageSampleLite,
+  type TerrainBounds,
+} from "./overlayRaster";
+import type { Link, PropagationEnvironment, Site } from "../types/radio";
+
+const bounds: TerrainBounds = {
+  minLat: 59.8,
+  maxLat: 60.0,
+  minLon: 10.6,
+  maxLon: 10.8,
+};
+
+const samples: CoverageSampleLite[] = [
+  { lat: 59.8, lon: 10.6, valueDbm: -112 },
+  { lat: 59.8, lon: 10.8, valueDbm: -92 },
+  { lat: 60.0, lon: 10.6, valueDbm: -99 },
+  { lat: 60.0, lon: 10.8, valueDbm: -72 },
+];
+
+const fromSite: Site = {
+  id: "a",
+  name: "A",
+  position: { lat: 59.9, lon: 10.65 },
+  groundElevationM: 120,
+  antennaHeightM: 15,
+  txPowerDbm: 20,
+  txGainDbi: 2,
+  rxGainDbi: 2,
+  cableLossDb: 1,
+};
+
+const toSite: Site = {
+  id: "b",
+  name: "B",
+  position: { lat: 59.93, lon: 10.74 },
+  groundElevationM: 140,
+  antennaHeightM: 12,
+  txPowerDbm: 20,
+  txGainDbi: 2,
+  rxGainDbi: 2,
+  cableLossDb: 1,
+};
+
+const link: Link = {
+  id: "link-1",
+  fromSiteId: fromSite.id,
+  toSiteId: toSite.id,
+  frequencyMHz: 868,
+};
+
+const environment: PropagationEnvironment = {
+  radioClimate: "Continental Temperate",
+  polarization: "Vertical",
+  clutterHeightM: 10,
+  groundDielectric: 15,
+  groundConductivity: 0.005,
+  atmosphericBendingNUnits: 301,
+};
+
+const terrainSampler = () => 135;
+
+describe("overlayRaster async builders", () => {
+  it("builds coverage raster pixels with expected metadata shape", async () => {
+    const raster = await buildCoverageOverlayPixelsAsync(
+      bounds,
+      samples,
+      "heatmap",
+      5,
+      { width: 16, height: 10 },
+      undefined,
+      terrainSampler,
+      { phase: "coverage", signature: "shape-test" },
+    );
+
+    expect(raster).not.toBeNull();
+    expect(raster?.width).toBe(16);
+    expect(raster?.height).toBe(10);
+    expect(raster?.pixels.length).toBe(16 * 10 * 4);
+    expect(raster?.coordinates).toEqual([
+      [bounds.minLon, bounds.maxLat],
+      [bounds.maxLon, bounds.maxLat],
+      [bounds.maxLon, bounds.minLat],
+      [bounds.minLon, bounds.minLat],
+    ]);
+  });
+
+  it("supports all overlay modes through async chunked builders", async () => {
+    const passFail = await buildSourcePassFailOverlayPixelsAsync(
+      bounds,
+      fromSite,
+      link,
+      toSite.antennaHeightM,
+      toSite.rxGainDbi,
+      environment,
+      -118,
+      0,
+      terrainSampler,
+      { width: 10, height: 10 },
+      24,
+      undefined,
+      { phase: "passfail", signature: "mode-passfail", frameBudgetMs: 2 },
+    );
+
+    const relay = await buildRelayCandidateOverlayPixelsAsync(
+      bounds,
+      fromSite,
+      toSite,
+      link,
+      environment,
+      0,
+      terrainSampler,
+      { width: 10, height: 10 },
+      24,
+      undefined,
+      { phase: "relay", signature: "mode-relay", frameBudgetMs: 2 },
+    );
+
+    const terrain = await buildTerrainShadeOverlayPixelsAsync(
+      bounds,
+      terrainSampler,
+      { width: 10, height: 10 },
+      undefined,
+      { phase: "terrain", signature: "mode-terrain", frameBudgetMs: 2 },
+    );
+
+    expect(passFail?.pixels.length).toBe(10 * 10 * 4);
+    expect(relay?.pixels.length).toBe(10 * 10 * 4);
+    expect(terrain?.pixels.length).toBe(10 * 10 * 4);
+    expect(relay?.minDbm).toEqual(expect.any(Number));
+    expect(relay?.maxDbm).toEqual(expect.any(Number));
+  });
+
+  it("cancels an in-flight overlay task without returning stale data", async () => {
+    let shouldCancel = false;
+    const promise = buildCoverageOverlayPixelsAsync(
+      bounds,
+      samples,
+      "contours",
+      5,
+      { width: 220, height: 220 },
+      undefined,
+      terrainSampler,
+      {
+        phase: "coverage",
+        signature: "cancel-test",
+        frameBudgetMs: 1,
+        longTaskMs: 1,
+        shouldCancel: () => shouldCancel,
+        onLongTask: () => {
+          shouldCancel = true;
+        },
+      },
+    );
+
+    await expect(promise).rejects.toBeInstanceOf(OverlayTaskCancelledError);
+  });
+});

--- a/src/lib/overlayRaster.ts
+++ b/src/lib/overlayRaster.ts
@@ -1,0 +1,666 @@
+import { classifyPassFailState, computeSourceCentricRxMetrics } from "./passFailState";
+import { STANDARD_SITE_RADIO } from "./linkRadio";
+import type { Link, PropagationEnvironment, Site } from "../types/radio";
+
+export type TerrainBounds = {
+  minLat: number;
+  maxLat: number;
+  minLon: number;
+  maxLon: number;
+};
+
+export type CoverageSampleLite = { lat: number; lon: number; valueDbm: number };
+
+export type OverlayRasterPixels = {
+  width: number;
+  height: number;
+  pixels: Uint8ClampedArray;
+  coordinates: [[number, number], [number, number], [number, number], [number, number]];
+  minDbm?: number;
+  maxDbm?: number;
+};
+
+export type OverlayRasterDataUrl = {
+  url: string;
+  coordinates: [[number, number], [number, number], [number, number], [number, number]];
+  minDbm?: number;
+  maxDbm?: number;
+};
+
+export type OverlayTaskContext = {
+  phase: string;
+  signature: string;
+  frameBudgetMs?: number;
+  longTaskMs?: number;
+  shouldCancel?: () => boolean;
+  onLongTask?: (payload: {
+    phase: string;
+    signature: string;
+    durationMs: number;
+    processed: number;
+    total: number;
+  }) => void;
+};
+
+const DEFAULT_FRAME_BUDGET_MS = 8;
+const DEFAULT_LONG_TASK_MS = 28;
+
+const nowMs = (): number =>
+  typeof performance !== "undefined" && typeof performance.now === "function"
+    ? performance.now()
+    : Date.now();
+
+const nextFrame = async (): Promise<void> => {
+  if (typeof window !== "undefined" && typeof window.requestAnimationFrame === "function") {
+    await new Promise<void>((resolve) => window.requestAnimationFrame(() => resolve()));
+    return;
+  }
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+};
+
+const clamp = (value: number, min: number, max: number): number => Math.max(min, Math.min(max, value));
+
+const overlayCoordinates = (bounds: TerrainBounds): OverlayRasterPixels["coordinates"] => [
+  [bounds.minLon, bounds.maxLat],
+  [bounds.maxLon, bounds.maxLat],
+  [bounds.maxLon, bounds.minLat],
+  [bounds.minLon, bounds.minLat],
+];
+
+export class OverlayTaskCancelledError extends Error {
+  constructor() {
+    super("overlay-task-cancelled");
+    this.name = "OverlayTaskCancelledError";
+  }
+}
+
+const throwIfCancelled = (context?: OverlayTaskContext): void => {
+  if (context?.shouldCancel?.()) throw new OverlayTaskCancelledError();
+};
+
+const runCooperativeLoop = async (
+  total: number,
+  runner: (index: number) => void,
+  context?: OverlayTaskContext,
+): Promise<void> => {
+  let processed = 0;
+  const frameBudgetMs = Math.max(1, context?.frameBudgetMs ?? DEFAULT_FRAME_BUDGET_MS);
+  const longTaskMs = Math.max(frameBudgetMs, context?.longTaskMs ?? DEFAULT_LONG_TASK_MS);
+
+  while (processed < total) {
+    throwIfCancelled(context);
+    const chunkStartedAt = nowMs();
+
+    while (processed < total) {
+      runner(processed);
+      processed += 1;
+      throwIfCancelled(context);
+      if (nowMs() - chunkStartedAt >= frameBudgetMs) {
+        break;
+      }
+    }
+
+    const chunkDuration = nowMs() - chunkStartedAt;
+    if (chunkDuration >= longTaskMs) {
+      context?.onLongTask?.({
+        phase: context.phase,
+        signature: context.signature,
+        durationMs: chunkDuration,
+        processed,
+        total,
+      });
+    }
+
+    if (processed < total) {
+      await nextFrame();
+    }
+  }
+};
+
+const coverageColorForDbm = (valueDbm: number): [number, number, number] => {
+  const stops: Array<{ v: number; c: [number, number, number] }> = [
+    { v: -125, c: [105, 42, 45] },
+    { v: -114, c: [156, 63, 49] },
+    { v: -104, c: [201, 92, 45] },
+    { v: -95, c: [226, 127, 45] },
+    { v: -86, c: [218, 175, 55] },
+    { v: -78, c: [164, 193, 68] },
+    { v: -70, c: [95, 178, 95] },
+    { v: -62, c: [64, 150, 178] },
+  ];
+  if (valueDbm <= stops[0].v) return stops[0].c;
+  if (valueDbm >= stops[stops.length - 1].v) return stops[stops.length - 1].c;
+  for (let i = 0; i < stops.length - 1; i += 1) {
+    const a = stops[i];
+    const b = stops[i + 1];
+    if (valueDbm < a.v || valueDbm > b.v) continue;
+    const t = (valueDbm - a.v) / (b.v - a.v);
+    return [
+      Math.round(a.c[0] + (b.c[0] - a.c[0]) * t),
+      Math.round(a.c[1] + (b.c[1] - a.c[1]) * t),
+      Math.round(a.c[2] + (b.c[2] - a.c[2]) * t),
+    ];
+  }
+  return [255, 255, 255];
+};
+
+const coverageColorAdaptive = (valueDbm: number, samples: CoverageSampleLite[]): [number, number, number] => {
+  if (samples.length < 2) return coverageColorForDbm(valueDbm);
+  let min = Number.POSITIVE_INFINITY;
+  let max = Number.NEGATIVE_INFINITY;
+  for (const sample of samples) {
+    min = Math.min(min, sample.valueDbm);
+    max = Math.max(max, sample.valueDbm);
+  }
+  const range = Math.max(6, max - min);
+  const normalized = -125 + ((valueDbm - min) / range) * 63;
+  return coverageColorForDbm(clamp(normalized, -125, -62));
+};
+
+const interpolateCoverageDbm = (samples: CoverageSampleLite[], lat: number, lon: number): number | null => {
+  if (!samples.length) return null;
+  let weightSum = 0;
+  let valueSum = 0;
+  for (const sample of samples) {
+    const dLat = sample.lat - lat;
+    const dLon = sample.lon - lon;
+    const d2 = dLat * dLat + dLon * dLon;
+    if (d2 < 1e-12) return sample.valueDbm;
+    const weight = 1 / d2;
+    weightSum += weight;
+    valueSum += sample.valueDbm * weight;
+  }
+  if (weightSum <= 0) return null;
+  return valueSum / weightSum;
+};
+
+const binarySearchFloor = (values: number[], target: number): number => {
+  let lo = 0;
+  let hi = values.length - 1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    const value = values[mid];
+    if (value <= target) {
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return clamp(hi, 0, values.length - 1);
+};
+
+const makeGridInterpolator = (
+  samples: CoverageSampleLite[],
+): ((lat: number, lon: number) => number | null) | null => {
+  if (samples.length < 4) return null;
+  const latSet = new Set<number>();
+  const lonSet = new Set<number>();
+  for (const sample of samples) {
+    latSet.add(sample.lat);
+    lonSet.add(sample.lon);
+  }
+  const lats = Array.from(latSet).sort((a, b) => a - b);
+  const lons = Array.from(lonSet).sort((a, b) => a - b);
+  if (lats.length < 2 || lons.length < 2) return null;
+  if (lats.length * lons.length !== samples.length) return null;
+
+  const latIndex = new globalThis.Map<number, number>();
+  const lonIndex = new globalThis.Map<number, number>();
+  lats.forEach((value, index) => latIndex.set(value, index));
+  lons.forEach((value, index) => lonIndex.set(value, index));
+
+  const values = new Float64Array(lats.length * lons.length);
+  const seen = new Uint8Array(lats.length * lons.length);
+  for (const sample of samples) {
+    const yi = latIndex.get(sample.lat);
+    const xi = lonIndex.get(sample.lon);
+    if (yi === undefined || xi === undefined) return null;
+    const idx = yi * lons.length + xi;
+    values[idx] = sample.valueDbm;
+    seen[idx] = 1;
+  }
+  for (const mark of seen) {
+    if (mark !== 1) return null;
+  }
+
+  return (lat, lon) => {
+    const latClamped = clamp(lat, lats[0], lats[lats.length - 1]);
+    const lonClamped = clamp(lon, lons[0], lons[lons.length - 1]);
+    const y0 = binarySearchFloor(lats, latClamped);
+    const x0 = binarySearchFloor(lons, lonClamped);
+    const y1 = Math.min(y0 + 1, lats.length - 1);
+    const x1 = Math.min(x0 + 1, lons.length - 1);
+
+    const lat0 = lats[y0];
+    const lat1 = lats[y1];
+    const lon0 = lons[x0];
+    const lon1 = lons[x1];
+    const ty = lat1 === lat0 ? 0 : (latClamped - lat0) / (lat1 - lat0);
+    const tx = lon1 === lon0 ? 0 : (lonClamped - lon0) / (lon1 - lon0);
+
+    const q00 = values[y0 * lons.length + x0];
+    const q10 = values[y0 * lons.length + x1];
+    const q01 = values[y1 * lons.length + x0];
+    const q11 = values[y1 * lons.length + x1];
+    const a = q00 + (q10 - q00) * tx;
+    const b = q01 + (q11 - q01) * tx;
+    return a + (b - a) * ty;
+  };
+};
+
+const computeSourceCentricRxDbm = (
+  lat: number,
+  lon: number,
+  fromSite: Site,
+  effectiveLink: Link,
+  receiverAntennaHeightM: number,
+  receiverRxGainDbi: number,
+  terrainSampler: (lat: number, lon: number) => number | null,
+  terrainSamples: number,
+  propagationEnvironment: PropagationEnvironment,
+): number =>
+  computeSourceCentricRxMetrics(
+    lat,
+    lon,
+    fromSite,
+    effectiveLink,
+    receiverAntennaHeightM,
+    receiverRxGainDbi,
+    terrainSampler,
+    terrainSamples,
+    propagationEnvironment,
+  ).rxDbm;
+
+export const buildCoverageOverlayPixelsAsync = async (
+  bounds: TerrainBounds,
+  samples: CoverageSampleLite[],
+  mode: "heatmap" | "contours",
+  bandStepDb: number,
+  dimensions: { width: number; height: number },
+  pointMask?: (lat: number, lon: number) => boolean,
+  terrainSampler?: (lat: number, lon: number) => number | null,
+  context?: OverlayTaskContext,
+): Promise<OverlayRasterPixels | null> => {
+  if (!samples.length) return null;
+  const gridInterpolator = makeGridInterpolator(samples);
+  const width = dimensions.width;
+  const height = dimensions.height;
+  const pixels = new Uint8ClampedArray(width * height * 4);
+
+  await runCooperativeLoop(
+    width * height,
+    (index) => {
+      const y = Math.floor(index / width);
+      const x = index - y * width;
+      const tY = y / Math.max(1, height - 1);
+      const lat = bounds.maxLat - (bounds.maxLat - bounds.minLat) * tY;
+      const tX = x / Math.max(1, width - 1);
+      const lon = bounds.minLon + (bounds.maxLon - bounds.minLon) * tX;
+      if (pointMask && !pointMask(lat, lon)) return;
+      if (terrainSampler && terrainSampler(lat, lon) === null) return;
+      const valueDbm = gridInterpolator
+        ? gridInterpolator(lat, lon)
+        : interpolateCoverageDbm(samples, lat, lon);
+      if (valueDbm === null) return;
+
+      let r = 0;
+      let g = 0;
+      let b = 0;
+      let a = 180;
+      if (mode === "heatmap") {
+        [r, g, b] = coverageColorAdaptive(valueDbm, samples);
+      } else {
+        const banded = Math.round(valueDbm / Math.max(1, bandStepDb)) * Math.max(1, bandStepDb);
+        [r, g, b] = coverageColorAdaptive(banded, samples);
+        a = 170;
+      }
+
+      const px = index * 4;
+      pixels[px] = r;
+      pixels[px + 1] = g;
+      pixels[px + 2] = b;
+      pixels[px + 3] = a;
+    },
+    context,
+  );
+
+  return {
+    width,
+    height,
+    pixels,
+    coordinates: overlayCoordinates(bounds),
+  };
+};
+
+export const buildSourcePassFailOverlayPixelsAsync = async (
+  bounds: TerrainBounds,
+  fromSite: Site,
+  effectiveLink: Link,
+  receiverAntennaHeightM: number,
+  receiverRxGainDbi: number,
+  propagationEnvironment: PropagationEnvironment,
+  rxTargetDbm: number,
+  environmentLossDb: number,
+  terrainSampler: (lat: number, lon: number) => number | null,
+  dimensions: { width: number; height: number },
+  terrainSamples: number,
+  pointMask?: (lat: number, lon: number) => boolean,
+  context?: OverlayTaskContext,
+): Promise<OverlayRasterPixels | null> => {
+  const width = dimensions.width;
+  const height = dimensions.height;
+  const pixels = new Uint8ClampedArray(width * height * 4);
+
+  await runCooperativeLoop(
+    width * height,
+    (index) => {
+      const y = Math.floor(index / width);
+      const x = index - y * width;
+      const tY = y / Math.max(1, height - 1);
+      const lat = bounds.maxLat - (bounds.maxLat - bounds.minLat) * tY;
+      const tX = x / Math.max(1, width - 1);
+      const lon = bounds.minLon + (bounds.maxLon - bounds.minLon) * tX;
+      if (pointMask && !pointMask(lat, lon)) return;
+      if (terrainSampler(lat, lon) === null) return;
+
+      const metrics = computeSourceCentricRxMetrics(
+        lat,
+        lon,
+        fromSite,
+        effectiveLink,
+        receiverAntennaHeightM,
+        receiverRxGainDbi,
+        terrainSampler,
+        terrainSamples,
+        propagationEnvironment,
+      );
+      const pass = metrics.rxDbm - environmentLossDb >= rxTargetDbm;
+      const losBlocked = metrics.terrainObstructed;
+      const state = classifyPassFailState(pass, losBlocked);
+
+      const px = index * 4;
+      if (state === "pass_clear") {
+        pixels[px] = 82;
+        pixels[px + 1] = 181;
+        pixels[px + 2] = 96;
+      } else if (state === "pass_blocked") {
+        pixels[px] = 232;
+        pixels[px + 1] = 170;
+        pixels[px + 2] = 72;
+      } else if (state === "fail_clear") {
+        pixels[px] = 235;
+        pixels[px + 1] = 120;
+        pixels[px + 2] = 70;
+      } else {
+        pixels[px] = 205;
+        pixels[px + 1] = 87;
+        pixels[px + 2] = 79;
+      }
+      pixels[px + 3] = 162;
+    },
+    context,
+  );
+
+  return {
+    width,
+    height,
+    pixels,
+    coordinates: overlayCoordinates(bounds),
+  };
+};
+
+export const buildRelayCandidateOverlayPixelsAsync = async (
+  bounds: TerrainBounds,
+  fromSite: Site,
+  toSite: Site,
+  effectiveLink: Link,
+  propagationEnvironment: PropagationEnvironment,
+  environmentLossDb: number,
+  terrainSampler: (lat: number, lon: number) => number | null,
+  dimensions: { width: number; height: number },
+  terrainSamples: number,
+  pointMask?: (lat: number, lon: number) => boolean,
+  context?: OverlayTaskContext,
+): Promise<OverlayRasterPixels | null> => {
+  const width = dimensions.width;
+  const height = dimensions.height;
+  const relayAntennaHeightM = Math.max(2, (fromSite.antennaHeightM + toSite.antennaHeightM) / 2);
+  const fallbackRelayGround = (fromSite.groundElevationM + toSite.groundElevationM) / 2;
+  const pixels = new Uint8ClampedArray(width * height * 4);
+  const bottleneck = new Float32Array(width * height).fill(-Infinity);
+  let minDbm = Number.POSITIVE_INFINITY;
+  let maxDbm = Number.NEGATIVE_INFINITY;
+
+  await runCooperativeLoop(
+    width * height,
+    (index) => {
+      const y = Math.floor(index / width);
+      const x = index - y * width;
+      const tY = y / Math.max(1, height - 1);
+      const lat = bounds.maxLat - (bounds.maxLat - bounds.minLat) * tY;
+      const tX = x / Math.max(1, width - 1);
+      const lon = bounds.minLon + (bounds.maxLon - bounds.minLon) * tX;
+      if (pointMask && !pointMask(lat, lon)) return;
+
+      const sampledGround = terrainSampler(lat, lon);
+      if (sampledGround === null) return;
+      const relayGround = sampledGround ?? fallbackRelayGround;
+
+      const relaySite: Site = {
+        id: "__relay_candidate__",
+        name: "Relay candidate",
+        position: { lat, lon },
+        antennaHeightM: relayAntennaHeightM,
+        groundElevationM: relayGround,
+        txPowerDbm: STANDARD_SITE_RADIO.txPowerDbm,
+        txGainDbi: STANDARD_SITE_RADIO.txGainDbi,
+        rxGainDbi: STANDARD_SITE_RADIO.rxGainDbi,
+        cableLossDb: STANDARD_SITE_RADIO.cableLossDb,
+      };
+
+      const fromToRelayRx = computeSourceCentricRxDbm(
+        lat,
+        lon,
+        fromSite,
+        effectiveLink,
+        relayAntennaHeightM,
+        relaySite.rxGainDbi,
+        terrainSampler,
+        terrainSamples,
+        propagationEnvironment,
+      );
+      const relayToTargetRx = computeSourceCentricRxDbm(
+        toSite.position.lat,
+        toSite.position.lon,
+        relaySite,
+        effectiveLink,
+        toSite.antennaHeightM,
+        toSite.rxGainDbi,
+        terrainSampler,
+        terrainSamples,
+        propagationEnvironment,
+      );
+      const bottleneckDbm = Math.min(fromToRelayRx, relayToTargetRx) - environmentLossDb;
+
+      bottleneck[index] = bottleneckDbm;
+      minDbm = Math.min(minDbm, bottleneckDbm);
+      maxDbm = Math.max(maxDbm, bottleneckDbm);
+    },
+    context,
+  );
+
+  if (!Number.isFinite(minDbm) || !Number.isFinite(maxDbm)) return null;
+  const dynamicRange = Math.max(6, maxDbm - minDbm);
+
+  await runCooperativeLoop(
+    width * height,
+    (index) => {
+      const value = bottleneck[index];
+      if (!Number.isFinite(value)) return;
+      const normalized = -125 + ((value - minDbm) / dynamicRange) * 63;
+      const [r, g, b] = coverageColorForDbm(clamp(normalized, -125, -62));
+      const px = index * 4;
+      pixels[px] = r;
+      pixels[px + 1] = g;
+      pixels[px + 2] = b;
+      pixels[px + 3] = 172;
+    },
+    context,
+  );
+
+  return {
+    width,
+    height,
+    pixels,
+    coordinates: overlayCoordinates(bounds),
+    minDbm,
+    maxDbm,
+  };
+};
+
+export const buildTerrainShadeOverlayPixelsAsync = async (
+  bounds: TerrainBounds,
+  sampler: (lat: number, lon: number) => number | null,
+  dimensions: { width: number; height: number },
+  pointMask?: (lat: number, lon: number) => boolean,
+  context?: OverlayTaskContext,
+): Promise<OverlayRasterPixels | null> => {
+  const width = dimensions.width;
+  const height = dimensions.height;
+  const elevations = new Float32Array(width * height);
+  const valid = new Uint8Array(width * height);
+  const allowed = new Uint8Array(width * height);
+  const pixels = new Uint8ClampedArray(width * height * 4);
+
+  let minElevation = Number.POSITIVE_INFINITY;
+  let maxElevation = Number.NEGATIVE_INFINITY;
+
+  await runCooperativeLoop(
+    width * height,
+    (index) => {
+      const y = Math.floor(index / width);
+      const x = index - y * width;
+      const tY = y / Math.max(1, height - 1);
+      const lat = bounds.maxLat - (bounds.maxLat - bounds.minLat) * tY;
+      const tX = x / Math.max(1, width - 1);
+      const lon = bounds.minLon + (bounds.maxLon - bounds.minLon) * tX;
+      const isAllowed = pointMask ? pointMask(lat, lon) : true;
+      const elevation = sampler(lat, lon);
+
+      if (isAllowed) {
+        allowed[index] = 1;
+      }
+      if (!isAllowed || elevation === null) return;
+
+      elevations[index] = elevation;
+      valid[index] = 1;
+      minElevation = Math.min(minElevation, elevation);
+      maxElevation = Math.max(maxElevation, elevation);
+    },
+    context,
+  );
+
+  if (!Number.isFinite(minElevation) || !Number.isFinite(maxElevation)) return null;
+
+  for (let pass = 0; pass < 3; pass += 1) {
+    await runCooperativeLoop(
+      width * height,
+      (index) => {
+        const y = Math.floor(index / width);
+        const x = index - y * width;
+        if (x <= 0 || y <= 0 || x >= width - 1 || y >= height - 1) return;
+        if (!allowed[index] || valid[index]) return;
+
+        const neighbors = [index - 1, index + 1, index - width, index + width];
+        let sum = 0;
+        let count = 0;
+        for (const neighbor of neighbors) {
+          if (!allowed[neighbor] || !valid[neighbor]) continue;
+          sum += elevations[neighbor];
+          count += 1;
+        }
+        if (!count) return;
+        elevations[index] = sum / count;
+        valid[index] = 1;
+      },
+      context,
+    );
+  }
+
+  const lightAzimuthRad = (315 * Math.PI) / 180;
+  const lightAltitudeRad = (45 * Math.PI) / 180;
+  const lx = Math.cos(lightAltitudeRad) * Math.sin(lightAzimuthRad);
+  const ly = Math.cos(lightAltitudeRad) * Math.cos(lightAzimuthRad);
+  const lz = Math.sin(lightAltitudeRad);
+  const centerLat = (bounds.minLat + bounds.maxLat) / 2;
+  const metersPerLon =
+    ((bounds.maxLon - bounds.minLon) * 111_320 * Math.max(0.1, Math.cos((centerLat * Math.PI) / 180))) /
+    Math.max(1, width - 1);
+  const metersPerLat = ((bounds.maxLat - bounds.minLat) * 111_320) / Math.max(1, height - 1);
+  const range = Math.max(1, maxElevation - minElevation);
+
+  await runCooperativeLoop(
+    width * height,
+    (index) => {
+      if (!allowed[index] || !valid[index]) {
+        pixels[index * 4 + 3] = 0;
+        return;
+      }
+      const y = Math.floor(index / width);
+      const x = index - y * width;
+      const x0 = Math.max(0, x - 1);
+      const x1 = Math.min(width - 1, x + 1);
+      const y0 = Math.max(0, y - 1);
+      const y1 = Math.min(height - 1, y + 1);
+      const left = elevations[y * width + x0];
+      const right = elevations[y * width + x1];
+      const top = elevations[y0 * width + x];
+      const bottom = elevations[y1 * width + x];
+
+      const dzdx = (right - left) / Math.max(1, (x1 - x0) * metersPerLon);
+      const dzdy = (bottom - top) / Math.max(1, (y1 - y0) * metersPerLat);
+
+      const nx = -dzdx;
+      const ny = -dzdy;
+      const nz = 1;
+      const norm = Math.hypot(nx, ny, nz) || 1;
+      const shade = Math.max(0, (nx * lx + ny * ly + nz * lz) / norm);
+
+      const elevationNorm = (elevations[index] - minElevation) / range;
+      const base = 58 + elevationNorm * 112;
+      const lit = clamp(base * 0.65 + shade * 145, 0, 255);
+
+      const px = index * 4;
+      pixels[px] = lit * 0.95;
+      pixels[px + 1] = lit;
+      pixels[px + 2] = lit * 1.04;
+      pixels[px + 3] = 210;
+    },
+    context,
+  );
+
+  return {
+    width,
+    height,
+    pixels,
+    coordinates: overlayCoordinates(bounds),
+  };
+};
+
+export const overlayPixelsToDataUrl = (raster: OverlayRasterPixels): OverlayRasterDataUrl | null => {
+  if (typeof document === "undefined") return null;
+  const canvas = document.createElement("canvas");
+  canvas.width = raster.width;
+  canvas.height = raster.height;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return null;
+  const image = ctx.createImageData(raster.width, raster.height);
+  image.data.set(raster.pixels);
+  ctx.putImageData(image, 0, 0);
+  return {
+    url: canvas.toDataURL("image/png"),
+    coordinates: raster.coordinates,
+    minDbm: raster.minDbm,
+    maxDbm: raster.maxDbm,
+  };
+};

--- a/src/lib/srtm.test.ts
+++ b/src/lib/srtm.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import type { SrtmTile } from "../types/radio";
+import { sampleSrtmElevation } from "./srtm";
+
+const makeTile = (params: {
+  key: string;
+  latStart: number;
+  lonStart: number;
+  values: number[];
+  size?: number;
+  sourceId?: string;
+  sourceKind?: SrtmTile["sourceKind"];
+  arcSecondSpacing?: 1 | 3;
+}): SrtmTile => {
+  const size = params.size ?? Math.round(Math.sqrt(params.values.length));
+  return {
+    key: params.key,
+    latStart: params.latStart,
+    lonStart: params.lonStart,
+    size,
+    width: size,
+    height: size,
+    arcSecondSpacing: params.arcSecondSpacing ?? 3,
+    elevations: new Int16Array(params.values),
+    sourceId: params.sourceId,
+    sourceKind: params.sourceKind,
+  };
+};
+
+describe("sampleSrtmElevation", () => {
+  it("samples expected nearest grid cell values", () => {
+    const tile = makeTile({
+      key: "N59E010",
+      latStart: 59,
+      lonStart: 10,
+      size: 3,
+      values: [
+        11, 12, 13,
+        21, 22, 23,
+        31, 32, 33,
+      ],
+      sourceId: "copernicus30",
+    });
+
+    expect(sampleSrtmElevation([tile], 59.95, 10.05)).toBe(11);
+    expect(sampleSrtmElevation([tile], 59.5, 10.5)).toBe(22);
+    expect(sampleSrtmElevation([tile], 59.05, 10.95)).toBe(33);
+  });
+
+  it("uses quality precedence when duplicate tile keys exist", () => {
+    const low = makeTile({
+      key: "N59E010",
+      latStart: 59,
+      lonStart: 10,
+      size: 2,
+      values: [90, 90, 90, 90],
+      sourceId: "copernicus90",
+      arcSecondSpacing: 3,
+    });
+    const high = makeTile({
+      key: "N59E010",
+      latStart: 59,
+      lonStart: 10,
+      size: 2,
+      values: [30, 30, 30, 30],
+      sourceId: "copernicus30",
+      arcSecondSpacing: 1,
+    });
+    const manual = makeTile({
+      key: "N59E010",
+      latStart: 59,
+      lonStart: 10,
+      size: 2,
+      values: [7, 7, 7, 7],
+      sourceKind: "manual-upload",
+      sourceId: "uploaded",
+      arcSecondSpacing: 1,
+    });
+
+    expect(sampleSrtmElevation([low, high], 59.7, 10.7)).toBe(30);
+    expect(sampleSrtmElevation([high, manual], 59.7, 10.7)).toBe(7);
+  });
+
+  it("samples correctly on tile boundary coordinates", () => {
+    const southWest = makeTile({
+      key: "N59E010",
+      latStart: 59,
+      lonStart: 10,
+      size: 2,
+      values: [5910, 5910, 5910, 5910],
+      sourceId: "copernicus30",
+    });
+    const northWest = makeTile({
+      key: "N60E010",
+      latStart: 60,
+      lonStart: 10,
+      size: 2,
+      values: [6010, 6010, 6010, 6010],
+      sourceId: "uploaded",
+      sourceKind: "manual-upload",
+    });
+
+    expect(sampleSrtmElevation([southWest, northWest], 60, 10.4)).toBe(6010);
+  });
+
+  it("returns null for nodata samples", () => {
+    const tile = makeTile({
+      key: "N59E010",
+      latStart: 59,
+      lonStart: 10,
+      size: 2,
+      values: [-32768, -32768, -32768, -32768],
+      sourceId: "copernicus30",
+    });
+    expect(sampleSrtmElevation([tile], 59.4, 10.4)).toBeNull();
+  });
+});

--- a/src/lib/srtm.ts
+++ b/src/lib/srtm.ts
@@ -1,5 +1,6 @@
 import type { SrtmTile } from "../types/radio";
 import { unzipSync } from "fflate";
+import { choosePreferredTerrainTile } from "./terrainTileRank";
 
 const HGT_FILENAME = /^([NS])(\d{2})([EW])(\d{3})\.hgt$/i;
 
@@ -110,12 +111,78 @@ const sampleFromTile = (tile: SrtmTile, lat: number, lon: number): number => {
   return tile.elevations[row * width + col];
 };
 
+const TILE_LOOKUP_CACHE = new WeakMap<ReadonlyArray<SrtmTile>, Map<string, SrtmTile>>();
+
+const tileKeyForStart = (latStart: number, lonStart: number): string => {
+  const ns = latStart >= 0 ? "N" : "S";
+  const ew = lonStart >= 0 ? "E" : "W";
+  return `${ns}${String(Math.floor(Math.abs(latStart))).padStart(2, "0")}${ew}${String(
+    Math.floor(Math.abs(lonStart)),
+  ).padStart(3, "0")}`;
+};
+
+const tileLookupFor = (tiles: ReadonlyArray<SrtmTile>): Map<string, SrtmTile> => {
+  const cached = TILE_LOOKUP_CACHE.get(tiles);
+  if (cached) return cached;
+
+  const lookup = new Map<string, SrtmTile>();
+  for (const tile of tiles) {
+    const existing = lookup.get(tile.key);
+    if (!existing) {
+      lookup.set(tile.key, tile);
+      continue;
+    }
+    lookup.set(tile.key, choosePreferredTerrainTile(existing, tile));
+  }
+
+  TILE_LOOKUP_CACHE.set(tiles, lookup);
+  return lookup;
+};
+
+const NEAR_INTEGER_EPSILON = 1e-9;
+
+const candidateTileKeysForCoordinate = (lat: number, lon: number): string[] => {
+  const latFloor = Math.floor(lat);
+  const lonFloor = Math.floor(lon);
+  const latStarts = [latFloor];
+  const lonStarts = [lonFloor];
+
+  if (Math.abs(lat - latFloor) <= NEAR_INTEGER_EPSILON) latStarts.push(latFloor - 1);
+  if (Math.abs(lon - lonFloor) <= NEAR_INTEGER_EPSILON) lonStarts.push(lonFloor - 1);
+
+  const keys = new Set<string>();
+  for (const latStart of latStarts) {
+    for (const lonStart of lonStarts) {
+      keys.add(tileKeyForStart(latStart, lonStart));
+    }
+  }
+  return Array.from(keys);
+};
+
+const pickTileForCoordinate = (
+  lookup: Map<string, SrtmTile>,
+  lat: number,
+  lon: number,
+): SrtmTile | null => {
+  let chosen: SrtmTile | null = null;
+
+  for (const key of candidateTileKeysForCoordinate(lat, lon)) {
+    const candidate = lookup.get(key);
+    if (!candidate) continue;
+    if (!inTile(candidate, lat, lon)) continue;
+    chosen = chosen ? choosePreferredTerrainTile(chosen, candidate) : candidate;
+  }
+
+  return chosen;
+};
+
 export const sampleSrtmElevation = (
   tiles: ReadonlyArray<SrtmTile>,
   lat: number,
   lon: number,
 ): number | null => {
-  const tile = tiles.find((candidate) => inTile(candidate, lat, lon));
+  const lookup = tileLookupFor(tiles);
+  const tile = pickTileForCoordinate(lookup, lat, lon);
   if (!tile) return null;
 
   const raw = sampleFromTile(tile, lat, lon);

--- a/src/lib/terrainMerge.ts
+++ b/src/lib/terrainMerge.ts
@@ -1,11 +1,5 @@
+import { terrainTileRank } from "./terrainTileRank";
 import type { SrtmTile } from "../types/radio";
-
-const tileQualityRank = (tile: SrtmTile): number => {
-  if (tile.sourceKind === "manual-upload") return 4;
-  if (tile.sourceId === "copernicus30") return 3;
-  if (tile.sourceId === "copernicus90") return 2;
-  return 1;
-};
 
 export const mergeSrtmTiles = (existing: SrtmTile[], incoming: SrtmTile[]): SrtmTile[] => {
   const dedup = new Map<string, SrtmTile>();
@@ -16,8 +10,8 @@ export const mergeSrtmTiles = (existing: SrtmTile[], incoming: SrtmTile[]): Srtm
       dedup.set(tile.key, tile);
       continue;
     }
-    const incomingRank = tileQualityRank(tile);
-    const previousRank = tileQualityRank(previous);
+    const incomingRank = terrainTileRank(tile);
+    const previousRank = terrainTileRank(previous);
     if (incomingRank >= previousRank) {
       dedup.set(tile.key, tile);
     }

--- a/src/lib/terrainTileRank.ts
+++ b/src/lib/terrainTileRank.ts
@@ -1,0 +1,20 @@
+import type { SrtmTile } from "../types/radio";
+
+export const terrainTileRank = (tile: SrtmTile): number => {
+  if (tile.sourceKind === "manual-upload") return 4;
+  if (tile.sourceId === "copernicus30") return 3;
+  if (tile.sourceId === "copernicus90") return 2;
+  return 1;
+};
+
+export const choosePreferredTerrainTile = (a: SrtmTile, b: SrtmTile): SrtmTile => {
+  const aRank = terrainTileRank(a);
+  const bRank = terrainTileRank(b);
+  if (aRank !== bRank) return aRank > bRank ? a : b;
+
+  const aSpacing = a.arcSecondSpacing ?? 3;
+  const bSpacing = b.arcSecondSpacing ?? 3;
+  if (aSpacing !== bSpacing) return aSpacing < bSpacing ? a : b;
+
+  return b;
+};

--- a/src/store/coverageStore.test.ts
+++ b/src/store/coverageStore.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { setAppStoreBridge, useCoverageStore } from "./coverageStore";
+import { resetCoverageSchedulerForTests, setAppStoreBridge, useCoverageStore } from "./coverageStore";
 import * as coverageLib from "../lib/coverage";
 import type { CoverageSample, Site } from "../types/radio";
 
@@ -15,7 +15,7 @@ const site: Site = {
   cableLossDb: 1,
 };
 
-const bridgeState = {
+const makeBridgeState = () => ({
   selectedCoverageResolution: "24",
   networks: [{ id: "net-1", memberships: [], frequencyMHz: 869.5 }],
   selectedNetworkId: "net-1",
@@ -39,10 +39,19 @@ const bridgeState = {
   selectedSiteIds: ["site-1"],
   isTerrainFetching: false,
   selectedOverlayRadiusOption: "50",
+});
+
+let bridgeState = makeBridgeState();
+
+const flushAsyncTicks = async (count = 8): Promise<void> => {
+  for (let index = 0; index < count; index += 1) {
+    await Promise.resolve();
+  }
 };
 
 describe("coverageStore simulation progress phases", () => {
   beforeEach(() => {
+    bridgeState = makeBridgeState();
     vi.useFakeTimers();
     vi.stubGlobal("window", {
       setTimeout,
@@ -52,6 +61,7 @@ describe("coverageStore simulation progress phases", () => {
         return 1;
       },
     });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
     useCoverageStore.setState({
       coverageSamples: [],
       isSimulationRecomputing: false,
@@ -62,6 +72,7 @@ describe("coverageStore simulation progress phases", () => {
       simulationSamplesTotal: 0,
       simulationRunToken: "",
     });
+    resetCoverageSchedulerForTests();
     setAppStoreBridge({
       getState: () => bridgeState as unknown as Record<string, unknown>,
       setState: vi.fn(),
@@ -89,19 +100,19 @@ describe("coverageStore simulation progress phases", () => {
     expect(useCoverageStore.getState().simulationStepLabel).toBe("Preparing simulation bounds...");
 
     vi.advanceTimersByTime(180);
-    await Promise.resolve();
+    await flushAsyncTicks();
 
     expect(useCoverageStore.getState().simulationProgressMode).toBe("determinate");
     expect(useCoverageStore.getState().simulationProgress).toBe(50);
     expect(useCoverageStore.getState().simulationStepLabel).toBe("Sampling simulation grid (7/14)");
 
     resolveBuild([{ lat: site.position.lat, lon: site.position.lon, valueDbm: -90 }]);
-    await Promise.resolve();
+    await flushAsyncTicks();
     expect(useCoverageStore.getState().simulationProgressMode).toBe("indeterminate");
     expect(useCoverageStore.getState().simulationStepLabel).toBe("Finalizing simulation overlay...");
 
     vi.advanceTimersByTime(700);
-    await Promise.resolve();
+    await flushAsyncTicks();
 
     expect(useCoverageStore.getState().isSimulationRecomputing).toBe(false);
     expect(useCoverageStore.getState().coverageSamples).toHaveLength(1);
@@ -125,10 +136,102 @@ describe("coverageStore simulation progress phases", () => {
 
     useCoverageStore.getState().recomputeCoverage();
     vi.advanceTimersByTime(220);
-    await Promise.resolve();
+    await flushAsyncTicks();
     vi.advanceTimersByTime(700);
-    await Promise.resolve();
+    await flushAsyncTicks();
 
     expect(capturedGridSize).toBe(24);
+  });
+
+  it("runs as single-flight with one queued rerun under rapid triggers", async () => {
+    let resolveFirst!: (value: CoverageSample[]) => void;
+    let resolveSecond!: (value: CoverageSample[]) => void;
+    const runResolvers: Array<(value: CoverageSample[]) => void> = [];
+    vi.spyOn(coverageLib, "buildCoverageAsync").mockImplementation(() => {
+      return new Promise<CoverageSample[]>((resolve) => {
+        runResolvers.push(resolve);
+        if (runResolvers.length === 1) resolveFirst = resolve;
+        if (runResolvers.length === 2) resolveSecond = resolve;
+      });
+    });
+
+    useCoverageStore.getState().recomputeCoverage();
+    vi.advanceTimersByTime(220);
+    await flushAsyncTicks();
+    expect(runResolvers).toHaveLength(1);
+
+    bridgeState.selectedCoverageResolution = "42";
+    useCoverageStore.getState().recomputeCoverage();
+    useCoverageStore.getState().recomputeCoverage();
+    useCoverageStore.getState().recomputeCoverage();
+    vi.advanceTimersByTime(220);
+    await flushAsyncTicks();
+
+    expect(runResolvers).toHaveLength(1);
+
+    resolveFirst([{ lat: site.position.lat, lon: site.position.lon, valueDbm: -95 }]);
+    await flushAsyncTicks();
+    vi.advanceTimersByTime(40);
+    await flushAsyncTicks();
+    expect(runResolvers).toHaveLength(2);
+
+    resolveSecond([{ lat: site.position.lat, lon: site.position.lon, valueDbm: -82 }]);
+    await flushAsyncTicks();
+    vi.advanceTimersByTime(760);
+    await flushAsyncTicks();
+    expect(useCoverageStore.getState().coverageSamples[0]?.valueDbm).toBe(-82);
+  });
+
+  it("skips recompute when effective simulation inputs are unchanged", async () => {
+    const buildSpy = vi.spyOn(coverageLib, "buildCoverageAsync").mockResolvedValue([]);
+
+    useCoverageStore.getState().recomputeCoverage();
+    vi.advanceTimersByTime(220);
+    await flushAsyncTicks();
+    vi.advanceTimersByTime(760);
+    await flushAsyncTicks();
+    expect(buildSpy).toHaveBeenCalledTimes(1);
+
+    useCoverageStore.getState().recomputeCoverage();
+    vi.advanceTimersByTime(220);
+    await flushAsyncTicks();
+    vi.advanceTimersByTime(760);
+    await flushAsyncTicks();
+    expect(buildSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not commit stale run results when a rerun is queued", async () => {
+    const runResolvers: Array<(value: CoverageSample[]) => void> = [];
+    vi.spyOn(coverageLib, "buildCoverageAsync").mockImplementation(() => {
+      return new Promise<CoverageSample[]>((resolve) => {
+        runResolvers.push(resolve);
+      });
+    });
+
+    useCoverageStore.getState().recomputeCoverage();
+    vi.advanceTimersByTime(220);
+    await flushAsyncTicks();
+    expect(runResolvers).toHaveLength(1);
+
+    bridgeState.selectedCoverageResolution = "42";
+    useCoverageStore.getState().recomputeCoverage();
+    vi.advanceTimersByTime(220);
+    await flushAsyncTicks();
+
+    runResolvers[0]([{ lat: site.position.lat, lon: site.position.lon, valueDbm: -110 }]);
+    await flushAsyncTicks();
+    vi.advanceTimersByTime(60);
+    await flushAsyncTicks();
+    expect(useCoverageStore.getState().coverageSamples).toEqual([]);
+
+    vi.advanceTimersByTime(80);
+    await flushAsyncTicks();
+    expect(runResolvers).toHaveLength(2);
+
+    runResolvers[1]([{ lat: site.position.lat, lon: site.position.lon, valueDbm: -70 }]);
+    await flushAsyncTicks();
+    vi.advanceTimersByTime(760);
+    await flushAsyncTicks();
+    expect(useCoverageStore.getState().coverageSamples[0]?.valueDbm).toBe(-70);
   });
 });

--- a/src/store/coverageStore.ts
+++ b/src/store/coverageStore.ts
@@ -15,8 +15,34 @@ import type { Site, SrtmTile } from "../types/radio";
 import type { CoverageSample } from "../types/radio";
 
 const COVERAGE_RECOMPUTE_DEBOUNCE_MS = 140;
+const COVERAGE_MIN_VISIBLE_MS = 600;
+const COVERAGE_LONG_TASK_WARN_MS = 160;
 
 let coverageRecomputeTimer: number | null = null;
+let coverageRunInFlight = false;
+let coverageRerunQueued = false;
+let coverageRunCounter = 0;
+let lastAppliedCoverageSignature = "";
+
+const nowMs = (): number =>
+  typeof performance !== "undefined" && typeof performance.now === "function"
+    ? performance.now()
+    : Date.now();
+
+const inDevDiagnostics =
+  typeof import.meta !== "undefined" &&
+  Boolean((import.meta as { env?: { DEV?: boolean } }).env?.DEV);
+
+const warnLongTask = (phase: string, signature: string, durationMs: number): void => {
+  if (!inDevDiagnostics) return;
+  if (!Number.isFinite(durationMs) || durationMs < COVERAGE_LONG_TASK_WARN_MS) return;
+  console.warn("[simulation-long-task]", {
+    scope: "coverage",
+    phase,
+    signature,
+    durationMs: Math.round(durationMs * 100) / 100,
+  });
+};
 
 type AppStoreBridge = {
   getState: () => Record<string, unknown>;
@@ -27,6 +53,17 @@ let appStoreBridge: AppStoreBridge | null = null;
 
 export function setAppStoreBridge(bridge: AppStoreBridge): void {
   appStoreBridge = bridge;
+}
+
+export function resetCoverageSchedulerForTests(): void {
+  if (coverageRecomputeTimer !== null) {
+    window.clearTimeout(coverageRecomputeTimer);
+    coverageRecomputeTimer = null;
+  }
+  coverageRunInFlight = false;
+  coverageRerunQueued = false;
+  coverageRunCounter = 0;
+  lastAppliedCoverageSignature = "";
 }
 
 export type CoverageState = {
@@ -41,6 +78,406 @@ export type CoverageState = {
   recomputeCoverage: () => void;
 };
 
+type NetworkLike = {
+  id: string;
+  frequencyMHz?: number;
+  frequencyOverrideMHz?: number;
+  memberships?: Array<{ siteId: string; systemId: string }>;
+  [key: string]: unknown;
+};
+
+type LinkLike = {
+  id: string;
+  fromSiteId: string;
+  toSiteId: string;
+  [key: string]: unknown;
+};
+
+type CoverageInputs = {
+  selectedCoverageResolution: "24" | "42" | "84" | "168";
+  effectiveCoverageResolution: "24" | "42" | "84" | "168";
+  networks: NetworkLike[];
+  selectedNetworkId: string;
+  sites: Site[];
+  systems: unknown[];
+  propagationModel: string;
+  srtmTiles: SrtmTile[];
+  links: LinkLike[];
+  selectedLinkId: string;
+  autoPropagationEnvironment: boolean;
+  propagationEnvironment: Record<string, unknown>;
+  propagationEnvironmentReason: string;
+  terrainLoadEpoch: number;
+  selectedSiteIds: string[];
+  isTerrainFetching: boolean;
+  selectedOverlayRadiusOptionRaw: unknown;
+};
+
+const normalizeCoverageResolution = (raw: unknown): "24" | "42" | "84" | "168" => {
+  if (raw === "24" || raw === "42" || raw === "84" || raw === "168") return raw;
+  if (raw === "high") return "42";
+  return "24";
+};
+
+const readCoverageInputs = (appState: Record<string, unknown>): CoverageInputs => {
+  const selectedCoverageResolution = normalizeCoverageResolution(appState.selectedCoverageResolution);
+  const isTerrainFetching = Boolean(appState.isTerrainFetching);
+  const effectiveCoverageResolution = isTerrainFetching ? "24" : selectedCoverageResolution;
+  return {
+    selectedCoverageResolution,
+    effectiveCoverageResolution,
+    networks: (appState.networks as NetworkLike[]) ?? [],
+    selectedNetworkId: (appState.selectedNetworkId as string) ?? "",
+    sites: (appState.sites as Site[]) ?? [],
+    systems: (appState.systems as unknown[]) ?? [],
+    propagationModel: (appState.propagationModel as string) ?? "",
+    srtmTiles: (appState.srtmTiles as SrtmTile[]) ?? [],
+    links: (appState.links as LinkLike[]) ?? [],
+    selectedLinkId: (appState.selectedLinkId as string) ?? "",
+    autoPropagationEnvironment: Boolean(appState.autoPropagationEnvironment),
+    propagationEnvironment: (appState.propagationEnvironment as Record<string, unknown>) ?? {},
+    propagationEnvironmentReason: (appState.propagationEnvironmentReason as string) ?? "",
+    terrainLoadEpoch: Number(appState.terrainLoadEpoch ?? 0),
+    selectedSiteIds: ((appState.selectedSiteIds as string[]) ?? []).filter((id) => typeof id === "string"),
+    isTerrainFetching,
+    selectedOverlayRadiusOptionRaw: appState.selectedOverlayRadiusOption,
+  };
+};
+
+const siteSignature = (site: Site): string =>
+  [
+    site.id,
+    site.position.lat.toFixed(6),
+    site.position.lon.toFixed(6),
+    site.groundElevationM,
+    site.antennaHeightM,
+    site.txPowerDbm,
+    site.txGainDbi,
+    site.rxGainDbi,
+    site.cableLossDb,
+  ].join(":");
+
+const linkSignature = (link: LinkLike): string => [link.id, link.fromSiteId, link.toSiteId].join(":");
+
+const networkSignature = (network: NetworkLike): string => {
+  const memberships = (network.memberships ?? [])
+    .map((member) => `${member.siteId}>${member.systemId}`)
+    .sort()
+    .join(",");
+  return [
+    network.id,
+    Number(network.frequencyMHz ?? 0).toFixed(3),
+    Number(network.frequencyOverrideMHz ?? 0).toFixed(3),
+    memberships,
+  ].join(":");
+};
+
+const environmentSignature = (environment: Record<string, unknown>): string =>
+  [
+    environment.clutterHeightM,
+    environment.polarization,
+    environment.groundDielectric,
+    environment.groundConductivity,
+    environment.radioClimate,
+    environment.atmosphericBendingNUnits,
+  ]
+    .map((value) => (value ?? ""))
+    .join(":");
+
+const coverageInputSignature = (inputs: CoverageInputs): string => {
+  const selectedNetwork = inputs.networks.find((network) => network.id === inputs.selectedNetworkId);
+  const selectedLink = inputs.links.find((link) => link.id === inputs.selectedLinkId) ?? inputs.links[0] ?? null;
+  return [
+    `res=${inputs.effectiveCoverageResolution}`,
+    `resRaw=${inputs.selectedCoverageResolution}`,
+    `network=${selectedNetwork ? networkSignature(selectedNetwork) : "none"}`,
+    `systems=${inputs.systems.length}`,
+    `sites=${inputs.sites.map(siteSignature).sort().join(";")}`,
+    `links=${inputs.links.map(linkSignature).sort().join(";")}`,
+    `selectedLink=${selectedLink ? linkSignature(selectedLink) : "none"}`,
+    `propModel=${inputs.propagationModel}`,
+    `autoEnv=${inputs.autoPropagationEnvironment ? 1 : 0}`,
+    `env=${environmentSignature(inputs.propagationEnvironment)}`,
+    `envReason=${inputs.propagationEnvironmentReason}`,
+    `terrainEpoch=${inputs.terrainLoadEpoch}`,
+    `terrainTiles=${inputs.srtmTiles.length}`,
+    `selectedSites=${inputs.selectedSiteIds.join(",")}`,
+    `terrainFetching=${inputs.isTerrainFetching ? 1 : 0}`,
+    `overlayRadius=${String(inputs.selectedOverlayRadiusOptionRaw ?? "")}`,
+  ].join("|");
+};
+
+const delayMs = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    window.setTimeout(resolve, Math.max(0, ms));
+  });
+
+const waitForNextPaint = async (): Promise<void> => {
+  if (typeof window !== "undefined" && typeof window.requestAnimationFrame === "function") {
+    await new Promise<void>((resolve) => window.requestAnimationFrame(() => resolve()));
+    await new Promise<void>((resolve) => window.requestAnimationFrame(() => resolve()));
+    return;
+  }
+  await delayMs(0);
+};
+
+const initializeRunState = (set: (patch: Partial<CoverageState>) => void, runId: string): void => {
+  set({
+    simulationRunToken: runId,
+    isSimulationRecomputing: true,
+    simulationProgress: 0,
+    simulationProgressMode: "indeterminate",
+    simulationStepLabel: "Preparing simulation bounds...",
+    simulationSamplesDone: 0,
+    simulationSamplesTotal: 0,
+  });
+};
+
+const queueCoverageRunFlush = (delay = COVERAGE_RECOMPUTE_DEBOUNCE_MS): void => {
+  if (coverageRecomputeTimer !== null) {
+    window.clearTimeout(coverageRecomputeTimer);
+    coverageRecomputeTimer = null;
+  }
+  coverageRecomputeTimer = window.setTimeout(() => {
+    coverageRecomputeTimer = null;
+    void flushCoverageRunQueue();
+  }, Math.max(0, delay));
+};
+
+const shouldSkipStaleCommit = (runSignature: string): boolean => {
+  if (!coverageRerunQueued || !appStoreBridge) return false;
+  const latestState = appStoreBridge.getState();
+  const latestInputs = readCoverageInputs(latestState);
+  const latestSignature = coverageInputSignature(latestInputs);
+  if (latestSignature === runSignature) {
+    coverageRerunQueued = false;
+    return false;
+  }
+  return true;
+};
+
+const finalizeRunComplete = (
+  set: (patch: Partial<CoverageState>) => void,
+  get: () => CoverageState,
+  runId: string,
+  coverageSamples: CoverageSample[],
+): void => {
+  if (get().simulationRunToken !== runId) return;
+  set({
+    coverageSamples,
+    isSimulationRecomputing: false,
+    simulationProgress: 100,
+    simulationProgressMode: "determinate",
+    simulationStepLabel: "",
+    simulationSamplesDone: 0,
+    simulationSamplesTotal: 0,
+  });
+  window.setTimeout(() => {
+    if (get().simulationRunToken === runId) {
+      set({ simulationProgress: 0, simulationRunToken: "" });
+    }
+  }, 320);
+};
+
+const runCoverageComputation = async (
+  set: (patch: Partial<CoverageState>) => void,
+  get: () => CoverageState,
+  runId: string,
+  runSignature: string,
+  inputs: CoverageInputs,
+): Promise<void> => {
+  const startedAt = nowMs();
+  let coverageSamples: CoverageSample[] = [];
+
+  try {
+    await waitForNextPaint();
+    if (get().simulationRunToken !== runId) return;
+
+    const gridSize = Number(inputs.effectiveCoverageResolution);
+    const network = inputs.networks.find((n) => n.id === inputs.selectedNetworkId);
+    if (!network) {
+      const waitMs = Math.max(0, COVERAGE_MIN_VISIBLE_MS - (nowMs() - startedAt));
+      if (waitMs > 0) await delayMs(waitMs);
+      if (get().simulationRunToken !== runId) return;
+      finalizeRunComplete(set, get, runId, []);
+      lastAppliedCoverageSignature = runSignature;
+      return;
+    }
+
+    const selectedLink = inputs.links.find((link) => link.id === inputs.selectedLinkId) ?? inputs.links[0] ?? null;
+    const fromSite = selectedLink ? inputs.sites.find((site) => site.id === selectedLink.fromSiteId) ?? null : null;
+    const toSite = selectedLink ? inputs.sites.find((site) => site.id === selectedLink.toSiteId) ?? null : null;
+    const autoEnvironmentStartedAt = nowMs();
+    const autoDerived =
+      inputs.autoPropagationEnvironment && fromSite && toSite
+        ? deriveDynamicPropagationEnvironment({
+            from: fromSite.position as { lat: number; lon: number },
+            to: toSite.position as { lat: number; lon: number },
+            fromGroundM: fromSite.groundElevationM as number,
+            toGroundM: toSite.groundElevationM as number,
+            terrainSampler: ({ lat, lon }: { lat: number; lon: number }) =>
+              sampleSrtmElevation(inputs.srtmTiles, lat, lon),
+          })
+        : null;
+    warnLongTask("auto-propagation-environment", runSignature, nowMs() - autoEnvironmentStartedAt);
+
+    const effectiveEnvironment = autoDerived?.environment ?? inputs.propagationEnvironment;
+    if (autoDerived) {
+      if (
+        inputs.propagationEnvironmentReason !== autoDerived.reason ||
+        inputs.propagationEnvironment.clutterHeightM !== autoDerived.environment.clutterHeightM ||
+        inputs.propagationEnvironment.polarization !== autoDerived.environment.polarization ||
+        inputs.propagationEnvironment.groundDielectric !== autoDerived.environment.groundDielectric ||
+        inputs.propagationEnvironment.groundConductivity !== autoDerived.environment.groundConductivity ||
+        inputs.propagationEnvironment.radioClimate !== autoDerived.environment.radioClimate ||
+        inputs.propagationEnvironment.atmosphericBendingNUnits !== autoDerived.environment.atmosphericBendingNUnits
+      ) {
+        appStoreBridge?.setState({
+          propagationEnvironment: autoDerived.environment,
+          propagationEnvironmentReason: autoDerived.reason,
+        });
+      }
+    }
+
+    const selectionCount = inputs.selectedSiteIds.length;
+    const selectedSingleSite =
+      selectionCount === 1
+        ? inputs.sites.find((site) => site.id === inputs.selectedSiteIds[0]) ?? null
+        : null;
+    const selectedOverlayRadiusOption = normalizeOverlayRadiusOptionForSelectionCount(
+      selectionCount,
+      inputs.selectedOverlayRadiusOptionRaw,
+    );
+    const overlayRadiusKm = resolveEffectiveOverlayRadiusKm({
+      selectionCount,
+      option: selectedOverlayRadiusOption,
+      selectedSingleSite,
+      srtmTiles: inputs.srtmTiles,
+      isTerrainFetching: inputs.isTerrainFetching,
+    });
+    const targetRadiusKm = resolveTargetOverlayRadiusKm(selectionCount, selectedOverlayRadiusOption);
+    const loadedRadiusCapKm = resolveLoadedOverlayRadiusCapKm(
+      selectionCount === 1 && selectedSingleSite ? [selectedSingleSite] : inputs.sites,
+      targetRadiusKm,
+      inputs.srtmTiles,
+      20,
+    );
+    const effectiveOverlayRadiusKm = Math.min(targetRadiusKm, overlayRadiusKm, loadedRadiusCapKm);
+
+    const boundsForCount = simulationAreaBoundsForSites(inputs.sites, { overlayRadiusKm: effectiveOverlayRadiusKm });
+    const sampleCount = boundsForCount
+      ? computeCoverageGridDimensions(gridSize, boundsForCount, 1).totalSamples
+      : 0;
+    set({
+      simulationProgress: 0,
+      simulationProgressMode: "determinate",
+      simulationStepLabel: "Sampling simulation grid...",
+      simulationSamplesDone: 0,
+      simulationSamplesTotal: sampleCount,
+    });
+
+    let lastProgress = 0;
+    const buildCoverageStartedAt = nowMs();
+    coverageSamples = await buildCoverageAsync(
+      gridSize,
+      network as Parameters<typeof buildCoverageAsync>[1],
+      inputs.sites as Parameters<typeof buildCoverageAsync>[2],
+      inputs.systems as Parameters<typeof buildCoverageAsync>[3],
+      effectiveEnvironment as Parameters<typeof buildCoverageAsync>[4],
+      ({ lat, lon }: { lat: number; lon: number }) => sampleSrtmElevation(inputs.srtmTiles, lat, lon),
+      {
+        sampleMultiplier: 1,
+        terrainSamples: 20,
+        overlayRadiusKm: effectiveOverlayRadiusKm,
+        onProgress: (progress: number) => {
+          if (get().simulationRunToken !== runId) return;
+          const next = Math.round(progress * 100);
+          if (next - lastProgress >= 2 || next >= 99) {
+            lastProgress = next;
+            set({ simulationProgress: next });
+          }
+        },
+        onSampleProgress: (processed, total) => {
+          if (get().simulationRunToken !== runId) return;
+          set({
+            simulationStepLabel: `Sampling simulation grid (${processed}/${total})`,
+            simulationSamplesDone: processed,
+            simulationSamplesTotal: total,
+          });
+        },
+        terrainCacheKey: `${inputs.effectiveCoverageResolution}|${inputs.selectedNetworkId}|${inputs.propagationModel}|${inputs.terrainLoadEpoch}`,
+      },
+    );
+    warnLongTask("coverage-build", runSignature, nowMs() - buildCoverageStartedAt);
+
+    if (get().simulationRunToken !== runId) return;
+
+    if (shouldSkipStaleCommit(runSignature)) {
+      set({
+        simulationProgress: 0,
+        simulationProgressMode: "indeterminate",
+        simulationStepLabel: "Preparing simulation bounds...",
+        simulationSamplesDone: 0,
+        simulationSamplesTotal: 0,
+      });
+      return;
+    }
+
+    set({
+      simulationProgressMode: "indeterminate",
+      simulationStepLabel: "Finalizing simulation overlay...",
+    });
+
+    const waitMs = Math.max(0, COVERAGE_MIN_VISIBLE_MS - (nowMs() - startedAt));
+    if (waitMs > 0) await delayMs(waitMs);
+    if (get().simulationRunToken !== runId) return;
+
+    finalizeRunComplete(set, get, runId, coverageSamples);
+    lastAppliedCoverageSignature = runSignature;
+    warnLongTask("coverage-total-run", runSignature, nowMs() - startedAt);
+  } catch (error) {
+    console.error("Coverage recompute failed", error);
+    if (get().simulationRunToken === runId) {
+      set({
+        isSimulationRecomputing: false,
+        simulationProgress: 0,
+        simulationProgressMode: "indeterminate",
+        simulationStepLabel: "",
+        simulationSamplesDone: 0,
+        simulationSamplesTotal: 0,
+      });
+    }
+  } finally {
+    coverageRunInFlight = false;
+    if (coverageRerunQueued) {
+      queueCoverageRunFlush(0);
+    }
+  }
+};
+
+const flushCoverageRunQueue = async (): Promise<void> => {
+  if (!appStoreBridge) return;
+  if (coverageRunInFlight) return;
+  if (!coverageRerunQueued) return;
+
+  const appState = appStoreBridge.getState();
+  const inputs = readCoverageInputs(appState);
+  const runSignature = coverageInputSignature(inputs);
+
+  if (runSignature === lastAppliedCoverageSignature) {
+    coverageRerunQueued = false;
+    return;
+  }
+
+  coverageRerunQueued = false;
+  coverageRunInFlight = true;
+  coverageRunCounter += 1;
+  const runId = `${Date.now()}-${coverageRunCounter.toString(36)}`;
+
+  initializeRunState(useCoverageStore.setState, runId);
+  await runCoverageComputation(useCoverageStore.setState, () => useCoverageStore.getState(), runId, runSignature, inputs);
+};
+
 export const useCoverageStore = create<CoverageState>((set, get) => ({
   coverageSamples: [],
   isSimulationRecomputing: false,
@@ -52,10 +489,11 @@ export const useCoverageStore = create<CoverageState>((set, get) => ({
   simulationRunToken: "",
   recomputeCoverage: () => {
     if (!appStoreBridge) return;
-
-    const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    coverageRerunQueued = true;
+    queueCoverageRunFlush(COVERAGE_RECOMPUTE_DEBOUNCE_MS);
+    if (coverageRunInFlight) return;
+    if (get().isSimulationRecomputing) return;
     set({
-      simulationRunToken: runId,
       isSimulationRecomputing: true,
       simulationProgress: 0,
       simulationProgressMode: "indeterminate",
@@ -63,207 +501,5 @@ export const useCoverageStore = create<CoverageState>((set, get) => ({
       simulationSamplesDone: 0,
       simulationSamplesTotal: 0,
     });
-
-    if (coverageRecomputeTimer !== null) {
-      window.clearTimeout(coverageRecomputeTimer);
-      coverageRecomputeTimer = null;
-    }
-
-    coverageRecomputeTimer = window.setTimeout(() => {
-      coverageRecomputeTimer = null;
-      const startedAt = Date.now();
-      if (get().simulationRunToken !== runId) return;
-
-      const runComputation = async () => {
-        if (get().simulationRunToken !== runId) return;
-
-        const appState = appStoreBridge!.getState();
-        const selectedCoverageResolutionRaw = appState.selectedCoverageResolution as string;
-        const selectedCoverageResolution =
-          selectedCoverageResolutionRaw === "24" ||
-          selectedCoverageResolutionRaw === "42" ||
-          selectedCoverageResolutionRaw === "84" ||
-          selectedCoverageResolutionRaw === "168"
-            ? selectedCoverageResolutionRaw
-            : selectedCoverageResolutionRaw === "high"
-              ? "42"
-              : "24";
-        const networks = appState.networks as Array<{ id: string; [key: string]: unknown }>;
-        const selectedNetworkId = appState.selectedNetworkId as string;
-        const sites = appState.sites as Site[];
-        const systems = appState.systems as unknown[];
-        const propagationModel = appState.propagationModel as string;
-        const srtmTiles = appState.srtmTiles as SrtmTile[];
-        const links = appState.links as Array<{ id: string; fromSiteId: string; toSiteId: string; [key: string]: unknown }>;
-        const selectedLinkId = appState.selectedLinkId as string;
-        const autoPropagationEnvironment = appState.autoPropagationEnvironment as boolean;
-        const propagationEnvironment = appState.propagationEnvironment as Record<string, unknown>;
-        const propagationEnvironmentReason = appState.propagationEnvironmentReason as string;
-        const terrainLoadEpoch = appState.terrainLoadEpoch as number;
-        const selectedSiteIds = (appState.selectedSiteIds as string[]) ?? [];
-        const isTerrainFetching = Boolean(appState.isTerrainFetching);
-        const selectedOverlayRadiusOptionRaw = appState.selectedOverlayRadiusOption;
-        const effectiveCoverageResolution = isTerrainFetching ? "24" : selectedCoverageResolution;
-        const gridSize = Number(effectiveCoverageResolution);
-
-        const network = networks.find((n) => n.id === selectedNetworkId);
-        if (!network) {
-          const finalize = () => {
-            if (get().simulationRunToken !== runId) return;
-            set({
-              coverageSamples: [],
-              isSimulationRecomputing: false,
-              simulationProgress: 100,
-              simulationProgressMode: "determinate",
-              simulationStepLabel: "",
-              simulationSamplesDone: 0,
-              simulationSamplesTotal: 0,
-            });
-            window.setTimeout(() => {
-              if (get().simulationRunToken === runId) {
-                set({ simulationProgress: 0, simulationRunToken: "" });
-              }
-            }, 260);
-          };
-          const waitMs = Math.max(0, 600 - (Date.now() - startedAt));
-          window.setTimeout(finalize, waitMs);
-          return;
-        }
-
-        const selectedLink = links.find((link) => link.id === selectedLinkId) ?? links[0] ?? null;
-        const fromSite = selectedLink ? sites.find((site) => site.id === selectedLink.fromSiteId) ?? null : null;
-        const toSite = selectedLink ? sites.find((site) => site.id === selectedLink.toSiteId) ?? null : null;
-        const autoDerived =
-          autoPropagationEnvironment && fromSite && toSite
-            ? deriveDynamicPropagationEnvironment({
-                from: fromSite.position as { lat: number; lon: number },
-                to: toSite.position as { lat: number; lon: number },
-                fromGroundM: fromSite.groundElevationM as number,
-                toGroundM: toSite.groundElevationM as number,
-                terrainSampler: ({ lat, lon }: { lat: number; lon: number }) =>
-                  sampleSrtmElevation(srtmTiles, lat, lon),
-              })
-            : null;
-        const effectiveEnvironment = autoDerived?.environment ?? propagationEnvironment;
-        if (autoDerived) {
-          if (
-            propagationEnvironmentReason !== autoDerived.reason ||
-            propagationEnvironment.clutterHeightM !== autoDerived.environment.clutterHeightM ||
-            propagationEnvironment.polarization !== autoDerived.environment.polarization ||
-            propagationEnvironment.groundDielectric !== autoDerived.environment.groundDielectric ||
-            propagationEnvironment.groundConductivity !== autoDerived.environment.groundConductivity ||
-            propagationEnvironment.radioClimate !== autoDerived.environment.radioClimate ||
-            propagationEnvironment.atmosphericBendingNUnits !== autoDerived.environment.atmosphericBendingNUnits
-          ) {
-            appStoreBridge!.setState({
-              propagationEnvironment: autoDerived.environment,
-              propagationEnvironmentReason: autoDerived.reason,
-            });
-          }
-        }
-
-        const selectionCount = selectedSiteIds.length;
-        const selectedSingleSite = selectionCount === 1
-          ? sites.find((site) => site.id === selectedSiteIds[0]) ?? null
-          : null;
-        const selectedOverlayRadiusOption = normalizeOverlayRadiusOptionForSelectionCount(
-          selectionCount,
-          selectedOverlayRadiusOptionRaw,
-        );
-        const overlayRadiusKm = resolveEffectiveOverlayRadiusKm({
-          selectionCount,
-          option: selectedOverlayRadiusOption,
-          selectedSingleSite,
-          srtmTiles,
-          isTerrainFetching,
-        });
-        const targetRadiusKm = resolveTargetOverlayRadiusKm(selectionCount, selectedOverlayRadiusOption);
-        const loadedRadiusCapKm = resolveLoadedOverlayRadiusCapKm(
-          selectionCount === 1 && selectedSingleSite ? [selectedSingleSite] : sites,
-          targetRadiusKm,
-          srtmTiles,
-          20,
-        );
-        const effectiveOverlayRadiusKm = Math.min(targetRadiusKm, overlayRadiusKm, loadedRadiusCapKm);
-
-        const boundsForCount = simulationAreaBoundsForSites(sites, { overlayRadiusKm: effectiveOverlayRadiusKm });
-        const sampleCount = boundsForCount
-          ? computeCoverageGridDimensions(gridSize, boundsForCount, 1).totalSamples
-          : 0;
-        set({
-          simulationProgress: 0,
-          simulationProgressMode: "determinate",
-          simulationStepLabel: "Sampling simulation grid...",
-          simulationSamplesDone: 0,
-          simulationSamplesTotal: sampleCount,
-        });
-        let lastProgress = 0;
-        const coverageSamples = await buildCoverageAsync(
-          gridSize,
-          network as Parameters<typeof buildCoverageAsync>[1],
-          sites as Parameters<typeof buildCoverageAsync>[2],
-          systems as Parameters<typeof buildCoverageAsync>[3],
-          effectiveEnvironment as Parameters<typeof buildCoverageAsync>[4],
-          ({ lat, lon }: { lat: number; lon: number }) =>
-            sampleSrtmElevation(srtmTiles, lat, lon),
-          {
-            sampleMultiplier: 1,
-            terrainSamples: 20,
-            overlayRadiusKm: effectiveOverlayRadiusKm,
-            onProgress: (progress: number) => {
-              if (get().simulationRunToken !== runId) return;
-              const next = Math.round(progress * 100);
-              if (next - lastProgress >= 2 || next >= 99) {
-                lastProgress = next;
-                set({ simulationProgress: next });
-              }
-            },
-            onSampleProgress: (processed, total) => {
-              if (get().simulationRunToken !== runId) return;
-              set({
-                simulationStepLabel: `Sampling simulation grid (${processed}/${total})`,
-                simulationSamplesDone: processed,
-                simulationSamplesTotal: total,
-              });
-            },
-            terrainCacheKey: `${effectiveCoverageResolution}|${selectedNetworkId}|${propagationModel}|${terrainLoadEpoch}`,
-          },
-        );
-        if (get().simulationRunToken !== runId) return;
-        set({
-          simulationProgressMode: "indeterminate",
-          simulationStepLabel: "Finalizing simulation overlay...",
-        });
-        const finalize = () => {
-          if (get().simulationRunToken === runId) {
-            set({
-              coverageSamples,
-              isSimulationRecomputing: false,
-              simulationProgress: 100,
-              simulationProgressMode: "determinate",
-              simulationStepLabel: "",
-              simulationSamplesDone: 0,
-              simulationSamplesTotal: 0,
-            });
-            window.setTimeout(() => {
-              if (get().simulationRunToken === runId) {
-                set({ simulationProgress: 0, simulationRunToken: "" });
-              }
-            }, 320);
-          }
-        };
-        const waitMs = Math.max(0, 600 - (Date.now() - startedAt));
-        window.setTimeout(finalize, waitMs);
-      };
-
-      // Let the browser paint the progress bar before starting heavy recomputation work.
-      if (typeof window !== "undefined" && typeof window.requestAnimationFrame === "function") {
-        window.requestAnimationFrame(() => {
-          window.requestAnimationFrame(runComputation);
-        });
-      } else {
-        window.setTimeout(runComputation, 0);
-      }
-    }, COVERAGE_RECOMPUTE_DEBOUNCE_MS);
   },
 }));


### PR DESCRIPTION
## Summary\n- index terrain sampling with cached tile-key lookup and shared quality precedence\n- harden coverage recompute scheduling to single-flight + queued rerun with input-signature no-op skip and stale-run guard\n- move map overlay generation to cancellable async chunked tasks while keeping previous overlay visible until the next render is ready\n- add dev-only long-task diagnostics for coverage/overlay phases\n\n## Validation\n- npm test\n- npm run build\n\nCloses #574