### PR TITLE
perf(#574): optimize overlay throughput and finalizing progress

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -51,6 +51,8 @@ import {
   recordSimulationRunCancelled,
 } from "../lib/simulationPerf";
 import { resolveSimulationBusyIndicatorState } from "../lib/simulationBusyIndicator";
+import { createLatestOnlyTaskScheduler, type LatestOnlyTask } from "../lib/latestOnlyTaskScheduler";
+import { createLruCache } from "../lib/lruCache";
 import { SimulationResultsSection } from "./SimulationResultsSection";
 import { ActionButton } from "./ActionButton";
 import { useMapControls } from "./map/useMapControls";
@@ -74,6 +76,17 @@ const readSectionBool = (key: string, fallback: boolean): boolean => {
 const writeSectionBool = (key: string, value: boolean): void => {
   try { localStorage.setItem(key, String(value)); } catch {}
 };
+
+const FNV_OFFSET_BASIS = 2166136261;
+const FNV_PRIME = 16777619;
+
+const updateFvnHash = (hash: number, value: number): number => {
+  const next = hash ^ (value & 0xff_ff_ff_ff);
+  return Math.imul(next, FNV_PRIME) >>> 0;
+};
+
+const roundHashValue = (value: number, factor = 10_000): number =>
+  Number.isFinite(value) ? Math.round(value * factor) : 0;
 
 const mapLineLayer = (linkColor: string, selectedColor: string): LayerProps => ({
   id: "link-lines",
@@ -554,6 +567,7 @@ export function MapView({
   const requestOpenSiteLibraryEntry = useAppStore((state) => state.requestOpenSiteLibraryEntry);
   const coverageSamples = useCoverageStore((state) => state.coverageSamples);
   const srtmTiles = useAppStore((state) => state.srtmTiles);
+  const terrainLoadEpoch = useAppStore((state) => state.terrainLoadEpoch);
   const terrainFetchStatus = useAppStore((state) => state.terrainFetchStatus);
   const terrainLoadingStartedAtMs = useAppStore((state) => state.terrainLoadingStartedAtMs);
   const terrainProgressPercent = useAppStore((state) => state.terrainProgressPercent);
@@ -1046,47 +1060,154 @@ export function MapView({
   const overlayLongTaskWarnedRef = useRef<Set<string>>(new Set());
   const showOverlayDiagnostics =
     import.meta.env.DEV || (typeof window !== "undefined" && window.location.hostname === "localhost");
-  const coverageOverlayTaskTokenRef = useRef(0);
-  const terrainOverlayTaskTokenRef = useRef(0);
+  const coverageOverlaySchedulerRef = useRef<ReturnType<typeof createLatestOnlyTaskScheduler> | null>(null);
+  const terrainOverlaySchedulerRef = useRef<ReturnType<typeof createLatestOnlyTaskScheduler> | null>(null);
+  if (!coverageOverlaySchedulerRef.current) {
+    coverageOverlaySchedulerRef.current = createLatestOnlyTaskScheduler();
+  }
+  if (!terrainOverlaySchedulerRef.current) {
+    terrainOverlaySchedulerRef.current = createLatestOnlyTaskScheduler();
+  }
+  const coverageOverlayRunCounterRef = useRef(0);
+  const terrainOverlayRunCounterRef = useRef(0);
+  const latestCoverageRunTokenRef = useRef("");
+  const coverageOverlayCacheRef = useRef(
+    createLruCache<OverlayRaster & { minDbm?: number; maxDbm?: number }>(4),
+  );
+  const terrainOverlayCacheRef = useRef(createLruCache<OverlayRaster>(3));
   const [overlayJobsInFlight, setOverlayJobsInFlight] = useState(0);
-  const beginOverlayJob = useCallback(() => {
+  const [overlayProgressMode, setOverlayProgressMode] = useState<"determinate" | "indeterminate">("indeterminate");
+  const [overlayProgressPercent, setOverlayProgressPercent] = useState<number | null>(null);
+  const overlayProgressByPipelineRef = useRef<{ coverage: number | null; terrain: number | null }>({
+    coverage: null,
+    terrain: null,
+  });
+  const syncOverlayProgressState = useCallback(() => {
+    const coverageProgress = overlayProgressByPipelineRef.current.coverage;
+    const terrainProgress = overlayProgressByPipelineRef.current.terrain;
+    const numeric = [coverageProgress, terrainProgress].filter((value): value is number => typeof value === "number");
+    if (!numeric.length) {
+      setOverlayProgressMode("indeterminate");
+      setOverlayProgressPercent(null);
+      return;
+    }
+    setOverlayProgressMode("determinate");
+    setOverlayProgressPercent(Math.max(...numeric));
+  }, []);
+  const setOverlayPipelineProgress = useCallback(
+    (pipeline: "coverage" | "terrain", percent: number | null) => {
+      const normalized =
+        typeof percent === "number" && Number.isFinite(percent)
+          ? Math.max(0, Math.min(100, Math.round(percent)))
+          : null;
+      if (overlayProgressByPipelineRef.current[pipeline] === normalized) return;
+      overlayProgressByPipelineRef.current[pipeline] = normalized;
+      syncOverlayProgressState();
+    },
+    [syncOverlayProgressState],
+  );
+  const beginOverlayJob = useCallback((pipeline: "coverage" | "terrain") => {
     let finished = false;
     setOverlayJobsInFlight((count) => count + 1);
+    setOverlayPipelineProgress(pipeline, null);
     return () => {
       if (finished) return;
       finished = true;
       setOverlayJobsInFlight((count) => Math.max(0, count - 1));
+      setOverlayPipelineProgress(pipeline, null);
     };
-  }, []);
+  }, [setOverlayPipelineProgress]);
   const [coverageOverlay, setCoverageOverlay] = useState<(OverlayRaster & { minDbm?: number; maxDbm?: number }) | null>(null);
   const [simulationTerrainOverlay, setSimulationTerrainOverlay] = useState<OverlayRaster | null>(null);
 
+  const logOverlaySchedulerEvent = useCallback(
+    (
+      pipeline: "coverage" | "terrain",
+      event: "queued" | "deduped-active" | "deduped-queued" | "cache-hit" | "started",
+      signature: string,
+      extra?: Record<string, unknown>,
+    ) => {
+      if (!showOverlayDiagnostics) return;
+      console.info("[simulation-overlay-scheduler]", {
+        pipeline,
+        event,
+        signature,
+        ...(extra ?? {}),
+      });
+    },
+    [showOverlayDiagnostics],
+  );
+
   useEffect(() => {
+    if (simulationRunToken) {
+      latestCoverageRunTokenRef.current = simulationRunToken;
+      return;
+    }
+    if (!isSimulationRecomputing) {
+      latestCoverageRunTokenRef.current = "";
+    }
+  }, [simulationRunToken, isSimulationRecomputing]);
+
+  useEffect(() => {
+    return () => {
+      coverageOverlaySchedulerRef.current?.dispose();
+      terrainOverlaySchedulerRef.current?.dispose();
+    };
+  }, []);
+
+  const overlaySampleDigest = useMemo(() => {
+    let hash = FNV_OFFSET_BASIS;
+    for (const sample of samplesForOverlay) {
+      hash = updateFvnHash(hash, roundHashValue(sample.lat, 100_000));
+      hash = updateFvnHash(hash, roundHashValue(sample.lon, 100_000));
+      hash = updateFvnHash(hash, roundHashValue(sample.valueDbm, 10));
+    }
+    return hash.toString(16);
+  }, [samplesForOverlay]);
+  const propagationEnvironmentDigest = useMemo(
+    () =>
+      [
+        propagationEnvironment.clutterHeightM,
+        propagationEnvironment.polarization,
+        propagationEnvironment.groundDielectric,
+        propagationEnvironment.groundConductivity,
+        propagationEnvironment.radioClimate,
+        propagationEnvironment.atmosphericBendingNUnits,
+      ]
+        .map((value) => String(value ?? ""))
+        .join(":"),
+    [propagationEnvironment],
+  );
+  const selectedSiteDigest = useMemo(() => selectedSiteIds.join(","), [selectedSiteIds]);
+
+  useEffect(() => {
+    const scheduler = coverageOverlaySchedulerRef.current!;
+    const cancelCoveragePipeline = (clearOverlay: boolean) => {
+      scheduler.clearQueue();
+      scheduler.cancelActive();
+      setOverlayPipelineProgress("coverage", null);
+      if (clearOverlay) setCoverageOverlay(null);
+    };
+
     if (coverageVizMode === "none") {
-      coverageOverlayTaskTokenRef.current += 1;
-      setCoverageOverlay(null);
+      cancelCoveragePipeline(true);
       return;
     }
     if (!overlayBounds) {
-      coverageOverlayTaskTokenRef.current += 1;
-      setCoverageOverlay(null);
+      cancelCoveragePipeline(true);
       return;
     }
 
     const mode = coverageVizMode;
     if (mode === "passfail" && (!activeSelectionLink || !selectedFromSite || !hasPassFailTopology)) {
-      coverageOverlayTaskTokenRef.current += 1;
-      setCoverageOverlay(null);
+      cancelCoveragePipeline(true);
       return;
     }
     if (mode === "relay" && (!activeSelectionLink || !selectedFromSite || !selectedToSite || !hasRelayTopology)) {
-      coverageOverlayTaskTokenRef.current += 1;
-      setCoverageOverlay(null);
+      cancelCoveragePipeline(true);
       return;
     }
 
-    coverageOverlayTaskTokenRef.current += 1;
-    const token = coverageOverlayTaskTokenRef.current;
     const signature = [
       mode,
       overlayBounds.minLat.toFixed(5),
@@ -1097,151 +1218,195 @@ export function MapView({
       overlayDimensions.height,
       effectiveBandStepDb,
       samplesForOverlay.length,
+      overlaySampleDigest,
       srtmTiles.length,
+      terrainLoadEpoch,
       effectiveGridSize,
+      overlayRadiusKm,
+      activeSelectionLink?.id ?? "",
+      selectedFromSite?.id ?? "",
+      selectedToSite?.id ?? "",
+      propagationEnvironmentDigest,
+      rxSensitivityTargetDbm,
+      environmentLossDb,
+      selectedSiteDigest,
     ].join("|");
-    const endOverlayJob = beginOverlayJob();
-    const taskBudget = overlayTaskBudgetForMode(mode);
-    const perfRunId = simulationRunToken || `overlay:${mode}:${token}`;
-    const overlayBuildStartedAt = performance.now();
+    const cached = coverageOverlayCacheRef.current.get(signature);
+    if (cached) {
+      scheduler.clearQueue();
+      scheduler.cancelActive();
+      setOverlayPipelineProgress("coverage", null);
+      logOverlaySchedulerEvent("coverage", "cache-hit", signature);
+      setCoverageOverlay(cached);
+      return;
+    }
 
-    const onLongTask = (payload: {
-      phase: string;
-      signature: string;
-      durationMs: number;
-      processed: number;
-      total: number;
-    }) => {
-      if (!showOverlayDiagnostics) return;
-      const warnKey = `${payload.phase}|${payload.signature}`;
-      const warned = overlayLongTaskWarnedRef.current;
-      if (warned.has(warnKey)) return;
-      warned.add(warnKey);
-      if (warned.size > 80) warned.clear();
-      console.warn("[simulation-long-task]", {
-        scope: "overlay",
-        ...payload,
+    const enqueueResult = scheduler.enqueue({
+      signature,
+      run: async (taskContext) => {
+        const endOverlayJob = beginOverlayJob("coverage");
+        const taskBudget = overlayTaskBudgetForMode(mode);
+        coverageOverlayRunCounterRef.current += 1;
+        const perfRunId =
+          latestCoverageRunTokenRef.current || `overlay:${mode}:${coverageOverlayRunCounterRef.current}`;
+        const overlayBuildStartedAt = performance.now();
+        let lastReportedProgress = -2;
+
+        const onLongTask = (payload: {
+          phase: string;
+          signature: string;
+          durationMs: number;
+          processed: number;
+          total: number;
+        }) => {
+          if (!showOverlayDiagnostics) return;
+          const warnKey = `${payload.phase}|${payload.signature}`;
+          const warned = overlayLongTaskWarnedRef.current;
+          if (warned.has(warnKey)) return;
+          warned.add(warnKey);
+          if (warned.size > 80) warned.clear();
+          console.warn("[simulation-long-task]", {
+            scope: "overlay",
+            ...payload,
+          });
+        };
+
+        const onProgress = (payload: { percent: number }) => {
+          if (taskContext.isCancelled()) return;
+          if (payload.percent < 100 && payload.percent - lastReportedProgress < 2) return;
+          lastReportedProgress = payload.percent;
+          setOverlayPipelineProgress("coverage", payload.percent);
+        };
+
+        const terrainSampler = (lat: number, lon: number) => sampleSrtmElevation(srtmTiles, lat, lon);
+
+        try {
+          const context = {
+            phase: mode,
+            signature,
+            frameBudgetMs: taskBudget.frameBudgetMs,
+            longTaskMs: taskBudget.longTaskMs,
+            shouldCancel: taskContext.isCancelled,
+            onLongTask,
+            onProgress,
+          } as const;
+          let rasterPixels: OverlayRasterPixels | null = null;
+          if (mode === "heatmap" || mode === "contours") {
+            rasterPixels = await buildCoverageOverlayPixelsAsync(
+              overlayBounds,
+              samplesForOverlay,
+              mode,
+              effectiveBandStepDb,
+              overlayDimensions,
+              overlayPointMask,
+              terrainSampler,
+              context,
+            );
+          } else if (mode === "passfail") {
+            const receiverAntennaHeightM = selectedToSite?.antennaHeightM ?? selectedFromSite!.antennaHeightM ?? 2;
+            const receiverRxGainDbi =
+              selectedToSite?.rxGainDbi ?? selectedFromSite!.rxGainDbi ?? STANDARD_SITE_RADIO.rxGainDbi;
+            rasterPixels = await buildSourcePassFailOverlayPixelsAsync(
+              overlayBounds,
+              selectedFromSite!,
+              activeSelectionLink!,
+              receiverAntennaHeightM,
+              receiverRxGainDbi,
+              propagationEnvironment,
+              rxSensitivityTargetDbm,
+              environmentLossDb,
+              terrainSampler,
+              overlayDimensions,
+              effectiveGridSize,
+              overlayPointMask,
+              context,
+            );
+          } else if (mode === "relay") {
+            rasterPixels = await buildRelayCandidateOverlayPixelsAsync(
+              overlayBounds,
+              selectedFromSite!,
+              selectedToSite!,
+              activeSelectionLink!,
+              propagationEnvironment,
+              environmentLossDb,
+              terrainSampler,
+              overlayDimensions,
+              effectiveGridSize,
+              overlayPointMask,
+              context,
+            );
+          }
+
+          const overlayBuildCompletedAt = performance.now();
+          if (taskContext.isCancelled()) {
+            recordSimulationRunCancelled({
+              runId: perfRunId,
+              phase: "overlay",
+              reason: "token-mismatch-after-build",
+              signature,
+              mode,
+            });
+            return;
+          }
+          if (!rasterPixels) {
+            setCoverageOverlay(null);
+            return;
+          }
+          const raster = overlayPixelsToDataUrl(rasterPixels);
+          const overlayEncodeCompletedAt = performance.now();
+          if (taskContext.isCancelled()) {
+            recordSimulationRunCancelled({
+              runId: perfRunId,
+              phase: "overlay",
+              reason: "token-mismatch-after-encode",
+              signature,
+              mode,
+            });
+            return;
+          }
+          recordSimulationOverlayPerf({
+            runId: perfRunId,
+            mode,
+            buildDurationMs: overlayBuildCompletedAt - overlayBuildStartedAt,
+            encodeDurationMs: overlayEncodeCompletedAt - overlayBuildCompletedAt,
+            width: rasterPixels.width,
+            height: rasterPixels.height,
+            pixelCount: rasterPixels.width * rasterPixels.height,
+            gridSize: effectiveGridSize,
+            effectiveRadiusKm: overlayRadiusKm,
+          });
+          const overlayValue = raster ? { ...raster } : null;
+          if (overlayValue) {
+            coverageOverlayCacheRef.current.set(signature, overlayValue);
+          }
+          setOverlayPipelineProgress("coverage", 100);
+          setCoverageOverlay(overlayValue);
+        } catch (error) {
+          if (error instanceof OverlayTaskCancelledError) {
+            recordSimulationRunCancelled({
+              runId: perfRunId,
+              phase: "overlay",
+              reason: "overlay-task-cancelled-error",
+              signature,
+              mode,
+            });
+            return;
+          }
+          console.error("Failed to render simulation overlay", error);
+        } finally {
+          endOverlayJob();
+        }
+      },
+    } satisfies LatestOnlyTask);
+    if (enqueueResult !== "started") {
+      logOverlaySchedulerEvent("coverage", enqueueResult, signature, {
+        activeMode: mode,
       });
-    };
-
-    const shouldCancel = () => coverageOverlayTaskTokenRef.current !== token;
-    const terrainSampler = (lat: number, lon: number) => sampleSrtmElevation(srtmTiles, lat, lon);
-
-    void (async () => {
-      try {
-        const context = {
-          phase: mode,
-          signature,
-          frameBudgetMs: taskBudget.frameBudgetMs,
-          longTaskMs: taskBudget.longTaskMs,
-          shouldCancel,
-          onLongTask,
-        } as const;
-        let rasterPixels: OverlayRasterPixels | null = null;
-        if (mode === "heatmap" || mode === "contours") {
-          rasterPixels = await buildCoverageOverlayPixelsAsync(
-            overlayBounds,
-            samplesForOverlay,
-            mode,
-            effectiveBandStepDb,
-            overlayDimensions,
-            overlayPointMask,
-            terrainSampler,
-            context,
-          );
-        } else if (mode === "passfail") {
-          const receiverAntennaHeightM = selectedToSite?.antennaHeightM ?? selectedFromSite!.antennaHeightM ?? 2;
-          const receiverRxGainDbi = selectedToSite?.rxGainDbi ?? selectedFromSite!.rxGainDbi ?? STANDARD_SITE_RADIO.rxGainDbi;
-          rasterPixels = await buildSourcePassFailOverlayPixelsAsync(
-            overlayBounds,
-            selectedFromSite!,
-            activeSelectionLink!,
-            receiverAntennaHeightM,
-            receiverRxGainDbi,
-            propagationEnvironment,
-            rxSensitivityTargetDbm,
-            environmentLossDb,
-            terrainSampler,
-            overlayDimensions,
-            effectiveGridSize,
-            overlayPointMask,
-            context,
-          );
-        } else if (mode === "relay") {
-          rasterPixels = await buildRelayCandidateOverlayPixelsAsync(
-            overlayBounds,
-            selectedFromSite!,
-            selectedToSite!,
-            activeSelectionLink!,
-            propagationEnvironment,
-            environmentLossDb,
-            terrainSampler,
-            overlayDimensions,
-            effectiveGridSize,
-            overlayPointMask,
-            context,
-          );
-        }
-
-        const overlayBuildCompletedAt = performance.now();
-        if (shouldCancel()) {
-          recordSimulationRunCancelled({
-            runId: perfRunId,
-            phase: "overlay",
-            reason: "token-mismatch-after-build",
-            signature,
-            mode,
-          });
-          return;
-        }
-        if (!rasterPixels) {
-          setCoverageOverlay(null);
-          return;
-        }
-        const raster = overlayPixelsToDataUrl(rasterPixels);
-        const overlayEncodeCompletedAt = performance.now();
-        if (shouldCancel()) {
-          recordSimulationRunCancelled({
-            runId: perfRunId,
-            phase: "overlay",
-            reason: "token-mismatch-after-encode",
-            signature,
-            mode,
-          });
-          return;
-        }
-        recordSimulationOverlayPerf({
-          runId: perfRunId,
-          mode,
-          buildDurationMs: overlayBuildCompletedAt - overlayBuildStartedAt,
-          encodeDurationMs: overlayEncodeCompletedAt - overlayBuildCompletedAt,
-          width: rasterPixels.width,
-          height: rasterPixels.height,
-          pixelCount: rasterPixels.width * rasterPixels.height,
-          gridSize: effectiveGridSize,
-          effectiveRadiusKm: overlayRadiusKm,
-        });
-        setCoverageOverlay(raster ? { ...raster } : null);
-      } catch (error) {
-        if (error instanceof OverlayTaskCancelledError) {
-          recordSimulationRunCancelled({
-            runId: perfRunId,
-            phase: "overlay",
-            reason: "overlay-task-cancelled-error",
-            signature,
-            mode,
-          });
-          return;
-        }
-        console.error("Failed to render simulation overlay", error);
-      } finally {
-        endOverlayJob();
-      }
-    })();
-    return () => {
-      coverageOverlayTaskTokenRef.current += 1;
-      endOverlayJob();
-    };
+      return;
+    }
+    logOverlaySchedulerEvent("coverage", "started", signature, {
+      activeMode: mode,
+    });
   }, [
     coverageVizMode,
     overlayBounds,
@@ -1253,16 +1418,21 @@ export function MapView({
     overlayDimensions,
     overlayPointMask,
     srtmTiles,
+    terrainLoadEpoch,
     effectiveBandStepDb,
     samplesForOverlay,
+    overlaySampleDigest,
     propagationEnvironment,
+    propagationEnvironmentDigest,
     rxSensitivityTargetDbm,
     environmentLossDb,
     effectiveGridSize,
     overlayRadiusKm,
-    simulationRunToken,
+    selectedSiteDigest,
     showOverlayDiagnostics,
     beginOverlayJob,
+    setOverlayPipelineProgress,
+    logOverlaySchedulerEvent,
   ]);
   const currentBandStepDb = effectiveBandStepDb;
 
@@ -1294,14 +1464,19 @@ export function MapView({
           : "Relay";
 
   useEffect(() => {
+    const scheduler = terrainOverlaySchedulerRef.current!;
+    const cancelTerrainPipeline = (clearOverlay: boolean) => {
+      scheduler.clearQueue();
+      scheduler.cancelActive();
+      setOverlayPipelineProgress("terrain", null);
+      if (clearOverlay) setSimulationTerrainOverlay(null);
+    };
+
     if (!showTerrainOverlay || !hasSimulationTerrain || !analysisBounds) {
-      terrainOverlayTaskTokenRef.current += 1;
-      setSimulationTerrainOverlay(null);
+      cancelTerrainPipeline(true);
       return;
     }
 
-    terrainOverlayTaskTokenRef.current += 1;
-    const token = terrainOverlayTaskTokenRef.current;
     const signature = [
       "terrain",
       analysisBounds.minLat.toFixed(5),
@@ -1311,119 +1486,154 @@ export function MapView({
       overlayDimensions.width,
       overlayDimensions.height,
       srtmTiles.length,
+      terrainLoadEpoch,
+      selectedSiteDigest,
+      overlayRadiusKm,
     ].join("|");
-    const endOverlayJob = beginOverlayJob();
-    const taskBudget = overlayTaskBudgetForMode("terrain");
-    const perfRunId = simulationRunToken || `overlay:terrain:${token}`;
-    const overlayBuildStartedAt = performance.now();
+    const cached = terrainOverlayCacheRef.current.get(signature);
+    if (cached) {
+      scheduler.clearQueue();
+      scheduler.cancelActive();
+      setOverlayPipelineProgress("terrain", null);
+      logOverlaySchedulerEvent("terrain", "cache-hit", signature);
+      setSimulationTerrainOverlay(cached);
+      return;
+    }
 
-    const shouldCancel = () => terrainOverlayTaskTokenRef.current !== token;
-    const onLongTask = (payload: {
-      phase: string;
-      signature: string;
-      durationMs: number;
-      processed: number;
-      total: number;
-    }) => {
-      if (!showOverlayDiagnostics) return;
-      const warnKey = `${payload.phase}|${payload.signature}`;
-      const warned = overlayLongTaskWarnedRef.current;
-      if (warned.has(warnKey)) return;
-      warned.add(warnKey);
-      if (warned.size > 80) warned.clear();
-      console.warn("[simulation-long-task]", {
-        scope: "overlay",
-        ...payload,
-      });
-    };
+    const enqueueResult = scheduler.enqueue({
+      signature,
+      run: async (taskContext) => {
+        const endOverlayJob = beginOverlayJob("terrain");
+        const taskBudget = overlayTaskBudgetForMode("terrain");
+        terrainOverlayRunCounterRef.current += 1;
+        const perfRunId =
+          latestCoverageRunTokenRef.current || `overlay:terrain:${terrainOverlayRunCounterRef.current}`;
+        const overlayBuildStartedAt = performance.now();
+        let lastReportedProgress = -2;
 
-    void (async () => {
-      try {
-        const rasterPixels = await buildTerrainShadeOverlayPixelsAsync(
-          analysisBounds,
-          (lat, lon) => sampleSrtmElevation(srtmTiles, lat, lon),
-          overlayDimensions,
-          overlayPointMask,
-          {
-            phase: "terrain-shade",
-            signature,
-            frameBudgetMs: taskBudget.frameBudgetMs,
-            longTaskMs: taskBudget.longTaskMs,
-            shouldCancel,
-            onLongTask,
-          },
-        );
-        const overlayBuildCompletedAt = performance.now();
-        if (shouldCancel()) {
-          recordSimulationRunCancelled({
-            runId: perfRunId,
-            phase: "overlay",
-            reason: "token-mismatch-after-build",
-            signature,
-            mode: "terrain",
+        const onLongTask = (payload: {
+          phase: string;
+          signature: string;
+          durationMs: number;
+          processed: number;
+          total: number;
+        }) => {
+          if (!showOverlayDiagnostics) return;
+          const warnKey = `${payload.phase}|${payload.signature}`;
+          const warned = overlayLongTaskWarnedRef.current;
+          if (warned.has(warnKey)) return;
+          warned.add(warnKey);
+          if (warned.size > 80) warned.clear();
+          console.warn("[simulation-long-task]", {
+            scope: "overlay",
+            ...payload,
           });
-          return;
-        }
-        if (!rasterPixels) {
-          setSimulationTerrainOverlay(null);
-          return;
-        }
-        const raster = overlayPixelsToDataUrl(rasterPixels);
-        const overlayEncodeCompletedAt = performance.now();
-        if (shouldCancel()) {
-          recordSimulationRunCancelled({
+        };
+
+        const onProgress = (payload: { percent: number }) => {
+          if (taskContext.isCancelled()) return;
+          if (payload.percent < 100 && payload.percent - lastReportedProgress < 2) return;
+          lastReportedProgress = payload.percent;
+          setOverlayPipelineProgress("terrain", payload.percent);
+        };
+
+        try {
+          const rasterPixels = await buildTerrainShadeOverlayPixelsAsync(
+            analysisBounds,
+            (lat, lon) => sampleSrtmElevation(srtmTiles, lat, lon),
+            overlayDimensions,
+            overlayPointMask,
+            {
+              phase: "terrain-shade",
+              signature,
+              frameBudgetMs: taskBudget.frameBudgetMs,
+              longTaskMs: taskBudget.longTaskMs,
+              shouldCancel: taskContext.isCancelled,
+              onLongTask,
+              onProgress,
+            },
+          );
+          const overlayBuildCompletedAt = performance.now();
+          if (taskContext.isCancelled()) {
+            recordSimulationRunCancelled({
+              runId: perfRunId,
+              phase: "overlay",
+              reason: "token-mismatch-after-build",
+              signature,
+              mode: "terrain",
+            });
+            return;
+          }
+          if (!rasterPixels) {
+            setSimulationTerrainOverlay(null);
+            return;
+          }
+          const raster = overlayPixelsToDataUrl(rasterPixels);
+          const overlayEncodeCompletedAt = performance.now();
+          if (taskContext.isCancelled()) {
+            recordSimulationRunCancelled({
+              runId: perfRunId,
+              phase: "overlay",
+              reason: "token-mismatch-after-encode",
+              signature,
+              mode: "terrain",
+            });
+            return;
+          }
+          recordSimulationOverlayPerf({
             runId: perfRunId,
-            phase: "overlay",
-            reason: "token-mismatch-after-encode",
-            signature,
             mode: "terrain",
+            buildDurationMs: overlayBuildCompletedAt - overlayBuildStartedAt,
+            encodeDurationMs: overlayEncodeCompletedAt - overlayBuildCompletedAt,
+            width: rasterPixels.width,
+            height: rasterPixels.height,
+            pixelCount: rasterPixels.width * rasterPixels.height,
+            gridSize: effectiveGridSize,
+            effectiveRadiusKm: overlayRadiusKm,
           });
-          return;
+          const overlayValue = raster ? { url: raster.url, coordinates: raster.coordinates } : null;
+          if (overlayValue) {
+            terrainOverlayCacheRef.current.set(signature, overlayValue);
+          }
+          setOverlayPipelineProgress("terrain", 100);
+          setSimulationTerrainOverlay(overlayValue);
+        } catch (error) {
+          if (error instanceof OverlayTaskCancelledError) {
+            recordSimulationRunCancelled({
+              runId: perfRunId,
+              phase: "overlay",
+              reason: "overlay-task-cancelled-error",
+              signature,
+              mode: "terrain",
+            });
+            return;
+          }
+          console.error("Failed to render terrain overlay", error);
+        } finally {
+          endOverlayJob();
         }
-        recordSimulationOverlayPerf({
-          runId: perfRunId,
-          mode: "terrain",
-          buildDurationMs: overlayBuildCompletedAt - overlayBuildStartedAt,
-          encodeDurationMs: overlayEncodeCompletedAt - overlayBuildCompletedAt,
-          width: rasterPixels.width,
-          height: rasterPixels.height,
-          pixelCount: rasterPixels.width * rasterPixels.height,
-          gridSize: effectiveGridSize,
-          effectiveRadiusKm: overlayRadiusKm,
-        });
-        setSimulationTerrainOverlay(raster ? { url: raster.url, coordinates: raster.coordinates } : null);
-      } catch (error) {
-        if (error instanceof OverlayTaskCancelledError) {
-          recordSimulationRunCancelled({
-            runId: perfRunId,
-            phase: "overlay",
-            reason: "overlay-task-cancelled-error",
-            signature,
-            mode: "terrain",
-          });
-          return;
-        }
-        console.error("Failed to render terrain overlay", error);
-      } finally {
-        endOverlayJob();
-      }
-    })();
-    return () => {
-      terrainOverlayTaskTokenRef.current += 1;
-      endOverlayJob();
-    };
+      },
+    } satisfies LatestOnlyTask);
+    if (enqueueResult !== "started") {
+      logOverlaySchedulerEvent("terrain", enqueueResult, signature);
+      return;
+    }
+    logOverlaySchedulerEvent("terrain", "started", signature);
   }, [
     showTerrainOverlay,
     hasSimulationTerrain,
     analysisBounds,
     srtmTiles,
+    terrainLoadEpoch,
     overlayDimensions,
     overlayPointMask,
+    selectedSiteDigest,
     effectiveGridSize,
     overlayRadiusKm,
-    simulationRunToken,
     showOverlayDiagnostics,
     beginOverlayJob,
+    setOverlayPipelineProgress,
+    logOverlaySchedulerEvent,
   ]);
 
   const webglAvailable = useMemo(() => supportsWebgl(), []);
@@ -1477,6 +1687,8 @@ export function MapView({
         simulationStepLabel,
         simulationProgress,
         overlayJobsInFlight,
+        overlayProgressMode,
+        overlayProgressPercent,
         isBackgroundBusy,
         backgroundBusyLabel,
         isTerrainFetching,
@@ -1490,6 +1702,8 @@ export function MapView({
       simulationStepLabel,
       simulationProgress,
       overlayJobsInFlight,
+      overlayProgressMode,
+      overlayProgressPercent,
       isBackgroundBusy,
       backgroundBusyLabel,
       isTerrainFetching,

--- a/src/lib/latestOnlyTaskScheduler.test.ts
+++ b/src/lib/latestOnlyTaskScheduler.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { createLatestOnlyTaskScheduler, type LatestOnlyTask } from "./latestOnlyTaskScheduler";
+
+const flushMicrotasks = async (count = 8): Promise<void> => {
+  for (let index = 0; index < count; index += 1) {
+    await Promise.resolve();
+  }
+};
+
+const task = (
+  signature: string,
+  run: LatestOnlyTask["run"],
+): LatestOnlyTask => ({
+  signature,
+  run,
+});
+
+describe("createLatestOnlyTaskScheduler", () => {
+  it("runs latest queued task after active task completes", async () => {
+    const order: string[] = [];
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const scheduler = createLatestOnlyTaskScheduler();
+
+    const firstTask = task("first", async () => {
+      order.push("first:start");
+      await firstGate;
+      order.push("first:done");
+    });
+    const secondTask = task("second", async () => {
+      order.push("second:done");
+    });
+    const thirdTask = task("third", async () => {
+      order.push("third:done");
+    });
+
+    expect(scheduler.enqueue(firstTask)).toBe("started");
+    expect(scheduler.enqueue(secondTask)).toBe("queued");
+    expect(scheduler.enqueue(thirdTask)).toBe("queued");
+
+    releaseFirst();
+    await flushMicrotasks();
+
+    expect(order).toEqual(["first:start", "first:done", "third:done"]);
+    expect(scheduler.snapshot()).toEqual({
+      running: false,
+      activeSignature: null,
+      queuedSignature: null,
+    });
+  });
+
+  it("deduplicates matching active and queued signatures", async () => {
+    const scheduler = createLatestOnlyTaskScheduler();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    expect(
+      scheduler.enqueue(
+        task("a", async () => {
+          await gate;
+        }),
+      ),
+    ).toBe("started");
+    expect(scheduler.enqueue(task("a", async () => {}))).toBe("deduped-active");
+    expect(scheduler.enqueue(task("b", async () => {}))).toBe("queued");
+    expect(scheduler.enqueue(task("b", async () => {}))).toBe("deduped-queued");
+
+    release();
+    await flushMicrotasks();
+  });
+
+  it("marks active task cancelled and still runs queued latest task", async () => {
+    const order: string[] = [];
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const scheduler = createLatestOnlyTaskScheduler();
+
+    expect(
+      scheduler.enqueue(
+        task("a", async (context) => {
+          order.push("a:start");
+          await gate;
+          if (context.isCancelled()) {
+            order.push("a:cancelled");
+            return;
+          }
+          order.push("a:done");
+        }),
+      ),
+    ).toBe("started");
+    expect(
+      scheduler.enqueue(
+        task("b", async () => {
+          order.push("b:done");
+        }),
+      ),
+    ).toBe("queued");
+
+    scheduler.cancelActive();
+    release();
+    await flushMicrotasks();
+
+    expect(order).toEqual(["a:start", "a:cancelled", "b:done"]);
+  });
+});

--- a/src/lib/latestOnlyTaskScheduler.ts
+++ b/src/lib/latestOnlyTaskScheduler.ts
@@ -1,0 +1,96 @@
+export type LatestOnlyTaskContext = {
+  isCancelled: () => boolean;
+};
+
+export type LatestOnlyTask = {
+  signature: string;
+  run: (context: LatestOnlyTaskContext) => Promise<void> | void;
+};
+
+export type LatestOnlyTaskEnqueueResult = "started" | "queued" | "deduped-active" | "deduped-queued";
+
+export type LatestOnlyTaskSchedulerSnapshot = {
+  running: boolean;
+  activeSignature: string | null;
+  queuedSignature: string | null;
+};
+
+export type LatestOnlyTaskScheduler = {
+  enqueue: (task: LatestOnlyTask) => LatestOnlyTaskEnqueueResult;
+  cancelActive: () => void;
+  clearQueue: () => void;
+  dispose: () => void;
+  snapshot: () => LatestOnlyTaskSchedulerSnapshot;
+};
+
+export const createLatestOnlyTaskScheduler = (): LatestOnlyTaskScheduler => {
+  let activeTask: { task: LatestOnlyTask; cancelled: boolean } | null = null;
+  let queuedTask: LatestOnlyTask | null = null;
+  let disposed = false;
+
+  const snapshot = (): LatestOnlyTaskSchedulerSnapshot => ({
+    running: activeTask !== null,
+    activeSignature: activeTask?.task.signature ?? null,
+    queuedSignature: queuedTask?.signature ?? null,
+  });
+
+  const launchIfIdle = (): void => {
+    if (disposed || activeTask || !queuedTask) return;
+    const current = queuedTask;
+    queuedTask = null;
+    activeTask = { task: current, cancelled: false };
+
+    void Promise.resolve()
+      .then(() =>
+        current.run({
+          isCancelled: () => activeTask?.task === current && activeTask.cancelled,
+        }),
+      )
+      .finally(() => {
+        if (activeTask?.task === current) {
+          activeTask = null;
+        }
+        launchIfIdle();
+      });
+  };
+
+  const enqueue = (task: LatestOnlyTask): LatestOnlyTaskEnqueueResult => {
+    if (disposed) return "deduped-active";
+    if (!activeTask) {
+      queuedTask = task;
+      launchIfIdle();
+      return "started";
+    }
+    if (activeTask.task.signature === task.signature) {
+      return "deduped-active";
+    }
+    if (queuedTask?.signature === task.signature) {
+      return "deduped-queued";
+    }
+    queuedTask = task;
+    return "queued";
+  };
+
+  const cancelActive = (): void => {
+    if (!activeTask) return;
+    activeTask.cancelled = true;
+  };
+
+  const clearQueue = (): void => {
+    queuedTask = null;
+  };
+
+  const dispose = (): void => {
+    disposed = true;
+    queuedTask = null;
+    cancelActive();
+  };
+
+  return {
+    enqueue,
+    cancelActive,
+    clearQueue,
+    dispose,
+    snapshot,
+  };
+};

--- a/src/lib/lruCache.test.ts
+++ b/src/lib/lruCache.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { createLruCache } from "./lruCache";
+
+describe("createLruCache", () => {
+  it("evicts least recently used entry when capacity is exceeded", () => {
+    const cache = createLruCache<number>(2);
+    cache.set("a", 1);
+    cache.set("b", 2);
+    expect(cache.get("a")).toBe(1);
+
+    cache.set("c", 3);
+
+    expect(cache.get("a")).toBe(1);
+    expect(cache.get("b")).toBeUndefined();
+    expect(cache.get("c")).toBe(3);
+  });
+
+  it("updates recency when setting an existing key", () => {
+    const cache = createLruCache<number>(2);
+    cache.set("a", 1);
+    cache.set("b", 2);
+    cache.set("a", 11);
+    cache.set("c", 3);
+
+    expect(cache.get("a")).toBe(11);
+    expect(cache.get("b")).toBeUndefined();
+    expect(cache.get("c")).toBe(3);
+  });
+
+  it("clear removes all entries", () => {
+    const cache = createLruCache<number>(2);
+    cache.set("a", 1);
+    cache.set("b", 2);
+    expect(cache.size()).toBe(2);
+    cache.clear();
+    expect(cache.size()).toBe(0);
+    expect(cache.get("a")).toBeUndefined();
+    expect(cache.get("b")).toBeUndefined();
+  });
+});

--- a/src/lib/lruCache.ts
+++ b/src/lib/lruCache.ts
@@ -1,0 +1,36 @@
+export type LruCache<T> = {
+  get: (key: string) => T | undefined;
+  set: (key: string, value: T) => void;
+  clear: () => void;
+  size: () => number;
+};
+
+export const createLruCache = <T>(capacity: number): LruCache<T> => {
+  const maxEntries = Math.max(1, Math.floor(capacity));
+  const store = new Map<string, T>();
+
+  return {
+    get: (key) => {
+      const value = store.get(key);
+      if (value === undefined) return undefined;
+      store.delete(key);
+      store.set(key, value);
+      return value;
+    },
+    set: (key, value) => {
+      if (store.has(key)) {
+        store.delete(key);
+      }
+      store.set(key, value);
+      while (store.size > maxEntries) {
+        const oldest = store.keys().next().value;
+        if (typeof oldest !== "string") break;
+        store.delete(oldest);
+      }
+    },
+    clear: () => {
+      store.clear();
+    },
+    size: () => store.size,
+  };
+};

--- a/src/lib/overlayRaster.test.ts
+++ b/src/lib/overlayRaster.test.ts
@@ -161,4 +161,33 @@ describe("overlayRaster async builders", () => {
 
     await expect(promise).rejects.toBeInstanceOf(OverlayTaskCancelledError);
   });
+
+  it("reports cooperative progress for overlay build callbacks", async () => {
+    const checkpoints: Array<{ processed: number; total: number; percent: number }> = [];
+    await buildCoverageOverlayPixelsAsync(
+      bounds,
+      samples,
+      "heatmap",
+      5,
+      { width: 40, height: 40 },
+      undefined,
+      terrainSampler,
+      {
+        phase: "coverage",
+        signature: "progress-test",
+        frameBudgetMs: 1,
+        onProgress: (payload) => {
+          checkpoints.push({
+            processed: payload.processed,
+            total: payload.total,
+            percent: payload.percent,
+          });
+        },
+      },
+    );
+
+    expect(checkpoints.length).toBeGreaterThan(0);
+    const last = checkpoints[checkpoints.length - 1];
+    expect(last).toEqual({ processed: 1600, total: 1600, percent: 100 });
+  });
 });

--- a/src/lib/overlayRaster.ts
+++ b/src/lib/overlayRaster.ts
@@ -40,6 +40,13 @@ export type OverlayTaskContext = {
     processed: number;
     total: number;
   }) => void;
+  onProgress?: (payload: {
+    phase: string;
+    signature: string;
+    processed: number;
+    total: number;
+    percent: number;
+  }) => void;
 };
 
 const DEFAULT_FRAME_BUDGET_MS = 8;
@@ -111,10 +118,53 @@ const runCooperativeLoop = async (
       });
     }
 
+    if (total > 0) {
+      context?.onProgress?.({
+        phase: context.phase,
+        signature: context.signature,
+        processed,
+        total,
+        percent: Math.round((processed / total) * 100),
+      });
+    }
+
     if (processed < total) {
       await nextFrame();
     }
   }
+
+  if (total > 0 && processed >= total) {
+    context?.onProgress?.({
+      phase: context.phase,
+      signature: context.signature,
+      processed: total,
+      total,
+      percent: 100,
+    });
+  }
+};
+
+const precomputeGridAxes = (
+  bounds: TerrainBounds,
+  dimensions: { width: number; height: number },
+): { latByRow: Float64Array; lonByCol: Float64Array } => {
+  const width = dimensions.width;
+  const height = dimensions.height;
+  const latByRow = new Float64Array(height);
+  const lonByCol = new Float64Array(width);
+  const latSpan = bounds.maxLat - bounds.minLat;
+  const lonSpan = bounds.maxLon - bounds.minLon;
+  const heightDivisor = Math.max(1, height - 1);
+  const widthDivisor = Math.max(1, width - 1);
+
+  for (let y = 0; y < height; y += 1) {
+    latByRow[y] = bounds.maxLat - latSpan * (y / heightDivisor);
+  }
+  for (let x = 0; x < width; x += 1) {
+    lonByCol[x] = bounds.minLon + lonSpan * (x / widthDivisor);
+  }
+
+  return { latByRow, lonByCol };
 };
 
 const coverageColorForDbm = (valueDbm: number): [number, number, number] => {
@@ -144,16 +194,28 @@ const coverageColorForDbm = (valueDbm: number): [number, number, number] => {
   return [255, 255, 255];
 };
 
-const coverageColorAdaptive = (valueDbm: number, samples: CoverageSampleLite[]): [number, number, number] => {
-  if (samples.length < 2) return coverageColorForDbm(valueDbm);
+const computeCoverageAdaptiveScale = (
+  samples: CoverageSampleLite[],
+): { min: number; range: number } | null => {
+  if (samples.length < 2) return null;
   let min = Number.POSITIVE_INFINITY;
   let max = Number.NEGATIVE_INFINITY;
   for (const sample of samples) {
     min = Math.min(min, sample.valueDbm);
     max = Math.max(max, sample.valueDbm);
   }
-  const range = Math.max(6, max - min);
-  const normalized = -125 + ((valueDbm - min) / range) * 63;
+  return {
+    min,
+    range: Math.max(6, max - min),
+  };
+};
+
+const coverageColorAdaptive = (
+  valueDbm: number,
+  scale: { min: number; range: number } | null,
+): [number, number, number] => {
+  if (!scale) return coverageColorForDbm(valueDbm);
+  const normalized = -125 + ((valueDbm - scale.min) / scale.range) * 63;
   return coverageColorForDbm(clamp(normalized, -125, -62));
 };
 
@@ -285,6 +347,8 @@ export const buildCoverageOverlayPixelsAsync = async (
   const gridInterpolator = makeGridInterpolator(samples);
   const width = dimensions.width;
   const height = dimensions.height;
+  const { latByRow, lonByCol } = precomputeGridAxes(bounds, dimensions);
+  const adaptiveScale = computeCoverageAdaptiveScale(samples);
   const pixels = new Uint8ClampedArray(width * height * 4);
 
   await runCooperativeLoop(
@@ -292,10 +356,8 @@ export const buildCoverageOverlayPixelsAsync = async (
     (index) => {
       const y = Math.floor(index / width);
       const x = index - y * width;
-      const tY = y / Math.max(1, height - 1);
-      const lat = bounds.maxLat - (bounds.maxLat - bounds.minLat) * tY;
-      const tX = x / Math.max(1, width - 1);
-      const lon = bounds.minLon + (bounds.maxLon - bounds.minLon) * tX;
+      const lat = latByRow[y];
+      const lon = lonByCol[x];
       if (pointMask && !pointMask(lat, lon)) return;
       if (terrainSampler && terrainSampler(lat, lon) === null) return;
       const valueDbm = gridInterpolator
@@ -308,10 +370,10 @@ export const buildCoverageOverlayPixelsAsync = async (
       let b = 0;
       let a = 180;
       if (mode === "heatmap") {
-        [r, g, b] = coverageColorAdaptive(valueDbm, samples);
+        [r, g, b] = coverageColorAdaptive(valueDbm, adaptiveScale);
       } else {
         const banded = Math.round(valueDbm / Math.max(1, bandStepDb)) * Math.max(1, bandStepDb);
-        [r, g, b] = coverageColorAdaptive(banded, samples);
+        [r, g, b] = coverageColorAdaptive(banded, adaptiveScale);
         a = 170;
       }
 
@@ -349,6 +411,7 @@ export const buildSourcePassFailOverlayPixelsAsync = async (
 ): Promise<OverlayRasterPixels | null> => {
   const width = dimensions.width;
   const height = dimensions.height;
+  const { latByRow, lonByCol } = precomputeGridAxes(bounds, dimensions);
   const pixels = new Uint8ClampedArray(width * height * 4);
 
   await runCooperativeLoop(
@@ -356,10 +419,8 @@ export const buildSourcePassFailOverlayPixelsAsync = async (
     (index) => {
       const y = Math.floor(index / width);
       const x = index - y * width;
-      const tY = y / Math.max(1, height - 1);
-      const lat = bounds.maxLat - (bounds.maxLat - bounds.minLat) * tY;
-      const tX = x / Math.max(1, width - 1);
-      const lon = bounds.minLon + (bounds.maxLon - bounds.minLon) * tX;
+      const lat = latByRow[y];
+      const lon = lonByCol[x];
       if (pointMask && !pointMask(lat, lon)) return;
       if (terrainSampler(lat, lon) === null) return;
 
@@ -424,10 +485,22 @@ export const buildRelayCandidateOverlayPixelsAsync = async (
 ): Promise<OverlayRasterPixels | null> => {
   const width = dimensions.width;
   const height = dimensions.height;
+  const { latByRow, lonByCol } = precomputeGridAxes(bounds, dimensions);
   const relayAntennaHeightM = Math.max(2, (fromSite.antennaHeightM + toSite.antennaHeightM) / 2);
   const fallbackRelayGround = (fromSite.groundElevationM + toSite.groundElevationM) / 2;
   const pixels = new Uint8ClampedArray(width * height * 4);
   const bottleneck = new Float32Array(width * height).fill(-Infinity);
+  const relaySite: Site = {
+    id: "__relay_candidate__",
+    name: "Relay candidate",
+    position: { lat: fromSite.position.lat, lon: fromSite.position.lon },
+    antennaHeightM: relayAntennaHeightM,
+    groundElevationM: fallbackRelayGround,
+    txPowerDbm: STANDARD_SITE_RADIO.txPowerDbm,
+    txGainDbi: STANDARD_SITE_RADIO.txGainDbi,
+    rxGainDbi: STANDARD_SITE_RADIO.rxGainDbi,
+    cableLossDb: STANDARD_SITE_RADIO.cableLossDb,
+  };
   let minDbm = Number.POSITIVE_INFINITY;
   let maxDbm = Number.NEGATIVE_INFINITY;
 
@@ -436,27 +509,16 @@ export const buildRelayCandidateOverlayPixelsAsync = async (
     (index) => {
       const y = Math.floor(index / width);
       const x = index - y * width;
-      const tY = y / Math.max(1, height - 1);
-      const lat = bounds.maxLat - (bounds.maxLat - bounds.minLat) * tY;
-      const tX = x / Math.max(1, width - 1);
-      const lon = bounds.minLon + (bounds.maxLon - bounds.minLon) * tX;
+      const lat = latByRow[y];
+      const lon = lonByCol[x];
       if (pointMask && !pointMask(lat, lon)) return;
 
       const sampledGround = terrainSampler(lat, lon);
       if (sampledGround === null) return;
       const relayGround = sampledGround ?? fallbackRelayGround;
-
-      const relaySite: Site = {
-        id: "__relay_candidate__",
-        name: "Relay candidate",
-        position: { lat, lon },
-        antennaHeightM: relayAntennaHeightM,
-        groundElevationM: relayGround,
-        txPowerDbm: STANDARD_SITE_RADIO.txPowerDbm,
-        txGainDbi: STANDARD_SITE_RADIO.txGainDbi,
-        rxGainDbi: STANDARD_SITE_RADIO.rxGainDbi,
-        cableLossDb: STANDARD_SITE_RADIO.cableLossDb,
-      };
+      relaySite.position.lat = lat;
+      relaySite.position.lon = lon;
+      relaySite.groundElevationM = relayGround;
 
       const fromToRelayRx = computeSourceCentricRxDbm(
         lat,
@@ -527,6 +589,7 @@ export const buildTerrainShadeOverlayPixelsAsync = async (
 ): Promise<OverlayRasterPixels | null> => {
   const width = dimensions.width;
   const height = dimensions.height;
+  const { latByRow, lonByCol } = precomputeGridAxes(bounds, dimensions);
   const elevations = new Float32Array(width * height);
   const valid = new Uint8Array(width * height);
   const allowed = new Uint8Array(width * height);
@@ -540,10 +603,8 @@ export const buildTerrainShadeOverlayPixelsAsync = async (
     (index) => {
       const y = Math.floor(index / width);
       const x = index - y * width;
-      const tY = y / Math.max(1, height - 1);
-      const lat = bounds.maxLat - (bounds.maxLat - bounds.minLat) * tY;
-      const tX = x / Math.max(1, width - 1);
-      const lon = bounds.minLon + (bounds.maxLon - bounds.minLon) * tX;
+      const lat = latByRow[y];
+      const lon = lonByCol[x];
       const isAllowed = pointMask ? pointMask(lat, lon) : true;
       const elevation = sampler(lat, lon);
 

--- a/src/lib/passFailState.ts
+++ b/src/lib/passFailState.ts
@@ -54,7 +54,8 @@ export const computeSourceCentricRxMetrics = (
 
   let terrainPenaltyDb = 0;
   let terrainObstructed = false;
-  const rxGround = terrainSampler(lat, lon);
+  const sampleTerrainAt = (sampleLat: number, sampleLon: number): number | null => terrainSampler(sampleLat, sampleLon);
+  const rxGround = sampleTerrainAt(lat, lon);
   if (rxGround !== null) {
     terrainPenaltyDb = estimateTerrainExcessLossDb({
       from: fromSite.position,
@@ -62,7 +63,8 @@ export const computeSourceCentricRxMetrics = (
       fromAntennaAbsM: fromSite.groundElevationM + fromSite.antennaHeightM,
       toAntennaAbsM: rxGround + receiverAntennaHeightM,
       frequencyMHz: effectiveLink.frequencyMHz,
-      terrainSampler: ({ lat: y, lon: x }) => terrainSampler(y, x),
+      terrainSampler: ({ lat: y, lon: x }) => sampleTerrainAt(y, x),
+      terrainSamplerAt: sampleTerrainAt,
       samples: terrainSamples,
       kFactor,
       clutterHeightM,
@@ -73,7 +75,8 @@ export const computeSourceCentricRxMetrics = (
       to: { lat, lon },
       fromAntennaAbsM: fromSite.groundElevationM + fromSite.antennaHeightM,
       toAntennaAbsM: rxGround + receiverAntennaHeightM,
-      terrainSampler: ({ lat: y, lon: x }) => terrainSampler(y, x),
+      terrainSampler: ({ lat: y, lon: x }) => sampleTerrainAt(y, x),
+      terrainSamplerAt: sampleTerrainAt,
       samples: Math.max(12, Math.round(terrainSamples * 0.66)),
       kFactor,
       clutterHeightM,

--- a/src/lib/simulationBusyIndicator.test.ts
+++ b/src/lib/simulationBusyIndicator.test.ts
@@ -9,6 +9,8 @@ describe("resolveSimulationBusyIndicatorState", () => {
       simulationStepLabel: "Sampling simulation grid (120/240)",
       simulationProgress: 50,
       overlayJobsInFlight: 2,
+      overlayProgressMode: "indeterminate",
+      overlayProgressPercent: null,
       isBackgroundBusy: true,
       backgroundBusyLabel: "Loading terrain 60%",
       isTerrainFetching: true,
@@ -31,6 +33,8 @@ describe("resolveSimulationBusyIndicatorState", () => {
       simulationStepLabel: "",
       simulationProgress: 0,
       overlayJobsInFlight: 1,
+      overlayProgressMode: "indeterminate",
+      overlayProgressPercent: null,
       isBackgroundBusy: false,
       backgroundBusyLabel: "",
       isTerrainFetching: false,
@@ -46,6 +50,30 @@ describe("resolveSimulationBusyIndicatorState", () => {
     });
   });
 
+  it("shows determinate overlay progress when provided", () => {
+    const state = resolveSimulationBusyIndicatorState({
+      isSimulationRecomputing: false,
+      simulationProgressMode: "indeterminate",
+      simulationStepLabel: "",
+      simulationProgress: 0,
+      overlayJobsInFlight: 1,
+      overlayProgressMode: "determinate",
+      overlayProgressPercent: 64,
+      isBackgroundBusy: false,
+      backgroundBusyLabel: "",
+      isTerrainFetching: false,
+      hasTerrainDownloadProgress: false,
+      terrainProgressPercent: 0,
+      terrainProgressTilesTotal: 0,
+    });
+
+    expect(state).toEqual({
+      label: "Finalizing simulation overlay... 64%",
+      progressMode: "determinate",
+      progressPercent: 64,
+    });
+  });
+
   it("retains terrain determinate progress behavior when background fetch is active", () => {
     const state = resolveSimulationBusyIndicatorState({
       isSimulationRecomputing: false,
@@ -53,6 +81,8 @@ describe("resolveSimulationBusyIndicatorState", () => {
       simulationStepLabel: "",
       simulationProgress: 0,
       overlayJobsInFlight: 0,
+      overlayProgressMode: "indeterminate",
+      overlayProgressPercent: null,
       isBackgroundBusy: true,
       backgroundBusyLabel: "Loading terrain 40%",
       isTerrainFetching: true,
@@ -75,6 +105,8 @@ describe("resolveSimulationBusyIndicatorState", () => {
       simulationStepLabel: "",
       simulationProgress: 0,
       overlayJobsInFlight: 0,
+      overlayProgressMode: "indeterminate",
+      overlayProgressPercent: null,
       isBackgroundBusy: false,
       backgroundBusyLabel: "",
       isTerrainFetching: false,

--- a/src/lib/simulationBusyIndicator.ts
+++ b/src/lib/simulationBusyIndicator.ts
@@ -4,6 +4,8 @@ export type SimulationBusyIndicatorInput = {
   simulationStepLabel: string;
   simulationProgress: number;
   overlayJobsInFlight: number;
+  overlayProgressMode: "determinate" | "indeterminate";
+  overlayProgressPercent: number | null;
   isBackgroundBusy: boolean;
   backgroundBusyLabel: string;
   isTerrainFetching: boolean;
@@ -37,6 +39,13 @@ export const resolveSimulationBusyIndicatorState = (
   }
 
   if (input.overlayJobsInFlight > 0) {
+    if (input.overlayProgressMode === "determinate" && typeof input.overlayProgressPercent === "number") {
+      return {
+        label: `Finalizing simulation overlay... ${input.overlayProgressPercent}%`,
+        progressMode: "determinate",
+        progressPercent: input.overlayProgressPercent,
+      };
+    }
     return {
       label: "Finalizing simulation overlay...",
       progressMode: "indeterminate",

--- a/src/lib/simulationPerf.ts
+++ b/src/lib/simulationPerf.ts
@@ -120,5 +120,17 @@ export const recordSimulationRunCancelled = (payload: {
 }): void => {
   if (!inDevDiagnostics) return;
   console.info("[simulation-perf-cancelled]", payload);
-  pendingByRun.delete(payload.runId);
+  if (payload.phase === "coverage") {
+    pendingByRun.delete(payload.runId);
+    return;
+  }
+
+  const pending = pendingByRun.get(payload.runId);
+  if (!pending) return;
+
+  // Overlay tasks can cancel and restart while the same coverage run is still active.
+  // Keep pending coverage timing so a later successful overlay can still emit a full run log.
+  if (!pending.coverage) {
+    pendingByRun.delete(payload.runId);
+  }
 };

--- a/src/lib/terrainLoss.test.ts
+++ b/src/lib/terrainLoss.test.ts
@@ -81,4 +81,28 @@ describe("estimateTerrainExcessLossDb", () => {
 
     expect(loss).toBeGreaterThan(10);
   });
+
+  it("supports terrainSamplerAt fast path with equivalent result", () => {
+    const withCoordinatesSampler = estimateTerrainExcessLossDb({
+      from: { lat: 59.9, lon: 10.7 },
+      to: { lat: 60.0, lon: 10.7 },
+      fromAntennaAbsM: 104,
+      toAntennaAbsM: 104,
+      frequencyMHz: 869.618,
+      terrainSampler: ridgeSampler,
+      samples: 48,
+    });
+    const withDirectSampler = estimateTerrainExcessLossDb({
+      from: { lat: 59.9, lon: 10.7 },
+      to: { lat: 60.0, lon: 10.7 },
+      fromAntennaAbsM: 104,
+      toAntennaAbsM: 104,
+      frequencyMHz: 869.618,
+      terrainSampler: ridgeSampler,
+      terrainSamplerAt: (lat, lon) => ridgeSampler({ lat, lon }),
+      samples: 48,
+    });
+
+    expect(withDirectSampler).toBeCloseTo(withCoordinatesSampler, 12);
+  });
 });

--- a/src/lib/terrainLoss.ts
+++ b/src/lib/terrainLoss.ts
@@ -1,4 +1,4 @@
-import { haversineDistanceKm, interpolateCoordinate } from "./geo";
+import { haversineDistanceKm } from "./geo";
 import type { Coordinates, Polarization } from "../types/radio";
 
 const clamp = (value: number, min: number, max: number): number =>
@@ -45,6 +45,7 @@ type TerrainLossInput = {
   toAntennaAbsM: number;
   frequencyMHz: number;
   terrainSampler: TerrainSampler;
+  terrainSamplerAt?: (lat: number, lon: number) => number | null;
   samples?: number;
   kFactor?: number;
   clutterHeightM?: number;
@@ -57,6 +58,7 @@ type TerrainLosInput = {
   fromAntennaAbsM: number;
   toAntennaAbsM: number;
   terrainSampler: TerrainSampler;
+  terrainSamplerAt?: (lat: number, lon: number) => number | null;
   samples?: number;
   kFactor?: number;
   clutterHeightM?: number;
@@ -69,6 +71,7 @@ export const estimateTerrainExcessLossDb = ({
   toAntennaAbsM,
   frequencyMHz,
   terrainSampler,
+  terrainSamplerAt,
   samples = 24,
   kFactor = 4 / 3,
   clutterHeightM = 0,
@@ -80,10 +83,16 @@ export const estimateTerrainExcessLossDb = ({
   const wavelengthM = 300 / Math.max(1, frequencyMHz);
 
   const trace: { distanceM: number; terrainM: number }[] = [];
+  const sampleTerrainAt =
+    terrainSamplerAt ??
+    ((lat: number, lon: number) => terrainSampler({ lat, lon }));
+  const latSpan = to.lat - from.lat;
+  const lonSpan = to.lon - from.lon;
   for (let i = 0; i < sampleCount; i += 1) {
     const t = sampleCount <= 1 ? 0 : i / (sampleCount - 1);
-    const p = interpolateCoordinate(from, to, t);
-    const terrain = terrainSampler(p);
+    const lat = from.lat + latSpan * t;
+    const lon = from.lon + lonSpan * t;
+    const terrain = sampleTerrainAt(lat, lon);
     if (terrain === null) continue;
     trace.push({
       distanceM: distanceM * t,
@@ -162,6 +171,7 @@ export const isTerrainLineObstructed = ({
   fromAntennaAbsM,
   toAntennaAbsM,
   terrainSampler,
+  terrainSamplerAt,
   samples = 24,
   kFactor = 4 / 3,
   clutterHeightM = 0,
@@ -170,11 +180,17 @@ export const isTerrainLineObstructed = ({
   const distanceKm = Math.max(0.001, haversineDistanceKm(from, to));
   const distanceM = distanceKm * 1000;
   const clutterBoost = Math.max(0, clutterHeightM) * 0.55;
+  const sampleTerrainAt =
+    terrainSamplerAt ??
+    ((lat: number, lon: number) => terrainSampler({ lat, lon }));
+  const latSpan = to.lat - from.lat;
+  const lonSpan = to.lon - from.lon;
 
   for (let i = 1; i < sampleCount - 1; i += 1) {
     const t = i / (sampleCount - 1);
-    const p = interpolateCoordinate(from, to, t);
-    const terrain = terrainSampler(p);
+    const lat = from.lat + latSpan * t;
+    const lon = from.lon + lonSpan * t;
+    const terrain = sampleTerrainAt(lat, lon);
     if (terrain === null) continue;
     const d1 = distanceM * t;
     const losM = fromAntennaAbsM + (toAntennaAbsM - fromAntennaAbsM) * t;


### PR DESCRIPTION
## Summary\n- add latest-only overlay task scheduler to dedupe/reduce cancel-restart churn\n- add bounded LRU overlay result cache and exact-signature cache hit path\n- add determinate finalizing progress through existing simulation busy indicator\n- optimize overlay hot paths (grid axis precompute, adaptive color scale reuse, non-alloc relay candidate reuse, terrainSamplerAt fast path)\n- add tests for scheduler, cache, overlay progress, and terrain fast path parity\n\n## Verification\n- npm test\n- npm run build\n