### PR TITLE
fix(panels): remove motion drift and unify inspector behavior

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1634,12 +1634,16 @@ export function AppShell() {
       return;
     }
     setMobileBottomPanelMode(nextMode);
-    setMobileBottomMotionPhase("entering");
-    mobileBottomMotionTimerRef.current = window.setTimeout(() => {
-      setMobileBottomMotionPhase("idle");
-      mobileBottomMotionTimerRef.current = null;
-    }, PANEL_MOTION_MS);
-  }, [clearMotionTimer]);
+    if (mobileBottomPanelMode === "hidden") {
+      setMobileBottomMotionPhase("entering");
+      mobileBottomMotionTimerRef.current = window.setTimeout(() => {
+        setMobileBottomMotionPhase("idle");
+        mobileBottomMotionTimerRef.current = null;
+      }, PANEL_MOTION_MS);
+      return;
+    }
+    setMobileBottomMotionPhase("idle");
+  }, [clearMotionTimer, mobileBottomPanelMode]);
 
   const shouldRenderMobileBottomPanel = mobileBottomPanelMode !== "hidden" || mobileBottomMotionPhase === "exiting";
   const mobileBottomPanelMotionClass =
@@ -1968,7 +1972,7 @@ export function AppShell() {
             !isMapExpanded &&
             shouldRenderInspectorPanel &&
             (isMobileViewport
-              ? mobileActivePanel === "inspector" && mobileBottomPanelMode !== "hidden"
+              ? mobileActivePanel === "inspector" && shouldRenderMobileBottomPanel
               : !isProfileExpanded)
           }
           showMultiSelectToggle={isMobileViewport}
@@ -2009,7 +2013,9 @@ export function AppShell() {
             </div>
           }
           readOnly={!canPersistWorkspace}
-          inspectorPanelClassName={inspectorPanelMotionClass}
+          inspectorPanelClassName={`${inspectorPanelMotionClass} ${
+            isMobileViewport && mobileActivePanel === "inspector" ? mobileBottomPanelMotionClass : ""
+          }`.trim()}
           onToggleMapExpanded={() => {
             setIsProfileExpanded(false);
             if (isMobileViewport && mobileBottomPanelMode === "full") {

--- a/src/index.css
+++ b/src/index.css
@@ -218,66 +218,54 @@ input {
 
 @keyframes panel-slide-in-left {
   from {
-    opacity: 0;
     transform: translateX(-108%);
   }
   to {
-    opacity: 1;
     transform: translateX(0);
   }
 }
 
 @keyframes panel-slide-out-left {
   from {
-    opacity: 1;
     transform: translateX(0);
   }
   to {
-    opacity: 0;
     transform: translateX(-108%);
   }
 }
 
 @keyframes panel-slide-in-right {
   from {
-    opacity: 0;
     transform: translateX(108%);
   }
   to {
-    opacity: 1;
     transform: translateX(0);
   }
 }
 
 @keyframes panel-slide-out-right {
   from {
-    opacity: 1;
     transform: translateX(0);
   }
   to {
-    opacity: 0;
     transform: translateX(108%);
   }
 }
 
 @keyframes panel-slide-in-bottom {
   from {
-    opacity: 0;
     transform: translateY(108%);
   }
   to {
-    opacity: 1;
     transform: translateY(0);
   }
 }
 
 @keyframes panel-slide-out-bottom {
   from {
-    opacity: 1;
     transform: translateY(0);
   }
   to {
-    opacity: 0;
     transform: translateY(108%);
   }
 }
@@ -322,7 +310,7 @@ input {
   -webkit-backdrop-filter: blur(var(--glass-panel-blur));
   backdrop-filter: blur(var(--glass-panel-blur));
   box-shadow: var(--shadow);
-  transition: opacity 350ms ease-out, transform 350ms ease-out, box-shadow 350ms ease-out;
+  transition: transform 350ms ease-out, box-shadow 350ms ease-out;
 }
 
 .sidebar-panel {
@@ -792,6 +780,7 @@ input {
   min-height: 0;
   z-index: 30;
   pointer-events: none;
+  transition: grid-template-rows 360ms ease-out, padding-right 360ms ease-out;
 }
 
 .workspace-panel > * {
@@ -1437,7 +1426,7 @@ input {
   bottom: 18px;
   right: 18px;
   z-index: 60;
-  width: min(var(--inspector-overlay-width), calc(100% - 36px));
+  width: min(clamp(280px, 20vw, 400px), calc(100% - 36px));
   max-height: none;
   overflow: auto;
   padding: 18px;
@@ -3018,6 +3007,8 @@ html.panorama-gesture-lock body {
     min-height: var(--mobile-panel-height);
     max-height: none;
     z-index: 85;
+    transform: translateY(0);
+    transition: transform 360ms ease-out, height 360ms ease-out, min-height 360ms ease-out;
   }
 
   .app-shell.is-mobile-shell.mobile-bottom-full .workspace-panel .mobile-workspace-panel,


### PR DESCRIPTION
## Summary
- make mobile hidden/normal transitions animate consistently for inspector by rendering inspector through the same hidden-phase gate used by other panels
- stop applying mobile enter animation on normal<->full transitions so navigator/profile/inspector resize instead of re-entering from bottom
- remove desktop panel fade from slide keyframes (desktop is now slide-only)
- smooth desktop workspace reflow with panel motion and remove right-inspector jump by decoupling inspector width from collapsing CSS var during slide

Closes #532