### PR TITLE
feat(panels): overhaul panel icons and add animations (Issue #532)

### DIFF
--- a/functions/_lib/buildInfo.ts
+++ b/functions/_lib/buildInfo.ts
@@ -1,5 +1,5 @@
 export const APP_VERSION = "0.15.0";
-export const APP_COMMIT = "85ef251f";
+export const APP_COMMIT = "af425524";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,5 +1,5 @@
 import { type CSSProperties, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { CircleAlert, CircleCheck, CircleUserRound, CircleX, CloudAlert, Copy, Globe, Info, Maximize2, PanelBottom, PanelBottomClose, PanelLeft, PanelLeftClose, PanelRight, PanelRightClose, Share, UserRoundPlus, UserRoundSearch, Users, X } from "lucide-react";
+import { CircleAlert, CircleCheck, CircleUserRound, CircleX, CloudAlert, Copy, Globe, Info, PanelBottomClose, PanelBottomOpen, PanelLeftClose, PanelLeftOpen, PanelRightClose, PanelRightOpen, Share, UserRoundPlus, UserRoundSearch, Users, X } from "lucide-react";
 import { type CollaboratorDirectoryUser, fetchCollaboratorDirectory, fetchDeepLinkStatus, fetchMe, setLocalDevRole } from "../lib/cloudUser";
 import { fetchCloudLibrary, fetchPublicSimulationLibrary, pushCloudLibrary } from "../lib/cloudLibrary";
 import { buildDeepLinkPathname, buildDeepLinkUrl, canonicalizeDeepLinkKey, parseDeepLinkFromLocation, slugifyName } from "../lib/deepLink";
@@ -1572,7 +1572,7 @@ export function AppShell() {
             title="Normal size"
             type="button"
           >
-            <PanelBottom aria-hidden="true" strokeWidth={1.8} />
+            <PanelBottomClose aria-hidden="true" strokeWidth={1.8} />
           </button>
         ) : (
           <>
@@ -1592,7 +1592,7 @@ export function AppShell() {
               title="Full size"
               type="button"
             >
-              <Maximize2 aria-hidden="true" strokeWidth={1.8} />
+              <PanelBottomOpen aria-hidden="true" strokeWidth={1.8} />
             </button>
           </>
         )}
@@ -1739,7 +1739,7 @@ export function AppShell() {
               title="Show Navigator"
               type="button"
             >
-              <PanelLeft aria-hidden="true" strokeWidth={1.8} />
+<PanelLeftOpen aria-hidden="true" strokeWidth={1.8} />
             </button>
           ) : null}
           {isInspectorHidden ? (
@@ -1753,7 +1753,7 @@ export function AppShell() {
               title="Show Inspector"
               type="button"
             >
-              <PanelRight aria-hidden="true" strokeWidth={1.8} />
+<PanelRightOpen aria-hidden="true" strokeWidth={1.8} />
             </button>
           ) : null}
           {isProfileHidden ? (
@@ -1767,7 +1767,7 @@ export function AppShell() {
               title="Show Profile"
               type="button"
             >
-              <PanelBottom aria-hidden="true" strokeWidth={1.8} />
+<PanelBottomOpen aria-hidden="true" strokeWidth={1.8} />
             </button>
           ) : null}
         </div>
@@ -1792,7 +1792,7 @@ export function AppShell() {
                   title={isNavigatorHidden ? "Show Navigator" : "Hide Navigator"}
                   type="button"
                 >
-                  {isNavigatorHidden ? <PanelLeft aria-hidden="true" strokeWidth={1.8} /> : <PanelLeftClose aria-hidden="true" strokeWidth={1.8} />}
+                  {isNavigatorHidden ? <PanelLeftOpen aria-hidden="true" strokeWidth={1.8} /> : <PanelLeftClose aria-hidden="true" strokeWidth={1.8} />}
                 </button>
               )
             }
@@ -1860,7 +1860,7 @@ export function AppShell() {
                   title={isInspectorHidden ? "Show Inspector" : "Hide Inspector"}
                   type="button"
                 >
-                  {isInspectorHidden ? <PanelRight aria-hidden="true" strokeWidth={1.8} /> : <PanelRightClose aria-hidden="true" strokeWidth={1.8} />}
+                  {isInspectorHidden ? <PanelRightOpen aria-hidden="true" strokeWidth={1.8} /> : <PanelRightClose aria-hidden="true" strokeWidth={1.8} />}
                 </button>
               ) : null}
               <div className="map-inspector-header-actions-right">
@@ -1926,7 +1926,7 @@ export function AppShell() {
                 title={isProfileHidden ? "Show Profile" : "Hide Profile"}
                 type="button"
               >
-                {isProfileHidden ? <PanelBottom aria-hidden="true" strokeWidth={1.8} /> : <PanelBottomClose aria-hidden="true" strokeWidth={1.8} />}
+                {isProfileHidden ? <PanelBottomOpen aria-hidden="true" strokeWidth={1.8} /> : <PanelBottomClose aria-hidden="true" strokeWidth={1.8} />}
               </button>
             }
             showExpandToggle
@@ -1950,7 +1950,7 @@ export function AppShell() {
                 title={isProfileHidden ? "Show Profile" : "Hide Profile"}
                 type="button"
               >
-                {isProfileHidden ? <PanelBottom aria-hidden="true" strokeWidth={1.8} /> : <PanelBottomClose aria-hidden="true" strokeWidth={1.8} />}
+                {isProfileHidden ? <PanelBottomOpen aria-hidden="true" strokeWidth={1.8} /> : <PanelBottomClose aria-hidden="true" strokeWidth={1.8} />}
               </button>
             }
             showExpandToggle

--- a/src/index.css
+++ b/src/index.css
@@ -185,6 +185,36 @@ input {
   }
 }
 
