### PR TITLE
feat(#101): FOV controls + adaptive panorama zoom sampling

### DIFF
--- a/src/components/PanoramaChart.tsx
+++ b/src/components/PanoramaChart.tsx
@@ -1,5 +1,5 @@
 import { scaleLinear } from "d3-scale";
-import { Compass, Maximize2, Minimize2, Trees, Waves } from "lucide-react";
+import { Compass, Maximize2, Minimize2, Trees, Waves, ZoomIn } from "lucide-react";
 import type { MouseEvent, ReactNode } from "react";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { STANDARD_SITE_RADIO } from "../lib/linkRadio";
@@ -7,7 +7,7 @@ import { createLatestOnlyTaskScheduler, type LatestOnlyTask } from "../lib/lates
 import { dispatchPanoramaInteraction } from "../lib/panoramaEvents";
 import {
   buildPanorama,
-  qualityToSampling,
+  resolvePanoramaSampling,
   type PanoramaNodeCandidate,
   type PanoramaNodeProjection,
   type PanoramaQuality,
@@ -15,8 +15,16 @@ import {
   type PanoramaResult,
   type PanoramaRaySample,
 } from "../lib/panorama";
-import { buildDepthBands, depthStyleForBand, resolveRenderedEndpoint } from "../lib/panoramaRender";
-import { cardinalLabelForAzimuth, formatAzimuthTick, resolvePanoramaWindow, unwrapAzimuthForWindow } from "../lib/panoramaView";
+import { buildDepthBands, buildNearBiasedDepthFractions, depthStyleForBand, resolveRenderedEndpoint } from "../lib/panoramaRender";
+import {
+  cardinalLabelForAzimuth,
+  chartXNormToAzimuthDeg,
+  formatAzimuthTick,
+  fovScaleToSpanDeg,
+  normalizeFovScale,
+  resolvePanoramaWindow,
+  unwrapAzimuthForWindow,
+} from "../lib/panoramaView";
 import { passFailStateLabel } from "../lib/passFailState";
 import { sampleSrtmElevation } from "../lib/srtm";
 import { useAppStore } from "../store/appStore";
@@ -55,6 +63,8 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
   const [includeClutter, setIncludeClutter] = useState(false);
   const [fitScaleMode, setFitScaleMode] = useState(true);
   const [mapHoverZoomEnabled, setMapHoverZoomEnabled] = useState(false);
+  const [zoomModeEnabled, setZoomModeEnabled] = useState(true);
+  const [fovScale, setFovScale] = useState(1.5);
   const [hoverTarget, setHoverTarget] = useState<HoverTarget | null>(null);
 
   const sites = useAppStore((state) => state.sites);
@@ -185,7 +195,12 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
           cableLossDb: selectedSiteEffective.cableLossDb,
         };
 
-    const sampling = qualityToSampling(quality);
+    const effectiveFovScale = normalizeFovScale(fovScale);
+    const windowSpanDeg = zoomModeEnabled ? fovScaleToSpanDeg(effectiveFovScale) : 360;
+    const windowCenterDegRaw = hoverAzimuth ?? 180;
+    const sampling = resolvePanoramaSampling(quality, { zoomModeEnabled, fovScale: effectiveFovScale });
+    const centerBucketSizeDeg = Math.max(1, Math.round(sampling.azimuthStepDeg * 4));
+    const windowCenterBucketDeg = Math.round(windowCenterDegRaw / centerBucketSizeDeg) * centerBucketSizeDeg;
     const signature = [
       selectedSiteEffective.id,
       selectedSiteEffective.position.lat.toFixed(6),
@@ -197,6 +212,10 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
       propagationEnvironment.atmosphericBendingNUnits,
       propagationEnvironment.clutterHeightM,
       quality,
+      zoomModeEnabled ? "zoom:on" : "zoom:off",
+      effectiveFovScale.toFixed(2),
+      windowSpanDeg.toFixed(3),
+      windowCenterBucketDeg.toFixed(3),
       sampling.azimuthStepDeg,
       sampling.radialSamples,
       terrainLoadEpoch,
@@ -233,6 +252,8 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
             maxRadiusKm: 200,
             azimuthStepDeg: sampling.azimuthStepDeg,
             radialSamples: sampling.radialSamples,
+            windowCenterDeg: zoomModeEnabled ? windowCenterBucketDeg : undefined,
+            windowSpanDeg: zoomModeEnabled ? windowSpanDeg : undefined,
           },
         });
         if (context.isCancelled()) return;
