### PR TITLE
feat(#101): single-site Panorama mode with map lens sync

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -27,6 +27,7 @@ import { resolveBasemapSelection } from "../lib/basemaps";
 import { useThemeVariant } from "../hooks/useThemeVariant";
 import { useAppStore } from "../store/appStore";
 import { LinkProfileChart } from "./LinkProfileChart";
+import { PanoramaChart } from "./PanoramaChart";
 import { ActionButton } from "./ActionButton";
 import { InlineCloseIconButton } from "./InlineCloseIconButton";
 import { MapView } from "./MapView";
@@ -156,6 +157,7 @@ export function AppShell() {
   const siteLibrary = useAppStore((state) => state.siteLibrary);
   const sites = useAppStore((state) => state.sites);
   const selectedSiteIds = useAppStore((state) => state.selectedSiteIds);
+  const isSingleSiteSelection = selectedSiteIds.length === 1;
   const loadDemoScenario = useAppStore((state) => state.loadDemoScenario);
   const initializeCloudSync = useAppStore((state) => state.initializeCloudSync);
   const performCloudSyncPush = useAppStore((state) => state.performCloudSyncPush);
@@ -1905,6 +1907,31 @@ export function AppShell() {
           />
         ) : null}
         {!isMobileViewport && !isMapExpanded && !isProfileHidden ? (
+          isSingleSiteSelection ? (
+          <PanoramaChart
+            isExpanded={isProfileExpanded}
+            onToggleExpanded={toggleProfileExpanded}
+            rowControls={
+              <button
+                aria-label={isProfileHidden ? "Show Profile panel" : "Hide Profile panel"}
+                className="chart-endpoint-swap chart-endpoint-icon"
+                onClick={() => {
+                  setIsProfileHidden((prev) => {
+                    const next = !prev;
+                    if (next) setIsProfileExpanded(false);
+                    return next;
+                  });
+                  emitProfileLayoutPulse();
+                }}
+                title={isProfileHidden ? "Show Profile" : "Hide Profile"}
+                type="button"
+              >
+                {isProfileHidden ? <PanelBottom aria-hidden="true" strokeWidth={1.8} /> : <PanelBottomClose aria-hidden="true" strokeWidth={1.8} />}
+              </button>
+            }
+            showExpandToggle
+          />
+          ) : (
           <LinkProfileChart
             isExpanded={isProfileExpanded}
             onToggleExpanded={toggleProfileExpanded}
@@ -1928,6 +1955,7 @@ export function AppShell() {
             }
             showExpandToggle
           />
+          )
         ) : null}
         {isMobileViewport && !isMapExpanded && mobileActivePanel === "profile" && mobileBottomPanelMode !== "hidden" ? (
           <div
@@ -1936,12 +1964,21 @@ export function AppShell() {
             id={mobileProfilePanelId}
             role="tabpanel"
           >
-            <LinkProfileChart
-              isExpanded={mobileBottomPanelMode === "full"}
-              onToggleExpanded={toggleProfileExpanded}
-              rowControls={panelSizeControls("Profile", "chart")}
-              showExpandToggle={false}
-            />
+            {isSingleSiteSelection ? (
+              <PanoramaChart
+                isExpanded={mobileBottomPanelMode === "full"}
+                onToggleExpanded={toggleProfileExpanded}
+                rowControls={panelSizeControls("Profile", "chart")}
+                showExpandToggle={false}
+              />
+            ) : (
+              <LinkProfileChart
+                isExpanded={mobileBottomPanelMode === "full"}
+                onToggleExpanded={toggleProfileExpanded}
+                rowControls={panelSizeControls("Profile", "chart")}
+                showExpandToggle={false}
+              />
+            )}
           </div>
         ) : null}
         {isMobileViewport && !isMapExpanded && mobileActivePanel === "navigator" && mobileBottomPanelMode !== "hidden" ? (

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -20,6 +20,7 @@ import {
   PROFILE_DRAFT_SITE_REQUEST_EVENT,
   type ProfileDraftSiteRequestDetail,
 } from "../lib/profileDraftEvent";
+import { subscribePanoramaInteraction, type PanoramaFocusPoint, type PanoramaInteractionEvent } from "../lib/panoramaEvents";
 import { useAppStore } from "../store/appStore";
 import { useCoverageStore } from "../store/coverageStore";
 import { TERRAIN_DATASET_LABEL } from "../lib/terrainDataset";
@@ -127,6 +128,16 @@ const profileLineLayer = (color: string): LayerProps => ({
     "line-color": color,
     "line-width": 3.6,
     "line-opacity": 0.9,
+  },
+});
+
+const panoramaRayLayer = (color: string): LayerProps => ({
+  id: "panorama-ray-line",
+  type: "line",
+  paint: {
+    "line-color": color,
+    "line-width": 2.8,
+    "line-opacity": 0.88,
   },
 });
 
@@ -523,6 +534,12 @@ type MapInspectorHoverInfo = {
   libraryEntryId?: string;
 };
 
+type PanoramaInteractionState = {
+  siteId: string;
+  hover: PanoramaFocusPoint | null;
+  locked: PanoramaFocusPoint | null;
+};
+
 const DEFAULT_MAP_VIEWPORT = {
   center: { lat: 59.9, lon: 10.75 },
   zoom: 8,
@@ -632,6 +649,8 @@ export function MapView({
   const setCoverageVizMode = useAppStore((state) => state.setMapOverlayMode);
   const selectedCoverageResolution = useAppStore((state) => state.selectedCoverageResolution);
   const setSelectedCoverageResolution = useAppStore((state) => state.setSelectedCoverageResolution);
+  const setDiscoveryVisibility = useAppStore((state) => state.setDiscoveryVisibility);
+  const setMapDiscoveryMqttNodes = useAppStore((state) => state.setMapDiscoveryMqttNodes);
   const recommendAndFetchTerrainForCurrentArea = useAppStore((state) => state.recommendAndFetchTerrainForCurrentArea);
   const selectedOverlayRadiusOption = useAppStore((state) => state.selectedOverlayRadiusOption);
   const setSelectedOverlayRadiusOption = useAppStore((state) => state.setSelectedOverlayRadiusOption);
@@ -653,6 +672,7 @@ export function MapView({
   const [mqttNodes, setMqttNodes] = useState<MeshmapNode[]>([]);
   const [mqttLoadStatus, setMqttLoadStatus] = useState<string | null>(null);
   const [overlayHoverInfo, setOverlayHoverInfo] = useState<MapInspectorHoverInfo | null>(null);
+  const [panoramaInteraction, setPanoramaInteraction] = useState<PanoramaInteractionState | null>(null);
   const [selectedDiscoveryLibraryEntryId, setSelectedDiscoveryLibraryEntryId] = useState<string | null>(null);
   const [mqttDuplicatePrompt, setMqttDuplicatePrompt] = useState<{
     node: MeshmapNode;
@@ -667,6 +687,12 @@ export function MapView({
     zoom: number;
   } | null>(null);
   const mapRef = useRef<MapRef | null>(null);
+  const panoramaLensBaseViewRef = useRef<{
+    center: { lat: number; lon: number };
+    zoom: number;
+    bearing: number;
+    pitch: number;
+  } | null>(null);
 
   useEffect(() => {
     const handleViewportChange = () => {
@@ -678,6 +704,48 @@ export function MapView({
       window.removeEventListener("resize", handleViewportChange);
       window.removeEventListener("orientationchange", handleViewportChange);
     };
+  }, []);
+
+  useEffect(() => {
+    setDiscoveryVisibility({ libraryVisible: showDiscoverySites, mqttVisible: showDiscoveryMqtt });
+  }, [showDiscoverySites, showDiscoveryMqtt, setDiscoveryVisibility]);
+
+  useEffect(() => {
+    setMapDiscoveryMqttNodes(mqttNodes);
+  }, [mqttNodes, setMapDiscoveryMqttNodes]);
+
+  useEffect(() => {
+    const unsubscribe = subscribePanoramaInteraction((event: PanoramaInteractionEvent) => {
+      setPanoramaInteraction((current) => {
+        if (event.type === "clear") {
+          if (!current || current.siteId !== event.siteId) return current;
+          return { ...current, hover: null, locked: null };
+        }
+        if (event.type === "leave") {
+          if (!current || current.siteId !== event.siteId) return current;
+          return { ...current, hover: null };
+        }
+        if (event.type === "hover") {
+          if (!current || current.siteId !== event.payload.siteId) {
+            return { siteId: event.payload.siteId, hover: event.payload, locked: null };
+          }
+          if (current.locked) return current;
+          return { ...current, hover: event.payload };
+        }
+        if (!current || current.siteId !== event.payload.siteId) {
+          return { siteId: event.payload.siteId, hover: null, locked: event.payload };
+        }
+        const unlock =
+          current.locked &&
+          Math.abs(current.locked.azimuthDeg - event.payload.azimuthDeg) < 0.01;
+        return {
+          ...current,
+          locked: unlock ? null : event.payload,
+          hover: unlock ? current.hover : null,
+        };
+      });
+    });
+    return unsubscribe;
   }, []);
 
   const hasNonAutoLinks = useMemo(
@@ -707,6 +775,7 @@ export function MapView({
   );
   const selectedSiteSet = useMemo(() => new Set(selectedSites.map((site) => site.id)), [selectedSites]);
   const selectionCount = selectedSites.length;
+  const singleSelectedSite = selectionCount === 1 ? selectedSites[0] ?? null : null;
   const previousSelectionCountRef = useRef(selectionCount);
   const selectedFromSite = selectedSites[0] ?? (selectedFromSiteId ? sites.find((site) => site.id === selectedFromSiteId) ?? null : null);
   const selectedToSite =
@@ -730,6 +799,57 @@ export function MapView({
       cableLossDb: selectedFromSite.cableLossDb,
     };
   }, [selectedFromSite, selectedToSite, selectedNetwork, selectedLink]);
+
+  useEffect(() => {
+    if (!singleSelectedSite) {
+      setPanoramaInteraction(null);
+      return;
+    }
+    setPanoramaInteraction((current) => {
+      if (!current) return current;
+      if (current.siteId === singleSelectedSite.id) return current;
+      return null;
+    });
+  }, [singleSelectedSite?.id]);
+
+  const activePanoramaFocus = panoramaInteraction?.locked ?? panoramaInteraction?.hover ?? null;
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    if (!singleSelectedSite || !activePanoramaFocus || activePanoramaFocus.siteId !== singleSelectedSite.id) {
+      const previous = panoramaLensBaseViewRef.current;
+      if (previous) {
+        map.easeTo({
+          center: [previous.center.lon, previous.center.lat],
+          zoom: previous.zoom,
+          bearing: previous.bearing,
+          pitch: previous.pitch,
+          duration: 260,
+          essential: true,
+        });
+      }
+      panoramaLensBaseViewRef.current = null;
+      return;
+    }
+
+    if (!panoramaLensBaseViewRef.current) {
+      const center = map.getCenter();
+      panoramaLensBaseViewRef.current = {
+        center: { lat: center.lat, lon: center.lng },
+        zoom: map.getZoom(),
+        bearing: map.getBearing(),
+        pitch: map.getPitch(),
+      };
+    }
+    const baseZoom = panoramaLensBaseViewRef.current?.zoom ?? map.getZoom();
+    map.easeTo({
+      center: [activePanoramaFocus.endpoint.lon, activePanoramaFocus.endpoint.lat],
+      zoom: Math.min(14, baseZoom + 1.8),
+      duration: 220,
+      essential: true,
+    });
+  }, [singleSelectedSite?.id, activePanoramaFocus?.siteId, activePanoramaFocus?.endpoint.lat, activePanoramaFocus?.endpoint.lon]);
   const hasHeatTopology = sites.length >= 1;
   const simulationLibrarySiteIds = useMemo(
     () =>
@@ -1001,6 +1121,32 @@ export function MapView({
     selectionCount === 2
       ? selectedProfile[Math.max(0, Math.min(selectedProfile.length - 1, profileCursorIndex))]
       : undefined;
+
+  const panoramaRayFeatures = useMemo(
+    () => ({
+      type: "FeatureCollection" as const,
+      features:
+        selectionCount === 1 &&
+        singleSelectedSite &&
+        activePanoramaFocus &&
+        activePanoramaFocus.siteId === singleSelectedSite.id
+          ? [
+              {
+                type: "Feature" as const,
+                properties: { id: "panorama-ray" },
+                geometry: {
+                  type: "LineString" as const,
+                  coordinates: [
+                    [singleSelectedSite.position.lon, singleSelectedSite.position.lat],
+                    [activePanoramaFocus.endpoint.lon, activePanoramaFocus.endpoint.lat],
+                  ],
+                },
+              },
+            ]
+          : [],
+    }),
+    [selectionCount, singleSelectedSite, activePanoramaFocus],
+  );
 
   const overlayResolutionScale = useMemo(() => {
     if (analysisBoundsDiagonalKm > 600) return 0.52;
@@ -2857,6 +3003,9 @@ export function MapView({
         <Source data={profileFeatures} id="profile-path" type="geojson">
           <Layer {...profileLineLayer(profileColor)} />
         </Source>
+        <Source data={panoramaRayFeatures} id="panorama-ray-path" type="geojson">
+          <Layer {...panoramaRayLayer(profileColor)} />
+        </Source>
 
         {coverageOverlay ? (
           <Source
@@ -2994,6 +3143,15 @@ export function MapView({
             longitude={cursorPoint.lon}
           >
             <div className="profile-map-cursor" />
+          </Marker>
+        ) : null}
+        {selectionCount === 1 && activePanoramaFocus && singleSelectedSite && activePanoramaFocus.siteId === singleSelectedSite.id ? (
+          <Marker
+            anchor="center"
+            latitude={activePanoramaFocus.endpoint.lat}
+            longitude={activePanoramaFocus.endpoint.lon}
+          >
+            <div className="profile-map-cursor panorama-map-cursor" />
           </Marker>
         ) : null}
       </Map>

--- a/src/components/PanoramaChart.tsx
+++ b/src/components/PanoramaChart.tsx
@@ -1,0 +1,457 @@
+import { scaleLinear } from "d3-scale";
+import { Lock, Maximize2, Minimize2, Trees, Unlock, Waves } from "lucide-react";
+import type { MouseEvent, ReactNode } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { STANDARD_SITE_RADIO } from "../lib/linkRadio";
+import { createLatestOnlyTaskScheduler, type LatestOnlyTask } from "../lib/latestOnlyTaskScheduler";
+import { dispatchPanoramaInteraction } from "../lib/panoramaEvents";
+import { buildPanorama, destinationForDistanceKm, qualityToSampling, type PanoramaNodeCandidate, type PanoramaQuality, type PanoramaResult } from "../lib/panorama";
+import { sampleSrtmElevation } from "../lib/srtm";
+import { useAppStore } from "../store/appStore";
+
+const M = { t: 14, r: 20, b: 32, l: 46 };
+const clamp = (value: number, min: number, max: number): number => Math.max(min, Math.min(max, value));
+
+type PanoramaChartProps = {
+  isExpanded: boolean;
+  onToggleExpanded: () => void;
+  showExpandToggle?: boolean;
+  rowControls?: ReactNode;
+};
+
+export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle = true, rowControls }: PanoramaChartProps) {
+  const chartHostRef = useRef<HTMLDivElement | null>(null);
+  const [chartSize, setChartSize] = useState<{ width: number; height: number } | null>(null);
+  const [hoverAzimuth, setHoverAzimuth] = useState<number | null>(null);
+  const [lockedAzimuth, setLockedAzimuth] = useState<number | null>(null);
+  const [includeClutter, setIncludeClutter] = useState(false);
+  const [verticalExaggeration, setVerticalExaggeration] = useState(true);
+
+  const sites = useAppStore((state) => state.sites);
+  const links = useAppStore((state) => state.links);
+  const selectedSiteIds = useAppStore((state) => state.selectedSiteIds);
+  const selectedNetworkId = useAppStore((state) => state.selectedNetworkId);
+  const networks = useAppStore((state) => state.networks);
+  const srtmTiles = useAppStore((state) => state.srtmTiles);
+  const propagationEnvironment = useAppStore((state) => state.propagationEnvironment);
+  const rxSensitivityTargetDbm = useAppStore((state) => state.rxSensitivityTargetDbm);
+  const environmentLossDb = useAppStore((state) => state.environmentLossDb);
+  const siteDragPreview = useAppStore((state) => state.siteDragPreview);
+  const siteLibrary = useAppStore((state) => state.siteLibrary);
+  const discoveryLibraryVisible = useAppStore((state) => state.discoveryLibraryVisible);
+  const discoveryMqttVisible = useAppStore((state) => state.discoveryMqttVisible);
+  const mqttNodes = useAppStore((state) => state.mapDiscoveryMqttNodes);
+
+  const selectedSite = useMemo(
+    () => selectedSiteIds.map((id) => sites.find((site) => site.id === id)).find((site): site is (typeof sites)[number] => Boolean(site)) ?? null,
+    [selectedSiteIds, sites],
+  );
+  const selectedNetwork = networks.find((network) => network.id === selectedNetworkId) ?? networks[0] ?? null;
+
+  const previewCount = Object.keys(siteDragPreview).length;
+  const quality: PanoramaQuality = previewCount > 0 ? "drag" : "full";
+
+  useLayoutEffect(() => {
+    const element = chartHostRef.current;
+    if (!element) return;
+    const update = () => {
+      const rect = element.getBoundingClientRect();
+      const width = Math.round(rect.width);
+      const height = Math.round(rect.height);
+      if (width <= 1 || height <= 1) return;
+      setChartSize((current) => {
+        if (current && current.width === width && current.height === height) return current;
+        return { width, height };
+      });
+    };
+    update();
+    const observer = typeof ResizeObserver !== "undefined" ? new ResizeObserver(update) : null;
+    observer?.observe(element);
+    return () => observer?.disconnect();
+  }, []);
+
+  const schedulerRef = useRef(createLatestOnlyTaskScheduler());
+  const cacheRef = useRef<Map<string, PanoramaResult>>(new Map());
+  const [panorama, setPanorama] = useState<PanoramaResult | null>(null);
+
+  const selectedSiteEffective = useMemo(() => {
+    if (!selectedSite) return null;
+    const preview = siteDragPreview[selectedSite.id];
+    if (!preview) return selectedSite;
+    return {
+      ...selectedSite,
+      position: preview.position,
+      groundElevationM: preview.groundElevationM,
+    };
+  }, [selectedSite, siteDragPreview]);
+
+  const nodeCandidates = useMemo<PanoramaNodeCandidate[]>(() => {
+    const simulation = sites.map((site) => ({
+      id: `sim:${site.id}`,
+      name: site.name,
+      lat: site.position.lat,
+      lon: site.position.lon,
+      groundElevationM: site.groundElevationM,
+      antennaHeightM: site.antennaHeightM,
+      rxGainDbi: site.rxGainDbi,
+    }));
+
+    const libraryById = new Set(simulation.map((entry) => entry.id.replace("sim:", "")));
+    const sharedLibrary = discoveryLibraryVisible
+      ? siteLibrary
+          .filter((entry) => (entry.visibility === "shared" || entry.visibility === "public") && !libraryById.has(entry.id))
+          .map((entry) => ({
+            id: `lib:${entry.id}`,
+            name: entry.name,
+            lat: entry.position.lat,
+            lon: entry.position.lon,
+            groundElevationM: entry.groundElevationM,
+            antennaHeightM: entry.antennaHeightM,
+            rxGainDbi: entry.rxGainDbi,
+          }))
+      : [];
+
+    const mqtt = discoveryMqttVisible
+      ? mqttNodes.map((node) => ({
+          id: `mqtt:${node.nodeId}`,
+          name: node.longName ?? node.shortName ?? node.nodeId,
+          lat: node.lat,
+          lon: node.lon,
+          groundElevationM: node.altitudeM ?? 0,
+          antennaHeightM: 2,
+          rxGainDbi: STANDARD_SITE_RADIO.rxGainDbi,
+        }))
+      : [];
+
+    return [...simulation, ...sharedLibrary, ...mqtt];
+  }, [sites, siteLibrary, mqttNodes, discoveryLibraryVisible, discoveryMqttVisible]);
+
+  useEffect(() => {
+    if (!selectedSiteEffective || !selectedNetwork) {
+      setPanorama(null);
+      return;
+    }
+
+    const effectiveLink = links[0]
+      ? {
+          ...links[0],
+          fromSiteId: selectedSiteEffective.id,
+          toSiteId: selectedSiteEffective.id,
+          frequencyMHz: selectedNetwork.frequencyOverrideMHz ?? selectedNetwork.frequencyMHz,
+          txPowerDbm: selectedSiteEffective.txPowerDbm,
+          txGainDbi: selectedSiteEffective.txGainDbi,
+          rxGainDbi: selectedSiteEffective.rxGainDbi,
+          cableLossDb: selectedSiteEffective.cableLossDb,
+        }
+      : {
+          id: "__panorama__",
+          fromSiteId: selectedSiteEffective.id,
+          toSiteId: selectedSiteEffective.id,
+          frequencyMHz: selectedNetwork.frequencyOverrideMHz ?? selectedNetwork.frequencyMHz,
+          txPowerDbm: selectedSiteEffective.txPowerDbm,
+          txGainDbi: selectedSiteEffective.txGainDbi,
+          rxGainDbi: selectedSiteEffective.rxGainDbi,
+          cableLossDb: selectedSiteEffective.cableLossDb,
+        };
+
+    const sampling = qualityToSampling(quality);
+    const signature = [
+      selectedSiteEffective.id,
+      selectedSiteEffective.position.lat.toFixed(6),
+      selectedSiteEffective.position.lon.toFixed(6),
+      selectedSiteEffective.groundElevationM,
+      selectedSiteEffective.antennaHeightM,
+      selectedNetwork.id,
+      effectiveLink.frequencyMHz,
+      propagationEnvironment.atmosphericBendingNUnits,
+      propagationEnvironment.clutterHeightM,
+      includeClutter ? 1 : 0,
+      quality,
+      sampling.azimuthStepDeg,
+      sampling.radialSamples,
+      srtmTiles.length,
+      nodeCandidates.length,
+      rxSensitivityTargetDbm,
+      environmentLossDb,
+    ].join("|");
+
+    const cached = cacheRef.current.get(signature);
+    if (cached) {
+      setPanorama(cached);
+      return;
+    }
+
+    const scheduler = schedulerRef.current;
+    scheduler.clearQueue();
+    scheduler.cancelActive();
+
+    const enqueueResult = scheduler.enqueue({
+      signature,
+      run: async (context) => {
+        const result = buildPanorama({
+          selectedSite: selectedSiteEffective,
+          effectiveLink,
+          propagationEnvironment,
+          rxSensitivityTargetDbm,
+          environmentLossDb,
+          quality,
+          terrainSampler: (lat, lon) => sampleSrtmElevation(srtmTiles, lat, lon),
+          nodeCandidates,
+          options: {
+            baseRadiusKm: 50,
+            maxRadiusKm: 200,
+            azimuthStepDeg: sampling.azimuthStepDeg,
+            radialSamples: sampling.radialSamples,
+            includeClutter,
+          },
+        });
+        if (context.isCancelled()) return;
+        cacheRef.current.set(signature, result);
+        if (cacheRef.current.size > 40) {
+          const oldest = cacheRef.current.keys().next().value;
+          if (oldest) cacheRef.current.delete(oldest);
+        }
+        setPanorama(result);
+      },
+    } satisfies LatestOnlyTask);
+
+    if (enqueueResult === "started") return;
+  }, [selectedSiteEffective, selectedNetwork, links, propagationEnvironment, includeClutter, quality, srtmTiles, nodeCandidates, rxSensitivityTargetDbm, environmentLossDb]);
+
+  const chartWidth = chartSize?.width ?? 0;
+  const chartHeight = chartSize?.height ?? 0;
+
+  const geometry = useMemo(() => {
+    if (!panorama || !chartSize) return null;
+    const yPadding = 2;
+    const yScaleSpan = (panorama.maxAngleDeg - panorama.minAngleDeg) + yPadding * 2;
+    const exaggeration = verticalExaggeration ? 1.45 : 1;
+    const yCenter = (panorama.maxAngleDeg + panorama.minAngleDeg) / 2;
+    const yDomain: [number, number] = [
+      yCenter - (yScaleSpan / 2) / exaggeration,
+      yCenter + (yScaleSpan / 2) / exaggeration,
+    ];
+    const x = scaleLinear().domain([0, 360]).range([M.l, chartWidth - M.r]);
+    const y = scaleLinear().domain(yDomain).range([chartHeight - M.b, M.t]);
+
+    const silhouettePoints = panorama.rays.map((ray) => ({ x: x(ray.azimuthDeg), y: y(ray.horizonAngleDeg) }));
+    const d = silhouettePoints.map((p, i) => `${i === 0 ? "M" : "L"}${p.x.toFixed(2)},${p.y.toFixed(2)}`).join(" ");
+    const area = `${d} L${chartWidth - M.r},${chartHeight - M.b} L${M.l},${chartHeight - M.b} Z`;
+
+    return {
+      x,
+      y,
+      d,
+      area,
+      ticksX: [0, 60, 120, 180, 240, 300, 360],
+      ticksY: [yDomain[0], (yDomain[0] + yDomain[1]) / 2, yDomain[1]],
+    };
+  }, [panorama, chartSize, chartWidth, chartHeight, verticalExaggeration]);
+
+  const activeAzimuth = lockedAzimuth ?? hoverAzimuth;
+  const activeRay = useMemo(() => {
+    if (!panorama || activeAzimuth == null) return null;
+    const steps = panorama.rays.length;
+    if (!steps) return null;
+    const index = Math.round((activeAzimuth / 360) * steps) % steps;
+    return panorama.rays[index] ?? null;
+  }, [panorama, activeAzimuth]);
+
+  useEffect(() => {
+    if (!selectedSiteEffective) return;
+    if (!activeRay) {
+      dispatchPanoramaInteraction({ type: "leave", siteId: selectedSiteEffective.id });
+      return;
+    }
+    const endpoint = destinationForDistanceKm(
+      selectedSiteEffective.position,
+      activeRay.azimuthDeg,
+      Math.max(0.1, activeRay.horizonDistanceKm || activeRay.maxDistanceKm),
+    );
+    dispatchPanoramaInteraction({
+      type: "hover",
+      payload: {
+        siteId: selectedSiteEffective.id,
+        azimuthDeg: activeRay.azimuthDeg,
+        endpoint,
+        horizonDistanceKm: activeRay.horizonDistanceKm,
+      },
+    });
+  }, [selectedSiteEffective, activeRay, lockedAzimuth]);
+
+  const onMove = (event: MouseEvent<SVGRectElement>) => {
+    if (!geometry) return;
+    const rect = event.currentTarget.getBoundingClientRect();
+    if (rect.width <= 1) return;
+    const xNorm = (event.clientX - rect.left) / rect.width;
+    const azimuth = clamp(xNorm * 360, 0, 360);
+    setHoverAzimuth(azimuth);
+  };
+
+  const onLeave = () => {
+    setHoverAzimuth(null);
+    if (!selectedSiteEffective) return;
+    dispatchPanoramaInteraction({ type: "leave", siteId: selectedSiteEffective.id });
+  };
+
+  const onClick = () => {
+    if (activeAzimuth == null || !selectedSiteEffective || !activeRay) return;
+    const endpoint = destinationForDistanceKm(
+      selectedSiteEffective.position,
+      activeRay.azimuthDeg,
+      Math.max(0.1, activeRay.horizonDistanceKm || activeRay.maxDistanceKm),
+    );
+    if (lockedAzimuth != null) {
+      dispatchPanoramaInteraction({ type: "clear", siteId: selectedSiteEffective.id });
+      setLockedAzimuth(null);
+      return;
+    }
+    dispatchPanoramaInteraction({
+      type: "toggle-lock",
+      payload: {
+        siteId: selectedSiteEffective.id,
+        azimuthDeg: activeRay.azimuthDeg,
+        endpoint,
+        horizonDistanceKm: activeRay.horizonDistanceKm,
+      },
+    });
+    setLockedAzimuth(activeAzimuth);
+  };
+
+  if (!selectedSiteEffective) {
+    return (
+      <section className="chart-panel chart-panel-empty">
+        <div className="chart-empty">Select one site to show panorama analysis.</div>
+      </section>
+    );
+  }
+
+  return (
+    <section className={`chart-panel ${isExpanded ? "is-expanded" : ""}`}>
+      <div className="chart-top-row">
+        <div className="chart-endpoints" aria-live="polite">
+          <span className="chart-endpoint chart-endpoint-left">{selectedSiteEffective.name}</span>
+          <span className="chart-endpoint-sep" aria-hidden>
+            →
+          </span>
+          <span className="chart-endpoint chart-endpoint-right">Panorama</span>
+        </div>
+        <div className="chart-action-row-controls">
+          <button
+            aria-label={verticalExaggeration ? "Disable vertical exaggeration" : "Enable vertical exaggeration"}
+            className={`chart-endpoint-swap chart-endpoint-icon ${verticalExaggeration ? "is-active" : ""}`}
+            onClick={() => setVerticalExaggeration((value) => !value)}
+            title={verticalExaggeration ? "Vertical exaggeration on" : "Vertical exaggeration off"}
+            type="button"
+          >
+            <Waves aria-hidden="true" strokeWidth={1.8} />
+          </button>
+          <button
+            aria-label={includeClutter ? "Disable clutter influence" : "Enable clutter influence"}
+            className={`chart-endpoint-swap chart-endpoint-icon ${includeClutter ? "is-active" : ""}`}
+            onClick={() => setIncludeClutter((value) => !value)}
+            title={includeClutter ? "Clutter on" : "Clutter off"}
+            type="button"
+          >
+            <Trees aria-hidden="true" strokeWidth={1.8} />
+          </button>
+          <button
+            aria-label={lockedAzimuth == null ? "Lock hovered direction" : "Unlock direction"}
+            className={`chart-endpoint-swap chart-endpoint-icon ${lockedAzimuth == null ? "" : "is-active"}`}
+            onClick={() => setLockedAzimuth((current) => (current == null ? activeAzimuth : null))}
+            title={lockedAzimuth == null ? "Lock direction" : "Unlock direction"}
+            type="button"
+          >
+            {lockedAzimuth == null ? <Lock aria-hidden="true" strokeWidth={1.8} /> : <Unlock aria-hidden="true" strokeWidth={1.8} />}
+          </button>
+          {showExpandToggle ? (
+            <button
+              aria-label={isExpanded ? "Exit full screen" : "Full screen"}
+              className={`chart-endpoint-swap chart-endpoint-icon ${isExpanded ? "is-active" : ""}`}
+              onClick={onToggleExpanded}
+              title={isExpanded ? "Exit full screen" : "Full screen"}
+              type="button"
+            >
+              {isExpanded ? <Minimize2 aria-hidden="true" strokeWidth={1.8} /> : <Maximize2 aria-hidden="true" strokeWidth={1.8} />}
+            </button>
+          ) : null}
+          {rowControls}
+        </div>
+      </div>
+
+      <div className="chart-action-row">
+        <div className="chart-hover-state">
+          <span className="state-dot state-dot-pass_clear" aria-hidden />
+          <span>Visible + pass</span>
+          <span className="state-dot state-dot-pass_blocked" aria-hidden />
+          <span>Blocked + pass</span>
+          <span className="state-dot state-dot-fail_clear" aria-hidden />
+          <span>Visible + fail</span>
+          <span className="state-dot state-dot-fail_blocked" aria-hidden />
+          <span>Blocked + fail</span>
+        </div>
+      </div>
+
+      <div className="chart-svg-wrap" ref={chartHostRef}>
+        {!geometry || !panorama ? (
+          <div className="chart-empty" aria-hidden="true" />
+        ) : (
+          <svg aria-label="Panorama" height={chartHeight} role="img" width={chartWidth}>
+            {geometry.ticksY.map((value) => (
+              <g className="chart-grid" key={`y-${value.toFixed(2)}`}>
+                <line x1={M.l} x2={chartWidth - M.r} y1={geometry.y(value)} y2={geometry.y(value)} />
+                <text textAnchor="end" x={M.l - 8} y={geometry.y(value) + 4}>
+                  {value.toFixed(1)}°
+                </text>
+              </g>
+            ))}
+
+            {geometry.ticksX.map((value) => (
+              <g className="chart-grid" key={`x-${value}`}>
+                <line x1={geometry.x(value)} x2={geometry.x(value)} y1={M.t} y2={chartHeight - M.b} />
+                <text textAnchor="middle" x={geometry.x(value)} y={chartHeight - 8}>
+                  {value.toFixed(0)}°
+                </text>
+              </g>
+            ))}
+
+            <path className="terrain-fill-path" d={geometry.area} />
+            <path className="terrain-line-neutral" d={geometry.d} />
+
+            {panorama.nodes.map((node) => (
+              <g key={node.id}>
+                <circle
+                  className={`panorama-node panorama-node-${node.state} ${node.visible ? "is-visible" : "is-hidden"}`}
+                  cx={geometry.x(node.azimuthDeg)}
+                  cy={geometry.y(node.elevationAngleDeg)}
+                  r={3.2}
+                />
+              </g>
+            ))}
+
+            {activeRay ? (
+              <line
+                className="profile-cursor"
+                x1={geometry.x(activeRay.azimuthDeg)}
+                x2={geometry.x(activeRay.azimuthDeg)}
+                y1={M.t}
+                y2={chartHeight - M.b}
+              />
+            ) : null}
+
+            <rect
+              className="profile-hitbox"
+              x={M.l}
+              y={M.t}
+              width={chartWidth - M.l - M.r}
+              height={chartHeight - M.t - M.b}
+              onClick={onClick}
+              onMouseLeave={onLeave}
+              onMouseMove={onMove}
+            />
+          </svg>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1802,6 +1802,11 @@ input {
   box-shadow: 0 0 0 6px var(--selection-soft);
 }
 
+.panorama-map-cursor {
+  background: var(--state-pass-clear);
+  box-shadow: 0 0 0 6px color-mix(in srgb, var(--state-pass-clear) 35%, transparent);
+}
+
 .chart-panel {
   overflow: hidden;
   padding: 10px 10px 8px;
@@ -2122,6 +2127,34 @@ input {
   stroke-width: 2.2;
   stroke-linecap: round;
   stroke-linejoin: round;
+}
+
+.panorama-node {
+  stroke-width: 1.1;
+}
+
+.panorama-node.is-hidden {
+  opacity: 0.52;
+}
+
+.panorama-node-pass_clear {
+  fill: var(--state-pass-clear);
+  stroke: color-mix(in srgb, var(--state-pass-clear) 40%, var(--text) 60%);
+}
+
+.panorama-node-pass_blocked {
+  fill: var(--state-pass-blocked);
+  stroke: color-mix(in srgb, var(--state-pass-blocked) 40%, var(--text) 60%);
+}
+
+.panorama-node-fail_clear {
+  fill: var(--state-fail-clear);
+  stroke: color-mix(in srgb, var(--state-fail-clear) 40%, var(--text) 60%);
+}
+
+.panorama-node-fail_blocked {
+  fill: var(--state-fail-blocked);
+  stroke: color-mix(in srgb, var(--state-fail-blocked) 40%, var(--text) 60%);
 }
 
 .earth-curvature-horizon {

--- a/src/lib/panorama.test.ts
+++ b/src/lib/panorama.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { azimuthFromToDeg, buildPanorama, destinationForDistanceKm, earthCurvatureDropM, qualityToSampling } from "./panorama";
+import type { Link, PropagationEnvironment, Site } from "../types/radio";
+
+const site: Site = {
+  id: "site-a",
+  name: "A",
+  position: { lat: 59.9, lon: 10.7 },
+  groundElevationM: 120,
+  antennaHeightM: 10,
+  txPowerDbm: 20,
+  txGainDbi: 2,
+  rxGainDbi: 2,
+  cableLossDb: 1,
+};
+
+const link: Link = {
+  id: "lnk",
+  fromSiteId: "site-a",
+  toSiteId: "site-b",
+  frequencyMHz: 869.5,
+};
+
+const env: PropagationEnvironment = {
+  radioClimate: "Maritime Temperate (Land)",
+  polarization: "Vertical",
+  clutterHeightM: 0,
+  groundDielectric: 15,
+  groundConductivity: 0.005,
+  atmosphericBendingNUnits: 301,
+};
+
+describe("panorama", () => {
+  it("provides expected quality defaults", () => {
+    expect(qualityToSampling("drag")).toEqual({ azimuthStepDeg: 5, radialSamples: 64 });
+    expect(qualityToSampling("full")).toEqual({ azimuthStepDeg: 1, radialSamples: 192 });
+  });
+
+  it("calculates geodesic helpers in expected range", () => {
+    const point = destinationForDistanceKm(site.position, 90, 10);
+    expect(point.lat).toBeGreaterThan(59);
+    expect(point.lon).toBeGreaterThan(site.position.lon);
+    const az = azimuthFromToDeg(site.position, point);
+    expect(az).toBeGreaterThan(80);
+    expect(az).toBeLessThan(100);
+    expect(earthCurvatureDropM(10, 1.33)).toBeGreaterThan(4);
+  });
+
+  it("builds panorama rays and node projections", () => {
+    const result = buildPanorama({
+      selectedSite: site,
+      effectiveLink: link,
+      propagationEnvironment: env,
+      rxSensitivityTargetDbm: -120,
+      environmentLossDb: 0,
+      quality: "drag",
+      terrainSampler: () => 120,
+      nodeCandidates: [
+        {
+          id: "n1",
+          name: "N1",
+          lat: 59.95,
+          lon: 10.8,
+          groundElevationM: 140,
+          antennaHeightM: 8,
+          rxGainDbi: 2,
+        },
+      ],
+      options: { baseRadiusKm: 50, maxRadiusKm: 80 },
+    });
+
+    expect(result.rays.length).toBe(72);
+    expect(result.radiusPolicyKm).toBe(50);
+    expect(result.nodes.length).toBe(1);
+    expect(result.nodes[0].state).toMatch(/pass_|fail_/);
+    expect(result.maxAngleDeg).toBeGreaterThan(result.minAngleDeg);
+  });
+});

--- a/src/lib/panorama.ts
+++ b/src/lib/panorama.ts
@@ -1,0 +1,257 @@
+import { computeSourceCentricRxMetrics, classifyPassFailState, type PassFailState } from "./passFailState";
+import { haversineDistanceKm } from "./geo";
+import type { Link, PropagationEnvironment, Site } from "../types/radio";
+
+const EARTH_RADIUS_M = 6_371_000;
+
+export type PanoramaQuality = "drag" | "full";
+
+export type PanoramaNodeCandidate = {
+  id: string;
+  name: string;
+  lat: number;
+  lon: number;
+  groundElevationM: number;
+  antennaHeightM: number;
+  rxGainDbi: number;
+};
+
+export type PanoramaNodeProjection = {
+  id: string;
+  name: string;
+  azimuthDeg: number;
+  distanceKm: number;
+  elevationAngleDeg: number;
+  visible: boolean;
+  state: PassFailState;
+};
+
+export type PanoramaRaySample = {
+  distanceKm: number;
+  angleDeg: number;
+  maxAngleBeforeDeg: number;
+};
+
+export type PanoramaRay = {
+  azimuthDeg: number;
+  maxDistanceKm: number;
+  horizonDistanceKm: number;
+  horizonAngleDeg: number;
+  samples: PanoramaRaySample[];
+};
+
+export type PanoramaResult = {
+  rays: PanoramaRay[];
+  nodes: PanoramaNodeProjection[];
+  minAngleDeg: number;
+  maxAngleDeg: number;
+  radiusPolicyKm: number;
+};
+
+export type PanoramaBuildOptions = {
+  baseRadiusKm?: number;
+  maxRadiusKm?: number;
+  azimuthStepDeg?: number;
+  radialSamples?: number;
+  includeClutter?: boolean;
+};
+
+const clamp = (value: number, min: number, max: number): number => Math.max(min, Math.min(max, value));
+
+const toRadians = (deg: number): number => (deg * Math.PI) / 180;
+const toDegrees = (rad: number): number => (rad * 180) / Math.PI;
+
+export const qualityToSampling = (quality: PanoramaQuality): { azimuthStepDeg: number; radialSamples: number } =>
+  quality === "drag"
+    ? { azimuthStepDeg: 5, radialSamples: 64 }
+    : { azimuthStepDeg: 1, radialSamples: 192 };
+
+export const earthCurvatureDropM = (distanceKm: number, kFactor: number): number => {
+  const distanceM = Math.max(0, distanceKm * 1000);
+  const effectiveRadiusM = EARTH_RADIUS_M * Math.max(0.5, kFactor);
+  return (distanceM * distanceM) / (2 * effectiveRadiusM);
+};
+
+export const destinationForDistanceKm = (
+  origin: { lat: number; lon: number },
+  azimuthDeg: number,
+  distanceKm: number,
+): { lat: number; lon: number } => {
+  const delta = (distanceKm * 1000) / EARTH_RADIUS_M;
+  const theta = toRadians(azimuthDeg);
+  const phi1 = toRadians(origin.lat);
+  const lambda1 = toRadians(origin.lon);
+
+  const sinPhi2 = Math.sin(phi1) * Math.cos(delta) + Math.cos(phi1) * Math.sin(delta) * Math.cos(theta);
+  const phi2 = Math.asin(clamp(sinPhi2, -1, 1));
+  const y = Math.sin(theta) * Math.sin(delta) * Math.cos(phi1);
+  const x = Math.cos(delta) - Math.sin(phi1) * Math.sin(phi2);
+  const lambda2 = lambda1 + Math.atan2(y, x);
+
+  return {
+    lat: toDegrees(phi2),
+    lon: ((toDegrees(lambda2) + 540) % 360) - 180,
+  };
+};
+
+export const azimuthFromToDeg = (from: { lat: number; lon: number }, to: { lat: number; lon: number }): number => {
+  const phi1 = toRadians(from.lat);
+  const phi2 = toRadians(to.lat);
+  const dLambda = toRadians(to.lon - from.lon);
+  const y = Math.sin(dLambda) * Math.cos(phi2);
+  const x = Math.cos(phi1) * Math.sin(phi2) - Math.sin(phi1) * Math.cos(phi2) * Math.cos(dLambda);
+  const theta = Math.atan2(y, x);
+  return (toDegrees(theta) + 360) % 360;
+};
+
+const resolveRayMaxDistanceKm = (
+  origin: { lat: number; lon: number },
+  azimuthDeg: number,
+  baseRadiusKm: number,
+  maxRadiusKm: number,
+  terrainSampler: (lat: number, lon: number) => number | null,
+): number => {
+  let maxReach = Math.max(1, baseRadiusKm);
+  for (let distanceKm = Math.ceil(baseRadiusKm); distanceKm <= maxRadiusKm; distanceKm += 1) {
+    const point = destinationForDistanceKm(origin, azimuthDeg, distanceKm);
+    if (terrainSampler(point.lat, point.lon) === null) break;
+    maxReach = distanceKm;
+  }
+  return maxReach;
+};
+
+const lookupMaxAngleBefore = (samples: PanoramaRaySample[], distanceKm: number): number => {
+  if (!samples.length) return -90;
+  let maxBefore = -90;
+  for (const sample of samples) {
+    if (sample.distanceKm >= distanceKm) break;
+    maxBefore = Math.max(maxBefore, sample.maxAngleBeforeDeg);
+  }
+  return maxBefore;
+};
+
+export const buildPanorama = (params: {
+  selectedSite: Site;
+  effectiveLink: Link;
+  propagationEnvironment: PropagationEnvironment;
+  rxSensitivityTargetDbm: number;
+  environmentLossDb: number;
+  quality: PanoramaQuality;
+  terrainSampler: (lat: number, lon: number) => number | null;
+  nodeCandidates: PanoramaNodeCandidate[];
+  options?: PanoramaBuildOptions;
+}): PanoramaResult => {
+  const { selectedSite, effectiveLink, propagationEnvironment, rxSensitivityTargetDbm, environmentLossDb, quality, terrainSampler, nodeCandidates } =
+    params;
+  const defaults = qualityToSampling(quality);
+  const baseRadiusKm = Math.max(1, params.options?.baseRadiusKm ?? 50);
+  const maxRadiusKm = Math.max(baseRadiusKm, params.options?.maxRadiusKm ?? 200);
+  const azimuthStepDeg = clamp(params.options?.azimuthStepDeg ?? defaults.azimuthStepDeg, 1, 45);
+  const radialSamples = Math.max(12, Math.round(params.options?.radialSamples ?? defaults.radialSamples));
+  const includeClutter = Boolean(params.options?.includeClutter);
+  const clutterHeightM = includeClutter ? Math.max(0, propagationEnvironment.clutterHeightM) : 0;
+
+  const kFactor = Math.max(0.5, 1 + (propagationEnvironment.atmosphericBendingNUnits - 250) / 153);
+  const sourceAbsM = selectedSite.groundElevationM + selectedSite.antennaHeightM;
+
+  const rays: PanoramaRay[] = [];
+  let minAngleDeg = Number.POSITIVE_INFINITY;
+  let maxAngleDeg = Number.NEGATIVE_INFINITY;
+
+  for (let azimuthDeg = 0; azimuthDeg < 360; azimuthDeg += azimuthStepDeg) {
+    const maxDistanceKm = resolveRayMaxDistanceKm(selectedSite.position, azimuthDeg, baseRadiusKm, maxRadiusKm, terrainSampler);
+    const samples: PanoramaRaySample[] = [];
+    let maxAngleSoFar = -90;
+    let horizonAngleDeg = -90;
+    let horizonDistanceKm = 0;
+
+    for (let i = 1; i <= radialSamples; i += 1) {
+      const distanceKm = (maxDistanceKm * i) / radialSamples;
+      const point = destinationForDistanceKm(selectedSite.position, azimuthDeg, distanceKm);
+      const terrainM = terrainSampler(point.lat, point.lon);
+      if (terrainM === null) break;
+      const dropM = earthCurvatureDropM(distanceKm, kFactor);
+      const relativeM = terrainM + clutterHeightM - sourceAbsM - dropM;
+      const angleDeg = toDegrees(Math.atan2(relativeM, Math.max(1, distanceKm * 1000)));
+
+      const maxAngleBeforeDeg = maxAngleSoFar;
+      maxAngleSoFar = Math.max(maxAngleSoFar, angleDeg);
+      if (maxAngleSoFar === angleDeg) {
+        horizonAngleDeg = angleDeg;
+        horizonDistanceKm = distanceKm;
+      }
+      samples.push({ distanceKm, angleDeg, maxAngleBeforeDeg });
+      minAngleDeg = Math.min(minAngleDeg, angleDeg);
+      maxAngleDeg = Math.max(maxAngleDeg, angleDeg);
+    }
+
+    rays.push({
+      azimuthDeg,
+      maxDistanceKm,
+      horizonDistanceKm,
+      horizonAngleDeg,
+      samples,
+    });
+  }
+
+  const azimuthCount = rays.length;
+  const nodes: PanoramaNodeProjection[] = nodeCandidates
+    .filter((candidate) => candidate.id !== selectedSite.id)
+    .map((candidate) => {
+      const azimuthDeg = azimuthFromToDeg(selectedSite.position, { lat: candidate.lat, lon: candidate.lon });
+      const distanceKm = Math.max(0.001, haversineDistanceKm(selectedSite.position, { lat: candidate.lat, lon: candidate.lon }));
+      const dropM = earthCurvatureDropM(distanceKm, kFactor);
+      const candidateAbs = candidate.groundElevationM + candidate.antennaHeightM;
+      const elevationAngleDeg = toDegrees(Math.atan2(candidateAbs - sourceAbsM - dropM, Math.max(1, distanceKm * 1000)));
+
+      const rayIndex = Math.round(azimuthDeg / azimuthStepDeg) % Math.max(1, azimuthCount);
+      const ray = rays[rayIndex] ?? rays[0];
+      const terrainBeforeDeg = ray ? lookupMaxAngleBefore(ray.samples, distanceKm) : -90;
+      const visible = elevationAngleDeg > terrainBeforeDeg;
+
+      const metrics = computeSourceCentricRxMetrics(
+        candidate.lat,
+        candidate.lon,
+        selectedSite,
+        effectiveLink,
+        candidate.antennaHeightM,
+        candidate.rxGainDbi,
+        terrainSampler,
+        quality === "drag" ? 16 : 24,
+        propagationEnvironment,
+      );
+      const pass = metrics.rxDbm - environmentLossDb >= rxSensitivityTargetDbm;
+      const state = classifyPassFailState(pass, metrics.terrainObstructed);
+
+      minAngleDeg = Math.min(minAngleDeg, elevationAngleDeg);
+      maxAngleDeg = Math.max(maxAngleDeg, elevationAngleDeg);
+
+      return {
+        id: candidate.id,
+        name: candidate.name,
+        azimuthDeg,
+        distanceKm,
+        elevationAngleDeg,
+        visible,
+        state,
+      };
+    });
+
+  if (!Number.isFinite(minAngleDeg) || !Number.isFinite(maxAngleDeg)) {
+    minAngleDeg = -5;
+    maxAngleDeg = 5;
+  }
+  if (maxAngleDeg - minAngleDeg < 4) {
+    const mid = (maxAngleDeg + minAngleDeg) / 2;
+    minAngleDeg = mid - 2;
+    maxAngleDeg = mid + 2;
+  }
+
+  return {
+    rays,
+    nodes,
+    minAngleDeg,
+    maxAngleDeg,
+    radiusPolicyKm: baseRadiusKm,
+  };
+};

--- a/src/lib/panoramaEvents.ts
+++ b/src/lib/panoramaEvents.ts
@@ -1,0 +1,32 @@
+export type PanoramaFocusPoint = {
+  siteId: string;
+  azimuthDeg: number;
+  endpoint: { lat: number; lon: number };
+  horizonDistanceKm: number;
+};
+
+export type PanoramaInteractionEvent =
+  | { type: "hover"; payload: PanoramaFocusPoint }
+  | { type: "leave"; siteId: string }
+  | { type: "toggle-lock"; payload: PanoramaFocusPoint }
+  | { type: "clear"; siteId: string };
+
+const EVENT_NAME = "panorama-interaction";
+
+export const dispatchPanoramaInteraction = (event: PanoramaInteractionEvent): void => {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent<PanoramaInteractionEvent>(EVENT_NAME, { detail: event }));
+};
+
+export const subscribePanoramaInteraction = (onEvent: (event: PanoramaInteractionEvent) => void): (() => void) => {
+  if (typeof window === "undefined") return () => undefined;
+  const handler = (raw: Event) => {
+    const custom = raw as CustomEvent<PanoramaInteractionEvent>;
+    if (!custom.detail) return;
+    onEvent(custom.detail);
+  };
+  window.addEventListener(EVENT_NAME, handler as EventListener);
+  return () => {
+    window.removeEventListener(EVENT_NAME, handler as EventListener);
+  };
+};

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -53,6 +53,7 @@ import type { LocaleCode } from "../i18n/locales";
 import type { UiColorTheme } from "../themes/types";
 import { getActiveHolidayTheme } from "../themes/holidayThemes";
 import type { CloudUser } from "../lib/cloudUser";
+import type { MeshmapNode } from "../lib/meshtasticMqtt";
 import type {
   CoverageResolution,
   Link,
@@ -430,6 +431,9 @@ type AppState = {
   pendingSiteLibraryOpenEntryId: string | null;
   scenarioOptions: { id: string; name: string }[];
   mapOverlayMode: MapOverlayMode;
+  discoveryLibraryVisible: boolean;
+  discoveryMqttVisible: boolean;
+  mapDiscoveryMqttNodes: MeshmapNode[];
   syncStatus: "syncing" | "synced" | "error";
   syncPending: boolean;
   pendingChangesCount: number;
@@ -576,6 +580,8 @@ type AppState = {
   requestOpenSiteLibraryEntry: (entryId: string) => void;
   clearOpenSiteLibraryEntryRequest: () => void;
   setMapOverlayMode: (mode: MapOverlayMode) => void;
+  setDiscoveryVisibility: (payload: { libraryVisible: boolean; mqttVisible: boolean }) => void;
+  setMapDiscoveryMqttNodes: (nodes: MeshmapNode[]) => void;
   applyFrequencyPresetToSelectedNetwork: () => void;
   updateSite: (id: string, patch: Partial<Site>) => void;
   setSiteDragPreview: (id: string, preview: { position: { lat: number; lon: number }; groundElevationM: number }) => void;
@@ -1244,6 +1250,9 @@ export const useAppStore = create<AppState>((set, get) => ({
   pendingSiteLibraryOpenEntryId: null,
   scenarioOptions: BUILTIN_SCENARIOS.map((scenario) => ({ id: scenario.id, name: scenario.name })),
   mapOverlayMode: "heatmap",
+  discoveryLibraryVisible: false,
+  discoveryMqttVisible: false,
+  mapDiscoveryMqttNodes: [],
   syncStatus: "synced",
   syncPending: false,
   pendingChangesCount: 0,
@@ -2029,62 +2038,6 @@ export const useAppStore = create<AppState>((set, get) => ({
       useCoverageStore.getState().recomputeCoverage();
     }
   },
-  selectSiteById: (id, additive = false) => {
-    set((state) => {
-      const validIds = new Set(state.sites.map((site) => site.id));
-      if (!validIds.has(id)) return state;
-      const current = normalizeSelectedSiteIds(state.selectedSiteIds, state.sites);
-      let nextSelection: string[];
-      if (!additive) {
-        nextSelection = [id];
-      } else if (current.includes(id)) {
-        nextSelection = current.filter((candidate) => candidate !== id);
-      } else {
-        nextSelection = [...current, id];
-      }
-      const normalizedSelection = normalizeSelectedSiteIds(nextSelection, state.sites);
-      const nextSelectedSiteId = normalizedSelection[0] ?? "";
-      const nextOverlay = defaultOverlayModeForSelectionCount(normalizedSelection.length);
-      if (
-        state.selectedSiteId === nextSelectedSiteId &&
-        state.selectedLinkId === "" &&
-        state.mapOverlayMode === nextOverlay &&
-        sameSiteSelection(state.selectedSiteIds, normalizedSelection)
-      ) {
-        return state;
-      }
-      return {
-        selectedSiteIds: normalizedSelection,
-        selectedSiteId: nextSelectedSiteId,
-        selectedLinkId: "",
-        mapOverlayMode: nextOverlay,
-      };
-    });
-  },
-  clearActiveSelection: () =>
-    set((state) => {
-      const nextOverlay = defaultOverlayModeForSelectionCount(0);
-      if (
-        !state.selectedSiteIds.length &&
-        !state.selectedSiteId &&
-        !state.selectedLinkId &&
-        !state.temporaryDirectionReversed &&
-        state.endpointPickTarget === null &&
-        state.profileCursorIndex === 0 &&
-        state.mapOverlayMode === nextOverlay
-      ) {
-        return state;
-      }
-      return {
-        selectedSiteIds: [],
-        selectedSiteId: "",
-        selectedLinkId: "",
-        temporaryDirectionReversed: false,
-        endpointPickTarget: null,
-        profileCursorIndex: 0,
-        mapOverlayMode: nextOverlay,
-      };
-    }),
   setSelectedNetworkId: (id) => {
     set({ selectedNetworkId: id });
     useCoverageStore.getState().recomputeCoverage();
@@ -3227,6 +3180,29 @@ export const useAppStore = create<AppState>((set, get) => ({
     set((state) => {
       if (state.mapOverlayMode === mode) return state;
       return { mapOverlayMode: mode };
+    }),
+  setDiscoveryVisibility: ({ libraryVisible, mqttVisible }) =>
+    set((state) => {
+      if (
+        state.discoveryLibraryVisible === libraryVisible &&
+        state.discoveryMqttVisible === mqttVisible
+      ) {
+        return state;
+      }
+      return {
+        discoveryLibraryVisible: libraryVisible,
+        discoveryMqttVisible: mqttVisible,
+      };
+    }),
+  setMapDiscoveryMqttNodes: (nodes) =>
+    set((state) => {
+      if (
+        state.mapDiscoveryMqttNodes.length === nodes.length &&
+        state.mapDiscoveryMqttNodes.every((node, index) => node.nodeId === nodes[index]?.nodeId)
+      ) {
+        return state;
+      }
+      return { mapDiscoveryMqttNodes: nodes };
     }),
   applyFrequencyPresetToSelectedNetwork: () => {
     const { currentUser, selectedScenarioId, simulationPresets } = get();


### PR DESCRIPTION
Implements issue #101 single-site Panorama mode as a parallel bottom-panel flow to path profile.

## Included
- Show Panorama panel when exactly one site is selected; keep existing path profile for link/2-site selection.
- Add panorama terrain/ray engine with dual quality (drag vs full), radius policy baseline 50km with opportunistic extension to loaded terrain.
- Add map synchronization via panorama interaction events:
  - hover ray endpoint lens zoom
  - click lock/unlock direction
  - panorama ray + focus marker on map
- Add vertical exaggeration/clutter icon toggles in existing panel icon row.
- Add compact pass/fail legend and node state markers in panorama.
- Add panorama math tests.

## Verification
- npm test
- npm run build
- npm run test -- --run src/lib/panorama.test.ts src/store/appStore.selectionRecompute.test.ts