### PR TITLE
feat(#101): refine single-site panorama UX

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -813,11 +813,17 @@ export function MapView({
   }, [singleSelectedSite?.id]);
 
   const activePanoramaFocus = panoramaInteraction?.locked ?? panoramaInteraction?.hover ?? null;
+  const panoramaHoverLensEnabled = Boolean(activePanoramaFocus?.mapHoverZoomEnabled);
 
   useEffect(() => {
     const map = mapRef.current;
     if (!map) return;
-    if (!singleSelectedSite || !activePanoramaFocus || activePanoramaFocus.siteId !== singleSelectedSite.id) {
+    if (
+      !singleSelectedSite ||
+      !activePanoramaFocus ||
+      activePanoramaFocus.siteId !== singleSelectedSite.id ||
+      !panoramaHoverLensEnabled
+    ) {
       const previous = panoramaLensBaseViewRef.current;
       if (previous) {
         map.easeTo({
@@ -843,13 +849,23 @@ export function MapView({
       };
     }
     const baseZoom = panoramaLensBaseViewRef.current?.zoom ?? map.getZoom();
+    const midLat = (singleSelectedSite.position.lat + activePanoramaFocus.endpoint.lat) / 2;
+    const midLon = (singleSelectedSite.position.lon + activePanoramaFocus.endpoint.lon) / 2;
     map.easeTo({
-      center: [activePanoramaFocus.endpoint.lon, activePanoramaFocus.endpoint.lat],
-      zoom: Math.min(14, baseZoom + 1.8),
+      center: [midLon, midLat],
+      zoom: Math.max(2.8, Math.min(13, baseZoom - 0.8)),
       duration: 220,
       essential: true,
     });
-  }, [singleSelectedSite?.id, activePanoramaFocus?.siteId, activePanoramaFocus?.endpoint.lat, activePanoramaFocus?.endpoint.lon]);
+  }, [
+    singleSelectedSite?.id,
+    singleSelectedSite?.position.lat,
+    singleSelectedSite?.position.lon,
+    activePanoramaFocus?.siteId,
+    activePanoramaFocus?.endpoint.lat,
+    activePanoramaFocus?.endpoint.lon,
+    panoramaHoverLensEnabled,
+  ]);
   const hasHeatTopology = sites.length >= 1;
   const simulationLibrarySiteIds = useMemo(
     () =>

--- a/src/components/PanoramaChart.tsx
+++ b/src/components/PanoramaChart.tsx
@@ -1,16 +1,28 @@
 import { scaleLinear } from "d3-scale";
-import { Lock, Maximize2, Minimize2, Trees, Unlock, Waves } from "lucide-react";
+import { Compass, Lock, Maximize2, Minimize2, Trees, Unlock, Waves } from "lucide-react";
 import type { MouseEvent, ReactNode } from "react";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { STANDARD_SITE_RADIO } from "../lib/linkRadio";
 import { createLatestOnlyTaskScheduler, type LatestOnlyTask } from "../lib/latestOnlyTaskScheduler";
 import { dispatchPanoramaInteraction } from "../lib/panoramaEvents";
-import { buildPanorama, destinationForDistanceKm, qualityToSampling, type PanoramaNodeCandidate, type PanoramaQuality, type PanoramaResult } from "../lib/panorama";
+import {
+  buildPanorama,
+  qualityToSampling,
+  type PanoramaNodeCandidate,
+  type PanoramaNodeProjection,
+  type PanoramaQuality,
+  type PanoramaRay,
+  type PanoramaResult,
+  type PanoramaRaySample,
+} from "../lib/panorama";
+import { cardinalLabelForAzimuth, formatAzimuthTick, resolvePanoramaWindow, unwrapAzimuthForWindow } from "../lib/panoramaView";
+import { passFailStateLabel } from "../lib/passFailState";
 import { sampleSrtmElevation } from "../lib/srtm";
 import { useAppStore } from "../store/appStore";
 
 const M = { t: 14, r: 20, b: 32, l: 46 };
 const clamp = (value: number, min: number, max: number): number => Math.max(min, Math.min(max, value));
+const normalizeAzimuth = (value: number): number => ((value % 360) + 360) % 360;
 
 type PanoramaChartProps = {
   isExpanded: boolean;
@@ -19,6 +31,23 @@ type PanoramaChartProps = {
   rowControls?: ReactNode;
 };
 
+type HoverTarget =
+  | {
+      kind: "terrain";
+      x: number;
+      y: number;
+      azimuthDeg: number;
+      sample: PanoramaRaySample | null;
+      ray: PanoramaRay;
+    }
+  | {
+      kind: "node";
+      x: number;
+      y: number;
+      azimuthDeg: number;
+      node: PanoramaNodeProjection;
+    };
+
 export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle = true, rowControls }: PanoramaChartProps) {
   const chartHostRef = useRef<HTMLDivElement | null>(null);
   const [chartSize, setChartSize] = useState<{ width: number; height: number } | null>(null);
@@ -26,6 +55,8 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
   const [lockedAzimuth, setLockedAzimuth] = useState<number | null>(null);
   const [includeClutter, setIncludeClutter] = useState(false);
   const [verticalExaggeration, setVerticalExaggeration] = useState(true);
+  const [mapHoverZoomEnabled, setMapHoverZoomEnabled] = useState(false);
+  const [hoverTarget, setHoverTarget] = useState<HoverTarget | null>(null);
 
   const sites = useAppStore((state) => state.sites);
   const links = useAppStore((state) => state.links);
@@ -41,6 +72,7 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
   const discoveryLibraryVisible = useAppStore((state) => state.discoveryLibraryVisible);
   const discoveryMqttVisible = useAppStore((state) => state.discoveryMqttVisible);
   const mqttNodes = useAppStore((state) => state.mapDiscoveryMqttNodes);
+  const terrainLoadEpoch = useAppStore((state) => state.terrainLoadEpoch);
 
   const selectedSite = useMemo(
     () => selectedSiteIds.map((id) => sites.find((site) => site.id === id)).find((site): site is (typeof sites)[number] => Boolean(site)) ?? null,
@@ -169,6 +201,7 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
       quality,
       sampling.azimuthStepDeg,
       sampling.radialSamples,
+      terrainLoadEpoch,
       srtmTiles.length,
       nodeCandidates.length,
       rxSensitivityTargetDbm,
@@ -185,7 +218,7 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
     scheduler.clearQueue();
     scheduler.cancelActive();
 
-    const enqueueResult = scheduler.enqueue({
+    scheduler.enqueue({
       signature,
       run: async (context) => {
         const result = buildPanorama({
@@ -214,47 +247,150 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
         setPanorama(result);
       },
     } satisfies LatestOnlyTask);
-
-    if (enqueueResult === "started") return;
-  }, [selectedSiteEffective, selectedNetwork, links, propagationEnvironment, includeClutter, quality, srtmTiles, nodeCandidates, rxSensitivityTargetDbm, environmentLossDb]);
+  }, [
+    selectedSiteEffective,
+    selectedNetwork,
+    links,
+    propagationEnvironment,
+    includeClutter,
+    quality,
+    srtmTiles,
+    nodeCandidates,
+    rxSensitivityTargetDbm,
+    environmentLossDb,
+    terrainLoadEpoch,
+  ]);
 
   const chartWidth = chartSize?.width ?? 0;
   const chartHeight = chartSize?.height ?? 0;
+  const activeAzimuth = lockedAzimuth ?? hoverAzimuth;
+
+  const xWindow = useMemo(() => {
+    if (activeAzimuth == null) return null;
+    return resolvePanoramaWindow(activeAzimuth, 90);
+  }, [activeAzimuth]);
+
+  const terrainFillGradientId = useMemo(() => `profile-terrain-fill-${Math.random().toString(36).slice(2, 11)}`, []);
 
   const geometry = useMemo(() => {
-    if (!panorama || !chartSize) return null;
-    const yPadding = 2;
-    const yScaleSpan = (panorama.maxAngleDeg - panorama.minAngleDeg) + yPadding * 2;
-    const exaggeration = verticalExaggeration ? 1.45 : 1;
-    const yCenter = (panorama.maxAngleDeg + panorama.minAngleDeg) / 2;
-    const yDomain: [number, number] = [
-      yCenter - (yScaleSpan / 2) / exaggeration,
-      yCenter + (yScaleSpan / 2) / exaggeration,
-    ];
-    const x = scaleLinear().domain([0, 360]).range([M.l, chartWidth - M.r]);
-    const y = scaleLinear().domain(yDomain).range([chartHeight - M.b, M.t]);
+    if (!panorama || !chartSize || !panorama.rays.length) return null;
+    const yPaddingDeg = 0.6;
+    const minHorizon = Math.min(...panorama.rays.map((ray) => ray.horizonAngleDeg));
+    const maxHorizon = Math.max(...panorama.rays.map((ray) => ray.horizonAngleDeg));
+    const rawMin = minHorizon - yPaddingDeg;
+    const rawMax = maxHorizon + yPaddingDeg;
+    const domainMin = Number.isFinite(rawMin) ? rawMin : panorama.minAngleDeg;
+    const domainMax = Number.isFinite(rawMax) && rawMax > domainMin ? rawMax : domainMin + 3;
+    const yRange = chartHeight - M.b - M.t;
 
-    const silhouettePoints = panorama.rays.map((ray) => ({ x: x(ray.azimuthDeg), y: y(ray.horizonAngleDeg) }));
-    const d = silhouettePoints.map((p, i) => `${i === 0 ? "M" : "L"}${p.x.toFixed(2)},${p.y.toFixed(2)}`).join(" ");
-    const area = `${d} L${chartWidth - M.r},${chartHeight - M.b} L${M.l},${chartHeight - M.b} Z`;
+    const yForAngle = (angle: number): number => {
+      const tRaw = clamp((angle - domainMin) / Math.max(0.001, domainMax - domainMin), 0, 1);
+      const t = verticalExaggeration ? Math.pow(tRaw, 0.8) : tRaw;
+      return M.t + (1 - t) * yRange;
+    };
+
+    const useWindow = Boolean(xWindow);
+    const xDomainStart = xWindow?.startDeg ?? 0;
+    const xDomainEnd = xWindow?.endDeg ?? 360;
+    const x = scaleLinear().domain([xDomainStart, xDomainEnd]).range([M.l, chartWidth - M.r]);
+    const xCenterForUnwrap = xWindow?.centerDeg ?? 180;
+
+    const visibleRays = panorama.rays
+      .map((ray) => {
+        const xValue = useWindow ? unwrapAzimuthForWindow(ray.azimuthDeg, xCenterForUnwrap) : ray.azimuthDeg;
+        return { ray, xValue };
+      })
+      .filter((entry) => !useWindow || (entry.xValue >= xDomainStart && entry.xValue <= xDomainEnd))
+      .sort((a, b) => a.xValue - b.xValue);
+
+    if (!visibleRays.length) return null;
+
+    const toPath = (points: { x: number; y: number }[]): string =>
+      points.map((point, index) => `${index === 0 ? "M" : "L"}${point.x.toFixed(2)},${point.y.toFixed(2)}`).join(" ");
+
+    const horizonPoints = visibleRays.map(({ ray, xValue }) => ({ x: x(xValue), y: yForAngle(ray.horizonAngleDeg) }));
+    const clutterPoints = visibleRays.map(({ ray, xValue }) => ({ x: x(xValue), y: yForAngle(ray.clutterHorizonAngleDeg) }));
+    const horizonPath = toPath(horizonPoints);
+    const horizonAreaPath = `${horizonPath} L${horizonPoints[horizonPoints.length - 1].x.toFixed(2)},${(chartHeight - M.b).toFixed(2)} L${horizonPoints[0].x.toFixed(2)},${(chartHeight - M.b).toFixed(2)} Z`;
+
+    const ridgeFractions = [0.18, 0.34, 0.52, 0.72, 0.9];
+    const ridgeBands = ridgeFractions.map((fraction, bandIndex) => {
+      const points = visibleRays.map(({ ray, xValue }) => {
+        const sampleIndex = Math.max(0, Math.min(ray.samples.length - 1, Math.round((ray.samples.length - 1) * fraction)));
+        const sample = ray.samples[sampleIndex] ?? ray.samples[ray.samples.length - 1];
+        return {
+          x: x(xValue),
+          y: yForAngle(sample?.angleDeg ?? ray.horizonAngleDeg),
+        };
+      });
+      const line = toPath(points);
+      const area = `${line} L${points[points.length - 1].x.toFixed(2)},${(chartHeight - M.b).toFixed(2)} L${points[0].x.toFixed(2)},${(chartHeight - M.b).toFixed(2)} Z`;
+      return {
+        key: `ridge-${bandIndex}`,
+        area,
+        line,
+        opacity: 0.08 + bandIndex * 0.05,
+      };
+    });
+
+    const clutterAreaPath = includeClutter
+      ? `${toPath(clutterPoints)} ${[...horizonPoints]
+          .reverse()
+          .map((point) => `L${point.x.toFixed(2)},${point.y.toFixed(2)}`)
+          .join(" ")} Z`
+      : "";
+
+    const ticksX = xWindow
+      ? Array.from({ length: 7 }, (_, index) => {
+          const ratio = index / 6;
+          return xDomainStart + (xDomainEnd - xDomainStart) * ratio;
+        })
+      : [0, 60, 120, 180, 240, 300, 360];
+
+    const ticksY = [domainMin, (domainMin + domainMax) / 2, domainMax];
+
+    const nodes = panorama.nodes
+      .map((node) => {
+        const xValue = useWindow ? unwrapAzimuthForWindow(node.azimuthDeg, xCenterForUnwrap) : node.azimuthDeg;
+        return {
+          node,
+          xValue,
+          cx: x(xValue),
+          cy: yForAngle(node.elevationAngleDeg),
+        };
+      })
+      .filter((entry) => !useWindow || (entry.xValue >= xDomainStart && entry.xValue <= xDomainEnd));
+
+    const azimuthForX = (xPx: number): number => normalizeAzimuth(x.invert(xPx));
 
     return {
       x,
-      y,
-      d,
-      area,
-      ticksX: [0, 60, 120, 180, 240, 300, 360],
-      ticksY: [yDomain[0], (yDomain[0] + yDomain[1]) / 2, yDomain[1]],
+      xWindow,
+      yForAngle,
+      horizonPath,
+      horizonAreaPath,
+      clutterPath: includeClutter ? toPath(clutterPoints) : "",
+      clutterAreaPath,
+      ridgeBands,
+      ticksX,
+      ticksY,
+      nodes,
+      visibleRays: visibleRays.map((entry) => entry.ray),
+      azimuthForX,
     };
-  }, [panorama, chartSize, chartWidth, chartHeight, verticalExaggeration]);
+  }, [panorama, chartSize, chartHeight, chartWidth, verticalExaggeration, xWindow, includeClutter]);
 
-  const activeAzimuth = lockedAzimuth ?? hoverAzimuth;
   const activeRay = useMemo(() => {
-    if (!panorama || activeAzimuth == null) return null;
-    const steps = panorama.rays.length;
-    if (!steps) return null;
-    const index = Math.round((activeAzimuth / 360) * steps) % steps;
-    return panorama.rays[index] ?? null;
+    if (!panorama || activeAzimuth == null || !panorama.rays.length) return null;
+    const nearest = panorama.rays.reduce(
+      (best, ray) => {
+        const dist = Math.abs(unwrapAzimuthForWindow(ray.azimuthDeg, activeAzimuth) - activeAzimuth);
+        if (dist < best.distance) return { ray, distance: dist };
+        return best;
+      },
+      { ray: panorama.rays[0], distance: Number.POSITIVE_INFINITY },
+    );
+    return nearest.ray;
   }, [panorama, activeAzimuth]);
 
   useEffect(() => {
@@ -263,11 +399,10 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
       dispatchPanoramaInteraction({ type: "leave", siteId: selectedSiteEffective.id });
       return;
     }
-    const endpoint = destinationForDistanceKm(
-      selectedSiteEffective.position,
-      activeRay.azimuthDeg,
-      Math.max(0.1, activeRay.horizonDistanceKm || activeRay.maxDistanceKm),
-    );
+    const endpoint = {
+      lat: activeRay.horizonLat,
+      lon: activeRay.horizonLon,
+    };
     dispatchPanoramaInteraction({
       type: "hover",
       payload: {
@@ -275,32 +410,79 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
         azimuthDeg: activeRay.azimuthDeg,
         endpoint,
         horizonDistanceKm: activeRay.horizonDistanceKm,
+        mapHoverZoomEnabled,
       },
     });
-  }, [selectedSiteEffective, activeRay, lockedAzimuth]);
+  }, [selectedSiteEffective, activeRay, mapHoverZoomEnabled]);
 
   const onMove = (event: MouseEvent<SVGRectElement>) => {
-    if (!geometry) return;
+    if (!geometry || !panorama) return;
     const rect = event.currentTarget.getBoundingClientRect();
-    if (rect.width <= 1) return;
-    const xNorm = (event.clientX - rect.left) / rect.width;
-    const azimuth = clamp(xNorm * 360, 0, 360);
+    if (rect.width <= 1 || rect.height <= 1) return;
+
+    const xNorm = clamp((event.clientX - rect.left) / rect.width, 0, 1);
+    const yNorm = clamp((event.clientY - rect.top) / rect.height, 0, 1);
+    const xPx = M.l + xNorm * (chartWidth - M.l - M.r);
+    const yPx = M.t + yNorm * (chartHeight - M.t - M.b);
+    const azimuth = geometry.azimuthForX(xPx);
     setHoverAzimuth(azimuth);
+
+    const nearestRay = panorama.rays.reduce(
+      (best, ray) => {
+        const dist = Math.abs(unwrapAzimuthForWindow(ray.azimuthDeg, azimuth) - azimuth);
+        return dist < best.distance ? { ray, distance: dist } : best;
+      },
+      { ray: panorama.rays[0], distance: Number.POSITIVE_INFINITY },
+    ).ray;
+
+    let nearestNode: { node: PanoramaNodeProjection; cx: number; cy: number; distancePx: number } | null = null;
+    for (const node of geometry.nodes) {
+      const dx = node.cx - xPx;
+      const dy = node.cy - yPx;
+      const distancePx = Math.sqrt(dx * dx + dy * dy);
+      if (distancePx > 12) continue;
+      if (!nearestNode || distancePx < nearestNode.distancePx) {
+        nearestNode = { node: node.node, cx: node.cx, cy: node.cy, distancePx };
+      }
+    }
+
+    if (nearestNode) {
+      setHoverTarget({
+        kind: "node",
+        x: nearestNode.cx,
+        y: nearestNode.cy,
+        azimuthDeg: nearestNode.node.azimuthDeg,
+        node: nearestNode.node,
+      });
+      return;
+    }
+
+    const sample = nearestRay.samples.find((entry) => Math.abs(entry.distanceKm - nearestRay.horizonDistanceKm) < 0.001) ?? nearestRay.samples[nearestRay.samples.length - 1] ?? null;
+    if (!sample) {
+      setHoverTarget(null);
+      return;
+    }
+
+    setHoverTarget({
+      kind: "terrain",
+      x: xPx,
+      y: yPx,
+      azimuthDeg: nearestRay.azimuthDeg,
+      sample,
+      ray: nearestRay,
+    });
   };
 
   const onLeave = () => {
     setHoverAzimuth(null);
+    setHoverTarget(null);
     if (!selectedSiteEffective) return;
     dispatchPanoramaInteraction({ type: "leave", siteId: selectedSiteEffective.id });
   };
 
   const onClick = () => {
     if (activeAzimuth == null || !selectedSiteEffective || !activeRay) return;
-    const endpoint = destinationForDistanceKm(
-      selectedSiteEffective.position,
-      activeRay.azimuthDeg,
-      Math.max(0.1, activeRay.horizonDistanceKm || activeRay.maxDistanceKm),
-    );
+    const endpoint = { lat: activeRay.horizonLat, lon: activeRay.horizonLon };
     if (lockedAzimuth != null) {
       dispatchPanoramaInteraction({ type: "clear", siteId: selectedSiteEffective.id });
       setLockedAzimuth(null);
@@ -313,6 +495,7 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
         azimuthDeg: activeRay.azimuthDeg,
         endpoint,
         horizonDistanceKm: activeRay.horizonDistanceKm,
+        mapHoverZoomEnabled,
       },
     });
     setLockedAzimuth(activeAzimuth);