@@ -255,15 +276,18 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
     rxSensitivityTargetDbm,
     environmentLossDb,
     terrainLoadEpoch,
+    zoomModeEnabled,
+    fovScale,
+    hoverAzimuth,
   ]);
 
   const chartWidth = chartSize?.width ?? 0;
   const chartHeight = chartSize?.height ?? 0;
 
   const xWindow = useMemo(() => {
-    if (hoverAzimuth == null) return null;
-    return resolvePanoramaWindow(hoverAzimuth, 90);
-  }, [hoverAzimuth]);
+    if (!zoomModeEnabled) return null;
+    return resolvePanoramaWindow(hoverAzimuth ?? 180, fovScaleToSpanDeg(fovScale));
+  }, [zoomModeEnabled, hoverAzimuth, fovScale]);
 
   const terrainFillGradientId = useMemo(() => `profile-terrain-fill-${Math.random().toString(36).slice(2, 11)}`, []);
 
@@ -327,13 +351,9 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
     const toPath = (points: { x: number; y: number }[]): string =>
       points.map((point, index) => `${index === 0 ? "M" : "L"}${point.x.toFixed(2)},${point.y.toFixed(2)}`).join(" ");
 
-    const horizonPoints = visibleRays.map(({ ray, xValue }) => ({ x: x(xValue), y: y(ray.horizonAngleDeg) }));
     const clutterPoints = visibleRays.map(({ ray, xValue }) => ({ x: x(xValue), y: y(ray.clutterHorizonAngleDeg) }));
