### PR TITLE
fix(#101): panorama ridge-aware lines and hard gesture capture

### DIFF
--- a/scripts/deploy-pages-safe.mjs
+++ b/scripts/deploy-pages-safe.mjs
@@ -159,6 +159,27 @@ const assert = (condition, message) => {
   if (!condition) throw new Error(message);
 };
 
+const parseDirtyPathsFromPorcelain = (statusStdout) =>
+  statusStdout
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .map((line) => {
+      const payload = line.length >= 4 ? line.slice(3).trim() : line.trim();
+      const renameIdx = payload.indexOf(" -> ");
+      if (renameIdx >= 0) return payload.slice(renameIdx + 4).trim();
+      return payload;
+    })
+    .filter(Boolean);
+
+async function cleanupAllowedDirtyFiles() {
+  const status = await run("git", ["status", "--porcelain"], { capture: true });
+  const dirtyPaths = parseDirtyPathsFromPorcelain(status.stdout);
+  const allowedDirty = dirtyPaths.filter((file) => ALLOWED_DIRTY_PATHS.has(file));
+  if (!allowedDirty.length) return;
+  await run("git", ["checkout", "--", ...allowedDirty]);
+  console.log(`[deploy-pages-safe] Cleaned generated files: ${allowedDirty.join(", ")}`);
+}
+
 async function verifyChartRegressionGuards() {
   const chartSource = await readFile(LINK_PROFILE_CHART_PATH, "utf8");
   const forbiddenPatterns = [
@@ -222,15 +243,7 @@ async function preflight(targetName, target) {
   const branch = await getGitRef();
   const commit = await getGitRef(["rev-parse", "--short", "HEAD"]);
   const status = await run("git", ["status", "--porcelain"], { capture: true });
-  const dirtyLines = status.stdout.split("\n").filter((line) => line.trim().length > 0);
-  const dirtyPaths = dirtyLines
-    .map((line) => {
-      const payload = line.length >= 4 ? line.slice(3).trim() : line.trim();
-      const renameIdx = payload.indexOf(" -> ");
-      if (renameIdx >= 0) return payload.slice(renameIdx + 4).trim();
-      return payload;
-    })
-    .filter(Boolean);
+  const dirtyPaths = parseDirtyPathsFromPorcelain(status.stdout);
   const unexpectedDirty = dirtyPaths.filter((file) => !ALLOWED_DIRTY_PATHS.has(file));
   assert(
     unexpectedDirty.length === 0,
@@ -337,24 +350,28 @@ async function main() {
     return replacements[ch] ?? "";
   });
 
-  await withWranglerConfig(target.configPath, async () => {
-    await run(wrangler, [
-      "pages",
-      "deploy",
-      "dist",
-      "--project-name",
-      target.projectName,
-      "--branch",
-      deployBranch,
-      "--commit-message",
-      commitMessage || commit,
-    ]);
-  });
+  try {
+    await withWranglerConfig(target.configPath, async () => {
+      await run(wrangler, [
+        "pages",
+        "deploy",
+        "dist",
+        "--project-name",
+        target.projectName,
+        "--branch",
+        deployBranch,
+        "--commit-message",
+        commitMessage || commit,
+      ]);
+    });
 
-  await verifyDeployment(target.projectName, commit);
-  console.log(
-    `[deploy-pages-safe] Success: target=${targetName} project=${target.projectName} branch=${deployBranch} commit=${commit}`,
-  );
+    await verifyDeployment(target.projectName, commit);
+    console.log(
+      `[deploy-pages-safe] Success: target=${targetName} project=${target.projectName} branch=${deployBranch} commit=${commit}`,
+    );
+  } finally {
+    await cleanupAllowedDirtyFiles();
+  }
 }
 
 main().catch((error) => {

--- a/src/components/PanoramaChart.tsx
+++ b/src/components/PanoramaChart.tsx
@@ -1,5 +1,5 @@
 import { scaleLinear } from "d3-scale";
-import { Compass, Maximize2, Minimize2, Trees, Waves, ZoomIn } from "lucide-react";
+import { AudioLines, Compass, Maximize2, Minimize2, Trees, Waves, ZoomIn } from "lucide-react";
 import { createPortal } from "react-dom";
 import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
@@ -59,11 +59,14 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
   const scrollbarTrackRef = useRef<HTMLDivElement | null>(null);
   const wavesButtonRef = useRef<HTMLButtonElement | null>(null);
   const fovButtonRef = useRef<HTMLButtonElement | null>(null);
+  const linesButtonRef = useRef<HTMLButtonElement | null>(null);
   const sliderPopoverRef = useRef<HTMLDivElement | null>(null);
   const pinchPointersRef = useRef<Map<number, { x: number; y: number }>>(new Map());
   const pinchStartRef = useRef<{ distance: number; fovScale: number; spanDeg: number; centerDeg: number } | null>(null);
   const panDragRef = useRef<{ pointerId: number; startX: number; startCenterDeg: number } | null>(null);
   const scrubDragRef = useRef<{ pointerId: number; startX: number; startCenterDeg: number } | null>(null);
+  const wheelGestureUnlockTimerRef = useRef<number | null>(null);
+  const [gestureLockActive, setGestureLockActive] = useState(false);
 
   const [chartSize, setChartSize] = useState<{ width: number; height: number } | null>(null);
   const [viewportCenterAzimuthDeg, setViewportCenterAzimuthDeg] = useState(180);
@@ -73,7 +76,7 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
   const [fovScale, setFovScale] = useState(1.5);
   const [hoverTarget, setHoverTarget] = useState<HoverTarget | null>(null);
   const [pinnedTarget, setPinnedTarget] = useState<HoverTarget | null>(null);
-  const [openSliderPopover, setOpenSliderPopover] = useState<"fov" | "vertical" | null>(null);
+  const [openSliderPopover, setOpenSliderPopover] = useState<"fov" | "vertical" | "lines" | null>(null);
   const [sliderPopoverPos, setSliderPopoverPos] = useState<{ left: number; top: number; direction: "up" | "down" } | null>(null);
   const [lineSampleCount, setLineSampleCount] = useState(10);
 
@@ -122,6 +125,47 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
     observer?.observe(element);
     return () => observer?.disconnect();
   }, []);
+
+  useEffect(() => {
+    const host = chartHostRef.current;
+    const scrub = scrollbarTrackRef.current;
+    if (!host || !scrub) return;
+    const captureWheel = (event: WheelEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+    };
+    const captureTouchMove = (event: TouchEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+    };
+    host.addEventListener("wheel", captureWheel, { passive: false, capture: true });
+    scrub.addEventListener("wheel", captureWheel, { passive: false, capture: true });
+    host.addEventListener("touchmove", captureTouchMove, { passive: false, capture: true });
+    scrub.addEventListener("touchmove", captureTouchMove, { passive: false, capture: true });
+    return () => {
+      host.removeEventListener("wheel", captureWheel, true);
+      scrub.removeEventListener("wheel", captureWheel, true);
+      host.removeEventListener("touchmove", captureTouchMove, true);
+      scrub.removeEventListener("touchmove", captureTouchMove, true);
+    };
+  }, [chartSize]);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (gestureLockActive) root.classList.add("panorama-gesture-lock");
+    else root.classList.remove("panorama-gesture-lock");
+    return () => root.classList.remove("panorama-gesture-lock");
+  }, [gestureLockActive]);
+
+  useEffect(
+    () => () => {
+      if (wheelGestureUnlockTimerRef.current != null) {
+        window.clearTimeout(wheelGestureUnlockTimerRef.current);
+        wheelGestureUnlockTimerRef.current = null;
+      }
+    },
+    [],
+  );
 
   const baseSchedulerRef = useRef(createLatestOnlyTaskScheduler());
   const detailSchedulerRef = useRef(createLatestOnlyTaskScheduler());
@@ -372,6 +416,7 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
 
   const geometry = useMemo(() => {
     if (!panorama || !chartSize || !panorama.rays.length) return null;
+    const anchorPanorama = basePanorama && basePanorama.rays.length ? basePanorama : panorama;
 
     const xDomainStart = xWindow.startDeg;
     const xDomainEnd = xWindow.endDeg;
@@ -389,10 +434,10 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
 
     if (!visibleRays.length) return null;
 
-    const minHorizon = Math.min(...panorama.rays.map((ray) => ray.horizonAngleDeg));
-    const maxHorizon = Math.max(...panorama.rays.map((ray) => ray.horizonAngleDeg));
-    const minSampleAngle = Math.min(...panorama.rays.flatMap((ray) => ray.samples.map((sample) => sample.angleDeg)));
-    const maxSampleAngle = Math.max(...panorama.rays.flatMap((ray) => ray.samples.map((sample) => sample.angleDeg)));
+    const minHorizon = Math.min(...anchorPanorama.rays.map((ray) => ray.horizonAngleDeg));
+    const maxHorizon = Math.max(...anchorPanorama.rays.map((ray) => ray.horizonAngleDeg));
+    const minSampleAngle = Math.min(...anchorPanorama.rays.flatMap((ray) => ray.samples.map((sample) => sample.angleDeg)));
+    const maxSampleAngle = Math.max(...anchorPanorama.rays.flatMap((ray) => ray.samples.map((sample) => sample.angleDeg)));
 
     const innerWidth = Math.max(1, chartWidth - M.l - M.r);
     const innerHeight = Math.max(1, chartHeight - M.t - M.b);
@@ -431,6 +476,12 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
         const xValue = unwrapAzimuthForWindow(ray.azimuthDeg, xCenterForUnwrap);
         const angleDeg = sample?.angleDeg ?? ray.horizonAngleDeg;
         return { x: x(xValue), y: y(angleDeg), angleDeg };
+      },
+      {
+        ridgeSnap: {
+          enabled: true,
+          windowRatio: 0.08,
+        },
       },
     );
     const ridgeBands = depthBands.map((band, bandIndex, all) => ({
@@ -489,7 +540,7 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
       nodes,
       maxVerticalScaleX,
     };
-  }, [panorama, chartSize, chartHeight, chartWidth, verticalBlend, xWindow, includeClutter, lineSampleCount]);
+  }, [panorama, basePanorama, chartSize, chartHeight, chartWidth, verticalBlend, xWindow, includeClutter, lineSampleCount]);
 
   const focusTarget = hoverTarget ?? pinnedTarget;
   const focusAzimuthDeg = focusTarget?.azimuthDeg ?? null;
