### PR TITLE
fix(#101): fix label truncation + remove vertical grid lines

### DIFF
--- a/src/components/PanoramaChart.tsx
+++ b/src/components/PanoramaChart.tsx
@@ -917,17 +917,12 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
     for (const value of geometry.ticksY) {
       ctx.fillText(`${value.toFixed(1)}°`, M.l - 8, geometry.y(value));
     }
-    // X-axis vertical grid lines and bottom labels
+    // X-axis bottom labels (no vertical grid lines)
     const dangerColor = parseRgb(resolveCssColor("var(--danger)", "rgb(255,107,107)")) ?? { r: 255, g: 107, b: 107 };
     ctx.textAlign = "center";
     ctx.textBaseline = "alphabetic";
     for (const tick of geometry.ticksX) {
       const gx = geometry.x(tick.value);
-      ctx.strokeStyle = tick.isCardinal ? toCanvasColor(borderColor, 1) : gridLineColor;
-      ctx.beginPath();
-      ctx.moveTo(gx, geometry.plotTop);
-      ctx.lineTo(gx, ch - M.b);
-      ctx.stroke();
       if (tick.isNorth) {
         ctx.font = '700 12px "IBM Plex Mono", monospace';
         ctx.fillStyle = toCanvasColor(dangerColor, 1);

--- a/src/index.css
+++ b/src/index.css
@@ -2248,18 +2248,14 @@ input {
   font-family: "IBM Plex Mono", monospace;
   white-space: nowrap;
   color: var(--text);
-  max-width: 20ch;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 .panorama-label-pill strong,
 .panorama-label-peak span {
+  display: block;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 18ch;
-  display: inline-block;
-  vertical-align: middle;
+  max-width: 20ch;
 }
 
 .panorama-label-peak {


### PR DESCRIPTION
## Summary
- Fix label truncation: move overflow/ellipsis to inner text elements (flex containers don't render ellipsis). Pill border stays intact, only text truncates.
- Remove vertical grid lines from panorama canvas (bottom labels kept).

## Test plan
- [ ] Long site names: pill fully visible, text shows "…" inside
- [ ] Long peak names: "…" after ~20 characters
- [ ] No vertical grid lines in panorama
- [ ] Azimuth labels (N/S/E/W + degrees) still render at bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)