### PR TITLE
fix(panels): refine desktop/mobile animation behavior for #532

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -205,6 +205,7 @@ export function AppShell() {
   const [isMobileViewport, setIsMobileViewport] = useState(false);
   const [mobileActivePanel, setMobileActivePanel] = useState<MobileWorkspacePanel>("navigator");
   const [mobileBottomPanelMode, setMobileBottomPanelMode] = useState<MobileBottomPanelMode>("normal");
+  const [mobileBottomMotionPhase, setMobileBottomMotionPhase] = useState<PanelMotionPhase>("idle");
   const [mobileControlsOccupied, setMobileControlsOccupied] = useState(0);
   const [mobileBottomOccupied, setMobileBottomOccupied] = useState(0);
   const [measuredSidebarWidth, setMeasuredSidebarWidth] = useState(0);
@@ -221,6 +222,7 @@ export function AppShell() {
   const navigatorMotionTimerRef = useRef<number | null>(null);
   const inspectorMotionTimerRef = useRef<number | null>(null);
   const profileMotionTimerRef = useRef<number | null>(null);
+  const mobileBottomMotionTimerRef = useRef<number | null>(null);
   const hadAuthenticatedSessionRef = useRef(false);
   const {
     showWelcomeModal,
@@ -1464,9 +1466,9 @@ export function AppShell() {
   const shellStyle = useMemo<CSSProperties | undefined>(() => {
     const style: CSSProperties = {
       ["--sidebar-overlay-width" as string]:
-        isNavigatorHidden && !isMapExpanded && !isProfileExpanded ? "0px" : "clamp(280px, 20vw, 400px)",
+        (isNavigatorHidden || navigatorMotionPhase === "exiting") && !isMapExpanded && !isProfileExpanded ? "0px" : "clamp(280px, 20vw, 400px)",
       ["--inspector-overlay-width" as string]:
-        isInspectorHidden || isMapExpanded || isProfileExpanded ? "0px" : "clamp(280px, 20vw, 400px)",
+        isInspectorHidden || inspectorMotionPhase === "exiting" || isMapExpanded || isProfileExpanded ? "0px" : "clamp(280px, 20vw, 400px)",
     };
     if (!isMobileViewport) return style;
     return {
@@ -1474,9 +1476,11 @@ export function AppShell() {
       ["--mobile-controls-occupied" as string]: `${mobileControlsOccupied}px`,
     };
   }, [
+    inspectorMotionPhase,
     isInspectorHidden,
     isMapExpanded,
     isMobileViewport,
+    navigatorMotionPhase,
     isNavigatorHidden,
     isProfileExpanded,
     mobileControlsOccupied,
@@ -1527,6 +1531,7 @@ export function AppShell() {
       clearMotionTimer(navigatorMotionTimerRef);
       clearMotionTimer(inspectorMotionTimerRef);
       clearMotionTimer(profileMotionTimerRef);
+      clearMotionTimer(mobileBottomMotionTimerRef);
     };
   }, [clearMotionTimer]);
 
@@ -1618,8 +1623,31 @@ export function AppShell() {
   };
 
   const setMobileBottomPanelVisibility = useCallback((nextMode: MobileBottomPanelMode) => {
+    clearMotionTimer(mobileBottomMotionTimerRef);
+    if (nextMode === "hidden") {
+      setMobileBottomMotionPhase("exiting");
+      mobileBottomMotionTimerRef.current = window.setTimeout(() => {
+        setMobileBottomPanelMode("hidden");
+        setMobileBottomMotionPhase("idle");
+        mobileBottomMotionTimerRef.current = null;
+      }, PANEL_MOTION_MS);
+      return;
+    }
     setMobileBottomPanelMode(nextMode);
-  }, []);
+    setMobileBottomMotionPhase("entering");
+    mobileBottomMotionTimerRef.current = window.setTimeout(() => {
+      setMobileBottomMotionPhase("idle");
+      mobileBottomMotionTimerRef.current = null;
+    }, PANEL_MOTION_MS);
+  }, [clearMotionTimer]);
+
+  const shouldRenderMobileBottomPanel = mobileBottomPanelMode !== "hidden" || mobileBottomMotionPhase === "exiting";
+  const mobileBottomPanelMotionClass =
+    mobileBottomMotionPhase === "entering"
+      ? "mobile-panel-motion-enter-bottom"
+      : mobileBottomMotionPhase === "exiting"
+        ? "mobile-panel-motion-exit-bottom"
+        : "";
 
   const closeShareModal = useCallback(() => {
     setShowShareModal(false);
@@ -2063,10 +2091,10 @@ export function AppShell() {
           />
           )
         ) : null}
-        {isMobileViewport && !isMapExpanded && mobileActivePanel === "profile" && mobileBottomPanelMode !== "hidden" ? (
+        {isMobileViewport && !isMapExpanded && mobileActivePanel === "profile" && shouldRenderMobileBottomPanel ? (
           <div
             aria-labelledby={mobileProfileTabId}
-            className="mobile-workspace-panel mobile-workspace-panel-shell"
+            className={`mobile-workspace-panel mobile-workspace-panel-shell ${mobileBottomPanelMotionClass}`.trim()}
             id={mobileProfilePanelId}
             role="tabpanel"
           >
@@ -2087,10 +2115,10 @@ export function AppShell() {
             )}
           </div>
         ) : null}
-        {isMobileViewport && !isMapExpanded && mobileActivePanel === "navigator" && mobileBottomPanelMode !== "hidden" ? (
+        {isMobileViewport && !isMapExpanded && mobileActivePanel === "navigator" && shouldRenderMobileBottomPanel ? (
           <div
             aria-labelledby={mobileNavigatorTabId}
-            className="mobile-workspace-panel mobile-workspace-panel-shell mobile-workspace-panel-navigator"
+            className={`mobile-workspace-panel mobile-workspace-panel-shell mobile-workspace-panel-navigator ${mobileBottomPanelMotionClass}`.trim()}
             id={mobileNavigatorPanelId}
             role="tabpanel"
           >

--- a/src/components/LinkProfileChart.tsx
+++ b/src/components/LinkProfileChart.tsx
@@ -1,6 +1,6 @@
 import { extent, max } from "d3-array";
 import { scaleLinear } from "d3-scale";
-import { ArrowLeftRight, Maximize2, Minimize2 } from "lucide-react";
+import { ArrowLeftRight, PanelBottomClose, PanelBottomOpen } from "lucide-react";
 import type { MouseEvent } from "react";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
@@ -695,7 +695,7 @@ export function LinkProfileChart({
 
   if (!hasMinimumTopology) {
     return (
-      <section className="chart-panel chart-panel-empty">
+      <section className={`chart-panel chart-panel-empty ${panelClassName ?? ""}`.trim()}>
         <div className="chart-empty">
           Select exactly two sites, or choose a saved link, to show path profile and LOS/Fresnel analysis.
         </div>
@@ -705,7 +705,7 @@ export function LinkProfileChart({
 
   if (tooManySelectedForProfile) {
     return (
-      <section className="chart-panel chart-panel-empty">
+      <section className={`chart-panel chart-panel-empty ${panelClassName ?? ""}`.trim()}>
         <div className="chart-empty">
           Select exactly two sites, or choose a saved link, to show path profile analysis.
         </div>
@@ -741,7 +741,7 @@ export function LinkProfileChart({
               title={isExpanded ? "Exit full screen" : "Full screen"}
               type="button"
             >
-              {isExpanded ? <Minimize2 aria-hidden="true" strokeWidth={1.8} /> : <Maximize2 aria-hidden="true" strokeWidth={1.8} />}
+              {isExpanded ? <PanelBottomClose aria-hidden="true" strokeWidth={1.8} /> : <PanelBottomOpen aria-hidden="true" strokeWidth={1.8} />}
             </button>
           ) : null}
           {rowControls}

--- a/src/components/PanoramaChart.tsx
+++ b/src/components/PanoramaChart.tsx
@@ -1,6 +1,6 @@
 import { scaleLinear } from "d3-scale";
 import { Surface } from "./ui/Surface";
-import { Info, MapPinned, Maximize2, Minimize2, Mountain, MountainSnow, MoveVertical, RadioTower, Tags, ZoomIn } from "lucide-react";
+import { Info, MapPinned, PanelBottomClose, PanelBottomOpen, Mountain, MountainSnow, MoveVertical, RadioTower, Tags, ZoomIn } from "lucide-react";
 import { createPortal } from "react-dom";
 import type { CSSProperties, MouseEvent as ReactMouseEvent, ReactNode } from "react";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
@@ -1337,7 +1337,7 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
 
   if (!selectedSiteEffective) {
     return (
-      <section className="chart-panel chart-panel-empty">
+      <section className={`chart-panel chart-panel-empty ${panelClassName ?? ""}`.trim()}>
         <div className="chart-empty">Select one site to show panorama analysis.</div>
       </section>
     );
@@ -1494,7 +1494,7 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
               title={isExpanded ? "Exit full screen" : "Full screen"}
               type="button"
             >
-              {isExpanded ? <Minimize2 aria-hidden="true" strokeWidth={1.8} /> : <Maximize2 aria-hidden="true" strokeWidth={1.8} />}
+              {isExpanded ? <PanelBottomClose aria-hidden="true" strokeWidth={1.8} /> : <PanelBottomOpen aria-hidden="true" strokeWidth={1.8} />}
             </button>
           ) : null}
           {rowControls}

--- a/src/index.css
+++ b/src/index.css
@@ -128,6 +128,7 @@ input {
   opacity: 1;
   animation: fade-in 260ms ease;
   animation-fill-mode: both;
+  transition: grid-template-columns 360ms ease-out;
 }
 
 .app-shell.is-map-expanded,
@@ -2787,6 +2788,17 @@ html.panorama-gesture-lock body {
     padding: 0;
     z-index: 45;
     transition: opacity 350ms ease-out, transform 350ms ease-out, height 350ms ease-out, min-height 350ms ease-out;
+    transform: translateY(0);
+    opacity: 1;
+  }
+
+  .mobile-panel-motion-enter-bottom {
+    animation: panel-slide-in-bottom 360ms ease-out both;
+  }
+
+  .mobile-panel-motion-exit-bottom {
+    animation: panel-slide-out-bottom 360ms ease-out both;
+    pointer-events: none;
   }
 
   .mobile-workspace-panel > * {
@@ -3010,9 +3022,10 @@ html.panorama-gesture-lock body {
 
   .app-shell.is-mobile-shell.mobile-bottom-full .workspace-panel .mobile-workspace-panel,
   .app-shell.is-mobile-shell.mobile-bottom-full .workspace-panel .map-inspector {
-    top: calc(12px + env(safe-area-inset-top));
+    top: auto;
     bottom: calc(var(--mobile-tabbar-offset) + var(--mobile-tabbar-height) + var(--mobile-panel-tab-gap));
-    height: auto;
+    height: calc(100dvh - var(--mobile-controls-top) - var(--mobile-tabbar-offset) - var(--mobile-tabbar-height) - var(--mobile-panel-tab-gap) - 12px);
+    min-height: calc(100dvh - var(--mobile-controls-top) - var(--mobile-tabbar-offset) - var(--mobile-tabbar-height) - var(--mobile-panel-tab-gap) - 12px);
     max-height: none;
   }
 


### PR DESCRIPTION
## Summary
- sync desktop content reflow with side-panel hide/show timing by tying column width changes to panel exit phase and animating shell columns
- restore bottom panel fullscreen controls to panel-bottom-open (expand) and panel-bottom-close (revert)
- apply panel motion class on panorama and profile empty-state branches so opening animation is consistent
- add explicit mobile enter/exit motion phase + classes and full-height numeric transitions so hide/show/full visibly animate

Closes #532