@@ -539,6 +590,7 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
 
   const onScrubPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
     if (!scrollbarTrackRef.current) return;
+    setGestureLockActive(true);
     const rect = scrollbarTrackRef.current.getBoundingClientRect();
     const xNorm = clamp((event.clientX - rect.left) / Math.max(1, rect.width), 0, 1);
     setViewportCenterAzimuthDeg(xNorm * 360);
@@ -557,6 +609,7 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
 
   const onScrubPointerEnd = (event: React.PointerEvent<HTMLDivElement>) => {
     if (scrubDragRef.current?.pointerId === event.pointerId) scrubDragRef.current = null;
+    setGestureLockActive(false);
   };
 
   const applyFovAtFocal = useCallback(
@@ -572,24 +625,33 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
   );
 
   const onWheelPanorama = (event: React.WheelEvent<HTMLDivElement>) => {
+    event.preventDefault();
     event.stopPropagation();
+    setGestureLockActive(true);
+    if (wheelGestureUnlockTimerRef.current != null) {
+      window.clearTimeout(wheelGestureUnlockTimerRef.current);
+      wheelGestureUnlockTimerRef.current = null;
+    }
+    wheelGestureUnlockTimerRef.current = window.setTimeout(() => {
+      setGestureLockActive(false);
+      wheelGestureUnlockTimerRef.current = null;
+    }, 160);
     const rect = event.currentTarget.getBoundingClientRect();
     const focalNorm = clamp((event.clientX - rect.left) / Math.max(1, rect.width), 0, 1);
     if (event.ctrlKey) {
-      event.preventDefault();
       const nextScale = normalizeFovScale(normalizedFovScale * Math.exp(-event.deltaY * 0.01));
       applyFovAtFocal(nextScale, focalNorm);
       return;
     }
     const dominantDelta = Math.abs(event.deltaX) > Math.abs(event.deltaY) ? event.deltaX : event.shiftKey ? event.deltaY : 0;
     if (dominantDelta === 0) return;
-    event.preventDefault();
     const deltaDeg = (dominantDelta / Math.max(1, chartWidth - M.l - M.r)) * viewportSpanDeg;
     setViewportCenterAzimuthDeg((current) => mod360(current + deltaDeg));
   };
 
   const onPointerDownPanorama = (event: React.PointerEvent<HTMLDivElement>) => {
     if (!geometry) return;
+    setGestureLockActive(true);
     panDragRef.current = { pointerId: event.pointerId, startX: event.clientX, startCenterDeg: viewportCenterAzimuthDeg };
     event.currentTarget.setPointerCapture(event.pointerId);
     pinchPointersRef.current.set(event.pointerId, { x: event.clientX, y: event.clientY });
@@ -639,6 +701,9 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
     if (panDragRef.current?.pointerId === event.pointerId) panDragRef.current = null;
     if (pinchPointersRef.current.size < 2) {
       pinchStartRef.current = null;
+    }
+    if (!panDragRef.current && pinchPointersRef.current.size === 0) {
+      setGestureLockActive(false);
     }
   };
 
