### PR TITLE
Issue #188: Terraform adoption baseline alignment

### DIFF
--- a/infra/terraform/environments/prod/backend.hcl.example
+++ b/infra/terraform/environments/prod/backend.hcl.example
@@ -1,14 +1,9 @@
 bucket = "linksim-terraform-state"
 key    = "state/prod/terraform.tfstate"
 region = "auto"
+endpoint = "https://85c57e0c4da3a747a09212dc5b090f52.r2.cloudflarestorage.com"
 
 skip_credentials_validation = true
 skip_metadata_api_check     = true
 skip_region_validation      = true
-skip_requesting_account_id  = true
-skip_s3_checksum            = true
-use_path_style              = true
-
-endpoints = {
-  s3 = "https://85c57e0c4da3a747a09212dc5b090f52.r2.cloudflarestorage.com"
-}
+force_path_style            = true

--- a/infra/terraform/environments/prod/terraform.tfvars
+++ b/infra/terraform/environments/prod/terraform.tfvars
@@ -1,5 +1,5 @@
 account_id                = "85c57e0c4da3a747a09212dc5b090f52"
-zone_id                   = "REPLACE_WITH_LINKSIM_LINK_ZONE_ID"
+zone_id                   = "a3e8d2285955eeb31f5a0757e7bc0181"
 project_name              = "linksim"
 project_production_branch = "main"
 pages_compatibility_date  = "2026-03-12"
@@ -28,21 +28,25 @@ r2_bucket_jurisdiction = "default"
 
 dns_records = {
   apex = {
-    name    = "@"
+    name    = "linksim.link"
     type    = "CNAME"
     content = "linksim.pages.dev"
     ttl     = 1
     proxied = true
-    comment = "Terraform managed: production routing"
   }
 }
 
 # Access app configuration; app and policy IDs stay in imports.env.
 access_application = {
-  name            = "LinkSim Access"
-  domain          = "linksim.link"
-  type            = "self_hosted"
-  policy_bindings = []
+  name   = "LinkSim Public App Shell"
+  domain = "linksim.link"
+  type   = "self_hosted"
+  policy_bindings = [
+    {
+      id         = "32915afb-f399-4c5c-90ea-e5bf0f377b7c"
+      precedence = 1
+    }
+  ]
 }
 
 # Import-first stubs. Populate with real policy keys/names/decisions before import.

--- a/infra/terraform/environments/staging/backend.hcl.example
+++ b/infra/terraform/environments/staging/backend.hcl.example
@@ -1,14 +1,9 @@
 bucket = "linksim-terraform-state"
 key    = "state/staging/terraform.tfstate"
 region = "auto"
+endpoint = "https://85c57e0c4da3a747a09212dc5b090f52.r2.cloudflarestorage.com"
 
 skip_credentials_validation = true
 skip_metadata_api_check     = true
 skip_region_validation      = true
-skip_requesting_account_id  = true
-skip_s3_checksum            = true
-use_path_style              = true
-
-endpoints = {
-  s3 = "https://85c57e0c4da3a747a09212dc5b090f52.r2.cloudflarestorage.com"
-}
+force_path_style            = true

--- a/infra/terraform/environments/staging/terraform.tfvars
+++ b/infra/terraform/environments/staging/terraform.tfvars
@@ -1,5 +1,5 @@
 account_id                = "85c57e0c4da3a747a09212dc5b090f52"
-zone_id                   = "REPLACE_WITH_LINKSIM_LINK_ZONE_ID"
+zone_id                   = "a3e8d2285955eeb31f5a0757e7bc0181"
 project_name              = "linksim-staging"
 project_production_branch = "main"
 pages_compatibility_date  = "2026-03-12"
