### PR TITLE
fix: restore selection-triggered simulation recompute and overlay busy indicator (#574)

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type MouseEvent, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent, type ReactNode } from "react";
 import { Egg, Fullscreen, Maximize2, Minimize2, Rabbit, RefreshCw, SquareStack, ZoomIn, ZoomOut } from "lucide-react";
 import Map, {
   Layer,
@@ -45,6 +45,7 @@ import {
   OverlayTaskCancelledError,
   type OverlayRasterPixels,
 } from "../lib/overlayRaster";
+import { resolveSimulationBusyIndicatorState } from "../lib/simulationBusyIndicator";
 import { SimulationResultsSection } from "./SimulationResultsSection";
 import { ActionButton } from "./ActionButton";
 import { useMapControls } from "./map/useMapControls";
@@ -1041,6 +1042,16 @@ export function MapView({
     import.meta.env.DEV || (typeof window !== "undefined" && window.location.hostname === "localhost");
   const coverageOverlayTaskTokenRef = useRef(0);
   const terrainOverlayTaskTokenRef = useRef(0);
+  const [overlayJobsInFlight, setOverlayJobsInFlight] = useState(0);
+  const beginOverlayJob = useCallback(() => {
+    let finished = false;
+    setOverlayJobsInFlight((count) => count + 1);
+    return () => {
+      if (finished) return;
+      finished = true;
+      setOverlayJobsInFlight((count) => Math.max(0, count - 1));
+    };
+  }, []);
   const [coverageOverlay, setCoverageOverlay] = useState<(OverlayRaster & { minDbm?: number; maxDbm?: number }) | null>(null);
   const [simulationTerrainOverlay, setSimulationTerrainOverlay] = useState<OverlayRaster | null>(null);
 
@@ -1083,6 +1094,7 @@ export function MapView({
       srtmTiles.length,
       effectiveGridSize,
     ].join("|");
+    const endOverlayJob = beginOverlayJob();
 
     const onLongTask = (payload: {
       phase: string;
@@ -1171,10 +1183,13 @@ export function MapView({
       } catch (error) {
         if (error instanceof OverlayTaskCancelledError) return;
         console.error("Failed to render simulation overlay", error);
+      } finally {
+        endOverlayJob();
       }
     })();
     return () => {
       coverageOverlayTaskTokenRef.current += 1;
+      endOverlayJob();
     };
   }, [
     coverageVizMode,
@@ -1194,6 +1209,7 @@ export function MapView({
     environmentLossDb,
     effectiveGridSize,
     showOverlayDiagnostics,
+    beginOverlayJob,
   ]);
   const currentBandStepDb = effectiveBandStepDb;
 
@@ -1243,6 +1259,7 @@ export function MapView({
       overlayDimensions.height,
       srtmTiles.length,
     ].join("|");
+    const endOverlayJob = beginOverlayJob();
 
     const shouldCancel = () => terrainOverlayTaskTokenRef.current !== token;
     const onLongTask = (payload: {
@@ -1289,10 +1306,13 @@ export function MapView({
       } catch (error) {
         if (error instanceof OverlayTaskCancelledError) return;
         console.error("Failed to render terrain overlay", error);
+      } finally {
+        endOverlayJob();
       }
     })();
     return () => {
       terrainOverlayTaskTokenRef.current += 1;
+      endOverlayJob();
     };
   }, [
     showTerrainOverlay,
@@ -1302,6 +1322,7 @@ export function MapView({
     overlayDimensions,
     overlayPointMask,
     showOverlayDiagnostics,
+    beginOverlayJob,
   ]);
 
   const webglAvailable = useMemo(() => supportsWebgl(), []);
@@ -1347,6 +1368,35 @@ export function MapView({
     : isTerrainRecommending
       ? terrainFetchStatus || "Checking terrain dataset coverage..."
       : "") + keepWorkingSuffix;
+  const simulationBusyIndicator = useMemo(
+    () =>
+      resolveSimulationBusyIndicatorState({
+        isSimulationRecomputing,
+        simulationProgressMode,
+        simulationStepLabel,
+        simulationProgress,
+        overlayJobsInFlight,
+        isBackgroundBusy,
+        backgroundBusyLabel,
+        isTerrainFetching,
+        hasTerrainDownloadProgress,
+        terrainProgressPercent,
+        terrainProgressTilesTotal,
+      }),
+    [
+      isSimulationRecomputing,
+      simulationProgressMode,
+      simulationStepLabel,
+      simulationProgress,
+      overlayJobsInFlight,
+      isBackgroundBusy,
+      backgroundBusyLabel,
+      isTerrainFetching,
+      hasTerrainDownloadProgress,
+      terrainProgressPercent,
+      terrainProgressTilesTotal,
+    ],
+  );
   const showLocalTerrainDiagnostics =
     import.meta.env.DEV || (typeof window !== "undefined" && window.location.hostname === "localhost");
   useEffect(() => {
@@ -1895,24 +1945,14 @@ export function MapView({
           {inspectorHeaderActions ? (
             <div className="map-inspector-header-row">{inspectorHeaderActions}</div>
           ) : null}
-          {isSimulationRecomputing || (isBackgroundBusy && backgroundBusyLabel) ? (
+          {simulationBusyIndicator ? (
             <div className="map-inspector-section">
               <p className="map-inspector-line">
-                {isSimulationRecomputing
-                  ? simulationProgressMode === "determinate"
-                    ? `${simulationStepLabel || "Sampling simulation grid..."} ${simulationProgress}%`
-                    : simulationStepLabel || "Recalculating simulation..."
-                  : (backgroundBusyLabel ?? "Working in background...")}
+                {simulationBusyIndicator.label || "Working in background..."}
               </p>
               <div className="map-progress-track">
-                {isSimulationRecomputing ? (
-                  simulationProgressMode === "determinate" ? (
-                    <div className="map-progress-fill" style={{ width: `${simulationProgress}%` }} />
-                  ) : (
-                    <div className="map-progress-fill map-progress-fill-indeterminate" />
-                  )
-                ) : isTerrainFetching && hasTerrainDownloadProgress && terrainProgressTilesTotal > 0 ? (
-                  <div className="map-progress-fill" style={{ width: `${terrainProgressPercent}%` }} />
+                {simulationBusyIndicator.progressMode === "determinate" ? (
+                  <div className="map-progress-fill" style={{ width: `${simulationBusyIndicator.progressPercent ?? 0}%` }} />
                 ) : (
                   <div className="map-progress-fill map-progress-fill-indeterminate" />
                 )}

--- a/src/lib/simulationBusyIndicator.test.ts
+++ b/src/lib/simulationBusyIndicator.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { resolveSimulationBusyIndicatorState } from "./simulationBusyIndicator";
+
+describe("resolveSimulationBusyIndicatorState", () => {
+  it("prioritizes active simulation recompute over overlay/background work", () => {
+    const state = resolveSimulationBusyIndicatorState({
+      isSimulationRecomputing: true,
+      simulationProgressMode: "determinate",
+      simulationStepLabel: "Sampling simulation grid (120/240)",
+      simulationProgress: 50,
+      overlayJobsInFlight: 2,
+      isBackgroundBusy: true,
+      backgroundBusyLabel: "Loading terrain 60%",
+      isTerrainFetching: true,
+      hasTerrainDownloadProgress: true,
+      terrainProgressPercent: 60,
+      terrainProgressTilesTotal: 100,
+    });
+
+    expect(state).toEqual({
+      label: "Sampling simulation grid (120/240) 50%",
+      progressMode: "determinate",
+      progressPercent: 50,
+    });
+  });
+
+  it("shows overlay-only in-flight work using the existing indeterminate simulation style", () => {
+    const state = resolveSimulationBusyIndicatorState({
+      isSimulationRecomputing: false,
+      simulationProgressMode: "indeterminate",
+      simulationStepLabel: "",
+      simulationProgress: 0,
+      overlayJobsInFlight: 1,
+      isBackgroundBusy: false,
+      backgroundBusyLabel: "",
+      isTerrainFetching: false,
+      hasTerrainDownloadProgress: false,
+      terrainProgressPercent: 0,
+      terrainProgressTilesTotal: 0,
+    });
+
+    expect(state).toEqual({
+      label: "Finalizing simulation overlay...",
+      progressMode: "indeterminate",
+      progressPercent: null,
+    });
+  });
+
+  it("retains terrain determinate progress behavior when background fetch is active", () => {
+    const state = resolveSimulationBusyIndicatorState({
+      isSimulationRecomputing: false,
+      simulationProgressMode: "indeterminate",
+      simulationStepLabel: "",
+      simulationProgress: 0,
+      overlayJobsInFlight: 0,
+      isBackgroundBusy: true,
+      backgroundBusyLabel: "Loading terrain 40%",
+      isTerrainFetching: true,
+      hasTerrainDownloadProgress: true,
+      terrainProgressPercent: 40,
+      terrainProgressTilesTotal: 200,
+    });
+
+    expect(state).toEqual({
+      label: "Loading terrain 40%",
+      progressMode: "determinate",
+      progressPercent: 40,
+    });
+  });
+
+  it("returns null when there is no active simulation/overlay/background work", () => {
+    const state = resolveSimulationBusyIndicatorState({
+      isSimulationRecomputing: false,
+      simulationProgressMode: "indeterminate",
+      simulationStepLabel: "",
+      simulationProgress: 0,
+      overlayJobsInFlight: 0,
+      isBackgroundBusy: false,
+      backgroundBusyLabel: "",
+      isTerrainFetching: false,
+      hasTerrainDownloadProgress: false,
+      terrainProgressPercent: 0,
+      terrainProgressTilesTotal: 0,
+    });
+
+    expect(state).toBeNull();
+  });
+});

--- a/src/lib/simulationBusyIndicator.ts
+++ b/src/lib/simulationBusyIndicator.ts
@@ -1,0 +1,67 @@
+export type SimulationBusyIndicatorInput = {
+  isSimulationRecomputing: boolean;
+  simulationProgressMode: "determinate" | "indeterminate";
+  simulationStepLabel: string;
+  simulationProgress: number;
+  overlayJobsInFlight: number;
+  isBackgroundBusy: boolean;
+  backgroundBusyLabel: string;
+  isTerrainFetching: boolean;
+  hasTerrainDownloadProgress: boolean;
+  terrainProgressPercent: number;
+  terrainProgressTilesTotal: number;
+};
+
+export type SimulationBusyIndicatorState = {
+  label: string;
+  progressMode: "determinate" | "indeterminate";
+  progressPercent: number | null;
+};
+
+export const resolveSimulationBusyIndicatorState = (
+  input: SimulationBusyIndicatorInput,
+): SimulationBusyIndicatorState | null => {
+  if (input.isSimulationRecomputing) {
+    if (input.simulationProgressMode === "determinate") {
+      return {
+        label: `${input.simulationStepLabel || "Sampling simulation grid..."} ${input.simulationProgress}%`,
+        progressMode: "determinate",
+        progressPercent: input.simulationProgress,
+      };
+    }
+    return {
+      label: input.simulationStepLabel || "Recalculating simulation...",
+      progressMode: "indeterminate",
+      progressPercent: null,
+    };
+  }
+
+  if (input.overlayJobsInFlight > 0) {
+    return {
+      label: "Finalizing simulation overlay...",
+      progressMode: "indeterminate",
+      progressPercent: null,
+    };
+  }
+
+  if (input.isBackgroundBusy && input.backgroundBusyLabel) {
+    if (
+      input.isTerrainFetching &&
+      input.hasTerrainDownloadProgress &&
+      input.terrainProgressTilesTotal > 0
+    ) {
+      return {
+        label: input.backgroundBusyLabel,
+        progressMode: "determinate",
+        progressPercent: input.terrainProgressPercent,
+      };
+    }
+    return {
+      label: input.backgroundBusyLabel,
+      progressMode: "indeterminate",
+      progressPercent: null,
+    };
+  }
+
+  return null;
+};

--- a/src/store/appStore.selectionRecompute.test.ts
+++ b/src/store/appStore.selectionRecompute.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const storage = vi.hoisted(() => {
+  const data = new Map<string, string>();
+  const mock = {
+    getItem: (key: string) => data.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      data.set(key, String(value));
+    },
+    removeItem: (key: string) => {
+      data.delete(key);
+    },
+    clear: () => {
+      data.clear();
+    },
+    key: (index: number) => Array.from(data.keys())[index] ?? null,
+    get length() {
+      return data.size;
+    },
+  };
+  vi.stubGlobal("localStorage", mock);
+  vi.stubGlobal("window", {
+    localStorage: mock,
+    setTimeout,
+    clearTimeout,
+  });
+  return { mock };
+});
+
+vi.mock("../lib/coverage", () => ({
+  buildCoverage: vi.fn(() => []),
+}));
+
+vi.mock("../lib/elevationService", () => ({
+  fetchElevations: vi.fn(async () => [123]),
+}));
+
+const seedSelectionState = (useAppStore: { setState: (patch: Record<string, unknown>) => void }) => {
+  useAppStore.setState({
+    sites: [
+      {
+        id: "site-1",
+        name: "Alpha",
+        position: { lat: 59.91, lon: 10.75 },
+        groundElevationM: 100,
+        antennaHeightM: 10,
+        txPowerDbm: 20,
+        txGainDbi: 2,
+        rxGainDbi: 2,
+        cableLossDb: 1,
+      },
+      {
+        id: "site-2",
+        name: "Beta",
+        position: { lat: 59.94, lon: 10.8 },
+        groundElevationM: 120,
+        antennaHeightM: 10,
+        txPowerDbm: 20,
+        txGainDbi: 2,
+        rxGainDbi: 2,
+        cableLossDb: 1,
+      },
+    ],
+    links: [
+      {
+        id: "lnk-1",
+        name: "Alpha-Beta",
+        fromSiteId: "site-1",
+        toSiteId: "site-2",
+        frequencyMHz: 869.618,
+      },
+    ],
+    selectedLinkId: "",
+    selectedSiteId: "site-1",
+    selectedSiteIds: ["site-1"],
+    mapOverlayMode: "passfail",
+    profileCursorIndex: 0,
+    temporaryDirectionReversed: false,
+    endpointPickTarget: null,
+  });
+};
+
+describe("appStore selection recompute triggers", () => {
+  beforeEach(() => {
+    storage.mock.clear();
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("triggers recompute for setSelectedLinkId only when selection state changes", async () => {
+    const recomputeCoverage = vi.fn();
+    vi.doMock("./coverageStore", () => ({
+      useCoverageStore: {
+        getState: () => ({ recomputeCoverage }),
+      },
+      setAppStoreBridge: vi.fn(),
+    }));
+
+    const { useAppStore } = await import("./appStore");
+    seedSelectionState(useAppStore);
+
+    useAppStore.getState().setSelectedLinkId("lnk-1");
+    expect(recomputeCoverage).toHaveBeenCalledTimes(1);
+
+    useAppStore.getState().setSelectedLinkId("lnk-1");
+    expect(recomputeCoverage).toHaveBeenCalledTimes(1);
+  });
+
+  it("triggers recompute for setSelectedSiteId only when selection state changes", async () => {
+    const recomputeCoverage = vi.fn();
+    vi.doMock("./coverageStore", () => ({
+      useCoverageStore: {
+        getState: () => ({ recomputeCoverage }),
+      },
+      setAppStoreBridge: vi.fn(),
+    }));
+
+    const { useAppStore } = await import("./appStore");
+    seedSelectionState(useAppStore);
+
+    useAppStore.getState().setSelectedSiteId("site-2");
+    expect(recomputeCoverage).toHaveBeenCalledTimes(1);
+
+    useAppStore.getState().setSelectedSiteId("site-2");
+    expect(recomputeCoverage).toHaveBeenCalledTimes(1);
+  });
+
+  it("triggers recompute for selectSiteById only when selection state changes", async () => {
+    const recomputeCoverage = vi.fn();
+    vi.doMock("./coverageStore", () => ({
+      useCoverageStore: {
+        getState: () => ({ recomputeCoverage }),
+      },
+      setAppStoreBridge: vi.fn(),
+    }));
+
+    const { useAppStore } = await import("./appStore");
+    seedSelectionState(useAppStore);
+
+    useAppStore.getState().selectSiteById("site-2");
+    expect(recomputeCoverage).toHaveBeenCalledTimes(1);
+
+    useAppStore.getState().selectSiteById("site-2");
+    expect(recomputeCoverage).toHaveBeenCalledTimes(1);
+  });
+
+  it("triggers recompute for clearActiveSelection only when selection state changes", async () => {
+    const recomputeCoverage = vi.fn();
+    vi.doMock("./coverageStore", () => ({
+      useCoverageStore: {
+        getState: () => ({ recomputeCoverage }),
+      },
+      setAppStoreBridge: vi.fn(),
+    }));
+
+    const { useAppStore } = await import("./appStore");
+    seedSelectionState(useAppStore);
+
+    useAppStore.getState().clearActiveSelection();
+    expect(recomputeCoverage).toHaveBeenCalledTimes(1);
+
+    useAppStore.getState().clearActiveSelection();
+    expect(recomputeCoverage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1900,7 +1900,8 @@ export const useAppStore = create<AppState>((set, get) => ({
     useCoverageStore.getState().recomputeCoverage();
   },
   requestFitToSites: () => set((state) => ({ fitSitesEpoch: state.fitSitesEpoch + 1 })),
-  setSelectedLinkId: (id) =>
+  setSelectedLinkId: (id) => {
+    let changed = false;
     set((state) => {
       const selectedLink = state.links.find((link) => link.id === id) ?? null;
       const selection = selectedLink
@@ -1917,6 +1918,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       ) {
         return state;
       }
+      changed = true;
       return {
         selectedLinkId: id,
         profileCursorIndex: 0,
@@ -1925,12 +1927,17 @@ export const useAppStore = create<AppState>((set, get) => ({
         selectedSiteId: selection[0] ?? state.selectedSiteId,
         mapOverlayMode: nextOverlay,
       };
-    }),
+    });
+    if (changed) {
+      useCoverageStore.getState().recomputeCoverage();
+    }
+  },
   setTemporaryDirectionReversed: (value) => set({ temporaryDirectionReversed: Boolean(value) }),
   toggleTemporaryDirectionReversed: () =>
     set((state) => ({ temporaryDirectionReversed: !state.temporaryDirectionReversed })),
   setProfileCursorIndex: (index) => set({ profileCursorIndex: Math.max(0, Math.floor(index)) }),
   setSelectedSiteId: (id) => {
+    let changed = false;
     set((state) => {
       const selection = normalizeSelectedSiteIds([id], state.sites);
       const nextSelectedSiteId = selection[0] ?? id;
@@ -1943,6 +1950,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       ) {
         return state;
       }
+      changed = true;
       return {
         selectedSiteId: nextSelectedSiteId,
         selectedSiteIds: selection,
@@ -1950,8 +1958,12 @@ export const useAppStore = create<AppState>((set, get) => ({
         mapOverlayMode: nextOverlay,
       };
     });
+    if (changed) {
+      useCoverageStore.getState().recomputeCoverage();
+    }
   },
   selectSiteById: (id, additive = false) => {
+    let changed = false;
     set((state) => {
       const validIds = new Set(state.sites.map((site) => site.id));
       if (!validIds.has(id)) return state;
@@ -1975,6 +1987,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       ) {
         return state;
       }
+      changed = true;
       return {
         selectedSiteIds: normalizedSelection,
         selectedSiteId: nextSelectedSiteId,
@@ -1982,8 +1995,12 @@ export const useAppStore = create<AppState>((set, get) => ({
         mapOverlayMode: nextOverlay,
       };
     });
+    if (changed) {
+      useCoverageStore.getState().recomputeCoverage();
+    }
   },
-  clearActiveSelection: () =>
+  clearActiveSelection: () => {
+    let changed = false;
     set((state) => {
       const nextOverlay = defaultOverlayModeForSelectionCount(0);
       if (
@@ -1997,6 +2014,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       ) {
         return state;
       }
+      changed = true;
       return {
         selectedSiteIds: [],
         selectedSiteId: "",
@@ -2006,7 +2024,11 @@ export const useAppStore = create<AppState>((set, get) => ({
         profileCursorIndex: 0,
         mapOverlayMode: nextOverlay,
       };
-    }),
+    });
+    if (changed) {
+      useCoverageStore.getState().recomputeCoverage();
+    }
+  },
   setSelectedNetworkId: (id) => {
     set({ selectedNetworkId: id });
     useCoverageStore.getState().recomputeCoverage();


### PR DESCRIPTION
## Summary
- restore `recomputeCoverage()` triggers for non-no-op selection actions in `appStore`
- reuse existing inspector progress section for overlay-only async render work
- keep cancellation-safe overlay job accounting so the indicator clears correctly
- add focused tests for selection trigger behavior and busy-indicator precedence

## Verification
- npm test
- npm run build