@@ -734,13 +799,22 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
 
   useEffect(() => {
     if (!openSliderPopover) return;
-    const anchor = openSliderPopover === "fov" ? fovButtonRef.current : wavesButtonRef.current;
+    const anchor =
+      openSliderPopover === "fov"
+        ? fovButtonRef.current
+        : openSliderPopover === "vertical"
+          ? wavesButtonRef.current
+          : linesButtonRef.current;
     if (!anchor) return;
     const updatePosition = () => {
       const rect = anchor.getBoundingClientRect();
-      const direction: "up" | "down" = rect.top < 220 ? "down" : "up";
+      const estimatedHeight = 264;
+      const spaceAbove = rect.top;
+      const spaceBelow = window.innerHeight - rect.bottom;
+      const direction: "up" | "down" = spaceAbove >= estimatedHeight || spaceAbove >= spaceBelow ? "up" : "down";
+      const left = clamp(rect.left + rect.width / 2, 84, window.innerWidth - 84);
       setSliderPopoverPos({
-        left: rect.left + rect.width / 2,
+        left,
         top: direction === "up" ? rect.top - 8 : rect.bottom + 8,
         direction,
       });
@@ -758,14 +832,24 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
     if (!openSliderPopover) return;
     const onPointerDown = (event: MouseEvent | TouchEvent) => {
       const target = event.target as Node | null;
-      const anchor = openSliderPopover === "fov" ? fovButtonRef.current : wavesButtonRef.current;
+      const anchor =
+        openSliderPopover === "fov"
+          ? fovButtonRef.current
+          : openSliderPopover === "vertical"
+            ? wavesButtonRef.current
+            : linesButtonRef.current;
       if (sliderPopoverRef.current?.contains(target)) return;
       if (anchor?.contains(target)) return;
       setOpenSliderPopover(null);
     };
     const onFocusIn = (event: FocusEvent) => {
       const target = event.target as Node | null;
-      const anchor = openSliderPopover === "fov" ? fovButtonRef.current : wavesButtonRef.current;
+      const anchor =
+        openSliderPopover === "fov"
+          ? fovButtonRef.current
+          : openSliderPopover === "vertical"
+            ? wavesButtonRef.current
+            : linesButtonRef.current;
       if (sliderPopoverRef.current?.contains(target)) return;
       if (anchor?.contains(target)) return;
       setOpenSliderPopover(null);
@@ -834,8 +918,8 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
                 value={normalizedFovScale}
                 valueLabel={`${Math.round(fovScaleToSpanDeg(normalizedFovScale))}°`}
               />
-            ) : (
-              <div className="panorama-slider-popover-stack">
+            ) : openSliderPopover === "vertical" ? (
+              <div className="panorama-slider-popover-single">
                 <UiSlider
                   ariaLabel="Panorama vertical exaggeration"
                   label="Vertical"
@@ -847,12 +931,16 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
                   value={verticalBlend}
                   valueLabel={`${currentVerticalScaleX.toFixed(1)}x`}
                 />
+              </div>
+            ) : (
+              <div className="panorama-slider-popover-single">
                 <UiSlider
                   ariaLabel="Panorama radial lines"
                   label="Lines"
-                  max={24}
+                  max={60}
                   min={4}
                   onChange={(value) => setLineSampleCount(Math.round(value))}
+                  orientation="vertical"
                   step={1}
                   value={lineSampleCount}
                   valueLabel={`${lineSampleCount}`}
@@ -900,6 +988,16 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
             type="button"
           >
             <ZoomIn aria-hidden="true" strokeWidth={1.8} />
+          </button>
+          <button
+            aria-label="Adjust terrain line count"
+            className={`chart-endpoint-swap chart-endpoint-icon ${openSliderPopover === "lines" ? "is-active" : ""}`}
+            onClick={() => setOpenSliderPopover((value) => (value === "lines" ? null : "lines"))}
+            ref={linesButtonRef}
+            title="Terrain lines"
+            type="button"
+          >
+            <AudioLines aria-hidden="true" strokeWidth={1.8} />
           </button>
           <button
             aria-label={mapHoverZoomEnabled ? "Disable map hover lens" : "Enable map hover lens"}

--- a/src/index.css
+++ b/src/index.css
@@ -1838,6 +1838,7 @@ input {
   position: relative;
   touch-action: none;
   overscroll-behavior: contain;
+  overscroll-behavior-x: none;
 }
 
 .chart-header {
@@ -2075,8 +2076,8 @@ input {
 .ui-slider-input {
   appearance: none;
   -webkit-appearance: none;
-  width: 120px;
-  height: 22px;
+  width: 148px;
+  height: 44px;
   border-radius: 999px;
   background: transparent;
   outline: none;
@@ -2087,8 +2088,8 @@ input {
 .ui-slider-input::-webkit-slider-thumb {
   appearance: none;
   -webkit-appearance: none;
-  width: 22px;
-  height: 22px;
+  width: 24px;
+  height: 24px;
   border-radius: 50%;
   background: var(--accent);
   border: 2px solid color-mix(in srgb, var(--surface) 88%, transparent);
@@ -2096,20 +2097,20 @@ input {
 }
 
 .ui-slider-input::-webkit-slider-runnable-track {
-  height: 5px;
+  height: 7px;
   border-radius: 999px;
   background: color-mix(in srgb, var(--border) 72%, var(--surface) 28%);
 }
 
 .ui-slider-input::-moz-range-track {
-  height: 5px;
+  height: 7px;
   border-radius: 999px;
   background: color-mix(in srgb, var(--border) 72%, var(--surface) 28%);
 }
 
 .ui-slider-input::-moz-range-thumb {
-  width: 22px;
-  height: 22px;
+  width: 24px;
+  height: 24px;
   border-radius: 50%;
   background: var(--accent);
   border: 2px solid color-mix(in srgb, var(--surface) 88%, transparent);
@@ -2119,27 +2120,32 @@ input {
 .ui-slider-vertical {
   flex-direction: column;
   align-items: center;
-  gap: 8px;
-  width: 78px;
-  min-height: 232px;
-  justify-content: space-between;
+  gap: 10px;
+  width: 92px;
+  min-height: 268px;
+  justify-content: center;
 }
 
 .ui-slider-vertical .ui-slider-input {
-  width: 160px;
-  transform: rotate(-90deg);
-  transform-origin: center;
+  -webkit-appearance: slider-vertical;
+  appearance: slider-vertical;
+  width: 44px;
+  height: 178px;
+  writing-mode: vertical-lr;
+  direction: rtl;
 }
 
 .panorama-slider-popover {
   position: fixed;
   z-index: 2100;
   transform: translate(-50%, calc(-100% - 6px));
-  min-width: 112px;
-  padding: 12px;
-  border-radius: 12px;
-  border: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
-  background: color-mix(in srgb, var(--surface-2) 94%, var(--surface) 6%);
+  min-width: 136px;
+  padding: 12px 10px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
+  background: color-mix(in srgb, var(--surface-2) var(--glass-panel-opacity), transparent);
+  -webkit-backdrop-filter: blur(var(--glass-panel-blur));
+  backdrop-filter: blur(var(--glass-panel-blur));
   box-shadow: var(--shadow-elev-3);
   animation: panorama-popover-rise 140ms ease-out;
 }
@@ -2152,6 +2158,11 @@ input {
 .panorama-slider-popover-stack {
   display: grid;
   gap: 12px;
+}
+
+.panorama-slider-popover-single {
+  display: grid;
+  place-items: center;
 }
 
 @keyframes panorama-popover-rise {
@@ -2178,7 +2189,7 @@ input {
 
 .panorama-scrollbar {
   width: 100%;
-  height: 18px;
+  height: 22px;
   position: relative;
   border-radius: 999px;
   background: color-mix(in srgb, var(--surface-2) 84%, var(--border) 16%);
@@ -2190,12 +2201,17 @@ input {
 
 .panorama-scrollbar-thumb {
   position: absolute;
-  top: 2px;
-  bottom: 2px;
+  top: 3px;
+  bottom: 3px;
   border-radius: 999px;
   background: color-mix(in srgb, var(--accent) 76%, var(--surface) 24%);
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 34%, var(--surface) 66%);
   pointer-events: none;
+}
+
+html.panorama-gesture-lock,
+html.panorama-gesture-lock body {
+  overscroll-behavior: none;
 }
 
 .chart-action-row > .chart-hover-state {

--- a/src/lib/panoramaRender.test.ts
+++ b/src/lib/panoramaRender.test.ts
@@ -39,11 +39,32 @@ describe("panoramaRender", () => {
         y: sample?.angleDeg ?? 0,
         angleDeg: sample?.angleDeg ?? Number.NEGATIVE_INFINITY,
       }),
+      { ridgeSnap: { enabled: false } },
     );
 
     expect(bands).toHaveLength(2);
     expect(bands[1].lineSegments).toHaveLength(1);
     expect(bands[1].lineSegments[0]).toContain("M60.00,4.00 L90.00,5.00");
+  });
+
+  it("snaps each depth band to local ridge candidates while preserving distance order", () => {
+    const ray = mkRay(0, [0, 1.2, 0.4, 3.1, 2.8, 4.5, 4.2, 5.4, 5.1]);
+    const bands = buildDepthBands(
+      [ray],
+      [0.2, 0.5, 0.8],
+      (_ray, sample) => ({
+        x: sample?.distanceKm ?? 0,
+        y: sample?.angleDeg ?? 0,
+        angleDeg: sample?.angleDeg ?? Number.NEGATIVE_INFINITY,
+      }),
+      { ridgeSnap: { enabled: true, windowRatio: 0.2 } },
+    );
+
+    expect(bands).toHaveLength(3);
+    const pickedDistances = bands.map((band) => band.points[0]?.sample?.distanceKm ?? 0);
+    expect(pickedDistances[1]).toBeGreaterThanOrEqual(pickedDistances[0]);
+    expect(pickedDistances[2]).toBeGreaterThanOrEqual(pickedDistances[1]);
+    expect(pickedDistances[2]).toBeGreaterThan(0);
   });
 
   it("returns monotonic near-to-far depth style falloff", () => {

--- a/src/lib/panoramaRender.ts
+++ b/src/lib/panoramaRender.ts
@@ -14,6 +14,13 @@ export type PanoramaDepthBand = {
   lineSegments: string[];
 };
 
+export type PanoramaBandSelectionOptions = {
+  ridgeSnap?: {
+    enabled?: boolean;
+    windowRatio?: number;
+  };
+};
+
 export type PanoramaDepthStyle = {
   strokeWidth: number;
   strokeOpacity: number;
@@ -72,23 +79,65 @@ export const buildDepthBands = (
   rays: PanoramaRay[],
   fractions: number[],
   mapPoint: (ray: PanoramaRay, sample: PanoramaRaySample | null) => { x: number; y: number; angleDeg: number },
+  options?: PanoramaBandSelectionOptions,
 ): PanoramaDepthBand[] => {
   if (!rays.length || !fractions.length) return [];
 
-  const rawBands = fractions.map((fraction, bandIndex) => {
-    const points: PanoramaDepthPoint[] = rays.map((ray) => {
-      const sampleIndex = Math.max(0, Math.min(ray.samples.length - 1, Math.round((ray.samples.length - 1) * fraction)));
-      const sample = ray.samples.length ? ray.samples[sampleIndex] ?? ray.samples[ray.samples.length - 1] : null;
+  const ridgeSnapEnabled = options?.ridgeSnap?.enabled !== false;
+  const ridgeWindowRatio = Math.max(0.01, Math.min(0.35, options?.ridgeSnap?.windowRatio ?? 0.08));
+
+  const pickSampleIndex = (
+    ray: PanoramaRay,
+    targetIndex: number,
+    minIndex: number,
+  ): number => {
+    if (!ray.samples.length) return 0;
+    const maxIndex = ray.samples.length - 1;
+    const clampedTarget = Math.max(0, Math.min(maxIndex, targetIndex));
+    if (!ridgeSnapEnabled) return Math.max(minIndex, clampedTarget);
+    const windowRadius = Math.max(1, Math.round(maxIndex * ridgeWindowRatio));
+    const start = Math.max(minIndex, clampedTarget - windowRadius);
+    const end = Math.min(maxIndex, clampedTarget + windowRadius);
+    let bestIndex = Math.max(minIndex, clampedTarget);
+    let bestScore = Number.NEGATIVE_INFINITY;
+    for (let i = start; i <= end; i += 1) {
+      const sample = ray.samples[i];
+      if (!sample) continue;
+      const crestScore = Math.max(0, sample.angleDeg - sample.maxAngleBeforeDeg);
+      const proximityScore = 1 - Math.min(1, Math.abs(i - clampedTarget) / Math.max(1, windowRadius));
+      const score = sample.angleDeg + crestScore * 0.35 + proximityScore * 0.08;
+      if (score > bestScore) {
+        bestScore = score;
+        bestIndex = i;
+      }
+    }
+    return Math.max(minIndex, bestIndex);
+  };
+
+  const rawBands: { bandIndex: number; depthRatio: number; points: PanoramaDepthPoint[] }[] = [];
+  for (let bandIndex = 0; bandIndex < fractions.length; bandIndex += 1) {
+    const fraction = fractions[bandIndex] ?? 1;
+    const points: PanoramaDepthPoint[] = [];
+    for (let rayIndex = 0; rayIndex < rays.length; rayIndex += 1) {
+      const ray = rays[rayIndex];
+      const maxIndex = Math.max(0, ray.samples.length - 1);
+      const targetIndex = Math.round(maxIndex * fraction);
+      const prevSample = bandIndex > 0 ? rawBands[bandIndex - 1]?.points[rayIndex]?.sample : null;
+      const minIndex = prevSample
+        ? Math.min(maxIndex, Math.max(0, Math.round((prevSample.distanceKm / Math.max(0.001, ray.maxDistanceKm)) * maxIndex)))
+        : 0;
+      const sampleIndex = pickSampleIndex(ray, targetIndex, minIndex);
+      const sample = ray.samples.length ? ray.samples[sampleIndex] ?? ray.samples[maxIndex] : null;
       const mapped = mapPoint(ray, sample);
-      return {
+      points.push({
         x: mapped.x,
         y: mapped.y,
         angleDeg: mapped.angleDeg,
         sample,
-      };
-    });
-    return { bandIndex, depthRatio: fraction, points };
-  });
+      });
+    }
+    rawBands.push({ bandIndex, depthRatio: fraction, points });
+  }
 
   const visibility: boolean[][] = rawBands.map(() => new Array<boolean>(rays.length).fill(false));
   for (let rayIndex = 0; rayIndex < rays.length; rayIndex += 1) {


### PR DESCRIPTION
## Summary
- add adaptive ridge-aware depth-line sampling to reduce missed terrain features between fixed bands
- harden panorama interaction gesture capture to prevent app/page scroll and browser nav gesture leakage
- stabilize panorama y-axis anchoring to the full-site (base 360) envelope while panning/FOV changes
- split lines control into dedicated icon/popover and improve vertical slider/popover layout and touch target sizing
- auto-clean generated buildInfo files after guarded deploys so local tree no longer stays dirty from deploy/build-info generation

## Verification
- npm test
- npm run build
