### PR TITLE
fix(#101): edge-stitched panorama detail and fill-occlusion parity

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -2054,7 +2054,7 @@ export function AppShell() {
         </section>
       ) : null}
       {isMapExpanded || isProfileExpanded || (!isMobileViewport && (isNavigatorHidden || isInspectorHidden || isProfileHidden)) ? (
-        <div className="floating-attribution-pill">
+        <div className="floating-attribution-pill ui-surface-pill">
           <span>&copy;</span>
           <a href={resolvedBasemap.attributionUrl} rel="noreferrer" target="_blank">
             {resolvedBasemap.attribution.replace(/©/g, "").trim()}

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -2355,7 +2355,7 @@ export function MapView({
   return (
     <div className={hasMinimumTopology ? "map-panel" : "map-panel map-panel-empty"}>
       <div className="map-controls map-controls-unified map-controls-icon-only">
-        <div className="map-controls-group map-controls-group-utility map-controls-utility-pill">
+        <div className="map-controls-group map-controls-group-utility map-controls-utility-pill ui-surface-pill">
           {showMultiSelectToggle ? (
             <button
               aria-label={isMultiSelectMode ? "Disable multi-select" : "Enable multi-select"}

--- a/src/components/PanoramaChart.tsx
+++ b/src/components/PanoramaChart.tsx
@@ -17,6 +17,7 @@ import {
   type PanoramaResult,
   type PanoramaRaySample,
 } from "../lib/panorama";
+import { composePanoramaWindow } from "../lib/panoramaCompose";
 import { buildDepthBands, buildNearBiasedDepthFractions, depthStyleForBand, resolveRenderedEndpoint } from "../lib/panoramaRender";
 import { cardinalLabelForAzimuth, formatAzimuthTick, fovScaleToSpanDeg, mod360, normalizeFovScale, resolvePanoramaWindow, unwrapAzimuthForWindow } from "../lib/panoramaView";
 import { centerForScaledWindow } from "../lib/panoramaViewport";
@@ -313,8 +314,6 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
     const cachedDetail = cacheRef.current.get(detailSignature);
     if (cachedDetail) {
       setDetailPanorama(cachedDetail);
-    } else {
-      setDetailPanorama(null);
     }
 
     if (!cachedBase) {
@@ -412,6 +411,18 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
     [viewportCenterAzimuthDeg, viewportSpanDeg],
   );
 
+  const composedWindow = useMemo(
+    () =>
+      composePanoramaWindow({
+        basePanorama,
+        detailPanorama,
+        centerDeg: xWindow.centerDeg,
+        startDeg: xWindow.startDeg,
+        endDeg: xWindow.endDeg,
+      }),
+    [basePanorama, detailPanorama, xWindow],
+  );
+
   const terrainFillGradientId = useMemo(() => `profile-terrain-fill-${Math.random().toString(36).slice(2, 11)}`, []);
 
   const geometry = useMemo(() => {
@@ -424,12 +435,8 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
     const x = scaleLinear().domain([xDomainStart, xDomainEnd]).range([M.l, chartWidth - M.r]);
     const xCenterForUnwrap = xWindow.centerDeg;
 
-    const visibleRays = panorama.rays
-      .map((ray) => {
-        const xValue = unwrapAzimuthForWindow(ray.azimuthDeg, xCenterForUnwrap);
-        return { ray, xValue };
-      })
-      .filter((entry) => entry.xValue >= xDomainStart && entry.xValue <= xDomainEnd)
+    const visibleRays = composedWindow.rays
+      .map((entry) => ({ ray: entry.ray, xValue: entry.xValue, source: entry.source }))
       .sort((a, b) => a.xValue - b.xValue);
 
     if (!visibleRays.length) return null;
@@ -488,13 +495,10 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
       key: `ridge-${bandIndex}`,
       style: depthStyleForBand(bandIndex, all.length),
       lineSegments: band.lineSegments,
-      fillPath:
-        band.points.length >= 2
-          ? `${toPath(band.points)} L${band.points[band.points.length - 1].x.toFixed(2)},${(chartHeight - M.b).toFixed(2)} L${band.points[0].x.toFixed(2)},${(chartHeight - M.b).toFixed(2)} Z`
-          : "",
+      fillPaths: band.fillSegments.map((segment) =>
+        `${toPath(segment)} L${segment[segment.length - 1].x.toFixed(2)},${(chartHeight - M.b).toFixed(2)} L${segment[0].x.toFixed(2)},${(chartHeight - M.b).toFixed(2)} Z`,
+      ),
     }));
-
-    const furthestBandFillPath = ridgeBands[ridgeBands.length - 1]?.fillPath ?? "";
     const clutterBasePoints = depthBands[depthBands.length - 1]?.points.map((point) => ({ x: point.x, y: point.y })) ?? clutterPoints;
 
     const clutterAreaPath = includeClutter
@@ -511,7 +515,8 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
 
     const ticksY = [domainMin, (domainMin + domainMax) / 2, domainMax];
 
-    const nodes = panorama.nodes
+    const nodeSource = detailPanorama?.nodes?.length ? detailPanorama.nodes : basePanorama?.nodes ?? panorama.nodes;
+    const nodes = nodeSource
       .map((node) => {
         const xValue = unwrapAzimuthForWindow(node.azimuthDeg, xCenterForUnwrap);
         return {
@@ -526,12 +531,14 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
     const fitSpan = Math.max(0.001, fitMax - fitMin);
     const trueSpan = Math.max(0.001, trueMax - trueMin);
     const maxVerticalScaleX = Math.max(1, trueSpan / fitSpan);
+    const nearestBandDistances = depthBands[0]?.points.map((point) => point.sample?.distanceKm ?? 0).filter((value) => Number.isFinite(value) && value > 0) ?? [];
+    const furthestBandDistances =
+      depthBands[depthBands.length - 1]?.points.map((point) => point.sample?.distanceKm ?? 0).filter((value) => Number.isFinite(value) && value > 0) ?? [];
 
     return {
       x,
       xWindow,
       y,
-      terrainFillPath: furthestBandFillPath,
       clutterPath: includeClutter ? toPath(clutterPoints) : "",
       clutterAreaPath,
       ridgeBands,
@@ -539,23 +546,34 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
       ticksY,
       nodes,
       maxVerticalScaleX,
+      coverageSegments: composedWindow.segments,
+      nearestLineDistanceKm: nearestBandDistances.length
+        ? { min: Math.min(...nearestBandDistances), max: Math.max(...nearestBandDistances) }
+        : null,
+      furthestLineDistanceKm: furthestBandDistances.length
+        ? { min: Math.min(...furthestBandDistances), max: Math.max(...furthestBandDistances) }
+        : null,
     };
-  }, [panorama, basePanorama, chartSize, chartHeight, chartWidth, verticalBlend, xWindow, includeClutter, lineSampleCount]);
+  }, [panorama, basePanorama, detailPanorama, composedWindow, chartSize, chartHeight, chartWidth, verticalBlend, xWindow, includeClutter, lineSampleCount]);
 
   const focusTarget = hoverTarget ?? pinnedTarget;
   const focusAzimuthDeg = focusTarget?.azimuthDeg ?? null;
+  const interactionRays = useMemo(() => {
+    const rays = composedWindow.rays.map((entry) => entry.ray);
+    return rays.length ? rays : panorama?.rays ?? [];
+  }, [composedWindow, panorama]);
 
   const activeRay = useMemo(() => {
-    if (!panorama || focusAzimuthDeg == null || !panorama.rays.length) return null;
-    return panorama.rays.reduce(
+    if (!interactionRays.length || focusAzimuthDeg == null) return null;
+    return interactionRays.reduce(
       (best, ray) => {
         const dist = Math.abs(unwrapAzimuthForWindow(ray.azimuthDeg, focusAzimuthDeg) - focusAzimuthDeg);
         if (dist < best.distance) return { ray, distance: dist };
         return best;
       },
-      { ray: panorama.rays[0], distance: Number.POSITIVE_INFINITY },
+      { ray: interactionRays[0], distance: Number.POSITIVE_INFINITY },
     ).ray;
-  }, [panorama, focusAzimuthDeg]);
+  }, [interactionRays, focusAzimuthDeg]);
 
   useEffect(() => {
     if (!selectedSiteEffective) return;
@@ -708,7 +726,7 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
   };
 
   const onMove = (event: ReactMouseEvent<SVGRectElement>) => {
-    if (!geometry || !panorama) return;
+    if (!geometry || !interactionRays.length) return;
     const rect = event.currentTarget.getBoundingClientRect();
     if (rect.width <= 1 || rect.height <= 1) return;
 
@@ -720,12 +738,12 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
     const unwrapped = geometry.x.invert(xPx);
     const azimuth = mod360(unwrapped);
 
-    const nearestRay = panorama.rays.reduce(
+    const nearestRay = interactionRays.reduce(
       (best, ray) => {
         const dist = Math.abs(unwrapAzimuthForWindow(ray.azimuthDeg, azimuth) - azimuth);
         return dist < best.distance ? { ray, distance: dist } : best;
       },
-      { ray: panorama.rays[0], distance: Number.POSITIVE_INFINITY },
+      { ray: interactionRays[0], distance: Number.POSITIVE_INFINITY },
     ).ray;
 
     let nearestNode: { node: PanoramaNodeProjection; cx: number; cy: number; distancePx: number } | null = null;
@@ -902,22 +920,24 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
     openSliderPopover && sliderPopoverPos && typeof document !== "undefined"
       ? createPortal(
           <div
-            className={`panorama-slider-popover ${sliderPopoverPos.direction === "down" ? "is-down" : ""}`}
+            className={`ui-surface-pill panorama-slider-popover ${sliderPopoverPos.direction === "down" ? "is-down" : ""}`}
             ref={sliderPopoverRef}
             style={{ left: `${sliderPopoverPos.left}px`, top: `${sliderPopoverPos.top}px` }}
           >
             {openSliderPopover === "fov" ? (
-              <UiSlider
-                ariaLabel="Panorama field of view"
-                label="FOV"
-                max={4}
-                min={1}
-                onChange={(value) => setFovScale(normalizeFovScale(value))}
-                orientation="vertical"
-                step={0.1}
-                value={normalizedFovScale}
-                valueLabel={`${Math.round(fovScaleToSpanDeg(normalizedFovScale))}°`}
-              />
+              <div className="panorama-slider-popover-single">
+                <UiSlider
+                  ariaLabel="Panorama field of view"
+                  label="FOV"
+                  max={4}
+                  min={1}
+                  onChange={(value) => setFovScale(normalizeFovScale(value))}
+                  orientation="vertical"
+                  step={0.1}
+                  value={normalizedFovScale}
+                  valueLabel={`${Math.round(fovScaleToSpanDeg(normalizedFovScale))}°`}
+                />
+              </div>
             ) : openSliderPopover === "vertical" ? (
               <div className="panorama-slider-popover-single">
                 <UiSlider
@@ -945,6 +965,14 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
                   value={lineSampleCount}
                   valueLabel={`${lineSampleCount}`}
                 />
+                {geometry?.nearestLineDistanceKm ? (
+                  <div className="panorama-lines-telemetry">
+                    <div>Near: {geometry.nearestLineDistanceKm.min.toFixed(1)}-{geometry.nearestLineDistanceKm.max.toFixed(1)} km</div>
+                    {geometry?.furthestLineDistanceKm ? (
+                      <div>Far: {geometry.furthestLineDistanceKm.min.toFixed(1)}-{geometry.furthestLineDistanceKm.max.toFixed(1)} km</div>
+                    ) : null}
+                  </div>
+                ) : null}
               </div>
             )}
           </div>,
@@ -1075,19 +1103,19 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
                 </g>
               ))}
 
-              {geometry.terrainFillPath ? <path className="terrain-fill-path" d={geometry.terrainFillPath} fill={`url(#${terrainFillGradientId})`} /> : null}
               {geometry.ridgeBands.map((band) => (
                 <g key={band.key}>
-                  {band.fillPath ? (
+                  {band.fillPaths.map((fillPath, fillIndex) => (
                     <path
                       className="panorama-ridge-band"
-                      d={band.fillPath}
+                      d={fillPath}
+                      key={`${band.key}-fill-${fillIndex}`}
                       style={{
                         opacity: band.style.fillOpacity,
                         fill: `color-mix(in srgb, var(--terrain) ${band.style.strokeMixTerrainPct}%, var(--surface-2) 55%)`,
                       }}
                     />
-                  ) : null}
+                  ))}
                   {band.lineSegments.map((segment, segmentIndex) => (
                     <path
                       className="panorama-ridge-line"

--- a/src/index.css
+++ b/src/index.css
@@ -1182,13 +1182,16 @@ input {
   flex: 0 0 auto;
 }
 
-.map-controls-utility-pill {
+.ui-surface-pill {
   border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
   border-radius: 999px;
   background: color-mix(in srgb, var(--surface-2) var(--glass-panel-opacity), transparent);
   -webkit-backdrop-filter: blur(var(--glass-panel-blur));
   backdrop-filter: blur(var(--glass-panel-blur));
   box-shadow: var(--shadow-elev-3);
+}
+
+.map-controls-utility-pill {
   margin: 2px;
   padding: 4px;
   gap: 4px;
@@ -1206,12 +1209,6 @@ input {
   gap: 4px;
   font-size: 0.68rem;
   color: var(--muted);
-  border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--surface-2) var(--glass-panel-opacity), transparent);
-  -webkit-backdrop-filter: blur(var(--glass-panel-blur));
-  backdrop-filter: blur(var(--glass-panel-blur));
-  box-shadow: var(--shadow-elev-3);
   padding: 6px 12px;
 }
 
@@ -2142,11 +2139,6 @@ input {
   min-width: 136px;
   padding: 12px 10px;
   border-radius: 999px;
-  border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
-  background: color-mix(in srgb, var(--surface-2) var(--glass-panel-opacity), transparent);
-  -webkit-backdrop-filter: blur(var(--glass-panel-blur));
-  backdrop-filter: blur(var(--glass-panel-blur));
-  box-shadow: var(--shadow-elev-3);
   animation: panorama-popover-rise 140ms ease-out;
 }
 
@@ -2163,6 +2155,17 @@ input {
 .panorama-slider-popover-single {
   display: grid;
   place-items: center;
+  gap: 8px;
+}
+
+.panorama-lines-telemetry {
+  display: grid;
+  gap: 4px;
+  font-size: 0.66rem;
+  line-height: 1.2;
+  color: var(--muted);
+  font-family: "IBM Plex Mono", monospace;
+  text-align: center;
 }
 
 @keyframes panorama-popover-rise {

--- a/src/lib/panorama.ts
+++ b/src/lib/panorama.ts
@@ -64,6 +64,8 @@ export type PanoramaResult = {
   minAngleDeg: number;
   maxAngleDeg: number;
   radiusPolicyKm: number;
+  coverageCenterDeg: number;
+  coverageSpanDeg: number;
 };
 
 export type PanoramaBuildOptions = {
@@ -363,5 +365,7 @@ export const buildPanorama = (params: {
     minAngleDeg,
     maxAngleDeg,
     radiusPolicyKm: baseRadiusKm,
+    coverageCenterDeg: normalizeAzimuth(params.options?.windowCenterDeg ?? 180),
+    coverageSpanDeg: clamp(params.options?.windowSpanDeg ?? 360, 10, 360),
   };
 };

--- a/src/lib/panoramaCompose.test.ts
+++ b/src/lib/panoramaCompose.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { composePanoramaWindow } from "./panoramaCompose";
+import type { PanoramaResult, PanoramaRay } from "./panorama";
+
+const mkRay = (azimuthDeg: number): PanoramaRay => ({
+  azimuthDeg,
+  maxDistanceKm: 10,
+  horizonDistanceKm: 8,
+  horizonLat: 0,
+  horizonLon: 0,
+  horizonTerrainM: 100,
+  horizonAngleDeg: 2,
+  clutterHorizonDistanceKm: 8,
+  clutterHorizonAngleDeg: 2,
+  samples: [
+    {
+      distanceKm: 1,
+      lat: 0,
+      lon: 0,
+      terrainM: 100,
+      angleDeg: 1,
+      clutterAngleDeg: 1,
+      maxAngleBeforeDeg: -90,
+    },
+  ],
+});
+
+const mkPanorama = (azimuths: number[]): PanoramaResult => ({
+  rays: azimuths.map((az) => mkRay(az)),
+  nodes: [],
+  minAngleDeg: -2,
+  maxAngleDeg: 3,
+  radiusPolicyKm: 50,
+  coverageCenterDeg: 180,
+  coverageSpanDeg: 360,
+});
+
+describe("composePanoramaWindow", () => {
+  it("stitches base edges with detail center coverage", () => {
+    const base = mkPanorama([0, 30, 60, 90, 120, 150, 180, 210, 240, 270, 300, 330]);
+    const detail = mkPanorama([120, 130, 140, 150, 160, 170, 180, 190, 200, 210, 220, 230, 240]);
+    const result = composePanoramaWindow({
+      basePanorama: base,
+      detailPanorama: detail,
+      centerDeg: 180,
+      startDeg: 60,
+      endDeg: 300,
+    });
+
+    expect(result.rays.length).toBeGreaterThan(0);
+    expect(result.segments.some((segment) => segment.source === "detail")).toBe(true);
+    const first = result.rays[0];
+    const last = result.rays[result.rays.length - 1];
+    expect(first.source).toBe("base");
+    expect(last.source).toBe("base");
+    expect(result.rays.some((entry) => entry.source === "detail")).toBe(true);
+  });
+
+  it("covers full window with base when no detail is available", () => {
+    const base = mkPanorama([0, 90, 180, 270]);
+    const result = composePanoramaWindow({
+      basePanorama: base,
+      detailPanorama: null,
+      centerDeg: 180,
+      startDeg: 0,
+      endDeg: 360,
+    });
+    expect(result.segments).toEqual([{ source: "base", startDeg: 0, endDeg: 360 }]);
+    expect(result.rays.every((entry) => entry.source === "base")).toBe(true);
+  });
+
+  it("produces contiguous segment coverage when base is present", () => {
+    const base = mkPanorama([0, 60, 120, 180, 240, 300]);
+    const detail = mkPanorama([140, 160, 180, 200, 220]);
+    const result = composePanoramaWindow({
+      basePanorama: base,
+      detailPanorama: detail,
+      centerDeg: 180,
+      startDeg: 60,
+      endDeg: 300,
+    });
+    const first = result.segments[0];
+    const last = result.segments[result.segments.length - 1];
+    expect(first?.startDeg).toBeCloseTo(60);
+    expect(last?.endDeg).toBeCloseTo(300);
+    for (let i = 1; i < result.segments.length; i += 1) {
+      expect(result.segments[i - 1].endDeg).toBeCloseTo(result.segments[i].startDeg);
+    }
+  });
+});

--- a/src/lib/panoramaCompose.ts
+++ b/src/lib/panoramaCompose.ts
@@ -1,0 +1,72 @@
+import { unwrapAzimuthForWindow } from "./panoramaView";
+import type { PanoramaRay, PanoramaResult } from "./panorama";
+
+export type PanoramaComposedRay = {
+  ray: PanoramaRay;
+  xValue: number;
+  source: "base" | "detail";
+};
+
+export type PanoramaCoverageSegment = {
+  source: "base" | "detail";
+  startDeg: number;
+  endDeg: number;
+};
+
+const inWindow = (value: number, start: number, end: number): boolean => value >= start && value <= end;
+
+const mapVisible = (rays: PanoramaRay[], centerDeg: number, startDeg: number, endDeg: number): Array<{ ray: PanoramaRay; xValue: number }> =>
+  rays
+    .map((ray) => {
+      const xValue = unwrapAzimuthForWindow(ray.azimuthDeg, centerDeg);
+      return { ray, xValue };
+    })
+    .filter((entry) => inWindow(entry.xValue, startDeg, endDeg))
+    .sort((a, b) => a.xValue - b.xValue);
+
+export const composePanoramaWindow = (params: {
+  basePanorama: PanoramaResult | null;
+  detailPanorama: PanoramaResult | null;
+  centerDeg: number;
+  startDeg: number;
+  endDeg: number;
+}): { rays: PanoramaComposedRay[]; segments: PanoramaCoverageSegment[] } => {
+  const { basePanorama, detailPanorama, centerDeg, startDeg, endDeg } = params;
+  const baseVisible = basePanorama ? mapVisible(basePanorama.rays, centerDeg, startDeg, endDeg) : [];
+  const detailVisible = detailPanorama ? mapVisible(detailPanorama.rays, centerDeg, startDeg, endDeg) : [];
+
+  if (!detailVisible.length) {
+    return {
+      rays: baseVisible.map((entry) => ({ ...entry, source: "base" as const })),
+      segments: baseVisible.length ? [{ source: "base", startDeg, endDeg }] : [],
+    };
+  }
+
+  if (!baseVisible.length) {
+    const start = detailVisible[0]?.xValue ?? startDeg;
+    const end = detailVisible[detailVisible.length - 1]?.xValue ?? endDeg;
+    return {
+      rays: detailVisible.map((entry) => ({ ...entry, source: "detail" as const })),
+      segments: [{ source: "detail", startDeg: start, endDeg: end }],
+    };
+  }
+
+  const detailStart = detailVisible[0]?.xValue ?? startDeg;
+  const detailEnd = detailVisible[detailVisible.length - 1]?.xValue ?? endDeg;
+
+  const leftBase = baseVisible.filter((entry) => entry.xValue < detailStart);
+  const rightBase = baseVisible.filter((entry) => entry.xValue > detailEnd);
+  const rays: PanoramaComposedRay[] = [
+    ...leftBase.map((entry) => ({ ...entry, source: "base" as const })),
+    ...detailVisible.map((entry) => ({ ...entry, source: "detail" as const })),
+    ...rightBase.map((entry) => ({ ...entry, source: "base" as const })),
+  ];
+
+  const segments: PanoramaCoverageSegment[] = [];
+  if (leftBase.length) segments.push({ source: "base", startDeg, endDeg: detailStart });
+  segments.push({ source: "detail", startDeg: detailStart, endDeg: detailEnd });
+  if (rightBase.length) segments.push({ source: "base", startDeg: detailEnd, endDeg });
+
+  return { rays, segments };
+};
+

--- a/src/lib/panoramaRender.test.ts
+++ b/src/lib/panoramaRender.test.ts
@@ -45,6 +45,8 @@ describe("panoramaRender", () => {
     expect(bands).toHaveLength(2);
     expect(bands[1].lineSegments).toHaveLength(1);
     expect(bands[1].lineSegments[0]).toContain("M60.00,4.00 L90.00,5.00");
+    expect(bands[1].fillSegments).toHaveLength(1);
+    expect(bands[1].fillSegments[0]).toHaveLength(2);
   });
 
   it("snaps each depth band to local ridge candidates while preserving distance order", () => {

--- a/src/lib/panoramaRender.ts
+++ b/src/lib/panoramaRender.ts
@@ -12,6 +12,7 @@ export type PanoramaDepthBand = {
   depthRatio: number;
   points: PanoramaDepthPoint[];
   lineSegments: string[];
+  fillSegments: PanoramaDepthPoint[][];
 };
 
 export type PanoramaBandSelectionOptions = {
@@ -51,6 +52,21 @@ const visibleLineSegments = (points: PanoramaDepthPoint[], visibleMask: boolean[
   }
   if (run.length >= 2) segments.push(linePath(run));
   return segments;
+};
+
+const visiblePointRuns = (points: PanoramaDepthPoint[], visibleMask: boolean[]): PanoramaDepthPoint[][] => {
+  const runs: PanoramaDepthPoint[][] = [];
+  let run: PanoramaDepthPoint[] = [];
+  for (let i = 0; i < points.length; i += 1) {
+    if (!visibleMask[i]) {
+      if (run.length >= 2) runs.push(run);
+      run = [];
+      continue;
+    }
+    run.push(points[i]);
+  }
+  if (run.length >= 2) runs.push(run);
+  return runs;
 };
 
 export const depthStyleForBand = (bandIndex: number, bandCount: number): PanoramaDepthStyle => {
@@ -153,6 +169,7 @@ export const buildDepthBands = (
   return rawBands.map((band, bandIndex) => ({
     ...band,
     lineSegments: visibleLineSegments(band.points, visibility[bandIndex]),
+    fillSegments: visiblePointRuns(band.points, visibility[bandIndex]),
   }));
 };
 


### PR DESCRIPTION
## Summary\n- replace panorama whole-chart detail/base switching with stitched composition (detail center + base-only edges)\n- preserve detail during window shifts to prevent flicker and edge blanking under fast panning\n- extend depth-band occlusion to fill geometry (segmented fill runs) to prevent background terrain bleed-through\n- introduce shared  wrapper and apply it to panorama popovers, map control pill, and attribution pill\n- add Lines popover telemetry for nearest/furthest rendered line distance ranges\n\n## Verification\n- npm test\n- npm run build\n