### PR TITLE
perf: recover staging simulation latency for #574

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -45,6 +45,11 @@ import {
   OverlayTaskCancelledError,
   type OverlayRasterPixels,
 } from "../lib/overlayRaster";
+import { overlayTaskBudgetForMode } from "../lib/overlayTaskBudget";
+import {
+  recordSimulationOverlayPerf,
+  recordSimulationRunCancelled,
+} from "../lib/simulationPerf";
 import { resolveSimulationBusyIndicatorState } from "../lib/simulationBusyIndicator";
 import { SimulationResultsSection } from "./SimulationResultsSection";
 import { ActionButton } from "./ActionButton";
@@ -574,6 +579,7 @@ export function MapView({
   const simulationProgress = useCoverageStore((state) => state.simulationProgress);
   const simulationProgressMode = useCoverageStore((state) => state.simulationProgressMode);
   const simulationStepLabel = useCoverageStore((state) => state.simulationStepLabel);
+  const simulationRunToken = useCoverageStore((state) => state.simulationRunToken);
   const isTerrainFetching = useAppStore((state) => state.isTerrainFetching);
   const isTerrainRecommending = useAppStore((state) => state.isTerrainRecommending);
   const basemapProvider = useAppStore((state) => state.basemapProvider);
@@ -1095,6 +1101,9 @@ export function MapView({
       effectiveGridSize,
     ].join("|");
     const endOverlayJob = beginOverlayJob();
+    const taskBudget = overlayTaskBudgetForMode(mode);
+    const perfRunId = simulationRunToken || `overlay:${mode}:${token}`;
+    const overlayBuildStartedAt = performance.now();
 
     const onLongTask = (payload: {
       phase: string;
@@ -1123,6 +1132,8 @@ export function MapView({
         const context = {
           phase: mode,
           signature,
+          frameBudgetMs: taskBudget.frameBudgetMs,
+          longTaskMs: taskBudget.longTaskMs,
           shouldCancel,
           onLongTask,
         } as const;
@@ -1172,16 +1183,56 @@ export function MapView({
           );
         }
 
-        if (shouldCancel()) return;
+        const overlayBuildCompletedAt = performance.now();
+        if (shouldCancel()) {
+          recordSimulationRunCancelled({
+            runId: perfRunId,
+            phase: "overlay",
+            reason: "token-mismatch-after-build",
+            signature,
+            mode,
+          });
+          return;
+        }
         if (!rasterPixels) {
           setCoverageOverlay(null);
           return;
         }
         const raster = overlayPixelsToDataUrl(rasterPixels);
-        if (shouldCancel()) return;
+        const overlayEncodeCompletedAt = performance.now();
+        if (shouldCancel()) {
+          recordSimulationRunCancelled({
+            runId: perfRunId,
+            phase: "overlay",
+            reason: "token-mismatch-after-encode",
+            signature,
+            mode,
+          });
+          return;
+        }
+        recordSimulationOverlayPerf({
+          runId: perfRunId,
+          mode,
+          buildDurationMs: overlayBuildCompletedAt - overlayBuildStartedAt,
+          encodeDurationMs: overlayEncodeCompletedAt - overlayBuildCompletedAt,
+          width: rasterPixels.width,
+          height: rasterPixels.height,
+          pixelCount: rasterPixels.width * rasterPixels.height,
+          gridSize: effectiveGridSize,
+          effectiveRadiusKm: overlayRadiusKm,
+        });
         setCoverageOverlay(raster ? { ...raster } : null);
       } catch (error) {
-        if (error instanceof OverlayTaskCancelledError) return;
+        if (error instanceof OverlayTaskCancelledError) {
+          recordSimulationRunCancelled({
+            runId: perfRunId,
+            phase: "overlay",
+            reason: "overlay-task-cancelled-error",
+            signature,
+            mode,
+          });
+          return;
+        }
         console.error("Failed to render simulation overlay", error);
       } finally {
         endOverlayJob();
@@ -1208,6 +1259,8 @@ export function MapView({
     rxSensitivityTargetDbm,
     environmentLossDb,
     effectiveGridSize,
+    overlayRadiusKm,
+    simulationRunToken,
     showOverlayDiagnostics,
     beginOverlayJob,
   ]);
@@ -1260,6 +1313,9 @@ export function MapView({
       srtmTiles.length,
     ].join("|");
     const endOverlayJob = beginOverlayJob();
+    const taskBudget = overlayTaskBudgetForMode("terrain");
+    const perfRunId = simulationRunToken || `overlay:terrain:${token}`;
+    const overlayBuildStartedAt = performance.now();
 
     const shouldCancel = () => terrainOverlayTaskTokenRef.current !== token;
     const onLongTask = (payload: {
@@ -1291,20 +1347,62 @@ export function MapView({
           {
             phase: "terrain-shade",
             signature,
+            frameBudgetMs: taskBudget.frameBudgetMs,
+            longTaskMs: taskBudget.longTaskMs,
             shouldCancel,
             onLongTask,
           },
         );
-        if (shouldCancel()) return;
+        const overlayBuildCompletedAt = performance.now();
+        if (shouldCancel()) {
+          recordSimulationRunCancelled({
+            runId: perfRunId,
+            phase: "overlay",
+            reason: "token-mismatch-after-build",
+            signature,
+            mode: "terrain",
+          });
+          return;
+        }
         if (!rasterPixels) {
           setSimulationTerrainOverlay(null);
           return;
         }
         const raster = overlayPixelsToDataUrl(rasterPixels);
-        if (shouldCancel()) return;
+        const overlayEncodeCompletedAt = performance.now();
+        if (shouldCancel()) {
+          recordSimulationRunCancelled({
+            runId: perfRunId,
+            phase: "overlay",
+            reason: "token-mismatch-after-encode",
+            signature,
+            mode: "terrain",
+          });
+          return;
+        }
+        recordSimulationOverlayPerf({
+          runId: perfRunId,
+          mode: "terrain",
+          buildDurationMs: overlayBuildCompletedAt - overlayBuildStartedAt,
+          encodeDurationMs: overlayEncodeCompletedAt - overlayBuildCompletedAt,
+          width: rasterPixels.width,
+          height: rasterPixels.height,
+          pixelCount: rasterPixels.width * rasterPixels.height,
+          gridSize: effectiveGridSize,
+          effectiveRadiusKm: overlayRadiusKm,
+        });
         setSimulationTerrainOverlay(raster ? { url: raster.url, coordinates: raster.coordinates } : null);
       } catch (error) {
-        if (error instanceof OverlayTaskCancelledError) return;
+        if (error instanceof OverlayTaskCancelledError) {
+          recordSimulationRunCancelled({
+            runId: perfRunId,
+            phase: "overlay",
+            reason: "overlay-task-cancelled-error",
+            signature,
+            mode: "terrain",
+          });
+          return;
+        }
         console.error("Failed to render terrain overlay", error);
       } finally {
         endOverlayJob();
@@ -1321,6 +1419,9 @@ export function MapView({
     srtmTiles,
     overlayDimensions,
     overlayPointMask,
+    effectiveGridSize,
+    overlayRadiusKm,
+    simulationRunToken,
     showOverlayDiagnostics,
     beginOverlayJob,
   ]);

--- a/src/lib/coverage.ts
+++ b/src/lib/coverage.ts
@@ -15,7 +15,6 @@ export type BuildCoverageOptions = {
   sampleMultiplier?: number;
   terrainSamples?: number;
   onProgress?: (progress: number) => void;
-  onSampleProgress?: (processed: number, total: number) => void;
   terrainCacheKey?: string;
   overlayRadiusKm?: number;
   singleSiteRadiusKm?: number;
@@ -34,6 +33,9 @@ export type CoverageGridDimensions = {
   totalSamples: number;
   targetSamples: number;
 };
+
+const COVERAGE_COMPUTE_CHUNK_SIZE = 48;
+const COVERAGE_COMPUTE_FRAME_BUDGET_MS = 12;
 
 export const computeCoverageGridDimensions = (
   gridSize: number,
@@ -301,7 +303,7 @@ export const buildCoverageAsync = async (
   const total = Math.max(1, samples.length);
   const notifyEvery = Math.max(1, Math.floor(total / 40));
   const results: CoverageSample[] = [];
-  const chunkSize = 8;
+  const chunkSize = COVERAGE_COMPUTE_CHUNK_SIZE;
   let chunkStartedAt = performance.now();
 
   for (let i = 0; i < samples.length; i += 1) {
@@ -331,8 +333,7 @@ export const buildCoverageAsync = async (
     if ((i + 1) % notifyEvery === 0 || i === samples.length - 1) {
       onProgress?.((i + 1) / total);
     }
-    options?.onSampleProgress?.(i + 1, total);
-    if ((i + 1) % chunkSize === 0 || performance.now() - chunkStartedAt > 7) {
+    if ((i + 1) % chunkSize === 0 || performance.now() - chunkStartedAt > COVERAGE_COMPUTE_FRAME_BUDGET_MS) {
       await new Promise<void>((resolve) => {
         if (typeof window !== "undefined" && typeof window.requestAnimationFrame === "function") {
           window.requestAnimationFrame(() => resolve());

--- a/src/lib/overlayTaskBudget.test.ts
+++ b/src/lib/overlayTaskBudget.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { overlayTaskBudgetForMode } from "./overlayTaskBudget";
+
+describe("overlayTaskBudgetForMode", () => {
+  it("allocates higher frame budget for pass/fail and relay than lighter modes", () => {
+    const heatmap = overlayTaskBudgetForMode("heatmap");
+    const contours = overlayTaskBudgetForMode("contours");
+    const terrain = overlayTaskBudgetForMode("terrain");
+    const passFail = overlayTaskBudgetForMode("passfail");
+    const relay = overlayTaskBudgetForMode("relay");
+
+    expect(passFail.frameBudgetMs).toBeGreaterThan(heatmap.frameBudgetMs);
+    expect(passFail.frameBudgetMs).toBeGreaterThan(contours.frameBudgetMs);
+    expect(passFail.frameBudgetMs).toBeGreaterThan(terrain.frameBudgetMs);
+    expect(relay.frameBudgetMs).toBeGreaterThan(heatmap.frameBudgetMs);
+    expect(relay.frameBudgetMs).toBeGreaterThan(terrain.frameBudgetMs);
+  });
+
+  it("always sets a long-task threshold not lower than frame budget", () => {
+    const modes = ["heatmap", "contours", "passfail", "relay", "terrain"] as const;
+    for (const mode of modes) {
+      const budget = overlayTaskBudgetForMode(mode);
+      expect(budget.longTaskMs).toBeGreaterThanOrEqual(budget.frameBudgetMs);
+    }
+  });
+});

--- a/src/lib/overlayTaskBudget.ts
+++ b/src/lib/overlayTaskBudget.ts
@@ -1,0 +1,16 @@
+export type OverlayTaskMode = "heatmap" | "contours" | "passfail" | "relay" | "terrain";
+
+export type OverlayTaskBudget = {
+  frameBudgetMs: number;
+  longTaskMs: number;
+};
+
+const BUDGET_BY_MODE: Record<OverlayTaskMode, OverlayTaskBudget> = {
+  heatmap: { frameBudgetMs: 9, longTaskMs: 30 },
+  contours: { frameBudgetMs: 9, longTaskMs: 30 },
+  passfail: { frameBudgetMs: 14, longTaskMs: 42 },
+  relay: { frameBudgetMs: 14, longTaskMs: 42 },
+  terrain: { frameBudgetMs: 8, longTaskMs: 28 },
+};
+
+export const overlayTaskBudgetForMode = (mode: OverlayTaskMode): OverlayTaskBudget => BUDGET_BY_MODE[mode];

--- a/src/lib/simulationPerf.ts
+++ b/src/lib/simulationPerf.ts
@@ -1,0 +1,99 @@
+type CoveragePerfRecord = {
+  runId: string;
+  signature: string;
+  durationMs: number;
+  sampleCount: number;
+  gridSize: number;
+  effectiveRadiusKm: number;
+};
+
+type OverlayPerfRecord = {
+  runId: string;
+  mode: "heatmap" | "contours" | "passfail" | "relay" | "terrain";
+  buildDurationMs: number;
+  encodeDurationMs: number;
+  width: number;
+  height: number;
+  pixelCount: number;
+  gridSize: number;
+  effectiveRadiusKm: number;
+};
+
+type PendingRunPerf = {
+  coverage?: CoveragePerfRecord;
+  overlay?: OverlayPerfRecord;
+  logged: boolean;
+};
+
+const inDevDiagnostics =
+  typeof import.meta !== "undefined" &&
+  Boolean((import.meta as { env?: { DEV?: boolean; MODE?: string } }).env?.DEV) &&
+  (import.meta as { env?: { MODE?: string } }).env?.MODE !== "test";
+
+const pendingByRun = new Map<string, PendingRunPerf>();
+
+const round2 = (value: number): number => Math.round(value * 100) / 100;
+
+const ensurePending = (runId: string): PendingRunPerf => {
+  const existing = pendingByRun.get(runId);
+  if (existing) return existing;
+  const created: PendingRunPerf = { logged: false };
+  pendingByRun.set(runId, created);
+  if (pendingByRun.size > 100) {
+    const oldest = pendingByRun.keys().next().value;
+    if (typeof oldest === "string") pendingByRun.delete(oldest);
+  }
+  return created;
+};
+
+const maybeLogRun = (runId: string): void => {
+  if (!inDevDiagnostics) return;
+  const pending = pendingByRun.get(runId);
+  if (!pending || pending.logged || !pending.coverage || !pending.overlay) return;
+
+  pending.logged = true;
+  console.info("[simulation-perf-run]", {
+    runId,
+    signature: pending.coverage.signature,
+    coverageComputeMs: round2(pending.coverage.durationMs),
+    overlayMode: pending.overlay.mode,
+    overlayBuildMs: round2(pending.overlay.buildDurationMs),
+    overlayEncodeMs: round2(pending.overlay.encodeDurationMs),
+    sampleCount: pending.coverage.sampleCount,
+    overlayPixelCount: pending.overlay.pixelCount,
+    overlayWidth: pending.overlay.width,
+    overlayHeight: pending.overlay.height,
+    gridSize: pending.coverage.gridSize,
+    overlayGridSize: pending.overlay.gridSize,
+    effectiveRadiusKm: pending.coverage.effectiveRadiusKm,
+    overlayRadiusKm: pending.overlay.effectiveRadiusKm,
+  });
+
+  pendingByRun.delete(runId);
+};
+
+export const recordSimulationCoveragePerf = (record: CoveragePerfRecord): void => {
+  if (!inDevDiagnostics) return;
+  const pending = ensurePending(record.runId);
+  pending.coverage = record;
+  maybeLogRun(record.runId);
+};
+
+export const recordSimulationOverlayPerf = (record: OverlayPerfRecord): void => {
+  if (!inDevDiagnostics) return;
+  const pending = ensurePending(record.runId);
+  pending.overlay = record;
+  maybeLogRun(record.runId);
+};
+
+export const recordSimulationRunCancelled = (payload: {
+  runId: string;
+  phase: "coverage" | "overlay";
+  reason: string;
+  signature?: string;
+  mode?: OverlayPerfRecord["mode"];
+}): void => {
+  if (!inDevDiagnostics) return;
+  console.info("[simulation-perf-cancelled]", payload);
+  pendingByRun.delete(payload.runId);
+};

--- a/src/store/coverageStore.test.ts
+++ b/src/store/coverageStore.test.ts
@@ -89,7 +89,6 @@ describe("coverageStore simulation progress phases", () => {
     vi.spyOn(coverageLib, "buildCoverageAsync").mockImplementation((...args) => {
       const options = args[6];
       options?.onProgress?.(0.5);
-      options?.onSampleProgress?.(7, 14);
       return new Promise<CoverageSample[]>((resolve) => {
         resolveBuild = resolve;
       });
@@ -104,7 +103,7 @@ describe("coverageStore simulation progress phases", () => {
 
     expect(useCoverageStore.getState().simulationProgressMode).toBe("determinate");
     expect(useCoverageStore.getState().simulationProgress).toBe(50);
-    expect(useCoverageStore.getState().simulationStepLabel).toBe("Sampling simulation grid (7/14)");
+    expect(useCoverageStore.getState().simulationStepLabel).toBe("Sampling simulation grid...");
 
     resolveBuild([{ lat: site.position.lat, lon: site.position.lon, valueDbm: -90 }]);
     await flushAsyncTicks();

--- a/src/store/coverageStore.ts
+++ b/src/store/coverageStore.ts
@@ -10,6 +10,10 @@ import {
   resolveEffectiveOverlayRadiusKm,
   resolveTargetOverlayRadiusKm,
 } from "../lib/simulationOverlayRadius";
+import {
+  recordSimulationCoveragePerf,
+  recordSimulationRunCancelled,
+} from "../lib/simulationPerf";
 import { sampleSrtmElevation } from "../lib/srtm";
 import type { Site, SrtmTile } from "../types/radio";
 import type { CoverageSample } from "../types/radio";
@@ -288,17 +292,35 @@ const runCoverageComputation = async (
 ): Promise<void> => {
   const startedAt = nowMs();
   let coverageSamples: CoverageSample[] = [];
+  let loggedCancellation = false;
+
+  const markCancelled = (reason: string): void => {
+    if (loggedCancellation) return;
+    loggedCancellation = true;
+    recordSimulationRunCancelled({
+      runId,
+      phase: "coverage",
+      reason,
+      signature: runSignature,
+    });
+  };
 
   try {
     await waitForNextPaint();
-    if (get().simulationRunToken !== runId) return;
+    if (get().simulationRunToken !== runId) {
+      markCancelled("token-mismatch-before-start");
+      return;
+    }
 
     const gridSize = Number(inputs.effectiveCoverageResolution);
     const network = inputs.networks.find((n) => n.id === inputs.selectedNetworkId);
     if (!network) {
       const waitMs = Math.max(0, COVERAGE_MIN_VISIBLE_MS - (nowMs() - startedAt));
       if (waitMs > 0) await delayMs(waitMs);
-      if (get().simulationRunToken !== runId) return;
+      if (get().simulationRunToken !== runId) {
+        markCancelled("token-mismatch-no-network");
+        return;
+      }
       finalizeRunComplete(set, get, runId, []);
       lastAppliedCoverageSignature = runSignature;
       return;
@@ -397,20 +419,16 @@ const runCoverageComputation = async (
             set({ simulationProgress: next });
           }
         },
-        onSampleProgress: (processed, total) => {
-          if (get().simulationRunToken !== runId) return;
-          set({
-            simulationStepLabel: `Sampling simulation grid (${processed}/${total})`,
-            simulationSamplesDone: processed,
-            simulationSamplesTotal: total,
-          });
-        },
         terrainCacheKey: `${inputs.effectiveCoverageResolution}|${inputs.selectedNetworkId}|${inputs.propagationModel}|${inputs.terrainLoadEpoch}`,
       },
     );
-    warnLongTask("coverage-build", runSignature, nowMs() - buildCoverageStartedAt);
+    const coverageComputeMs = nowMs() - buildCoverageStartedAt;
+    warnLongTask("coverage-build", runSignature, coverageComputeMs);
 
-    if (get().simulationRunToken !== runId) return;
+    if (get().simulationRunToken !== runId) {
+      markCancelled("token-mismatch-after-coverage-build");
+      return;
+    }
 
     if (shouldSkipStaleCommit(runSignature)) {
       set({
@@ -420,8 +438,18 @@ const runCoverageComputation = async (
         simulationSamplesDone: 0,
         simulationSamplesTotal: 0,
       });
+      markCancelled("stale-signature-superseded");
       return;
     }
+
+    recordSimulationCoveragePerf({
+      runId,
+      signature: runSignature,
+      durationMs: coverageComputeMs,
+      sampleCount,
+      gridSize,
+      effectiveRadiusKm: effectiveOverlayRadiusKm,
+    });
 
     set({
       simulationProgressMode: "indeterminate",
@@ -430,7 +458,10 @@ const runCoverageComputation = async (
 
     const waitMs = Math.max(0, COVERAGE_MIN_VISIBLE_MS - (nowMs() - startedAt));
     if (waitMs > 0) await delayMs(waitMs);
-    if (get().simulationRunToken !== runId) return;
+    if (get().simulationRunToken !== runId) {
+      markCancelled("token-mismatch-before-finalize");
+      return;
+    }
 
     finalizeRunComplete(set, get, runId, coverageSamples);
     lastAppliedCoverageSignature = runSignature;


### PR DESCRIPTION
## Summary
- remove per-sample simulation progress churn and keep phase + percent-only progress updates
- retune coverage cooperative chunking for throughput while keeping non-blocking behavior
- add mode-based overlay frame/long-task budgets (`passfail`/`relay` higher than lighter modes)
- add dev-only structured simulation perf diagnostics (coverage + overlay consolidated run logs, plus cancellation markers)

## Verification
- npm test
- npm run build