@@ -326,16 +509,34 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
     );
   }
 
+  const cardinal = activeRay ? cardinalLabelForAzimuth(activeRay.azimuthDeg) : null;
+  const hoverPopover = hoverTarget
+    ? hoverTarget.kind === "terrain"
+      ? {
+          title: `${hoverTarget.azimuthDeg.toFixed(1)}°${cardinal ? ` (${cardinal})` : ""}`,
+          rows: [
+            `Coordinates: ${hoverTarget.sample?.lat.toFixed(5)}, ${hoverTarget.sample?.lon.toFixed(5)}`,
+            `Distance: ${hoverTarget.sample?.distanceKm.toFixed(2)} km`,
+            `Terrain elevation: ${Math.round(hoverTarget.sample?.terrainM ?? 0)} m`,
+            `Status: ${hoverTarget.sample && hoverTarget.sample.angleDeg > hoverTarget.sample.maxAngleBeforeDeg ? "Horizon crest" : "Blocked before horizon"}`,
+          ],
+        }
+      : {
+          title: `${hoverTarget.node.name}`,
+          rows: [
+            `${hoverTarget.node.azimuthDeg.toFixed(1)}°${cardinalLabelForAzimuth(hoverTarget.node.azimuthDeg) ? ` (${cardinalLabelForAzimuth(hoverTarget.node.azimuthDeg)})` : ""}`,
+            `Coordinates: ${hoverTarget.node.lat.toFixed(5)}, ${hoverTarget.node.lon.toFixed(5)}`,
+            `Distance: ${hoverTarget.node.distanceKm.toFixed(2)} km`,
+            `${passFailStateLabel(hoverTarget.node.state)} • ${hoverTarget.node.visible ? "Visible" : "Blocked"}`,
+            `Clearance margin: ${hoverTarget.node.clearanceMarginM.toFixed(1)} m`,
+          ],
+        }
+    : null;
+
   return (
     <section className={`chart-panel ${isExpanded ? "is-expanded" : ""}`}>
       <div className="chart-top-row">
-        <div className="chart-endpoints" aria-live="polite">
-          <span className="chart-endpoint chart-endpoint-left">{selectedSiteEffective.name}</span>
-          <span className="chart-endpoint-sep" aria-hidden>
-            →
-          </span>
-          <span className="chart-endpoint chart-endpoint-right">Panorama</span>
-        </div>
+        <h3 className="panorama-header-title">Panorama from {selectedSiteEffective.name}</h3>
         <div className="chart-action-row-controls">
           <button
             aria-label={verticalExaggeration ? "Disable vertical exaggeration" : "Enable vertical exaggeration"}
@@ -354,6 +555,15 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
             type="button"
           >
             <Trees aria-hidden="true" strokeWidth={1.8} />
+          </button>
+          <button
+            aria-label={mapHoverZoomEnabled ? "Disable map hover lens" : "Enable map hover lens"}
+            className={`chart-endpoint-swap chart-endpoint-icon ${mapHoverZoomEnabled ? "is-active" : ""}`}
+            onClick={() => setMapHoverZoomEnabled((value) => !value)}
+            title={mapHoverZoomEnabled ? "Map hover lens on" : "Map hover lens off"}
+            type="button"
+          >
+            <Compass aria-hidden="true" strokeWidth={1.8} />
           </button>
           <button
             aria-label={lockedAzimuth == null ? "Lock hovered direction" : "Unlock direction"}
@@ -396,60 +606,90 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
         {!geometry || !panorama ? (
           <div className="chart-empty" aria-hidden="true" />
         ) : (
-          <svg aria-label="Panorama" height={chartHeight} role="img" width={chartWidth}>
-            {geometry.ticksY.map((value) => (
-              <g className="chart-grid" key={`y-${value.toFixed(2)}`}>
-                <line x1={M.l} x2={chartWidth - M.r} y1={geometry.y(value)} y2={geometry.y(value)} />
-                <text textAnchor="end" x={M.l - 8} y={geometry.y(value) + 4}>
-                  {value.toFixed(1)}°
-                </text>
-              </g>
-            ))}
+          <>
+            <svg aria-label="Panorama" height={chartHeight} role="img" width={chartWidth}>
+              <defs>
+                <linearGradient id={terrainFillGradientId} x1="0" x2="0" y1="0" y2="1">
+                  <stop offset="0%" stopColor="color-mix(in srgb, var(--terrain) 70%, var(--accent) 30%)" stopOpacity="0.86" />
+                  <stop offset="100%" stopColor="color-mix(in srgb, var(--terrain) 18%, var(--surface-2) 82%)" stopOpacity="0.22" />
+                </linearGradient>
+              </defs>
 
-            {geometry.ticksX.map((value) => (
-              <g className="chart-grid" key={`x-${value}`}>
-                <line x1={geometry.x(value)} x2={geometry.x(value)} y1={M.t} y2={chartHeight - M.b} />
-                <text textAnchor="middle" x={geometry.x(value)} y={chartHeight - 8}>
-                  {value.toFixed(0)}°
-                </text>
-              </g>
-            ))}
+              {geometry.ticksY.map((value) => (
+                <g className="chart-grid" key={`y-${value.toFixed(2)}`}>
+                  <line x1={M.l} x2={chartWidth - M.r} y1={geometry.yForAngle(value)} y2={geometry.yForAngle(value)} />
+                  <text textAnchor="end" x={M.l - 8} y={geometry.yForAngle(value) + 4}>
+                    {value.toFixed(1)}°
+                  </text>
+                </g>
+              ))}
 
-            <path className="terrain-fill-path" d={geometry.area} />
-            <path className="terrain-line-neutral" d={geometry.d} />
+              {geometry.ticksX.map((value) => (
+                <g className="chart-grid" key={`x-${value.toFixed(2)}`}>
+                  <line x1={geometry.x(value)} x2={geometry.x(value)} y1={M.t} y2={chartHeight - M.b} />
+                  <text textAnchor="middle" x={geometry.x(value)} y={chartHeight - 8}>
+                    {formatAzimuthTick(value)}
+                  </text>
+                </g>
+              ))}
 
-            {panorama.nodes.map((node) => (
-              <g key={node.id}>
+              <path className="terrain-fill-path" d={geometry.horizonAreaPath} fill={`url(#${terrainFillGradientId})`} />
+              {geometry.ridgeBands.map((band) => (
+                <g key={band.key}>
+                  <path className="panorama-ridge-band" d={band.area} style={{ opacity: band.opacity }} />
+                  <path className="panorama-ridge-line" d={band.line} style={{ opacity: Math.min(0.7, band.opacity + 0.2) }} />
+                </g>
+              ))}
+              {includeClutter && geometry.clutterAreaPath ? <path className="panorama-clutter-haze" d={geometry.clutterAreaPath} /> : null}
+              {includeClutter && geometry.clutterPath ? <path className="panorama-clutter-line" d={geometry.clutterPath} /> : null}
+              <path className="terrain-line-neutral" d={geometry.horizonPath} />
+
+              {geometry.nodes.map((node) => (
                 <circle
-                  className={`panorama-node panorama-node-${node.state} ${node.visible ? "is-visible" : "is-hidden"}`}
-                  cx={geometry.x(node.azimuthDeg)}
-                  cy={geometry.y(node.elevationAngleDeg)}
+                  key={node.node.id}
+                  className={`panorama-node panorama-node-${node.node.state} ${node.node.visible ? "is-visible" : "is-hidden"}`}
+                  cx={node.cx}
+                  cy={node.cy}
                   r={3.2}
                 />
-              </g>
-            ))}
+              ))}
 
-            {activeRay ? (
-              <line
-                className="profile-cursor"
-                x1={geometry.x(activeRay.azimuthDeg)}
-                x2={geometry.x(activeRay.azimuthDeg)}
-                y1={M.t}
-                y2={chartHeight - M.b}
+              {activeRay ? (
+                <line
+                  className="profile-cursor"
+                  x1={geometry.x(geometry.xWindow ? unwrapAzimuthForWindow(activeRay.azimuthDeg, geometry.xWindow.centerDeg) : activeRay.azimuthDeg)}
+                  x2={geometry.x(geometry.xWindow ? unwrapAzimuthForWindow(activeRay.azimuthDeg, geometry.xWindow.centerDeg) : activeRay.azimuthDeg)}
+                  y1={M.t}
+                  y2={chartHeight - M.b}
+                />
+              ) : null}
+
+              <rect
+                className="profile-hitbox"
+                x={M.l}
+                y={M.t}
+                width={chartWidth - M.l - M.r}
+                height={chartHeight - M.t - M.b}
+                onClick={onClick}
+                onMouseLeave={onLeave}
+                onMouseMove={onMove}
               />
+            </svg>
+            {hoverPopover && hoverTarget ? (
+              <div
+                className="chart-hover-popover"
+                style={{
+                  left: `${clamp(hoverTarget.x, 170, chartWidth - 170)}px`,
+                  top: `${clamp(hoverTarget.y - 12, 46, chartHeight - 14)}px`,
+                }}
+              >
+                <div className="chart-hover-popover-row"><strong>{hoverPopover.title}</strong></div>
+                {hoverPopover.rows.map((row) => (
+                  <div className="chart-hover-popover-row" key={row}>{row}</div>
+                ))}
+              </div>
             ) : null}
-
-            <rect
-              className="profile-hitbox"
-              x={M.l}
-              y={M.t}
-              width={chartWidth - M.l - M.r}
-              height={chartHeight - M.t - M.b}
-              onClick={onClick}
-              onMouseLeave={onLeave}
-              onMouseMove={onMove}
-            />
-          </svg>
+          </>
         )}
       </div>
     </section>

--- a/src/index.css
+++ b/src/index.css
@@ -1891,6 +1891,18 @@ input {
   text-align: right;
 }
 
+.panorama-header-title {
+  margin: 0;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.86rem;
+  font-weight: 600;
+  color: var(--text);
+  letter-spacing: 0.01em;
+}
+
 .chart-panel svg {
   display: block;
   width: 100%;
@@ -2127,6 +2139,28 @@ input {
   stroke-width: 2.2;
   stroke-linecap: round;
   stroke-linejoin: round;
+}
+
+.panorama-ridge-band {
+  fill: color-mix(in srgb, var(--terrain) 64%, var(--surface-2) 36%);
+}
+
+.panorama-ridge-line {
+  fill: none;
+  stroke: color-mix(in srgb, var(--terrain) 66%, var(--text) 34%);
+  stroke-width: 1.1;
+}
+
+.panorama-clutter-haze {
+  fill: color-mix(in srgb, var(--state-fail-blocked) 34%, transparent);
+  opacity: 0.35;
+}
+
+.panorama-clutter-line {
+  fill: none;
+  stroke: color-mix(in srgb, var(--state-fail-blocked) 62%, var(--text) 38%);
+  stroke-width: 1.6;
+  stroke-dasharray: 4 3;
 }
 
 .panorama-node {

--- a/src/lib/panorama.ts
+++ b/src/lib/panorama.ts
@@ -19,16 +19,28 @@ export type PanoramaNodeCandidate = {
 export type PanoramaNodeProjection = {
   id: string;
   name: string;
+  lat: number;
+  lon: number;
+  groundElevationM: number;
+  antennaHeightM: number;
+  targetElevationM: number;
   azimuthDeg: number;
   distanceKm: number;
   elevationAngleDeg: number;
+  terrainBeforeDeg: number;
+  angularClearanceDeg: number;
+  clearanceMarginM: number;
   visible: boolean;
   state: PassFailState;
 };
 
 export type PanoramaRaySample = {
   distanceKm: number;
+  lat: number;
+  lon: number;
+  terrainM: number;
   angleDeg: number;
+  clutterAngleDeg: number;
   maxAngleBeforeDeg: number;
 };
 
@@ -36,7 +48,12 @@ export type PanoramaRay = {
   azimuthDeg: number;
   maxDistanceKm: number;
   horizonDistanceKm: number;
+  horizonLat: number;
+  horizonLon: number;
+  horizonTerrainM: number;
   horizonAngleDeg: number;
+  clutterHorizonDistanceKm: number;
+  clutterHorizonAngleDeg: number;
   samples: PanoramaRaySample[];
 };
 
@@ -130,6 +147,16 @@ const lookupMaxAngleBefore = (samples: PanoramaRaySample[], distanceKm: number):
   return maxBefore;
 };
 
+const clearanceMarginMeters = (
+  elevationAngleDeg: number,
+  terrainBeforeDeg: number,
+  distanceKm: number,
+): number => {
+  const distanceM = Math.max(1, distanceKm * 1000);
+  const deltaRad = toRadians(elevationAngleDeg - terrainBeforeDeg);
+  return Math.tan(deltaRad) * distanceM;
+};
+
 export const buildPanorama = (params: {
   selectedSite: Site;
   effectiveLink: Link;
@@ -162,8 +189,14 @@ export const buildPanorama = (params: {
     const maxDistanceKm = resolveRayMaxDistanceKm(selectedSite.position, azimuthDeg, baseRadiusKm, maxRadiusKm, terrainSampler);
     const samples: PanoramaRaySample[] = [];
     let maxAngleSoFar = -90;
+    let maxClutterAngleSoFar = -90;
     let horizonAngleDeg = -90;
     let horizonDistanceKm = 0;
+    let horizonLat = selectedSite.position.lat;
+    let horizonLon = selectedSite.position.lon;
+    let horizonTerrainM = selectedSite.groundElevationM;
+    let clutterHorizonAngleDeg = -90;
+    let clutterHorizonDistanceKm = 0;
 
     for (let i = 1; i <= radialSamples; i += 1) {
       const distanceKm = (maxDistanceKm * i) / radialSamples;
@@ -171,25 +204,49 @@ export const buildPanorama = (params: {
       const terrainM = terrainSampler(point.lat, point.lon);
       if (terrainM === null) break;
       const dropM = earthCurvatureDropM(distanceKm, kFactor);
-      const relativeM = terrainM + clutterHeightM - sourceAbsM - dropM;
-      const angleDeg = toDegrees(Math.atan2(relativeM, Math.max(1, distanceKm * 1000)));
+      const distanceM = Math.max(1, distanceKm * 1000);
+      const relativeTerrainM = terrainM - sourceAbsM - dropM;
+      const relativeClutterM = terrainM + clutterHeightM - sourceAbsM - dropM;
+      const angleDeg = toDegrees(Math.atan2(relativeTerrainM, distanceM));
+      const clutterAngleDeg = toDegrees(Math.atan2(relativeClutterM, distanceM));
 
       const maxAngleBeforeDeg = maxAngleSoFar;
       maxAngleSoFar = Math.max(maxAngleSoFar, angleDeg);
       if (maxAngleSoFar === angleDeg) {
         horizonAngleDeg = angleDeg;
         horizonDistanceKm = distanceKm;
+        horizonLat = point.lat;
+        horizonLon = point.lon;
+        horizonTerrainM = terrainM;
       }
-      samples.push({ distanceKm, angleDeg, maxAngleBeforeDeg });
+      maxClutterAngleSoFar = Math.max(maxClutterAngleSoFar, clutterAngleDeg);
+      if (maxClutterAngleSoFar === clutterAngleDeg) {
+        clutterHorizonAngleDeg = clutterAngleDeg;
+        clutterHorizonDistanceKm = distanceKm;
+      }
+      samples.push({
+        distanceKm,
+        lat: point.lat,
+        lon: point.lon,
+        terrainM,
+        angleDeg,
+        clutterAngleDeg,
+        maxAngleBeforeDeg,
+      });
       minAngleDeg = Math.min(minAngleDeg, angleDeg);
-      maxAngleDeg = Math.max(maxAngleDeg, angleDeg);
+      maxAngleDeg = Math.max(maxAngleDeg, includeClutter ? clutterAngleDeg : angleDeg);
     }
 
     rays.push({
       azimuthDeg,
       maxDistanceKm,
       horizonDistanceKm,
+      horizonLat,
+      horizonLon,
+      horizonTerrainM,
       horizonAngleDeg,
+      clutterHorizonDistanceKm,
+      clutterHorizonAngleDeg,
       samples,
     });
   }
@@ -208,6 +265,8 @@ export const buildPanorama = (params: {
       const ray = rays[rayIndex] ?? rays[0];
       const terrainBeforeDeg = ray ? lookupMaxAngleBefore(ray.samples, distanceKm) : -90;
       const visible = elevationAngleDeg > terrainBeforeDeg;
+      const angularClearanceDeg = elevationAngleDeg - terrainBeforeDeg;
+      const clearanceMarginM = clearanceMarginMeters(elevationAngleDeg, terrainBeforeDeg, distanceKm);
 
       const metrics = computeSourceCentricRxMetrics(
         candidate.lat,
@@ -229,9 +288,17 @@ export const buildPanorama = (params: {
       return {
         id: candidate.id,
         name: candidate.name,
+        lat: candidate.lat,
+        lon: candidate.lon,
+        groundElevationM: candidate.groundElevationM,
+        antennaHeightM: candidate.antennaHeightM,
+        targetElevationM: candidateAbs,
         azimuthDeg,
         distanceKm,
         elevationAngleDeg,
+        terrainBeforeDeg,
+        angularClearanceDeg,
+        clearanceMarginM,
         visible,
         state,
       };

--- a/src/lib/panoramaEvents.ts
+++ b/src/lib/panoramaEvents.ts
@@ -3,6 +3,7 @@ export type PanoramaFocusPoint = {
   azimuthDeg: number;
   endpoint: { lat: number; lon: number };
   horizonDistanceKm: number;
+  mapHoverZoomEnabled?: boolean;
 };
 
 export type PanoramaInteractionEvent =

--- a/src/lib/panoramaView.test.ts
+++ b/src/lib/panoramaView.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { cardinalLabelForAzimuth, formatAzimuthTick, resolvePanoramaWindow, unwrapAzimuthForWindow } from "./panoramaView";
+
+describe("panoramaView", () => {
+  it("formats cardinal directions at exact compass quadrants", () => {
+    expect(cardinalLabelForAzimuth(0)).toBe("N");
+    expect(cardinalLabelForAzimuth(90)).toBe("E");
+    expect(cardinalLabelForAzimuth(180)).toBe("S");
+    expect(cardinalLabelForAzimuth(270)).toBe("W");
+    expect(formatAzimuthTick(360)).toBe("N");
+    expect(formatAzimuthTick(120)).toBe("120°");
+  });
+
+  it("resolves a centered 90 degree window for hover zoom", () => {
+    const window = resolvePanoramaWindow(12, 90);
+    expect(window.centerDeg).toBe(12);
+    expect(window.startDeg).toBeCloseTo(-33);
+    expect(window.endDeg).toBeCloseTo(57);
+  });
+
+  it("unwraps azimuth around 360 boundaries against a local reference", () => {
+    expect(unwrapAzimuthForWindow(355, 2)).toBeCloseTo(-5);
+    expect(unwrapAzimuthForWindow(5, 358)).toBeCloseTo(365);
+    expect(unwrapAzimuthForWindow(40, 80)).toBe(40);
+  });
+});

--- a/src/lib/panoramaView.ts
+++ b/src/lib/panoramaView.ts
@@ -1,0 +1,46 @@
+const mod360 = (value: number): number => ((value % 360) + 360) % 360;
+
+export const cardinalLabelForAzimuth = (azimuthDeg: number): "N" | "E" | "S" | "W" | null => {
+  const normalized = mod360(azimuthDeg);
+  if (Math.abs(normalized - 0) < 0.0001 || Math.abs(normalized - 360) < 0.0001) return "N";
+  if (Math.abs(normalized - 90) < 0.0001) return "E";
+  if (Math.abs(normalized - 180) < 0.0001) return "S";
+  if (Math.abs(normalized - 270) < 0.0001) return "W";
+  return null;
+};
+
+export const formatAzimuthTick = (azimuthDeg: number): string => {
+  const cardinal = cardinalLabelForAzimuth(azimuthDeg);
+  if (cardinal) return cardinal;
+  return `${mod360(azimuthDeg).toFixed(0)}°`;
+};
+
+export type PanoramaWindow = {
+  centerDeg: number;
+  spanDeg: number;
+  startDeg: number;
+  endDeg: number;
+};
+
+export const resolvePanoramaWindow = (centerDeg: number, spanDeg = 90): PanoramaWindow => {
+  const span = Math.max(10, Math.min(360, spanDeg));
+  const center = mod360(centerDeg);
+  const startDeg = center - span / 2;
+  const endDeg = center + span / 2;
+  return { centerDeg: center, spanDeg: span, startDeg, endDeg };
+};
+
+export const unwrapAzimuthForWindow = (azimuthDeg: number, referenceDeg: number): number => {
+  const normalized = mod360(azimuthDeg);
+  const candidates = [normalized - 360, normalized, normalized + 360];
+  let best = candidates[0];
+  let bestDistance = Math.abs(best - referenceDeg);
+  for (const candidate of candidates.slice(1)) {
+    const distance = Math.abs(candidate - referenceDeg);
+    if (distance < bestDistance) {
+      best = candidate;
+      bestDistance = distance;
+    }
+  }
+  return best;
+};


### PR DESCRIPTION
## Summary\n- apply Panorama UX revision for issue #101\n- switch hover zoom to chart x-axis (90° window) with lock/unlock\n- keep map stationary by default and gate map hover lens behind toggle (off by default)\n- add layered ridge rendering + separate clutter haze/line\n- add path-profile styled hover popover for terrain/site nodes\n- update cardinal axis labels and Panorama header text\n\n## Verification\n- npm test\n- npm run build\n\nCloses #101