### PR TITLE
feat(#101): LOS-clipped panorama depth and hover lens sync

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -849,10 +849,8 @@ export function MapView({
       };
     }
     const baseZoom = panoramaLensBaseViewRef.current?.zoom ?? map.getZoom();
-    const midLat = (singleSelectedSite.position.lat + activePanoramaFocus.endpoint.lat) / 2;
-    const midLon = (singleSelectedSite.position.lon + activePanoramaFocus.endpoint.lon) / 2;
     map.easeTo({
-      center: [midLon, midLat],
+      center: [activePanoramaFocus.endpoint.lon, activePanoramaFocus.endpoint.lat],
       zoom: Math.max(2.8, Math.min(13, baseZoom - 0.8)),
       duration: 220,
       essential: true,

--- a/src/components/PanoramaChart.tsx
+++ b/src/components/PanoramaChart.tsx
@@ -15,6 +15,7 @@ import {
   type PanoramaResult,
   type PanoramaRaySample,
 } from "../lib/panorama";
+import { buildDepthBands, depthStyleForBand, resolveRenderedEndpoint } from "../lib/panoramaRender";
 import { cardinalLabelForAzimuth, formatAzimuthTick, resolvePanoramaWindow, unwrapAzimuthForWindow } from "../lib/panoramaView";
 import { passFailStateLabel } from "../lib/passFailState";
 import { sampleSrtmElevation } from "../lib/srtm";
@@ -331,25 +332,24 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
     const horizonPath = toPath(horizonPoints);
     const horizonAreaPath = `${horizonPath} L${horizonPoints[horizonPoints.length - 1].x.toFixed(2)},${(chartHeight - M.b).toFixed(2)} L${horizonPoints[0].x.toFixed(2)},${(chartHeight - M.b).toFixed(2)} Z`;
 
-    const ridgeFractions = [0.18, 0.34, 0.52, 0.72, 0.9];
-    const ridgeBands = ridgeFractions.map((fraction, bandIndex) => {
-      const points = visibleRays.map(({ ray, xValue }) => {
-        const sampleIndex = Math.max(0, Math.min(ray.samples.length - 1, Math.round((ray.samples.length - 1) * fraction)));
-        const sample = ray.samples[sampleIndex] ?? ray.samples[ray.samples.length - 1];
-        return {
-          x: x(xValue),
-          y: y(sample?.angleDeg ?? ray.horizonAngleDeg),
-        };
-      });
-      const line = toPath(points);
-      const area = `${line} L${points[points.length - 1].x.toFixed(2)},${(chartHeight - M.b).toFixed(2)} L${points[0].x.toFixed(2)},${(chartHeight - M.b).toFixed(2)} Z`;
-      return {
-        key: `ridge-${bandIndex}`,
-        area,
-        line,
-        opacity: 0.08 + bandIndex * 0.05,
-      };
-    });
+    const ridgeFractions = [0.14, 0.28, 0.42, 0.58, 0.74, 0.9];
+    const ridgeBands = buildDepthBands(
+      visibleRays.map((entry) => entry.ray),
+      ridgeFractions,
+      (ray, sample) => {
+        const xValue = useWindow ? unwrapAzimuthForWindow(ray.azimuthDeg, xCenterForUnwrap) : ray.azimuthDeg;
+        const angleDeg = sample?.angleDeg ?? ray.horizonAngleDeg;
+        return { x: x(xValue), y: y(angleDeg), angleDeg };
+      },
+    ).map((band, bandIndex, all) => ({
+      key: `ridge-${bandIndex}`,
+      style: depthStyleForBand(bandIndex, all.length),
+      lineSegments: band.lineSegments,
+      fillPath:
+        band.points.length >= 2
+          ? `${toPath(band.points)} L${band.points[band.points.length - 1].x.toFixed(2)},${(chartHeight - M.b).toFixed(2)} L${band.points[0].x.toFixed(2)},${(chartHeight - M.b).toFixed(2)} Z`
+          : "",
+    }));
 
     const clutterAreaPath = includeClutter
       ? `${toPath(clutterPoints)} ${[...horizonPoints]
@@ -409,7 +409,13 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
 
   useEffect(() => {
     if (!selectedSiteEffective) return;
-    if (!activeRay) {
+    const renderedEndpoint = resolveRenderedEndpoint({
+      hoveredNode: hoverTarget?.kind === "node" ? hoverTarget.node : null,
+      hoveredSample: hoverTarget?.kind === "terrain" ? hoverTarget.sample : null,
+      hoveredAzimuthDeg: hoverTarget?.azimuthDeg ?? null,
+      fallbackRay: activeRay,
+    });
+    if (!renderedEndpoint) {
       dispatchPanoramaInteraction({ type: "leave", siteId: selectedSiteEffective.id });
       return;
     }
@@ -417,13 +423,13 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
       type: "hover",
       payload: {
         siteId: selectedSiteEffective.id,
-        azimuthDeg: activeRay.azimuthDeg,
-        endpoint: { lat: activeRay.horizonLat, lon: activeRay.horizonLon },
-        horizonDistanceKm: activeRay.horizonDistanceKm,
+        azimuthDeg: renderedEndpoint.azimuthDeg,
+        endpoint: renderedEndpoint.endpoint,
+        horizonDistanceKm: renderedEndpoint.distanceKm,
         mapHoverZoomEnabled,
       },
     });
-  }, [selectedSiteEffective, activeRay, mapHoverZoomEnabled]);
+  }, [selectedSiteEffective, activeRay, hoverTarget, mapHoverZoomEnabled]);
 
   const onMove = (event: MouseEvent<SVGRectElement>) => {
     if (!geometry || !panorama) return;
@@ -615,8 +621,28 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
               <path className="terrain-fill-path" d={geometry.horizonAreaPath} fill={`url(#${terrainFillGradientId})`} />
               {geometry.ridgeBands.map((band) => (
                 <g key={band.key}>
-                  <path className="panorama-ridge-band" d={band.area} style={{ opacity: band.opacity }} />
-                  <path className="panorama-ridge-line" d={band.line} style={{ opacity: Math.min(0.7, band.opacity + 0.2) }} />
+                  {band.fillPath ? (
+                    <path
+                      className="panorama-ridge-band"
+                      d={band.fillPath}
+                      style={{
+                        opacity: band.style.fillOpacity,
+                        fill: `color-mix(in srgb, var(--terrain) ${band.style.strokeMixTerrainPct}%, var(--surface-2) 55%)`,
+                      }}
+                    />
+                  ) : null}
+                  {band.lineSegments.map((segment, segmentIndex) => (
+                    <path
+                      className="panorama-ridge-line"
+                      d={segment}
+                      key={`${band.key}-segment-${segmentIndex}`}
+                      style={{
+                        strokeWidth: band.style.strokeWidth,
+                        strokeOpacity: band.style.strokeOpacity,
+                        stroke: `color-mix(in srgb, var(--terrain) ${band.style.strokeMixTerrainPct}%, var(--muted) ${band.style.strokeMixMutedPct}%)`,
+                      }}
+                    />
+                  ))}
                 </g>
               ))}
               {includeClutter && geometry.clutterAreaPath ? <path className="panorama-clutter-haze" d={geometry.clutterAreaPath} /> : null}

--- a/src/lib/panoramaRender.test.ts
+++ b/src/lib/panoramaRender.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { buildDepthBands, depthStyleForBand, resolveRenderedEndpoint } from "./panoramaRender";
+import type { PanoramaRay } from "./panorama";
+
+const mkRay = (azimuthDeg: number, samples: number[]): PanoramaRay => ({
+  azimuthDeg,
+  maxDistanceKm: 10,
+  horizonDistanceKm: 10,
+  horizonLat: 0,
+  horizonLon: 0,
+  horizonTerrainM: 100,
+  horizonAngleDeg: samples[samples.length - 1] ?? -5,
+  clutterHorizonDistanceKm: 10,
+  clutterHorizonAngleDeg: samples[samples.length - 1] ?? -5,
+  samples: samples.map((angleDeg, index) => ({
+    distanceKm: index + 1,
+    lat: 0,
+    lon: 0,
+    terrainM: 100 + index,
+    angleDeg,
+    clutterAngleDeg: angleDeg,
+    maxAngleBeforeDeg: -90,
+  })),
+});
+
+describe("panoramaRender", () => {
+  it("clips farther depth line where foreground angle is higher and reappears later", () => {
+    const rays: PanoramaRay[] = [
+      mkRay(0, [2, 1]), // near > far
+      mkRay(30, [3, 2]), // near > far
+      mkRay(60, [1, 4]), // far > near -> visible again
+      mkRay(90, [1, 5]), // far > near -> visible again
+    ];
+    const bands = buildDepthBands(
+      rays,
+      [0, 1],
+      (ray, sample) => ({
+        x: ray.azimuthDeg,
+        y: sample?.angleDeg ?? 0,
+        angleDeg: sample?.angleDeg ?? Number.NEGATIVE_INFINITY,
+      }),
+    );
+
+    expect(bands).toHaveLength(2);
+    expect(bands[1].lineSegments).toHaveLength(1);
+    expect(bands[1].lineSegments[0]).toContain("M60.00,4.00 L90.00,5.00");
+  });
+
+  it("returns monotonic near-to-far depth style falloff", () => {
+    const near = depthStyleForBand(0, 5);
+    const far = depthStyleForBand(4, 5);
+    expect(near.strokeWidth).toBeGreaterThan(far.strokeWidth);
+    expect(near.strokeOpacity).toBeGreaterThan(far.strokeOpacity);
+    expect(near.strokeMixTerrainPct).toBeGreaterThan(far.strokeMixTerrainPct);
+    expect(near.strokeMixMutedPct).toBeLessThan(far.strokeMixMutedPct);
+  });
+
+  it("resolves rendered endpoint from hovered node/sample before fallback ray", () => {
+    const ray = mkRay(120, [3, 5, 8]);
+    ray.horizonLat = 10;
+    ray.horizonLon = 20;
+    ray.horizonDistanceKm = 9;
+    const fromNode = resolveRenderedEndpoint({
+      hoveredNode: { lat: 1, lon: 2, azimuthDeg: 40, distanceKm: 3 },
+      hoveredSample: ray.samples[0],
+      hoveredAzimuthDeg: 120,
+      fallbackRay: ray,
+    });
+    expect(fromNode?.endpoint).toEqual({ lat: 1, lon: 2 });
+    expect(fromNode?.azimuthDeg).toBe(40);
+
+    const fromSample = resolveRenderedEndpoint({
+      hoveredSample: { ...ray.samples[1], lat: 3, lon: 4, distanceKm: 7 },
+      hoveredAzimuthDeg: 200,
+      fallbackRay: ray,
+    });
+    expect(fromSample?.endpoint).toEqual({ lat: 3, lon: 4 });
+    expect(fromSample?.distanceKm).toBe(7);
+
+    const fromFallback = resolveRenderedEndpoint({ fallbackRay: ray });
+    expect(fromFallback?.endpoint).toEqual({ lat: 10, lon: 20 });
+    expect(fromFallback?.distanceKm).toBe(9);
+  });
+});

--- a/src/lib/panoramaRender.ts
+++ b/src/lib/panoramaRender.ts
@@ -1,0 +1,130 @@
+import type { PanoramaRay, PanoramaRaySample } from "./panorama";
+
+export type PanoramaDepthPoint = {
+  x: number;
+  y: number;
+  angleDeg: number;
+  sample: PanoramaRaySample | null;
+};
+
+export type PanoramaDepthBand = {
+  bandIndex: number;
+  depthRatio: number;
+  points: PanoramaDepthPoint[];
+  lineSegments: string[];
+};
+
+export type PanoramaDepthStyle = {
+  strokeWidth: number;
+  strokeOpacity: number;
+  fillOpacity: number;
+  strokeMixTerrainPct: number;
+  strokeMixMutedPct: number;
+};
+
+export type PanoramaRenderedEndpoint = {
+  endpoint: { lat: number; lon: number };
+  azimuthDeg: number;
+  distanceKm: number;
+};
+
+const linePath = (points: PanoramaDepthPoint[]): string =>
+  points.map((point, index) => `${index === 0 ? "M" : "L"}${point.x.toFixed(2)},${point.y.toFixed(2)}`).join(" ");
+
+const visibleLineSegments = (points: PanoramaDepthPoint[], visibleMask: boolean[]): string[] => {
+  const segments: string[] = [];
+  let run: PanoramaDepthPoint[] = [];
+  for (let i = 0; i < points.length; i += 1) {
+    if (!visibleMask[i]) {
+      if (run.length >= 2) segments.push(linePath(run));
+      run = [];
+      continue;
+    }
+    run.push(points[i]);
+  }
+  if (run.length >= 2) segments.push(linePath(run));
+  return segments;
+};
+
+export const depthStyleForBand = (bandIndex: number, bandCount: number): PanoramaDepthStyle => {
+  const denom = Math.max(1, bandCount - 1);
+  const depthRatio = bandIndex / denom;
+  const nearRatio = 1 - depthRatio;
+  return {
+    strokeWidth: 0.7 + nearRatio * 1.3,
+    strokeOpacity: 0.24 + nearRatio * 0.68,
+    fillOpacity: 0.03 + nearRatio * 0.1,
+    strokeMixTerrainPct: Math.round(30 + nearRatio * 58),
+    strokeMixMutedPct: Math.round(12 + depthRatio * 68),
+  };
+};
+
+export const buildDepthBands = (
+  rays: PanoramaRay[],
+  fractions: number[],
+  mapPoint: (ray: PanoramaRay, sample: PanoramaRaySample | null) => { x: number; y: number; angleDeg: number },
+): PanoramaDepthBand[] => {
+  if (!rays.length || !fractions.length) return [];
+
+  const rawBands = fractions.map((fraction, bandIndex) => {
+    const points: PanoramaDepthPoint[] = rays.map((ray) => {
+      const sampleIndex = Math.max(0, Math.min(ray.samples.length - 1, Math.round((ray.samples.length - 1) * fraction)));
+      const sample = ray.samples.length ? ray.samples[sampleIndex] ?? ray.samples[ray.samples.length - 1] : null;
+      const mapped = mapPoint(ray, sample);
+      return {
+        x: mapped.x,
+        y: mapped.y,
+        angleDeg: mapped.angleDeg,
+        sample,
+      };
+    });
+    return { bandIndex, depthRatio: fraction, points };
+  });
+
+  const visibility: boolean[][] = rawBands.map(() => new Array<boolean>(rays.length).fill(false));
+  for (let rayIndex = 0; rayIndex < rays.length; rayIndex += 1) {
+    let foregroundAngle = Number.NEGATIVE_INFINITY;
+    for (let bandIndex = 0; bandIndex < rawBands.length; bandIndex += 1) {
+      const angle = rawBands[bandIndex].points[rayIndex]?.angleDeg ?? Number.NEGATIVE_INFINITY;
+      const isVisible = Number.isFinite(angle) && angle > foregroundAngle;
+      visibility[bandIndex][rayIndex] = isVisible;
+      if (isVisible) foregroundAngle = angle;
+    }
+  }
+
+  return rawBands.map((band, bandIndex) => ({
+    ...band,
+    lineSegments: visibleLineSegments(band.points, visibility[bandIndex]),
+  }));
+};
+
+export const resolveRenderedEndpoint = (params: {
+  hoveredNode?: { lat: number; lon: number; azimuthDeg: number; distanceKm: number } | null;
+  hoveredSample?: PanoramaRaySample | null;
+  hoveredAzimuthDeg?: number | null;
+  fallbackRay?: PanoramaRay | null;
+}): PanoramaRenderedEndpoint | null => {
+  const { hoveredNode, hoveredSample, hoveredAzimuthDeg, fallbackRay } = params;
+  if (hoveredNode) {
+    return {
+      endpoint: { lat: hoveredNode.lat, lon: hoveredNode.lon },
+      azimuthDeg: hoveredNode.azimuthDeg,
+      distanceKm: hoveredNode.distanceKm,
+    };
+  }
+  if (hoveredSample && hoveredAzimuthDeg != null) {
+    return {
+      endpoint: { lat: hoveredSample.lat, lon: hoveredSample.lon },
+      azimuthDeg: hoveredAzimuthDeg,
+      distanceKm: hoveredSample.distanceKm,
+    };
+  }
+  if (fallbackRay) {
+    return {
+      endpoint: { lat: fallbackRay.horizonLat, lon: fallbackRay.horizonLon },
+      azimuthDeg: fallbackRay.azimuthDeg,
+      distanceKm: fallbackRay.horizonDistanceKm,
+    };
+  }
+  return null;
+};


### PR DESCRIPTION
## Summary\n- add strict per-azimuth LOS clipping for panorama depth lines\n- add depth styling falloff (hue shift + width/opacity ramp near->far)\n- use rendered hover endpoint as canonical map ray/lens target\n- keep clutter as independent visual overlay (no base terrain reshape)\n\n## Verification\n- npm run test -- --run src/lib/panoramaRender.test.ts src/lib/panorama.test.ts src/lib/panoramaView.test.ts\n- npm run build\n\nRefs #101