### PR TITLE
Issue 101: LOS-only labels and shading-only panorama

### DIFF
--- a/functions/_lib/buildInfo.ts
+++ b/functions/_lib/buildInfo.ts
@@ -1,5 +1,5 @@
 export const APP_VERSION = "0.15.0";
-export const APP_COMMIT = "c6140f35";
+export const APP_COMMIT = "5bda0efc";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {

--- a/src/components/PanoramaChart.tsx
+++ b/src/components/PanoramaChart.tsx
@@ -19,7 +19,8 @@ import {
 } from "../lib/panorama";
 import { composePanoramaWindow } from "../lib/panoramaCompose";
 import { resolveVisiblePanoramaLabels, type PanoramaLabelCandidate } from "../lib/panoramaLabels";
-import { queryPanoramaPeaks } from "../lib/panoramaPeaks";
+import { loadPanoramaPeaks, type PanoramaPeakCandidate } from "../lib/panoramaPeaks";
+import { isPeakLosVisible, nearestSampleForDistance } from "../lib/panoramaLos";
 import { buildDepthBands, buildNearBiasedDepthFractions, depthStyleForBand, resolveRenderedEndpoint } from "../lib/panoramaRender";
 import { cardinalLabelForAzimuth, formatAzimuthTick, fovScaleToSpanDeg, mod360, normalizeFovScale, resolvePanoramaWindow, unwrapAzimuthForWindow } from "../lib/panoramaView";
 import { centerForScaledWindow } from "../lib/panoramaViewport";
@@ -29,6 +30,7 @@ import { useAppStore } from "../store/appStore";
 import { UiSlider } from "./UiSlider";
 
 const M = { t: 22, r: 20, b: 32, l: 46 };
+const LABEL_RAIL_HEIGHT = 34;
 const clamp = (value: number, min: number, max: number): number => Math.max(min, Math.min(max, value));
 
 type PanoramaChartProps = {
@@ -83,6 +85,7 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
   const [openSliderPopover, setOpenSliderPopover] = useState<"fov" | "vertical" | "lines" | null>(null);
   const [sliderPopoverPos, setSliderPopoverPos] = useState<{ left: number; top: number; direction: "up" | "down" } | null>(null);
   const [lineSampleCount, setLineSampleCount] = useState(10);
+  const [peakCandidates, setPeakCandidates] = useState<PanoramaPeakCandidate[]>([]);
 
   const sites = useAppStore((state) => state.sites);
   const links = useAppStore((state) => state.links);
@@ -177,6 +180,7 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
   const detailContextRef = useRef<string>("");
   const [basePanorama, setBasePanorama] = useState<PanoramaResult | null>(null);
   const [detailPanoramas, setDetailPanoramas] = useState<PanoramaResult[]>([]);
+  const terrainClipId = useMemo(() => `panorama-terrain-clip-${Math.random().toString(36).slice(2, 11)}`, []);
 
   const selectedSiteEffective = useMemo(() => {
     if (!selectedSite) return null;
@@ -234,6 +238,31 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
     setPinnedTarget(null);
     setHoverTarget(null);
   }, [selectedSiteEffective?.id]);
+
+  useEffect(() => {
+    if (!selectedSiteEffective || !chartSize) {
+      setPeakCandidates([]);
+      return;
+    }
+    let cancelled = false;
+    const spanDeg = viewportSpanDeg;
+    const centerBucketDeg = Math.max(0.5, Math.round(spanDeg / 12));
+    const centerDeg = Math.round(viewportCenterAzimuthDeg / centerBucketDeg) * centerBucketDeg;
+    const window = resolvePanoramaWindow(centerDeg, spanDeg);
+    void loadPanoramaPeaks({
+      origin: selectedSiteEffective.position,
+      centerDeg,
+      startDeg: window.startDeg,
+      endDeg: window.endDeg,
+      maxDistanceKm: 500,
+      limit: 3200,
+    }).then((peaks) => {
+      if (!cancelled) setPeakCandidates(peaks);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedSiteEffective, chartSize, viewportCenterAzimuthDeg, viewportSpanDeg]);
 
   useEffect(() => {
     if (!selectedSiteEffective || !selectedNetwork) {
@@ -446,8 +475,6 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
     [basePanorama, detailPanoramas, xWindow],
   );
 
-  const terrainFillGradientId = useMemo(() => `profile-terrain-fill-${Math.random().toString(36).slice(2, 11)}`, []);
-
   const geometry = useMemo(() => {
     if (!panorama || !chartSize || !panorama.rays.length) return null;
     const anchorPanorama = basePanorama && basePanorama.rays.length ? basePanorama : panorama;
@@ -457,6 +484,8 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
     const xSpan = Math.max(0.001, xDomainEnd - xDomainStart);
     const x = scaleLinear().domain([xDomainStart, xDomainEnd]).range([M.l, chartWidth - M.r]);
     const xCenterForUnwrap = xWindow.centerDeg;
+    const plotTop = M.t + LABEL_RAIL_HEIGHT;
+    const plotBottom = chartHeight - M.b;
 
     const visibleRays = composedWindow.rays
       .map((entry) => ({ ray: entry.ray, xValue: entry.xValue, source: entry.source }))
@@ -470,7 +499,7 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
     const maxSampleAngle = Math.max(...anchorPanorama.rays.flatMap((ray) => ray.samples.map((sample) => sample.angleDeg)));
 
     const innerWidth = Math.max(1, chartWidth - M.l - M.r);
-    const innerHeight = Math.max(1, chartHeight - M.t - M.b);
+    const innerHeight = Math.max(1, plotBottom - plotTop);
     const horizonPad = 0.5;
 
     const fitMin = minHorizon - horizonPad;
@@ -492,7 +521,7 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
       domainMax = panorama.maxAngleDeg;
     }
 
-    const y = scaleLinear().domain([domainMin, domainMax]).range([chartHeight - M.b, M.t]);
+    const y = scaleLinear().domain([domainMin, domainMax]).range([plotBottom, plotTop]);
 
     const toPath = (points: { x: number; y: number }[]): string =>
       points.map((point, index) => `${index === 0 ? "M" : "L"}${point.x.toFixed(2)},${point.y.toFixed(2)}`).join(" ");
@@ -561,29 +590,11 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
       flush();
       return paths;
     };
-    const ridgeBands = depthBands.map((band, bandIndex, all) => {
-      const stripPaths =
-        bandIndex < all.length - 1
-          ? toStripFillPaths(depthBands, bandIndex, bandIndex + 1)
-          : band.fillSegments.map(
-              (segment) =>
-                `${toPath(segment)} L${segment[segment.length - 1].x.toFixed(2)},${(chartHeight - M.b).toFixed(2)} L${segment[0].x.toFixed(2)},${(chartHeight - M.b).toFixed(2)} Z`,
-            );
-      const topCapPaths =
-        bandIndex === 0
-          ? band.fillSegments.map(
-              (segment) =>
-                `${toPath(segment)} L${segment[segment.length - 1].x.toFixed(2)},${(chartHeight - M.b).toFixed(2)} L${segment[0].x.toFixed(2)},${(chartHeight - M.b).toFixed(2)} Z`,
-            )
-          : [];
-      return {
-        key: `ridge-${bandIndex}`,
-        style: depthStyleForBand(bandIndex, all.length),
-        isBaseFill: bandIndex === all.length - 1,
-        lineSegments: band.lineSegments,
-        fillPaths: [...stripPaths, ...topCapPaths],
-      };
-    });
+    const ridgeBands = depthBands.map((band, bandIndex, all) => ({
+      key: `ridge-${bandIndex}`,
+      style: depthStyleForBand(bandIndex, all.length),
+      lineSegments: band.lineSegments,
+    }));
     const sampleDrivenBandCount = Math.min(
       20,
       Math.max(8, Math.round((visibleRays[0]?.ray.samples.length ?? 64) / 10)),
@@ -637,10 +648,10 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
         }
         const slopeNorm = slopeSamples > 0 ? Math.min(1.4, (avgSlopeDeg / slopeSamples) * 4.2) : 0;
         const curvatureNorm = slopeSamples > 0 ? Math.min(1.4, (avgCurvatureDeg / slopeSamples) * 5.1) : 0;
-        const baseAlpha = 0.03 + depthNearFactor * 0.11;
-        const reliefAlpha = slopeNorm * 0.07 + curvatureNorm * 0.06;
-        const nearBoost = Math.min(0.06, pxPerDeg * 0.0022);
-        const alpha = Math.min(0.34, baseAlpha + reliefAlpha + nearBoost);
+        const baseAlpha = 0.12 + depthNearFactor * 0.2;
+        const reliefAlpha = slopeNorm * 0.14 + curvatureNorm * 0.12;
+        const nearBoost = Math.min(0.14, pxPerDeg * 0.0038);
+        const alpha = Math.min(0.72, baseAlpha + reliefAlpha + nearBoost);
         return paths.map((path) => ({ path, alpha }));
       });
     const clutterBasePoints = depthBands[depthBands.length - 1]?.points.map((point) => ({ x: point.x, y: point.y })) ?? clutterPoints;
@@ -671,18 +682,15 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
           cy: y(node.elevationAngleDeg),
         };
       })
-      .filter((entry) => entry.xValue >= xDomainStart && entry.xValue <= xDomainEnd);
+      .filter((entry) => entry.xValue >= xDomainStart && entry.xValue <= xDomainEnd)
+      .filter((entry) => {
+        if (entry.node.id.startsWith("sim:")) return true;
+        if (entry.node.id.startsWith("lib:") || entry.node.id.startsWith("mqtt:")) return entry.node.visible;
+        return true;
+      });
 
-    const peakCandidates = selectedSiteEffective
-      ? queryPanoramaPeaks({
-          origin: selectedSiteEffective.position,
-          centerDeg: xCenterForUnwrap,
-          startDeg: xDomainStart,
-          endDeg: xDomainEnd,
-          maxDistanceKm: 600,
-          limit: 2200,
-        })
-      : [];
+    const kFactor = Math.max(0.5, 1 + (propagationEnvironment.atmosphericBendingNUnits - 250) / 153);
+    const sourceAbsM = selectedSiteEffective ? selectedSiteEffective.groundElevationM + selectedSiteEffective.antennaHeightM : 0;
     const peakLabels = peakCandidates
       .map((peak) => {
         const xValue = unwrapAzimuthForWindow(peak.azimuthDeg, xCenterForUnwrap);
@@ -695,15 +703,15 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
           },
           { entry: visibleRays[0], dist: Number.POSITIVE_INFINITY },
         ).entry.ray;
-        const sample =
-          nearestRay.samples.reduce(
-            (best, item) => {
-              const dist = Math.abs(item.distanceKm - peak.distanceKm);
-              if (dist < best.dist) return { item, dist };
-              return best;
-            },
-            { item: nearestRay.samples[nearestRay.samples.length - 1] ?? null, dist: Number.POSITIVE_INFINITY },
-          ).item ?? null;
+        const sample = nearestSampleForDistance(nearestRay.samples, peak.distanceKm);
+        const visibleLos = isPeakLosVisible({
+          samples: nearestRay.samples,
+          distanceKm: peak.distanceKm,
+          peakElevationM: peak.elevationM,
+          sourceAbsM,
+          kFactor,
+        });
+        if (!visibleLos) return null;
         const yAngle = sample?.angleDeg ?? nearestRay.horizonAngleDeg;
         return {
           id: `peak:${peak.id}`,
@@ -732,7 +740,7 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
           chartWidth,
           leftPadding: M.l,
           rightPadding: M.r,
-          topY: M.t + 2,
+          topY: M.t + 4,
         })
       : [];
 
