### PR TITLE
fix(panels): stabilize panel motion behavior for issue #532

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -55,6 +55,8 @@ const BLANK_SIM_NOTICE_ID = "blank-simulation-guidance";
 // - profile => BottomPanel shell (legacy term retained in code for stability)
 type MobileWorkspacePanel = "navigator" | "inspector" | "profile";
 type MobileBottomPanelMode = "hidden" | "normal" | "full";
+type PanelMotionPhase = "idle" | "entering" | "exiting";
+const PANEL_MOTION_MS = 360;
 type AppNotice = {
   id: string;
   message: string;
@@ -177,6 +179,9 @@ export function AppShell() {
   const [isNavigatorHidden, setIsNavigatorHidden] = useState(() => readPanelBool(UI_PANEL_KEYS.navigatorHidden, false));
   const [isInspectorHidden, setIsInspectorHidden] = useState(() => readPanelBool(UI_PANEL_KEYS.inspectorHidden, false));
   const [isProfileHidden, setIsProfileHidden] = useState(() => readPanelBool(UI_PANEL_KEYS.profileHidden, false));
+  const [navigatorMotionPhase, setNavigatorMotionPhase] = useState<PanelMotionPhase>("idle");
+  const [inspectorMotionPhase, setInspectorMotionPhase] = useState<PanelMotionPhase>("idle");
+  const [profileMotionPhase, setProfileMotionPhase] = useState<PanelMotionPhase>("idle");
   const [accessState, setAccessState] = useState<"checking" | "granted" | "readonly" | "pending" | "locked">("checking");
   const [accessDiagnosticMessage, setAccessDiagnosticMessage] = useState<string | null>(null);
   // Derived early so effects below can reference them without temporal dead zone.
@@ -213,6 +218,9 @@ export function AppShell() {
   const cloudInitSeenRef = useRef(false);
   const cloudInitSettledRef = useRef(false);
   const appShellRef = useRef<HTMLElement | null>(null);
+  const navigatorMotionTimerRef = useRef<number | null>(null);
+  const inspectorMotionTimerRef = useRef<number | null>(null);
+  const profileMotionTimerRef = useRef<number | null>(null);
   const hadAuthenticatedSessionRef = useRef(false);
   const {
     showWelcomeModal,
@@ -1507,6 +1515,101 @@ export function AppShell() {
     window.setTimeout(fire, 120);
   }, []);
 
+  const clearMotionTimer = useCallback((timerRef: { current: number | null }) => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      clearMotionTimer(navigatorMotionTimerRef);
+      clearMotionTimer(inspectorMotionTimerRef);
+      clearMotionTimer(profileMotionTimerRef);
+    };
+  }, [clearMotionTimer]);
+
+  const showNavigatorPanel = useCallback(() => {
+    clearMotionTimer(navigatorMotionTimerRef);
+    setIsNavigatorHidden(false);
+    setNavigatorMotionPhase("entering");
+    navigatorMotionTimerRef.current = window.setTimeout(() => {
+      setNavigatorMotionPhase("idle");
+      navigatorMotionTimerRef.current = null;
+    }, PANEL_MOTION_MS);
+    emitProfileLayoutPulse();
+  }, [clearMotionTimer, emitProfileLayoutPulse]);
+
+  const hideNavigatorPanel = useCallback(() => {
+    clearMotionTimer(navigatorMotionTimerRef);
+    setNavigatorMotionPhase("exiting");
+    navigatorMotionTimerRef.current = window.setTimeout(() => {
+      setIsNavigatorHidden(true);
+      setNavigatorMotionPhase("idle");
+      navigatorMotionTimerRef.current = null;
+      emitProfileLayoutPulse();
+    }, PANEL_MOTION_MS);
+    emitProfileLayoutPulse();
+  }, [clearMotionTimer, emitProfileLayoutPulse]);
+
+  const showInspectorPanel = useCallback(() => {
+    clearMotionTimer(inspectorMotionTimerRef);
+    setIsInspectorHidden(false);
+    setInspectorMotionPhase("entering");
+    inspectorMotionTimerRef.current = window.setTimeout(() => {
+      setInspectorMotionPhase("idle");
+      inspectorMotionTimerRef.current = null;
+    }, PANEL_MOTION_MS);
+    emitProfileLayoutPulse();
+  }, [clearMotionTimer, emitProfileLayoutPulse]);
+
+  const hideInspectorPanel = useCallback(() => {
+    clearMotionTimer(inspectorMotionTimerRef);
+    setInspectorMotionPhase("exiting");
+    inspectorMotionTimerRef.current = window.setTimeout(() => {
+      setIsInspectorHidden(true);
+      setInspectorMotionPhase("idle");
+      inspectorMotionTimerRef.current = null;
+      emitProfileLayoutPulse();
+    }, PANEL_MOTION_MS);
+    emitProfileLayoutPulse();
+  }, [clearMotionTimer, emitProfileLayoutPulse]);
+
+  const showProfilePanel = useCallback(() => {
+    clearMotionTimer(profileMotionTimerRef);
+    setIsProfileHidden(false);
+    setProfileMotionPhase("entering");
+    profileMotionTimerRef.current = window.setTimeout(() => {
+      setProfileMotionPhase("idle");
+      profileMotionTimerRef.current = null;
+    }, PANEL_MOTION_MS);
+    emitProfileLayoutPulse();
+  }, [clearMotionTimer, emitProfileLayoutPulse]);
+
+  const hideProfilePanel = useCallback(() => {
+    clearMotionTimer(profileMotionTimerRef);
+    setProfileMotionPhase("exiting");
+    profileMotionTimerRef.current = window.setTimeout(() => {
+      setIsProfileHidden(true);
+      setProfileMotionPhase("idle");
+      profileMotionTimerRef.current = null;
+      emitProfileLayoutPulse();
+    }, PANEL_MOTION_MS);
+    emitProfileLayoutPulse();
+  }, [clearMotionTimer, emitProfileLayoutPulse]);
+
+  const shouldRenderNavigatorPanel = !isNavigatorHidden || navigatorMotionPhase === "exiting";
+  const shouldRenderInspectorPanel = !isInspectorHidden || inspectorMotionPhase === "exiting";
+  const shouldRenderProfilePanel = !isProfileHidden || profileMotionPhase === "exiting";
+
+  const navigatorPanelMotionClass =
+    navigatorMotionPhase === "entering" ? "panel-motion-enter-left" : navigatorMotionPhase === "exiting" ? "panel-motion-exit-left" : "";
+  const inspectorPanelMotionClass =
+    inspectorMotionPhase === "entering" ? "panel-motion-enter-right" : inspectorMotionPhase === "exiting" ? "panel-motion-exit-right" : "";
+  const profilePanelMotionClass =
+    profileMotionPhase === "entering" ? "panel-motion-enter-bottom" : profileMotionPhase === "exiting" ? "panel-motion-exit-bottom" : "";
+
   const toggleProfileExpanded = () => {
     setIsMapExpanded(false);
     setMobileActivePanel("profile");
@@ -1732,10 +1835,7 @@ export function AppShell() {
             <button
               aria-label="Show Navigator panel"
               className="map-control-btn map-control-btn-icon collapsed-panel-btn collapsed-panel-btn-navigator"
-              onClick={() => {
-                setIsNavigatorHidden(false);
-                emitProfileLayoutPulse();
-              }}
+              onClick={showNavigatorPanel}
               title="Show Navigator"
               type="button"
             >
@@ -1746,10 +1846,7 @@ export function AppShell() {
             <button
               aria-label="Show Inspector panel"
               className="map-control-btn map-control-btn-icon collapsed-panel-btn collapsed-panel-btn-inspector"
-              onClick={() => {
-                setIsInspectorHidden(false);
-                emitProfileLayoutPulse();
-              }}
+              onClick={showInspectorPanel}
               title="Show Inspector"
               type="button"
             >
@@ -1760,10 +1857,7 @@ export function AppShell() {
             <button
               aria-label="Show Profile panel"
               className="map-control-btn map-control-btn-icon collapsed-panel-btn collapsed-panel-btn-profile"
-              onClick={() => {
-                setIsProfileHidden(false);
-                emitProfileLayoutPulse();
-              }}
+              onClick={showProfilePanel}
               title="Show Profile"
               type="button"
             >
@@ -1772,7 +1866,7 @@ export function AppShell() {
           ) : null}
         </div>
       ) : null}
-      {!isMobileViewport && !isMapExpanded && !isProfileExpanded && !isNavigatorHidden && (accessState === "granted" || accessState === "readonly" || isAnonymousBootstrapShell) ? (
+      {!isMobileViewport && !isMapExpanded && !isProfileExpanded && shouldRenderNavigatorPanel && (accessState === "granted" || accessState === "readonly" || isAnonymousBootstrapShell) ? (
           <Sidebar
             authBootstrapPending={accessState === "checking"}
             hideLibraryBrowsing={isReadOnlyShell}
@@ -1786,8 +1880,11 @@ export function AppShell() {
                   aria-label={isNavigatorHidden ? "Show Navigator panel" : "Hide Navigator panel"}
                   className="user-icon-button"
                   onClick={() => {
-                    setIsNavigatorHidden((prev) => !prev);
-                    emitProfileLayoutPulse();
+                    if (isNavigatorHidden) {
+                      showNavigatorPanel();
+                      return;
+                    }
+                    hideNavigatorPanel();
                   }}
                   title={isNavigatorHidden ? "Show Navigator" : "Hide Navigator"}
                   type="button"
@@ -1796,6 +1893,7 @@ export function AppShell() {
                 </button>
               )
             }
+            panelClassName={navigatorPanelMotionClass}
             simulationDisplayLabel={undefined}
         />
       ) : null}
@@ -1840,7 +1938,7 @@ export function AppShell() {
           isMapExpanded={isMapExpanded}
           showInspector={
             !isMapExpanded &&
-            !isInspectorHidden &&
+            shouldRenderInspectorPanel &&
             (isMobileViewport
               ? mobileActivePanel === "inspector" && mobileBottomPanelMode !== "hidden"
               : !isProfileExpanded)
@@ -1854,8 +1952,11 @@ export function AppShell() {
                   aria-label={isInspectorHidden ? "Show Inspector panel" : "Hide Inspector panel"}
                   className="map-control-btn map-control-btn-icon"
                   onClick={() => {
-                    setIsInspectorHidden((prev) => !prev);
-                    emitProfileLayoutPulse();
+                    if (isInspectorHidden) {
+                      showInspectorPanel();
+                      return;
+                    }
+                    hideInspectorPanel();
                   }}
                   title={isInspectorHidden ? "Show Inspector" : "Hide Inspector"}
                   type="button"
@@ -1880,6 +1981,7 @@ export function AppShell() {
             </div>
           }
           readOnly={!canPersistWorkspace}
+          inspectorPanelClassName={inspectorPanelMotionClass}
           onToggleMapExpanded={() => {
             setIsProfileExpanded(false);
             if (isMobileViewport && mobileBottomPanelMode === "full") {
@@ -1906,22 +2008,23 @@ export function AppShell() {
             setMobileBottomPanelVisibility={setMobileBottomPanelVisibility}
           />
         ) : null}
-        {!isMobileViewport && !isMapExpanded && !isProfileHidden ? (
+        {!isMobileViewport && !isMapExpanded && shouldRenderProfilePanel ? (
           isSingleSiteSelection ? (
           <PanoramaChart
             isExpanded={isProfileExpanded}
             onToggleExpanded={toggleProfileExpanded}
             rowControls={
+              isProfileExpanded ? null :
               <button
                 aria-label={isProfileHidden ? "Show Profile panel" : "Hide Profile panel"}
                 className="chart-endpoint-swap chart-endpoint-icon"
                 onClick={() => {
-                  setIsProfileHidden((prev) => {
-                    const next = !prev;
-                    if (next) setIsProfileExpanded(false);
-                    return next;
-                  });
-                  emitProfileLayoutPulse();
+                  if (isProfileHidden) {
+                    showProfilePanel();
+                    return;
+                  }
+                  setIsProfileExpanded(false);
+                  hideProfilePanel();
                 }}
                 title={isProfileHidden ? "Show Profile" : "Hide Profile"}
                 type="button"
@@ -1929,6 +2032,7 @@ export function AppShell() {
                 {isProfileHidden ? <PanelBottomOpen aria-hidden="true" strokeWidth={1.8} /> : <PanelBottomClose aria-hidden="true" strokeWidth={1.8} />}
               </button>
             }
+            panelClassName={profilePanelMotionClass}
             showExpandToggle
           />
           ) : (
@@ -1936,16 +2040,17 @@ export function AppShell() {
             isExpanded={isProfileExpanded}
             onToggleExpanded={toggleProfileExpanded}
             rowControls={
+              isProfileExpanded ? null :
               <button
                 aria-label={isProfileHidden ? "Show Profile panel" : "Hide Profile panel"}
                 className="chart-endpoint-swap chart-endpoint-icon"
                 onClick={() => {
-                  setIsProfileHidden((prev) => {
-                    const next = !prev;
-                    if (next) setIsProfileExpanded(false);
-                    return next;
-                  });
-                  emitProfileLayoutPulse();
+                  if (isProfileHidden) {
+                    showProfilePanel();
+                    return;
+                  }
+                  setIsProfileExpanded(false);
+                  hideProfilePanel();
                 }}
                 title={isProfileHidden ? "Show Profile" : "Hide Profile"}
                 type="button"
@@ -1953,6 +2058,7 @@ export function AppShell() {
                 {isProfileHidden ? <PanelBottomOpen aria-hidden="true" strokeWidth={1.8} /> : <PanelBottomClose aria-hidden="true" strokeWidth={1.8} />}
               </button>
             }
+            panelClassName={profilePanelMotionClass}
             showExpandToggle
           />
           )

--- a/src/components/LinkProfileChart.tsx
+++ b/src/components/LinkProfileChart.tsx
@@ -51,6 +51,7 @@ type LinkProfileChartProps = {
   onToggleExpanded: () => void;
   showExpandToggle?: boolean;
   rowControls?: ReactNode;
+  panelClassName?: string;
 };
 
 export function LinkProfileChart({
@@ -58,6 +59,7 @@ export function LinkProfileChart({
   onToggleExpanded,
   showExpandToggle = true,
   rowControls,
+  panelClassName,
 }: LinkProfileChartProps) {
   const chartHostRef = useRef<HTMLDivElement | null>(null);
   const [hostAttachRevision, setHostAttachRevision] = useState(0);
@@ -712,7 +714,7 @@ export function LinkProfileChart({
   }
 
   return (
-    <section className={`chart-panel ${isExpanded ? "is-expanded" : ""}`} data-profile-revision={profileRevision}>
+    <section className={`chart-panel ${isExpanded ? "is-expanded" : ""} ${panelClassName ?? ""}`.trim()} data-profile-revision={profileRevision}>
       <div className="chart-top-row">
         <div className="chart-endpoints" aria-live="polite">
           <span className="chart-endpoint chart-endpoint-left">{fromSiteName}</span>

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -464,6 +464,7 @@ const computeSiteFitBounds = (
 type MapViewProps = {
   isMapExpanded: boolean;
   showInspector?: boolean;
+  inspectorPanelClassName?: string;
   showMultiSelectToggle?: boolean;
   readOnly?: boolean;
   canPersist?: boolean;
@@ -548,6 +549,7 @@ const DEFAULT_MAP_VIEWPORT = {
 export function MapView({
   isMapExpanded,
   showInspector = true,
+  inspectorPanelClassName,
   showMultiSelectToggle = false,
   readOnly = false,
   canPersist = true,
@@ -2416,7 +2418,7 @@ export function MapView({
         </div>
       ) : null}
       {showInspector ? (
-        <aside className="map-inspector" aria-live="polite">
+        <aside className={`map-inspector ${inspectorPanelClassName ?? ""}`.trim()} aria-live="polite">
           {inspectorHeaderActions ? (
             <div className="map-inspector-header-row">{inspectorHeaderActions}</div>
           ) : null}

--- a/src/components/PanoramaChart.tsx
+++ b/src/components/PanoramaChart.tsx
@@ -97,6 +97,7 @@ type PanoramaChartProps = {
   onToggleExpanded: () => void;
   showExpandToggle?: boolean;
   rowControls?: ReactNode;
+  panelClassName?: string;
 };
 
 type HoverTarget =
@@ -118,7 +119,7 @@ type HoverTarget =
 
 const pointerDistance = (a: { x: number; y: number }, b: { x: number; y: number }): number => Math.hypot(a.x - b.x, a.y - b.y);
 
-export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle = true, rowControls }: PanoramaChartProps) {
+export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle = true, rowControls, panelClassName }: PanoramaChartProps) {
   const chartHostRef = useRef<HTMLDivElement | null>(null);
   const terrainCanvasRef = useRef<HTMLCanvasElement | null>(null);
   const scrollbarTrackRef = useRef<HTMLDivElement | null>(null);
@@ -1433,7 +1434,7 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
   const scrubberLeftPct = clamp((viewportCenterAzimuthDeg / 360) * 100 - scrubberWidthPct / 2, 0, 100 - scrubberWidthPct);
 
   return (
-    <section className={`chart-panel ${isExpanded ? "is-expanded" : ""}`}>
+    <section className={`chart-panel ${isExpanded ? "is-expanded" : ""} ${panelClassName ?? ""}`.trim()}>
       <div className="chart-top-row">
         <h3 className="panorama-header-title">Panorama from {selectedSiteEffective.name}</h3>
         <div className="chart-action-row-controls">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -224,6 +224,7 @@ type SidebarProps = {
   readOnly?: boolean;
   authBootstrapPending?: boolean;
   panelToggleControl?: ReactNode;
+  panelClassName?: string;
   /** Override the computed simulation name shown in the Simulation section header. */
   simulationDisplayLabel?: string;
 };
@@ -234,6 +235,7 @@ export function Sidebar({
   readOnly = false,
   authBootstrapPending = false,
   panelToggleControl,
+  panelClassName,
   simulationDisplayLabel,
 }: SidebarProps) {
   const { theme, colorTheme, variant } = useThemeVariant();
@@ -1767,7 +1769,7 @@ export function Sidebar({
   };
 
   return (
-    <aside className="sidebar-panel">
+    <aside className={`sidebar-panel ${panelClassName ?? ""}`.trim()}>
       <UserAdminPanel authBootstrapPending={authBootstrapPending} extraActions={panelToggleControl} onOpenHelp={onOpenHelp} />
       <header>
         <div className="sidebar-title-row">

--- a/src/index.css
+++ b/src/index.css
@@ -215,6 +215,99 @@ input {
   }
 }
 
+@keyframes panel-slide-in-left {
+  from {
+    opacity: 0;
+    transform: translateX(-108%);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes panel-slide-out-left {
+  from {
+    opacity: 1;
+    transform: translateX(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateX(-108%);
+  }
+}
+
+@keyframes panel-slide-in-right {
+  from {
+    opacity: 0;
+    transform: translateX(108%);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes panel-slide-out-right {
+  from {
+    opacity: 1;
+    transform: translateX(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateX(108%);
+  }
+}
+
+@keyframes panel-slide-in-bottom {
+  from {
+    opacity: 0;
+    transform: translateY(108%);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes panel-slide-out-bottom {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(108%);
+  }
+}
+
+.panel-motion-enter-left {
+  animation: panel-slide-in-left 360ms ease-out both;
+}
+
+.panel-motion-exit-left {
+  animation: panel-slide-out-left 360ms ease-out both;
+  pointer-events: none;
+}
+
+.panel-motion-enter-right {
+  animation: panel-slide-in-right 360ms ease-out both;
+}
+
+.panel-motion-exit-right {
+  animation: panel-slide-out-right 360ms ease-out both;
+  pointer-events: none;
+}
+
+.panel-motion-enter-bottom {
+  animation: panel-slide-in-bottom 360ms ease-out both;
+}
+
+.panel-motion-exit-bottom {
+  animation: panel-slide-out-bottom 360ms ease-out both;
+  pointer-events: none;
+}
+
 .sidebar-panel,
 .map-inspector,
 .chart-panel {


### PR DESCRIPTION
## Summary
- fix desktop panel hide/show to animate with explicit enter/exit phases before unmounting
- remove the desktop profile hide button while the profile panel is expanded
- keep inspector/sidebar/profile panel shells renderable during exit animation and pass motion classes through panel components
- keep icon semantics aligned with panel open/close mappings

## Notes
- mobile swipe gestures are split into follow-up issue #623 to avoid repeating the prior hook-order runtime regression

Closes #532