### PR TITLE
Fix antenna height in hover path profile (issue #491)

### DIFF
--- a/src/lib/profileHoverSegments.test.ts
+++ b/src/lib/profileHoverSegments.test.ts
@@ -29,7 +29,7 @@ describe("buildHoverProfileSegments", () => {
     const fromToCursor = segments[0]?.points ?? [];
     const toToCursor = segments[1]?.points ?? [];
     expect(fromToCursor[1]?.losM).toBeCloseTo(117, 6);
-    expect(toToCursor[0]?.losM).toBeCloseTo(115, 6);
+    expect(toToCursor[0]?.losM).toBeCloseTo(117, 6);
     expect(toToCursor[1]?.losM).toBeCloseTo(127, 6);
   });
 

--- a/src/lib/profileHoverSegments.ts
+++ b/src/lib/profileHoverSegments.ts
@@ -72,7 +72,7 @@ export const buildHoverProfileSegments = (
   );
   const toSegment = buildSegment(
     toSegmentPoints,
-    cursorPoint.terrainM + fromAntennaHeightM,
+    cursorPoint.terrainM + toAntennaHeightM,
     toStart.terrainM + toAntennaHeightM,
     frequencyMHz,
   );


### PR DESCRIPTION
## Summary
- Fix bug in hover profile segments where the LOS line from cursor to destination site incorrectly used the source antenna height at the cursor point instead of the destination antenna height
- This caused LOS lines to not meet at the cursor when sites had different antenna heights
- Updated test to match corrected behavior