@@ -747,6 +755,8 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
       x,
       xWindow,
       y,
+      plotTop,
+      plotBottom,
       clutterPath: includeClutter ? toPath(clutterPoints) : "",
       clutterAreaPath,
       ridgeBands,
@@ -777,6 +787,8 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
     includeClutter,
     lineSampleCount,
     selectedSiteEffective,
+    peakCandidates,
+    propagationEnvironment.atmosphericBendingNUnits,
     showLabels,
   ]);
 
@@ -957,7 +969,7 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
     const xNorm = clamp((event.clientX - rect.left) / rect.width, 0, 1);
     const yNorm = clamp((event.clientY - rect.top) / rect.height, 0, 1);
     const xPx = M.l + xNorm * (chartWidth - M.l - M.r);
-    const yPx = M.t + yNorm * (chartHeight - M.t - M.b);
+    const yPx = geometry.plotTop + yNorm * (chartHeight - geometry.plotTop - M.b);
 
     const unwrapped = geometry.x.invert(xPx);
     const azimuth = mod360(unwrapped);
@@ -1312,11 +1324,48 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
           <>
             <svg aria-label="Panorama" height={chartHeight} role="img" width={chartWidth}>
               <defs>
-                <linearGradient id={terrainFillGradientId} x1="0" x2="0" y1="0" y2="1">
-                  <stop offset="0%" stopColor="color-mix(in srgb, var(--terrain) 70%, var(--accent) 30%)" stopOpacity="0.86" />
-                  <stop offset="100%" stopColor="color-mix(in srgb, var(--terrain) 18%, var(--surface-2) 82%)" stopOpacity="0.22" />
-                </linearGradient>
+                <clipPath id={terrainClipId}>
+                  <rect x={M.l} y={geometry.plotTop} width={chartWidth - M.l - M.r} height={geometry.plotBottom - geometry.plotTop} />
+                </clipPath>
               </defs>
