### PR TITLE
fix(#101): icon size and stable anchor dedup

### DIFF
--- a/src/components/PanoramaChart.tsx
+++ b/src/components/PanoramaChart.tsx
@@ -588,12 +588,6 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
     const stableMaxSampleAngle = Math.max(...stablePanorama.rays.flatMap((ray) => ray.samples.map((sample) => sample.angleDeg)));
     const stableMinSampleAngle = Math.min(...stablePanorama.rays.flatMap((ray) => ray.samples.map((sample) => sample.angleDeg)));
 
-    // Use the stable 360° base panorama for the Y-domain top anchor so that
-    // panning doesn't cause the viewport to jump as detail panoramas load in.
-    const stablePanorama = basePanorama ?? anchorPanorama;
-    const stableMaxSampleAngle = Math.max(...stablePanorama.rays.flatMap((ray) => ray.samples.map((sample) => sample.angleDeg)));
-    const stableMinSampleAngle = Math.min(...stablePanorama.rays.flatMap((ray) => ray.samples.map((sample) => sample.angleDeg)));
-
     const innerWidth = Math.max(1, chartWidth - M.l - M.r);
     const innerHeight = Math.max(1, plotBottom - plotTop);
     const horizonPad = 0.5;

--- a/src/index.css
+++ b/src/index.css
@@ -1916,7 +1916,7 @@ input {
   letter-spacing: 0.01em;
 }
 
-.chart-panel svg {
+.chart-panel svg:not(.lucide) {
   display: block;
   width: 100%;
   height: 100%;
@@ -1924,6 +1924,12 @@ input {
   max-height: none;
   position: relative;
   z-index: 1;
+}
+
+.chart-panel .lucide {
+  width: auto;
+  height: auto;
+  min-height: unset;
 }
 
 .chart-panel.is-expanded .chart-svg-wrap {


### PR DESCRIPTION
Fixes .chart-panel svg rule stretching Lucide icons; removes duplicate stable-anchor declarations from squash merge.