-    const horizonPath = toPath(horizonPoints);
-    const horizonAreaPath = `${horizonPath} L${horizonPoints[horizonPoints.length - 1].x.toFixed(2)},${(chartHeight - M.b).toFixed(2)} L${horizonPoints[0].x.toFixed(2)},${(chartHeight - M.b).toFixed(2)} Z`;
-
-    const ridgeFractions = [0.14, 0.28, 0.42, 0.58, 0.74, 0.9];
-    const ridgeBands = buildDepthBands(
+    const ridgeFractions = buildNearBiasedDepthFractions(10);
+    const depthBands = buildDepthBands(
       visibleRays.map((entry) => entry.ray),
       ridgeFractions,
       (ray, sample) => {
@@ -341,7 +361,8 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
         const angleDeg = sample?.angleDeg ?? ray.horizonAngleDeg;
         return { x: x(xValue), y: y(angleDeg), angleDeg };
       },
-    ).map((band, bandIndex, all) => ({
+    );
+    const ridgeBands = depthBands.map((band, bandIndex, all) => ({
       key: `ridge-${bandIndex}`,
       style: depthStyleForBand(bandIndex, all.length),
       lineSegments: band.lineSegments,
@@ -351,8 +372,13 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
           : "",
     }));
 
+    const furthestBandFillPath = ridgeBands[ridgeBands.length - 1]?.fillPath ?? "";
+    const clutterBasePoints =
+      depthBands[depthBands.length - 1]?.points.map((point) => ({ x: point.x, y: point.y })) ??
+      clutterPoints;
+
     const clutterAreaPath = includeClutter
-      ? `${toPath(clutterPoints)} ${[...horizonPoints]
+      ? `${toPath(clutterPoints)} ${[...clutterBasePoints]
           .reverse()
           .map((point) => `L${point.x.toFixed(2)},${point.y.toFixed(2)}`)
           .join(" ")} Z`
@@ -383,8 +409,7 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
       x,
       xWindow,
       y,
-      horizonPath,
-      horizonAreaPath,
+      terrainFillPath: furthestBandFillPath,
       clutterPath: includeClutter ? toPath(clutterPoints) : "",
       clutterAreaPath,
       ridgeBands,
@@ -441,7 +466,7 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
     const xPx = M.l + xNorm * (chartWidth - M.l - M.r);
     const yPx = M.t + yNorm * (chartHeight - M.t - M.b);
 
-    const azimuth = xNorm * 360;
+    const azimuth = chartXNormToAzimuthDeg(xNorm);
     setHoverAzimuth(azimuth);
 
     const nearestRay = panorama.rays.reduce(
@@ -551,6 +576,31 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
             <Trees aria-hidden="true" strokeWidth={1.8} />
           </button>
           <button
+            aria-label={zoomModeEnabled ? "Disable chart zoom mode" : "Enable chart zoom mode"}
+            className={`chart-endpoint-swap chart-endpoint-icon ${zoomModeEnabled ? "is-active" : ""}`}
+            onClick={() => setZoomModeEnabled((value) => !value)}
+            title={zoomModeEnabled ? "Chart zoom mode on" : "Chart zoom mode off"}
+            type="button"
+          >
+            <ZoomIn aria-hidden="true" strokeWidth={1.8} />
+          </button>
+          {zoomModeEnabled ? (
+            <label className="panorama-fov-control">
+              <span className="panorama-fov-label">FOV</span>
+              <input
+                aria-label="Panorama FOV"
+                className="panorama-fov-slider"
+                max={4}
+                min={1}
+                onChange={(event) => setFovScale(normalizeFovScale(Number(event.currentTarget.value)))}
+                step={0.1}
+                type="range"
+                value={fovScale}
+              />
+              <span className="panorama-fov-value">{fovScale.toFixed(1)}x</span>
+            </label>
+          ) : null}
+          <button
             aria-label={mapHoverZoomEnabled ? "Disable map hover lens" : "Enable map hover lens"}
             className={`chart-endpoint-swap chart-endpoint-icon ${mapHoverZoomEnabled ? "is-active" : ""}`}
             onClick={() => setMapHoverZoomEnabled((value) => !value)}
@@ -618,7 +668,7 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
                 </g>
               ))}
 
-              <path className="terrain-fill-path" d={geometry.horizonAreaPath} fill={`url(#${terrainFillGradientId})`} />
+              {geometry.terrainFillPath ? <path className="terrain-fill-path" d={geometry.terrainFillPath} fill={`url(#${terrainFillGradientId})`} /> : null}
               {geometry.ridgeBands.map((band) => (
                 <g key={band.key}>
                   {band.fillPath ? (
@@ -647,7 +697,6 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
               ))}
               {includeClutter && geometry.clutterAreaPath ? <path className="panorama-clutter-haze" d={geometry.clutterAreaPath} /> : null}
               {includeClutter && geometry.clutterPath ? <path className="panorama-clutter-line" d={geometry.clutterPath} /> : null}
-              <path className="terrain-line-neutral" d={geometry.horizonPath} />
 
               {geometry.nodes.map((node) => (
                 <circle

--- a/src/index.css
+++ b/src/index.css
@@ -2046,6 +2046,71 @@ input {
   justify-content: flex-end;
 }
 
+.panorama-fov-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+  border-radius: 10px;
+  border: 1px solid color-mix(in srgb, var(--border) 74%, transparent);
+  background: color-mix(in srgb, var(--surface-2) 86%, transparent);
+  min-width: 178px;
+}
+
+.panorama-fov-label {
+  font-size: 0.7rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--muted);
+  font-weight: 700;
+  font-family: "IBM Plex Mono", monospace;
+}
+
+.panorama-fov-slider {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 92px;
+  height: 4px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--border) 72%, var(--surface) 28%);
+  outline: none;
+  cursor: pointer;
+}
+
+.panorama-fov-slider::-webkit-slider-thumb {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 2px solid color-mix(in srgb, var(--surface) 88%, transparent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.panorama-fov-slider::-moz-range-track {
+  height: 4px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--border) 72%, var(--surface) 28%);
+}
+
+.panorama-fov-slider::-moz-range-thumb {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 2px solid color-mix(in srgb, var(--surface) 88%, transparent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.panorama-fov-value {
+  min-width: 34px;
+  text-align: right;
+  font-size: 0.72rem;
+  color: var(--text);
+  font-family: "IBM Plex Mono", monospace;
+}
+
 .chart-action-row > .chart-hover-state {
   min-height: 26px;
   flex: 1;

--- a/src/lib/panorama.test.ts
+++ b/src/lib/panorama.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { azimuthFromToDeg, buildPanorama, destinationForDistanceKm, earthCurvatureDropM, qualityToSampling } from "./panorama";
+import { azimuthFromToDeg, buildPanorama, destinationForDistanceKm, earthCurvatureDropM, qualityToSampling, resolvePanoramaSampling } from "./panorama";
 import type { Link, PropagationEnvironment, Site } from "../types/radio";
 
 const site: Site = {
@@ -34,6 +34,14 @@ describe("panorama", () => {
   it("provides expected quality defaults", () => {
     expect(qualityToSampling("drag")).toEqual({ azimuthStepDeg: 5, radialSamples: 64 });
     expect(qualityToSampling("full")).toEqual({ azimuthStepDeg: 1, radialSamples: 192 });
+  });
+
+  it("increases azimuth density as FOV narrows in zoom mode", () => {
+    const normal = resolvePanoramaSampling("full", { zoomModeEnabled: false, fovScale: 4 });
+    const zoomed = resolvePanoramaSampling("full", { zoomModeEnabled: true, fovScale: 4 });
+    expect(normal.azimuthStepDeg).toBe(1);
+    expect(zoomed.azimuthStepDeg).toBe(0.25);
+    expect(zoomed.radialSamples).toBe(normal.radialSamples);
   });
 
   it("calculates geodesic helpers in expected range", () => {
@@ -74,5 +82,30 @@ describe("panorama", () => {
     expect(result.nodes.length).toBe(1);
     expect(result.nodes[0].state).toMatch(/pass_|fail_/);
     expect(result.maxAngleDeg).toBeGreaterThan(result.minAngleDeg);
+  });
+
+  it("supports window-focused azimuth sweeps for zoomed recompute", () => {
+    const result = buildPanorama({
+      selectedSite: site,
+      effectiveLink: link,
+      propagationEnvironment: env,
+      rxSensitivityTargetDbm: -120,
+      environmentLossDb: 0,
+      quality: "full",
+      terrainSampler: () => 120,
+      nodeCandidates: [],
+      options: {
+        baseRadiusKm: 50,
+        maxRadiusKm: 80,
+        azimuthStepDeg: 0.5,
+        windowCenterDeg: 350,
+        windowSpanDeg: 90,
+      },
+    });
+
+    expect(result.rays.length).toBeGreaterThan(150);
+    expect(result.rays.length).toBeLessThan(220);
+    expect(result.rays.some((ray) => ray.azimuthDeg < 10)).toBe(true);
+    expect(result.rays.some((ray) => ray.azimuthDeg > 340)).toBe(true);
   });
 });

--- a/src/lib/panorama.ts
+++ b/src/lib/panorama.ts
@@ -1,5 +1,6 @@
 import { computeSourceCentricRxMetrics, classifyPassFailState, type PassFailState } from "./passFailState";
 import { haversineDistanceKm } from "./geo";
+import { normalizeFovScale } from "./panoramaView";
 import type { Link, PropagationEnvironment, Site } from "../types/radio";
 
 const EARTH_RADIUS_M = 6_371_000;
@@ -70,6 +71,8 @@ export type PanoramaBuildOptions = {
   maxRadiusKm?: number;
   azimuthStepDeg?: number;
   radialSamples?: number;
+  windowCenterDeg?: number;
+  windowSpanDeg?: number;
 };
 
 const clamp = (value: number, min: number, max: number): number => Math.max(min, Math.min(max, value));
@@ -81,6 +84,16 @@ export const qualityToSampling = (quality: PanoramaQuality): { azimuthStepDeg: n
   quality === "drag"
     ? { azimuthStepDeg: 5, radialSamples: 64 }
     : { azimuthStepDeg: 1, radialSamples: 192 };
+
+export const resolvePanoramaSampling = (quality: PanoramaQuality, options?: { zoomModeEnabled?: boolean; fovScale?: number }) => {
+  const defaults = qualityToSampling(quality);
+  if (!options?.zoomModeEnabled) return defaults;
+  const fovScale = normalizeFovScale(options.fovScale ?? 1);
+  return {
+    azimuthStepDeg: Math.max(0.25, defaults.azimuthStepDeg / fovScale),
+    radialSamples: defaults.radialSamples,
+  };
+};
 
 export const earthCurvatureDropM = (distanceKm: number, kFactor: number): number => {
   const distanceM = Math.max(0, distanceKm * 1000);
@@ -156,6 +169,35 @@ const clearanceMarginMeters = (
   return Math.tan(deltaRad) * distanceM;
 };
 
+const normalizeAzimuth = (azimuthDeg: number): number => ((azimuthDeg % 360) + 360) % 360;
+
+const angularDistanceDeg = (a: number, b: number): number => {
+  const diff = Math.abs(normalizeAzimuth(a) - normalizeAzimuth(b)) % 360;
+  return diff > 180 ? 360 - diff : diff;
+};
+
+const buildAzimuthSweep = (azimuthStepDeg: number, windowCenterDeg?: number, windowSpanDeg?: number): number[] => {
+  const step = Math.max(0.25, azimuthStepDeg);
+  const span = Math.max(10, Math.min(360, windowSpanDeg ?? 360));
+  if (span >= 359.999) {
+    const values: number[] = [];
+    for (let azimuthDeg = 0; azimuthDeg < 360; azimuthDeg += step) {
+      values.push(normalizeAzimuth(azimuthDeg));
+    }
+    return values.length ? values : [0];
+  }
+
+  const center = normalizeAzimuth(windowCenterDeg ?? 180);
+  const start = center - span / 2;
+  const count = Math.max(2, Math.ceil(span / step) + 1);
+  const values: number[] = [];
+  for (let i = 0; i < count; i += 1) {
+    const ratio = count <= 1 ? 0 : i / (count - 1);
+    values.push(normalizeAzimuth(start + span * ratio));
+  }
+  return values;
+};
+
 export const buildPanorama = (params: {
   selectedSite: Site;
   effectiveLink: Link;
@@ -172,7 +214,7 @@ export const buildPanorama = (params: {
   const defaults = qualityToSampling(quality);
   const baseRadiusKm = Math.max(1, params.options?.baseRadiusKm ?? 50);
   const maxRadiusKm = Math.max(baseRadiusKm, params.options?.maxRadiusKm ?? 200);
-  const azimuthStepDeg = clamp(params.options?.azimuthStepDeg ?? defaults.azimuthStepDeg, 1, 45);
+  const azimuthStepDeg = clamp(params.options?.azimuthStepDeg ?? defaults.azimuthStepDeg, 0.25, 45);
   const radialSamples = Math.max(12, Math.round(params.options?.radialSamples ?? defaults.radialSamples));
   const clutterHeightM = Math.max(0, propagationEnvironment.clutterHeightM);
 
@@ -183,7 +225,8 @@ export const buildPanorama = (params: {
   let minAngleDeg = Number.POSITIVE_INFINITY;
   let maxAngleDeg = Number.NEGATIVE_INFINITY;
 
-  for (let azimuthDeg = 0; azimuthDeg < 360; azimuthDeg += azimuthStepDeg) {
+  const azimuthSweep = buildAzimuthSweep(azimuthStepDeg, params.options?.windowCenterDeg, params.options?.windowSpanDeg);
+  for (const azimuthDeg of azimuthSweep) {
     const maxDistanceKm = resolveRayMaxDistanceKm(selectedSite.position, azimuthDeg, baseRadiusKm, maxRadiusKm, terrainSampler);
     const samples: PanoramaRaySample[] = [];
     let maxAngleSoFar = -90;
@@ -249,7 +292,6 @@ export const buildPanorama = (params: {
     });
   }
 
-  const azimuthCount = rays.length;
   const nodes: PanoramaNodeProjection[] = nodeCandidates
     .filter((candidate) => candidate.id !== selectedSite.id)
     .map((candidate) => {
@@ -259,8 +301,11 @@ export const buildPanorama = (params: {
       const candidateAbs = candidate.groundElevationM + candidate.antennaHeightM;
       const elevationAngleDeg = toDegrees(Math.atan2(candidateAbs - sourceAbsM - dropM, Math.max(1, distanceKm * 1000)));
 
-      const rayIndex = Math.round(azimuthDeg / azimuthStepDeg) % Math.max(1, azimuthCount);
-      const ray = rays[rayIndex] ?? rays[0];
+      const ray =
+        rays.reduce<PanoramaRay | null>((best, candidate) => {
+          if (!best) return candidate;
+          return angularDistanceDeg(candidate.azimuthDeg, azimuthDeg) < angularDistanceDeg(best.azimuthDeg, azimuthDeg) ? candidate : best;
+        }, null) ?? rays[0];
       const terrainBeforeDeg = ray ? lookupMaxAngleBefore(ray.samples, distanceKm) : -90;
       const visible = elevationAngleDeg > terrainBeforeDeg;
       const angularClearanceDeg = elevationAngleDeg - terrainBeforeDeg;

--- a/src/lib/panoramaRender.test.ts
+++ b/src/lib/panoramaRender.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildDepthBands, depthStyleForBand, resolveRenderedEndpoint } from "./panoramaRender";
+import { buildDepthBands, buildNearBiasedDepthFractions, depthStyleForBand, resolveRenderedEndpoint } from "./panoramaRender";
 import type { PanoramaRay } from "./panorama";
 
 const mkRay = (azimuthDeg: number, samples: number[]): PanoramaRay => ({
@@ -53,6 +53,16 @@ describe("panoramaRender", () => {
     expect(near.strokeOpacity).toBeGreaterThan(far.strokeOpacity);
     expect(near.strokeMixTerrainPct).toBeGreaterThan(far.strokeMixTerrainPct);
     expect(near.strokeMixMutedPct).toBeLessThan(far.strokeMixMutedPct);
+  });
+
+  it("builds ten near-biased fractions ending at horizon depth", () => {
+    const fractions = buildNearBiasedDepthFractions(10);
+    expect(fractions).toHaveLength(10);
+    expect(fractions[0]).toBeLessThan(0.1);
+    expect(fractions[fractions.length - 1]).toBe(1);
+    for (let i = 1; i < fractions.length; i += 1) {
+      expect(fractions[i]).toBeGreaterThan(fractions[i - 1]);
+    }
   });
 
   it("resolves rendered endpoint from hovered node/sample before fallback ray", () => {

--- a/src/lib/panoramaRender.ts
+++ b/src/lib/panoramaRender.ts
@@ -59,6 +59,15 @@ export const depthStyleForBand = (bandIndex: number, bandCount: number): Panoram
   };
 };
 
+export const buildNearBiasedDepthFractions = (lineCount: number): number[] => {
+  const count = Math.max(1, Math.round(lineCount));
+  if (count === 1) return [1];
+  return Array.from({ length: count }, (_, index) => {
+    const t = (index + 1) / count;
+    return Number(Math.pow(t, 1.6).toFixed(6));
+  });
+};
+
 export const buildDepthBands = (
   rays: PanoramaRay[],
   fractions: number[],

--- a/src/lib/panoramaView.test.ts
+++ b/src/lib/panoramaView.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { cardinalLabelForAzimuth, formatAzimuthTick, resolvePanoramaWindow, unwrapAzimuthForWindow } from "./panoramaView";
+import {
+  cardinalLabelForAzimuth,
+  chartXNormToAzimuthDeg,
+  formatAzimuthTick,
+  fovScaleToSpanDeg,
+  normalizeFovScale,
+  resolvePanoramaWindow,
+  unwrapAzimuthForWindow,
+} from "./panoramaView";
 
 describe("panoramaView", () => {
   it("formats cardinal directions at exact compass quadrants", () => {
@@ -16,6 +24,22 @@ describe("panoramaView", () => {
     expect(window.centerDeg).toBe(12);
     expect(window.startDeg).toBeCloseTo(-33);
     expect(window.endDeg).toBeCloseTo(57);
+  });
+
+  it("maps FOV scale to panorama span", () => {
+    expect(normalizeFovScale(0.3)).toBe(1);
+    expect(normalizeFovScale(5)).toBe(4);
+    expect(fovScaleToSpanDeg(1)).toBe(360);
+    expect(fovScaleToSpanDeg(4)).toBe(90);
+    expect(fovScaleToSpanDeg(1.5)).toBeCloseTo(240);
+  });
+
+  it("maps chart x ratio directly to azimuth domain", () => {
+    expect(chartXNormToAzimuthDeg(0)).toBe(0);
+    expect(chartXNormToAzimuthDeg(0.5)).toBe(180);
+    expect(chartXNormToAzimuthDeg(1)).toBe(360);
+    expect(chartXNormToAzimuthDeg(-1)).toBe(0);
+    expect(chartXNormToAzimuthDeg(2)).toBe(360);
   });
 
   it("unwraps azimuth around 360 boundaries against a local reference", () => {

--- a/src/lib/panoramaView.ts
+++ b/src/lib/panoramaView.ts
@@ -1,4 +1,5 @@
 const mod360 = (value: number): number => ((value % 360) + 360) % 360;
+const clamp = (value: number, min: number, max: number): number => Math.max(min, Math.min(max, value));
 
 export const cardinalLabelForAzimuth = (azimuthDeg: number): "N" | "E" | "S" | "W" | null => {
   const normalized = mod360(azimuthDeg);
@@ -29,6 +30,12 @@ export const resolvePanoramaWindow = (centerDeg: number, spanDeg = 90): Panorama
   const endDeg = center + span / 2;
   return { centerDeg: center, spanDeg: span, startDeg, endDeg };
 };
+
+export const normalizeFovScale = (fovScale: number): number => clamp(fovScale, 1, 4);
+
+export const fovScaleToSpanDeg = (fovScale: number): number => 360 / normalizeFovScale(fovScale);
+
+export const chartXNormToAzimuthDeg = (xNorm: number): number => clamp(xNorm, 0, 1) * 360;
 
 export const unwrapAzimuthForWindow = (azimuthDeg: number, referenceDeg: number): number => {
   const normalized = mod360(azimuthDeg);


### PR DESCRIPTION
## Summary\n- remove dedicated panorama horizon stroke and rely on terrain depth rendering\n- render 10 near-biased depth lines for stronger pseudo-3D layering\n- add chart zoom-mode toggle with inline FOV slider (1x-4x), default ON at 1.5x\n- implement FOV mapping (1x=360, 4x=90) and adaptive window-focused azimuth sampling\n\n## Validation\n- npm test\n- npm run build\n