+
+              <g clipPath={`url(#${terrainClipId})`}>
+                {geometry.sampleShadePaths.map((shadePath, shadeIndex) => (
+                  <path
+                    className="panorama-shade-band"
+                    d={shadePath.path}
+                    key={`shade-${shadeIndex}`}
+                    style={{ opacity: shadePath.alpha }}
+                  />
+                ))}
+                {geometry.ridgeBands.map((band) => (
+                  <g key={band.key}>
+                    {band.lineSegments.map((segment, segmentIndex) => (
+                      <path
+                        className="panorama-ridge-line"
+                        d={segment}
+                        key={`${band.key}-segment-${segmentIndex}`}
+                        style={{
+                          strokeWidth: band.style.strokeWidth,
+                          strokeOpacity: band.style.strokeOpacity,
+                          stroke: `color-mix(in srgb, var(--terrain) ${band.style.strokeMixTerrainPct}%, var(--muted) ${band.style.strokeMixMutedPct}%)`,
+                        }}
+                      />
+                    ))}
+                  </g>
+                ))}
+                {includeClutter && geometry.clutterAreaPath ? <path className="panorama-clutter-haze" d={geometry.clutterAreaPath} /> : null}
+                {includeClutter && geometry.clutterPath ? <path className="panorama-clutter-line" d={geometry.clutterPath} /> : null}
+                {geometry.nodes.map((node) => (
+                  <circle
+                    key={node.node.id}
+                    className={`panorama-node panorama-node-${node.node.state} ${node.node.visible ? "is-visible" : "is-hidden"}`}
+                    cx={node.cx}
+                    cy={node.cy}
+                    r={3.2}
+                  />
+                ))}
+              </g>
 
               {geometry.ticksY.map((value) => (
                 <g className="chart-grid" key={`y-${value.toFixed(2)}`}>
@@ -1329,61 +1378,11 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
 
               {geometry.ticksX.map((value) => (
                 <g className="chart-grid" key={`x-${value.toFixed(2)}`}>
-                  <line x1={geometry.x(value)} x2={geometry.x(value)} y1={M.t} y2={chartHeight - M.b} />
+                  <line x1={geometry.x(value)} x2={geometry.x(value)} y1={geometry.plotTop} y2={chartHeight - M.b} />
                   <text textAnchor="middle" x={geometry.x(value)} y={chartHeight - 8}>
                     {formatAzimuthTick(value)}
                   </text>
                 </g>
-              ))}
-
-              {geometry.sampleShadePaths.map((shadePath, shadeIndex) => (
-                <path
-                  className="panorama-shade-band"
-                  d={shadePath.path}
-                  key={`shade-${shadeIndex}`}
-                  style={{ opacity: shadePath.alpha }}
-                />
-              ))}
-              {geometry.ridgeBands.map((band) => (
-                <g key={band.key}>
-                  {band.fillPaths.map((fillPath, fillIndex) => (
-                    <path
-                      className="panorama-ridge-band"
-                      d={fillPath}
-                      key={`${band.key}-fill-${fillIndex}`}
-                      style={{
-                        opacity: band.style.fillOpacity + (band.isBaseFill ? 0.08 : 0),
-                        fill: band.isBaseFill
-                          ? `url(#${terrainFillGradientId})`
-                          : `color-mix(in srgb, var(--terrain) ${band.style.strokeMixTerrainPct}%, var(--surface-2) 55%)`,
-                      }}
-                    />
-                  ))}
-                  {band.lineSegments.map((segment, segmentIndex) => (
-                    <path
-                      className="panorama-ridge-line"
-                      d={segment}
-                      key={`${band.key}-segment-${segmentIndex}`}
-                      style={{
-                        strokeWidth: band.style.strokeWidth,
-                        strokeOpacity: band.style.strokeOpacity,
-                        stroke: `color-mix(in srgb, var(--terrain) ${band.style.strokeMixTerrainPct}%, var(--muted) ${band.style.strokeMixMutedPct}%)`,
-                      }}
-                    />
-                  ))}
-                </g>
-              ))}
-              {includeClutter && geometry.clutterAreaPath ? <path className="panorama-clutter-haze" d={geometry.clutterAreaPath} /> : null}
-              {includeClutter && geometry.clutterPath ? <path className="panorama-clutter-line" d={geometry.clutterPath} /> : null}
-
-              {geometry.nodes.map((node) => (
-                <circle
-                  key={node.node.id}
-                  className={`panorama-node panorama-node-${node.node.state} ${node.node.visible ? "is-visible" : "is-hidden"}`}
-                  cx={node.cx}
-                  cy={node.cy}
-                  r={3.2}
-                />
               ))}
               {geometry.labels.map((label) => (
                 <g className="panorama-label-layer" key={label.id}>
@@ -1404,7 +1403,7 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
                   className="profile-cursor"
                   x1={geometry.x(unwrapAzimuthForWindow(activeRay.azimuthDeg, focusAzimuthDeg))}
                   x2={geometry.x(unwrapAzimuthForWindow(activeRay.azimuthDeg, focusAzimuthDeg))}
-                  y1={M.t}
+                  y1={geometry.plotTop}
                   y2={chartHeight - M.b}
                 />
               ) : null}
@@ -1412,9 +1411,9 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
               <rect
                 className="profile-hitbox"
                 x={M.l}
-                y={M.t}
+                y={geometry.plotTop}
                 width={chartWidth - M.l - M.r}
-                height={chartHeight - M.t - M.b}
+                height={chartHeight - geometry.plotTop - M.b}
                 onClick={onClick}
                 onMouseLeave={onLeave}
                 onMouseMove={onMove}

--- a/src/index.css
+++ b/src/index.css
@@ -2121,7 +2121,9 @@ input {
 }
 
 .ui-slider-vertical {
-  flex-direction: column;
+  display: grid;
+  grid-template-rows: auto auto auto;
+  justify-items: center;
   align-items: center;
   gap: 10px;
   width: 92px;
@@ -2175,7 +2177,7 @@ input {
 }
 
 .panorama-shade-band {
-  fill: color-mix(in srgb, var(--terrain) 58%, var(--surface-2) 42%);
+  fill: color-mix(in srgb, var(--terrain) 72%, var(--surface-2) 28%);
 }
 
 @keyframes panorama-popover-rise {
@@ -2322,13 +2324,9 @@ html.panorama-gesture-lock body {
   stroke-linejoin: round;
 }
 
-.panorama-ridge-band {
-  fill: color-mix(in srgb, var(--terrain) 64%, var(--surface-2) 36%);
-}
-
 .panorama-ridge-line {
   fill: none;
-  stroke: color-mix(in srgb, var(--terrain) 66%, var(--text) 34%);
+  stroke: color-mix(in srgb, var(--terrain) 74%, var(--text) 26%);
   stroke-width: 1.1;
 }
 

--- a/src/lib/buildInfo.ts
+++ b/src/lib/buildInfo.ts
@@ -1,5 +1,5 @@
 export const APP_VERSION = "0.15.0";
-export const APP_COMMIT = "c6140f35";
+export const APP_COMMIT = "5bda0efc";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {

--- a/src/lib/panoramaLos.test.ts
+++ b/src/lib/panoramaLos.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { isPeakLosVisible, maxTerrainAngleBeforeDistance, nearestSampleForDistance, peakElevationAngleDeg } from "./panoramaLos";
+import type { PanoramaRaySample } from "./panorama";
+
+const mkSamples = (angles: number[]): PanoramaRaySample[] =>
+  angles.map((angleDeg, index) => ({
+    distanceKm: index + 1,
+    lat: 60,
+    lon: 10,
+    terrainM: 100 + index,
+    angleDeg,
+    clutterAngleDeg: angleDeg,
+    maxAngleBeforeDeg: index === 0 ? Number.NEGATIVE_INFINITY : Math.max(...angles.slice(0, index)),
+  }));
+
+describe("panoramaLos", () => {
+  it("returns max terrain angle before a target distance", () => {
+    const samples = mkSamples([-1.4, -0.8, 1.2, 0.4]);
+    expect(maxTerrainAngleBeforeDistance(samples, 3)).toBeCloseTo(-0.8, 5);
+    expect(maxTerrainAngleBeforeDistance(samples, 4)).toBeCloseTo(1.2, 5);
+  });
+
+  it("returns nearest sample for a distance", () => {
+    const samples = mkSamples([-1, 0.2, 1.5, 0.8]);
+    expect(nearestSampleForDistance(samples, 2.1)?.distanceKm).toBe(2);
+    expect(nearestSampleForDistance(samples, 2.7)?.distanceKm).toBe(3);
+  });
+
+  it("computes peak elevation angle with curvature", () => {
+    const noCurvature = peakElevationAngleDeg({ sourceAbsM: 500, peakElevationM: 1500, distanceKm: 10, kFactor: 10 });
+    const withCurvature = peakElevationAngleDeg({ sourceAbsM: 500, peakElevationM: 1500, distanceKm: 10, kFactor: 1 });
+    expect(withCurvature).toBeLessThan(noCurvature);
+  });
+
+  it("flags peaks as visible only when above terrain obstruction envelope", () => {
+    const samples = mkSamples([-0.8, 0.6, 1.8, 1.2, 0.4]);
+    const visible = isPeakLosVisible({
+      samples,
+      distanceKm: 5,
+      peakElevationM: 2200,
+      sourceAbsM: 400,
+      kFactor: 1,
+    });
+    const blocked = isPeakLosVisible({
+      samples,
+      distanceKm: 5,
+      peakElevationM: 450,
+      sourceAbsM: 400,
+      kFactor: 1,
+    });
+    expect(visible).toBe(true);
+    expect(blocked).toBe(false);
+  });
+});

--- a/src/lib/panoramaLos.ts
+++ b/src/lib/panoramaLos.ts
@@ -1,0 +1,61 @@
+import { earthCurvatureDropM, type PanoramaRaySample } from "./panorama";
+
+const toDegrees = (rad: number): number => (rad * 180) / Math.PI;
+
+export const maxTerrainAngleBeforeDistance = (samples: PanoramaRaySample[], distanceKm: number): number => {
+  if (!samples.length || distanceKm <= 0) return Number.NEGATIVE_INFINITY;
+  let maxBefore = Number.NEGATIVE_INFINITY;
+  for (const sample of samples) {
+    if (sample.distanceKm >= distanceKm) break;
+    maxBefore = Math.max(maxBefore, sample.angleDeg);
+  }
+  return maxBefore;
+};
+
+export const nearestSampleForDistance = (samples: PanoramaRaySample[], distanceKm: number): PanoramaRaySample | null => {
+  if (!samples.length) return null;
+  let best = samples[0];
+  let bestDist = Math.abs(best.distanceKm - distanceKm);
+  for (let i = 1; i < samples.length; i += 1) {
+    const sample = samples[i];
+    const dist = Math.abs(sample.distanceKm - distanceKm);
+    if (dist < bestDist) {
+      best = sample;
+      bestDist = dist;
+    }
+  }
+  return best;
+};
+
+export const peakElevationAngleDeg = (params: {
+  sourceAbsM: number;
+  peakElevationM: number;
+  distanceKm: number;
+  kFactor: number;
+}): number => {
+  const { sourceAbsM, peakElevationM, distanceKm, kFactor } = params;
+  const distanceM = Math.max(1, distanceKm * 1000);
+  const dropM = earthCurvatureDropM(distanceKm, kFactor);
+  const relativeM = peakElevationM - sourceAbsM - dropM;
+  return toDegrees(Math.atan2(relativeM, distanceM));
+};
+
+export const isPeakLosVisible = (params: {
+  samples: PanoramaRaySample[];
+  distanceKm: number;
+  peakElevationM: number | null;
+  sourceAbsM: number;
+  kFactor: number;
+}): boolean => {
+  const { samples, distanceKm, peakElevationM, sourceAbsM, kFactor } = params;
+  if (!Number.isFinite(distanceKm) || distanceKm <= 0 || peakElevationM == null) return false;
+  const terrainBeforeDeg = maxTerrainAngleBeforeDistance(samples, distanceKm);
+  if (!Number.isFinite(terrainBeforeDeg)) return false;
+  const targetAngleDeg = peakElevationAngleDeg({
+    sourceAbsM,
+    peakElevationM,
+    distanceKm,
+    kFactor,
+  });
+  return targetAngleDeg > terrainBeforeDeg;
+};

--- a/src/lib/panoramaPeaks.test.ts
+++ b/src/lib/panoramaPeaks.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "vitest";
-import { OPEN_PEAK_MAP_STATS, queryPanoramaPeaks } from "./panoramaPeaks";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { OPEN_PEAK_MAP_STATS, loadPanoramaPeaks, queryPanoramaPeaks } from "./panoramaPeaks";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("open peak index", () => {
   it("loads a full local summit dataset", () => {
@@ -30,5 +34,41 @@ describe("queryPanoramaPeaks", () => {
       maxDistanceKm: 120,
     });
     expect(peaks.every((peak) => peak.azimuthDeg >= 45 && peak.azimuthDeg <= 135)).toBe(true);
+  });
+});
+
+describe("loadPanoramaPeaks", () => {
+  it("dedupes concurrent tile fetches and returns candidates", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({ elements: [] }), { status: 200, headers: { "content-type": "application/json" } }));
+
+    const params = {
+      origin: { lat: 61.6601, lon: 8.2998 },
+      centerDeg: 180,
+      startDeg: 90,
+      endDeg: 270,
+      maxDistanceKm: 4,
+      limit: 100,
+    } as const;
+
+    const [a, b] = await Promise.all([loadPanoramaPeaks(params), loadPanoramaPeaks(params)]);
+    expect(a).toEqual(b);
+    expect(fetchMock).toHaveBeenCalled();
+    // Multiple tile keys are expected, but concurrent queries should share the same in-flight tile requests.
+    expect(fetchMock.mock.calls.length).toBeLessThan(12);
+  });
+
+  it("falls back to local index when tile loading fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("offline"));
+    const peaks = await loadPanoramaPeaks({
+      origin: { lat: 61.64, lon: 8.31 },
+      centerDeg: 180,
+      startDeg: -180,
+      endDeg: 180,
+      maxDistanceKm: 80,
+      limit: 200,
+    });
+    expect(peaks.length).toBeGreaterThan(0);
   });
 });

--- a/src/lib/panoramaPeaks.ts
+++ b/src/lib/panoramaPeaks.ts
@@ -11,21 +11,60 @@ export type PanoramaPeakCandidate = {
   elevationM: number | null;
   azimuthDeg: number;
   distanceKm: number;
+  source: "local-index" | "overpass-tile";
+};
+
+export type PanoramaPeakTileMeta = {
+  tileId: string;
+  version: string;
+  fetchedAt: number;
+  ttlMs: number;
+  bounds: { south: number; west: number; north: number; east: number };
+  source: "overpass";
+};
+
+export type PanoramaPeakTileEntry = {
+  id: string;
+  name: string;
+  lat: number;
+  lon: number;
+  elevationM: number | null;
+  source: "overpass-tile";
 };
 
 type PeakIndex = Map<string, OpenPeakMapIndexEntry[]>;
+type TilePayload = { meta: PanoramaPeakTileMeta; entries: PanoramaPeakTileEntry[] };
+
+const OVERPASS_URL = "https://overpass-api.de/api/interpreter";
+const TILE_DEG = 0.5;
+const TILE_CACHE_VERSION = "v2";
+const TILE_TTL_MS = 1000 * 60 * 60 * 24 * 30;
+const CACHE_NAME = "panorama-peak-tiles-v2";
+const CACHE_PATH_PREFIX = "/__panorama_peak_tiles_v2__/";
+const MAX_TILE_FETCH = 96;
+
+const memoryTileCache = new Map<string, TilePayload>();
+const pendingTileFetches = new Map<string, Promise<TilePayload>>();
 
 const clamp = (value: number, min: number, max: number): number => Math.max(min, Math.min(max, value));
 
 const bucketLat = (lat: number): number => Math.floor(lat);
 const bucketLon = (lon: number): number => Math.floor(lon);
 const bucketKey = (latBucket: number, lonBucket: number): string => `${latBucket}:${lonBucket}`;
+const tileIndex = (value: number): number => Math.floor(value / TILE_DEG);
+
+const tileBoundsFromKey = (key: string): { south: number; west: number; north: number; east: number } => {
+  const [latToken, lonToken] = key.split(":");
+  const lat = Number(latToken);
+  const lon = Number(lonToken);
+  const south = lat * TILE_DEG;
+  const west = lon * TILE_DEG;
+  return { south, west, north: south + TILE_DEG, east: west + TILE_DEG };
+};
 
 const PEAK_INDEX: PeakIndex = (() => {
   const next: PeakIndex = new Map();
-  for (const [key, entries] of Object.entries(OPEN_PEAK_MAP_INDEX_BUCKETS)) {
-    next.set(key, entries);
-  }
+  for (const [key, entries] of Object.entries(OPEN_PEAK_MAP_INDEX_BUCKETS)) next.set(key, entries);
   return next;
 })();
 
@@ -40,17 +79,33 @@ const inWindow = (azimuthDeg: number, centerDeg: number, startDeg: number, endDe
   return unwrapped >= startDeg && unwrapped <= endDeg;
 };
 
-export const queryPanoramaPeaks = (params: {
+const resolveTileKeysForRadius = (origin: { lat: number; lon: number }, maxDistanceKm: number): string[] => {
+  const latRadiusDeg = clamp(maxDistanceKm / 111, 0.1, 12);
+  const lonScale = Math.max(0.2, Math.cos((origin.lat * Math.PI) / 180));
+  const lonRadiusDeg = clamp(maxDistanceKm / (111 * lonScale), 0.1, 18);
+  const minLatTile = tileIndex(origin.lat - latRadiusDeg);
+  const maxLatTile = tileIndex(origin.lat + latRadiusDeg);
+  const minLonTile = tileIndex(origin.lon - lonRadiusDeg);
+  const maxLonTile = tileIndex(origin.lon + lonRadiusDeg);
+  const keys: string[] = [];
+  for (let latTile = minLatTile; latTile <= maxLatTile; latTile += 1) {
+    for (let lonTile = minLonTile; lonTile <= maxLonTile; lonTile += 1) {
+      keys.push(`${latTile}:${lonTile}`);
+      if (keys.length >= MAX_TILE_FETCH) return keys;
+    }
+  }
+  return keys;
+};
+
+const queryLocalIndex = (params: {
   origin: { lat: number; lon: number };
   centerDeg: number;
   startDeg: number;
   endDeg: number;
   maxDistanceKm: number;
-  limit?: number;
+  limit: number;
 }): PanoramaPeakCandidate[] => {
-  const { origin, centerDeg, startDeg, endDeg, maxDistanceKm } = params;
-  const limit = Math.max(1, Math.min(2400, params.limit ?? 1200));
-
+  const { origin, centerDeg, startDeg, endDeg, maxDistanceKm, limit } = params;
   const latRadiusDeg = clamp(maxDistanceKm / 111, 0.1, 12);
   const lonScale = Math.max(0.2, Math.cos((origin.lat * Math.PI) / 180));
   const lonRadiusDeg = clamp(maxDistanceKm / (111 * lonScale), 0.1, 18);
@@ -58,7 +113,6 @@ export const queryPanoramaPeaks = (params: {
   const maxLat = bucketLat(origin.lat + latRadiusDeg);
   const minLon = bucketLon(origin.lon - lonRadiusDeg);
   const maxLon = bucketLon(origin.lon + lonRadiusDeg);
-
   const matches: PanoramaPeakCandidate[] = [];
   for (let latBucket = minLat; latBucket <= maxLat; latBucket += 1) {
     for (let lonBucket = minLon; lonBucket <= maxLon; lonBucket += 1) {
@@ -77,11 +131,186 @@ export const queryPanoramaPeaks = (params: {
           elevationM: Number.isFinite(peak.elevationM) ? peak.elevationM : null,
           azimuthDeg,
           distanceKm,
+          source: "local-index",
         });
       }
     }
   }
-
   matches.sort((a, b) => a.distanceKm - b.distanceKm);
   return matches.slice(0, limit);
+};
+
+const cacheRequestForTile = (tileId: string): Request => new Request(`${CACHE_PATH_PREFIX}${encodeURIComponent(tileId)}.json`);
+
+const parseOverpassPeakResponse = (payload: unknown, tileId: string, bounds: PanoramaPeakTileMeta["bounds"]): TilePayload => {
+  const elements = Array.isArray((payload as { elements?: unknown[] })?.elements) ? (payload as { elements: unknown[] }).elements : [];
+  const entries: PanoramaPeakTileEntry[] = [];
+  for (const item of elements) {
+    const element = item as {
+      id?: number | string;
+      type?: string;
+      lat?: number;
+      lon?: number;
+      center?: { lat?: number; lon?: number };
+      tags?: Record<string, unknown>;
+    };
+    const tags = element.tags ?? {};
+    const name = String(tags.name ?? "").trim();
+    if (!name) continue;
+    const lat = typeof element.lat === "number" ? element.lat : typeof element.center?.lat === "number" ? element.center.lat : null;
+    const lon = typeof element.lon === "number" ? element.lon : typeof element.center?.lon === "number" ? element.center.lon : null;
+    if (lat === null || lon === null) continue;
+    const rawEle = String(tags.ele ?? "").trim();
+    const eleNumber = Number(rawEle.replace(/[^0-9.+-]/g, ""));
+    entries.push({
+      id: `${String(element.type ?? "node")}:${String(element.id ?? `${lat.toFixed(6)}:${lon.toFixed(6)}`)}`,
+      name,
+      lat: Number(lat.toFixed(6)),
+      lon: Number(lon.toFixed(6)),
+      elevationM: Number.isFinite(eleNumber) ? Math.round(eleNumber) : null,
+      source: "overpass-tile",
+    });
+  }
+  const unique = new Map<string, PanoramaPeakTileEntry>();
+  for (const entry of entries) unique.set(`${entry.name.toLowerCase()}|${entry.lat.toFixed(5)}|${entry.lon.toFixed(5)}`, entry);
+  return {
+    meta: {
+      tileId,
+      version: TILE_CACHE_VERSION,
+      fetchedAt: Date.now(),
+      ttlMs: TILE_TTL_MS,
+      bounds,
+      source: "overpass",
+    },
+    entries: [...unique.values()],
+  };
+};
+
+const fetchTileFromNetwork = async (tileId: string): Promise<TilePayload> => {
+  const bounds = tileBoundsFromKey(tileId);
+  const query = `[out:json][timeout:25];
+(
+  node["natural"~"^(peak|volcano|saddle)$"]["name"](${bounds.south},${bounds.west},${bounds.north},${bounds.east});
+  way["natural"~"^(peak|volcano|saddle)$"]["name"](${bounds.south},${bounds.west},${bounds.north},${bounds.east});
+  relation["natural"~"^(peak|volcano|saddle)$"]["name"](${bounds.south},${bounds.west},${bounds.north},${bounds.east});
+);
+out center tags;`;
+  const response = await fetch(OVERPASS_URL, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded;charset=UTF-8" },
+    body: `data=${encodeURIComponent(query)}`,
+    cache: "no-store",
+  });
+  if (!response.ok) throw new Error(`Peak tile fetch failed (${response.status})`);
+  const data = (await response.json()) as unknown;
+  return parseOverpassPeakResponse(data, tileId, bounds);
+};
+
+const readTileFromPersistentCache = async (tileId: string): Promise<TilePayload | null> => {
+  if (typeof window === "undefined" || !("caches" in window)) return null;
+  const cache = await caches.open(CACHE_NAME);
+  const match = await cache.match(cacheRequestForTile(tileId));
+  if (!match) return null;
+  const payload = (await match.json()) as TilePayload;
+  if (!payload?.meta?.fetchedAt || payload.meta.version !== TILE_CACHE_VERSION) return null;
+  return payload;
+};
+
+const writeTileToPersistentCache = async (tileId: string, payload: TilePayload): Promise<void> => {
+  if (typeof window === "undefined" || !("caches" in window)) return;
+  const cache = await caches.open(CACHE_NAME);
+  await cache.put(
+    cacheRequestForTile(tileId),
+    new Response(JSON.stringify(payload), { headers: { "content-type": "application/json", "cache-control": "no-store" } }),
+  );
+};
+
+const loadTile = async (tileId: string): Promise<TilePayload> => {
+  const inMemory = memoryTileCache.get(tileId);
+  if (inMemory && Date.now() - inMemory.meta.fetchedAt <= inMemory.meta.ttlMs) return inMemory;
+  const pending = pendingTileFetches.get(tileId);
+  if (pending) return pending;
+  const task = (async () => {
+    const cached = await readTileFromPersistentCache(tileId);
+    if (cached && Date.now() - cached.meta.fetchedAt <= cached.meta.ttlMs) {
+      memoryTileCache.set(tileId, cached);
+      return cached;
+    }
+    const fetched = await fetchTileFromNetwork(tileId);
+    memoryTileCache.set(tileId, fetched);
+    await writeTileToPersistentCache(tileId, fetched);
+    return fetched;
+  })();
+  pendingTileFetches.set(tileId, task);
+  try {
+    return await task;
+  } finally {
+    pendingTileFetches.delete(tileId);
+  }
+};
+
+const mergeTileEntriesToCandidates = (params: {
+  entries: PanoramaPeakTileEntry[];
+  origin: { lat: number; lon: number };
+  centerDeg: number;
+  startDeg: number;
+  endDeg: number;
+  maxDistanceKm: number;
+  limit: number;
+}): PanoramaPeakCandidate[] => {
+  const { entries, origin, centerDeg, startDeg, endDeg, maxDistanceKm, limit } = params;
+  const candidates: PanoramaPeakCandidate[] = [];
+  for (const peak of entries) {
+    const distanceKm = haversineDistanceKm(origin, { lat: peak.lat, lon: peak.lon });
+    if (distanceKm <= 0.05 || distanceKm > maxDistanceKm) continue;
+    const azimuthDeg = mod360(azimuthFromToDeg(origin, { lat: peak.lat, lon: peak.lon }));
+    if (!inWindow(azimuthDeg, centerDeg, startDeg, endDeg)) continue;
+    candidates.push({
+      id: peak.id,
+      name: peak.name,
+      lat: peak.lat,
+      lon: peak.lon,
+      elevationM: peak.elevationM,
+      azimuthDeg,
+      distanceKm,
+      source: "overpass-tile",
+    });
+  }
+  candidates.sort((a, b) => a.distanceKm - b.distanceKm);
+  return candidates.slice(0, limit);
+};
+
+export const queryPanoramaPeaks = (params: {
+  origin: { lat: number; lon: number };
+  centerDeg: number;
+  startDeg: number;
+  endDeg: number;
+  maxDistanceKm: number;
+  limit?: number;
+}): PanoramaPeakCandidate[] =>
+  queryLocalIndex({
+    ...params,
+    limit: Math.max(1, Math.min(2400, params.limit ?? 1200)),
+  });
+
+export const loadPanoramaPeaks = async (params: {
+  origin: { lat: number; lon: number };
+  centerDeg: number;
+  startDeg: number;
+  endDeg: number;
+  maxDistanceKm: number;
+  limit?: number;
+}): Promise<PanoramaPeakCandidate[]> => {
+  const limit = Math.max(1, Math.min(2400, params.limit ?? 1200));
+  const tileKeys = resolveTileKeysForRadius(params.origin, params.maxDistanceKm);
+  const tilePayloads = await Promise.allSettled(tileKeys.map((key) => loadTile(key)));
+  const entries = tilePayloads
+    .filter((item): item is PromiseFulfilledResult<TilePayload> => item.status === "fulfilled")
+    .flatMap((item) => item.value.entries);
+  if (entries.length) {
+    const merged = mergeTileEntriesToCandidates({ ...params, entries, limit });
+    if (merged.length) return merged;
+  }
+  // Fallback for transient network failures.
+  return queryLocalIndex({ ...params, limit });
 };


### PR DESCRIPTION
## Summary\n- switch panorama terrain rendering to shading-centric mode with strict plot clipping\n- gate peak labels by LOS using terrain-before-distance checks\n- gate Library/MQTT panorama nodes/labels by LOS visibility\n- replace sparse peak subset with on-demand tile loading + persistent cache + request dedupe\n- add panorama LOS helper tests and tile loader tests\n\n## Validation\n- npm test\n- npm run build