@@ -28,21 +28,25 @@ r2_bucket_jurisdiction = "default"
 
 dns_records = {
   staging = {
-    name    = "staging"
+    name    = "staging.linksim.link"
     type    = "CNAME"
     content = "linksim-staging.pages.dev"
     ttl     = 1
     proxied = true
-    comment = "Terraform managed: staging routing"
   }
 }
 
 # Access app configuration; app and policy IDs stay in imports.env.
 access_application = {
-  name            = "LinkSim Staging Access"
-  domain          = "staging.linksim.link"
-  type            = "self_hosted"
-  policy_bindings = []
+  name   = "LinkSim Staging Public App Shell"
+  domain = "staging.linksim.link"
+  type   = "self_hosted"
+  policy_bindings = [
+    {
+      id         = "32915afb-f399-4c5c-90ea-e5bf0f377b7c"
+      precedence = 1
+    }
+  ]
 }
 
 # Import-first stubs. Populate with real policy keys/names/decisions before import.

--- a/infra/terraform/modules/linksim_cloudflare/main.tf
+++ b/infra/terraform/modules/linksim_cloudflare/main.tf
@@ -71,6 +71,9 @@ resource "cloudflare_pages_domain" "custom_domains" {
 resource "cloudflare_d1_database" "database" {
   account_id = var.account_id
   name       = var.d1_database_name
+  read_replication = {
+    mode = var.d1_read_replication_mode
+  }
 
   lifecycle {
     prevent_destroy = true
@@ -119,6 +122,9 @@ resource "cloudflare_zero_trust_access_application" "app" {
   ]
 
   lifecycle {
+    # Adoption step safety: avoid mutating live Access app defaults/policy wiring
+    # until all intended app/policy resources are modeled in Terraform.
+    ignore_changes  = all
     prevent_destroy = true
   }
 }

--- a/infra/terraform/modules/linksim_cloudflare/variables.tf
+++ b/infra/terraform/modules/linksim_cloudflare/variables.tf
@@ -52,6 +52,12 @@ variable "d1_database_id" {
   type        = string
 }
 
+variable "d1_read_replication_mode" {
+  description = "D1 read replication mode."
+  type        = string
+  default     = "disabled"
+}
+
 variable "d1_binding_name" {
   description = "Pages D1 binding name."
   type        = string

--- a/infra/terraform/scripts/init.sh
+++ b/infra/terraform/scripts/init.sh
@@ -27,7 +27,9 @@ if ! command -v terraform >/dev/null 2>&1; then
 fi
 
 if [[ "${BACKEND_MODE}" == "disabled" ]]; then
-  terraform -chdir="${ENV_DIR}" init -backend=false
+  TMP_TF_DATA_DIR="$(mktemp -d)"
+  trap 'rm -rf "${TMP_TF_DATA_DIR}"' EXIT
+  TF_DATA_DIR="${TMP_TF_DATA_DIR}" terraform -chdir="${ENV_DIR}" init -backend=false
   exit 0
 fi
 

--- a/infra/terraform/scripts/validate.sh
+++ b/infra/terraform/scripts/validate.sh
@@ -15,7 +15,9 @@ for env in "${TARGETS[@]}"; do
     echo "Unknown environment: ${env}"
     exit 1
   fi
-  terraform -chdir="${ENV_DIR}" init -backend=false
-  terraform -chdir="${ENV_DIR}" validate
+  TMP_TF_DATA_DIR="$(mktemp -d)"
+  TF_DATA_DIR="${TMP_TF_DATA_DIR}" terraform -chdir="${ENV_DIR}" init -backend=false
+  TF_DATA_DIR="${TMP_TF_DATA_DIR}" terraform -chdir="${ENV_DIR}" validate
+  rm -rf "${TMP_TF_DATA_DIR}"
   echo "[validate] ${env} ok"
 done


### PR DESCRIPTION
## Summary
- align Terraform staging/prod tfvars to live imported resources (zone IDs, DNS names, Access app names/policy binding)
- update backend examples to Terraform 1.5-compatible S3 backend args for R2
- add D1 read replication mode modeling to prevent import drift
- keep Access application in adoption-safe mode with `ignore_changes = all`
- fix local `tf:validate`/`init --backend=false` reliability by using temporary `TF_DATA_DIR`

## Why
After live import into state, baseline plan revealed drift from placeholder/default assumptions. This PR codifies the known-good baseline so import-first rollout remains zero-diff and safe.

## Verification
- npm run tf:fmt
- npm run tf:validate
- npm test
- npm run build
