### PR TITLE
fix(#101): ship-ready cleanup — labels, cursor, remove debug

### DIFF
--- a/src/components/PanoramaChart.tsx
+++ b/src/components/PanoramaChart.tsx
@@ -147,19 +147,12 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
   const [peakCandidates, setPeakCandidates] = useState<PanoramaPeakCandidate[]>([]);
   const [peakLoadStatus, setPeakLoadStatus] = useState<"idle" | "loading" | "ready" | "error">("idle");
   const [, setPeakLoadError] = useState<string | null>(null);
-  // Temporary debug shading sliders — remove once values are finalised.
-  const { theme: themeVariant } = useThemeVariant();
-  const [dbgShadowMult, setDbgShadowMult] = useState(0.7);
-  const [dbgHighMult, setDbgHighMult] = useState(0.5);
-  const [dbgReliefAlpha, setDbgReliefAlpha] = useState(0.9);
-  const [dbgHazeStart, setDbgHazeStart] = useState(() => themeVariant === "dark" ? 0.5 : 0);
-  const [dbgHazeRange, setDbgHazeRange] = useState(0.55);
-  const [shadingDebugOpen, setShadingDebugOpen] = useState(false);
+  const { theme: themeMode } = useThemeVariant();
+  const shadingHazeStart = themeMode === "dark" ? 0.5 : 0;
   const [legendPopoverOpen, setLegendPopoverOpen] = useState(false);
   const [legendPopoverPos, setLegendPopoverPos] = useState<{ left: number; top: number; direction: "up" | "down" } | null>(null);
   const peakErrorLogTsRef = useRef(0);
 
-  useEffect(() => { setDbgHazeStart(themeVariant === "dark" ? 0.5 : 0); }, [themeVariant]);
 
   const sites = useAppStore((state) => state.sites);
   const links = useAppStore((state) => state.links);
@@ -888,13 +881,13 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
 
         // Pass 1: Relief shading (always rendered).
         drawTerrainPass((haze, lambert) => {
-          const base = blendRgb(terrainColor, surfaceColor, dbgHazeStart + haze * dbgHazeRange);
-          const lighten = lambert > 0.4 ? ((lambert - 0.4) / 0.6) * dbgHighMult : 0;
-          const darken = lambert < 0.4 ? ((0.4 - lambert) / 0.4) * dbgShadowMult : 0;
+          const base = blendRgb(terrainColor, surfaceColor, shadingHazeStart + haze * 0.55);
+          const lighten = lambert > 0.4 ? ((lambert - 0.4) / 0.6) * 1.0 : 0;
+          const darken = lambert < 0.4 ? ((0.4 - lambert) / 0.4) * 0.7 : 0;
           return brightenRgb(base, lighten - darken);
         });
         ctx.save();
-        ctx.globalAlpha = dbgReliefAlpha;
+        ctx.globalAlpha = 0.9;
         ctx.setTransform(1, 0, 0, 1, 0, 0);
         ctx.drawImage(offscreen, 0, 0);
         ctx.restore();
@@ -988,7 +981,7 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
       ctx.lineTo(label.x, label.y);
       ctx.stroke();
     }
-  }, [geometry, chartSize, dbgShadowMult, dbgHighMult, dbgReliefAlpha, dbgHazeStart, dbgHazeRange]);
+  }, [geometry, chartSize, shadingHazeStart]);
 
   const focusTarget = hoverTarget ?? pinnedTarget;
   const focusAzimuthDeg = focusTarget?.azimuthDeg ?? null;
@@ -1632,81 +1625,6 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
         />
       </div>
       {sliderPopover}
