### PR TITLE
Fix cursor height in hover profile (issue #491)

### DIFF
--- a/src/lib/profileHoverSegments.test.ts
+++ b/src/lib/profileHoverSegments.test.ts
@@ -28,8 +28,8 @@ describe("buildHoverProfileSegments", () => {
 
     const fromToCursor = segments[0]?.points ?? [];
     const toToCursor = segments[1]?.points ?? [];
-    expect(fromToCursor[1]?.losM).toBeCloseTo(117, 6);
-    expect(toToCursor[0]?.losM).toBeCloseTo(117, 6);
+    expect(fromToCursor[1]?.losM).toBeCloseTo(112, 6);
+    expect(toToCursor[0]?.losM).toBeCloseTo(112, 6);
     expect(toToCursor[1]?.losM).toBeCloseTo(127, 6);
   });
 

--- a/src/lib/profileHoverSegments.ts
+++ b/src/lib/profileHoverSegments.ts
@@ -61,18 +61,19 @@ export const buildHoverProfileSegments = (
 
   const fromStart = profile[0];
   const toStart = profile[profile.length - 1];
+  const isFullPath = clampedCursorIndex >= profile.length - 1;
   const fromSegmentPoints = profile.slice(0, clampedCursorIndex + 1);
   const toSegmentPoints = profile.slice(clampedCursorIndex);
 
   const fromSegment = buildSegment(
     fromSegmentPoints,
     fromStart.terrainM + fromAntennaHeightM,
-    cursorPoint.terrainM + toAntennaHeightM,
+    isFullPath ? toStart.terrainM + toAntennaHeightM : cursorPoint.terrainM + 2,
     frequencyMHz,
   );
   const toSegment = buildSegment(
     toSegmentPoints,
-    cursorPoint.terrainM + toAntennaHeightM,
+    isFullPath ? fromStart.terrainM + fromAntennaHeightM : cursorPoint.terrainM + 2,
     toStart.terrainM + toAntennaHeightM,
     frequencyMHz,
   );


### PR DESCRIPTION
## Summary
- Fix cursor height in hover profile segments: Use terrain+2m at cursor point instead of site antenna heights
- When hovering in the middle of the path, the cursor represents a generic receiver at terrain elevation with a default 2m antenna
- When at full path (cursor at endpoint), keep using actual site antenna heights so the lines go directly to the antennas