+@keyframes panel-toggle-bounce {
+  0% {
+    opacity: 0;
+    transform: translateY(-50%) scale(0.8);
+  }
+  60% {
+    opacity: 1;
+    transform: translateY(-50%) scale(1.1);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(-50%) scale(1);
+  }
+}
+
+@keyframes panel-toggle-bounce-exit {
+  0% {
+    opacity: 1;
+    transform: translateY(-50%) scale(1);
+  }
+  40% {
+    opacity: 1;
+    transform: translateY(-50%) scale(1.1);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-50%) scale(0.8);
+  }
+}
+
 .sidebar-panel,
 .map-inspector,
 .chart-panel {
@@ -198,6 +228,7 @@ input {
   -webkit-backdrop-filter: blur(var(--glass-panel-blur));
   backdrop-filter: blur(var(--glass-panel-blur));
   box-shadow: var(--shadow);
+  transition: opacity 350ms ease-out, transform 350ms ease-out, box-shadow 350ms ease-out;
 }
 
 .sidebar-panel {
@@ -210,6 +241,7 @@ input {
   font-family: "Space Grotesk", "Avenir Next", sans-serif;
   max-height: calc(100vh - 36px);
   overflow: auto;
+  transition: opacity 350ms ease-out, transform 350ms ease-out, box-shadow 350ms ease-out;
 }
 
 .sidebar-grow {
@@ -717,12 +749,24 @@ input {
   left: 26px;
   top: 50%;
   transform: translateY(-50%);
+  animation: panel-toggle-bounce 200ms ease-out 50ms both;
+  transition: opacity 150ms ease, transform 150ms ease, background-color 150ms ease, border-color 150ms ease;
 }
 
 .collapsed-panel-btn-inspector {
   right: 26px;
   top: 50%;
   transform: translateY(-50%);
+  animation: panel-toggle-bounce 200ms ease-out 50ms both;
+  transition: opacity 150ms ease, transform 150ms ease, background-color 150ms ease, border-color 150ms ease;
+}
+
+.collapsed-panel-btn-profile {
+  left: 50%;
+  bottom: 70px;
+  transform: translateX(-50%);
+  animation: panel-toggle-bounce 200ms ease-out 50ms both;
+  transition: opacity 150ms ease, transform 150ms ease, background-color 150ms ease, border-color 150ms ease;
 }
 
 .app-shell:not(.is-profile-hidden) .collapsed-panel-btn-navigator,
@@ -2649,6 +2693,7 @@ html.panorama-gesture-lock body {
     box-shadow: none;
     padding: 0;
     z-index: 45;
+    transition: opacity 350ms ease-out, transform 350ms ease-out, height 350ms ease-out, min-height 350ms ease-out;
   }
 
   .mobile-workspace-panel > * {

--- a/src/lib/buildInfo.ts
+++ b/src/lib/buildInfo.ts
@@ -1,5 +1,5 @@
 export const APP_VERSION = "0.15.0";
-export const APP_COMMIT = "85ef251f";
+export const APP_COMMIT = "af425524";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {


### PR DESCRIPTION
## Summary

- Replace `Maximize2` with `PanelBottomOpen` for expand-to-full on bottom panel
- Use `PanelLeftOpen`/`PanelRightOpen`/`PanelBottomOpen` for show state (hidden→visible) icons
- Use proper close icons (`PanelLeftClose`/`PanelRightClose`/`PanelBottomClose`) when panel is visible
- Add panel-toggle-bounce keyframes with bounce effect for overlay toggle buttons
- Add 350ms transitions for panel hide/show animation on desktop and mobile

## Changes

- **AppShell.tsx**: Icon imports and usage updates
- **index.css**: Keyframes and transitions added

## Issue

Fixes #532