-      {shadingDebugOpen && (
-        <Surface variant="card" className="panorama-shading-debug">
-          <div className="panorama-shading-debug-header">
-            <strong className="panorama-shading-debug-title">Shading debug</strong>
-            <button
-              aria-label="Close debug panel"
-              className="panorama-shading-debug-close"
-              onClick={() => setShadingDebugOpen(false)}
-              type="button"
-            >
-              ×
-            </button>
-          </div>
-          <div className="panorama-shading-debug-sliders">
-            <UiSlider
-              ariaLabel="Shadow strength"
-              label="Shadow"
-              max={1}
-              min={0}
-              onChange={setDbgShadowMult}
-              orientation="vertical"
-              step={0.01}
-              value={dbgShadowMult}
-              valueLabel={dbgShadowMult.toFixed(2)}
-            />
-            <UiSlider
-              ariaLabel="Highlight strength"
-              label="Highlight"
-              max={1}
-              min={0}
-              onChange={setDbgHighMult}
-              orientation="vertical"
-              step={0.01}
-              value={dbgHighMult}
-              valueLabel={dbgHighMult.toFixed(2)}
-            />
-            <UiSlider
-              ariaLabel="Relief alpha"
-              label="R.Alpha"
-              max={1}
-              min={0}
-              onChange={setDbgReliefAlpha}
-              orientation="vertical"
-              step={0.01}
-              value={dbgReliefAlpha}
-              valueLabel={dbgReliefAlpha.toFixed(2)}
-            />
-            <UiSlider
-              ariaLabel="Haze start"
-              label="Haze0"
-              max={0.5}
-              min={0}
-              onChange={setDbgHazeStart}
-              orientation="vertical"
-              step={0.01}
-              value={dbgHazeStart}
-              valueLabel={dbgHazeStart.toFixed(2)}
-            />
-            <UiSlider
-              ariaLabel="Haze range"
-              label="HazeR"
-              max={1}
-              min={0}
-              onChange={setDbgHazeRange}
-              orientation="vertical"
-              step={0.01}
-              value={dbgHazeRange}
-              valueLabel={dbgHazeRange.toFixed(2)}
-            />
-          </div>
-        </Surface>
-      )}
-      <button className="panorama-shading-debug-toggle" onClick={() => setShadingDebugOpen(v => !v)} type="button">
-        dbg
-      </button>
     </section>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -2248,6 +2248,18 @@ input {
   font-family: "IBM Plex Mono", monospace;
   white-space: nowrap;
   color: var(--text);
+  max-width: 20ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.panorama-label-pill strong,
+.panorama-label-peak span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 18ch;
+  display: inline-block;
+  vertical-align: middle;
 }
 
 .panorama-label-peak {
@@ -2295,69 +2307,6 @@ input {
   color: var(--text);
 }
 
-/* Temporary shading debug panel */
-.panorama-shading-debug {
-  position: fixed;
-  top: 52px;
-  left: 8px;
-  z-index: 9999;
-  padding: 10px 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.panorama-shading-debug-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.panorama-shading-debug-title {
-  font-size: 0.72rem;
-  font-family: "IBM Plex Mono", monospace;
-  color: var(--text);
-}
-
-.panorama-shading-debug-close {
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 0 2px;
-  font-size: 1rem;
-  line-height: 1;
-  color: var(--muted);
-  border-radius: var(--radius-btn);
-}
-.panorama-shading-debug-close:hover {
-  color: var(--text);
-}
-
-.panorama-shading-debug-sliders {
-  display: flex;
-  flex-direction: row;
-  gap: 12px;
-  align-items: flex-end;
-}
-
-.panorama-shading-debug-toggle {
-  position: fixed;
-  top: 52px;
-  left: 8px;
-  z-index: 10000;
-  font-size: 0.65rem;
-  padding: 2px 6px;
-  border-radius: var(--radius-btn);
-  background: var(--surface-2);
-  border: 1px solid var(--border);
-  color: var(--text);
-  cursor: pointer;
-  opacity: 0.5;
-}
-.panorama-shading-debug-toggle:hover {
-  opacity: 1;
-}
 
 .panorama-shade-band {
   fill: color-mix(in srgb, var(--terrain) 72%, var(--surface-2) 28%);
@@ -2467,6 +2416,14 @@ html.panorama-gesture-lock body {
 .profile-hitbox {
   fill: transparent;
   cursor: crosshair;
+}
+
+/* In panorama mode, use grab instead of crosshair */
+.chart-svg-wrap:has(.panorama-terrain-canvas) .profile-hitbox {
+  cursor: grab;
+}
+.chart-svg-wrap:has(.panorama-terrain-canvas):active .profile-hitbox {
+  cursor: grabbing;
 }
 
 .terrain-fill-path {


### PR DESCRIPTION
## Summary
- Truncate panorama labels at 20ch with ellipsis
- Fix cursor: panorama uses `grab`/`grabbing` instead of `crosshair` (via `:has()`)
- Remove shading debug panel, toggle, all `dbg*` state — hardcode final values (highlight=max)
- Remove ~60 lines of debug CSS
- Created #616 for remaining gallery componentization backlog

## Test plan
- [ ] Long label names truncated with "…"
- [ ] Panorama shows grab cursor, grabbing on drag
- [ ] No "dbg" button visible
- [ ] Shading renders correctly with hardcoded values

🤖 Generated with [Claude Code](https://claude.com/claude-code)