### PR TITLE
fix(panels): align desktop profile expansion and panel motion

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -223,6 +223,8 @@ export function AppShell() {
   const inspectorMotionTimerRef = useRef<number | null>(null);
   const profileMotionTimerRef = useRef<number | null>(null);
   const mobileBottomMotionTimerRef = useRef<number | null>(null);
+  const navigatorWasHiddenBeforeProfileExpandRef = useRef(false);
+  const inspectorWasHiddenBeforeProfileExpandRef = useRef(false);
   const hadAuthenticatedSessionRef = useRef(false);
   const {
     showWelcomeModal,
@@ -1618,7 +1620,23 @@ export function AppShell() {
   const toggleProfileExpanded = () => {
     setIsMapExpanded(false);
     setMobileActivePanel("profile");
-    setIsProfileExpanded((prev) => !prev);
+    setIsProfileExpanded((prev) => {
+      const next = !prev;
+      if (!isMobileViewport) {
+        if (next) {
+          navigatorWasHiddenBeforeProfileExpandRef.current = isNavigatorHidden;
+          inspectorWasHiddenBeforeProfileExpandRef.current = isInspectorHidden;
+          if (!isNavigatorHidden) hideNavigatorPanel();
+          if (!isInspectorHidden) hideInspectorPanel();
+        } else {
+          if (!navigatorWasHiddenBeforeProfileExpandRef.current) showNavigatorPanel();
+          if (!inspectorWasHiddenBeforeProfileExpandRef.current) showInspectorPanel();
+          navigatorWasHiddenBeforeProfileExpandRef.current = false;
+          inspectorWasHiddenBeforeProfileExpandRef.current = false;
+        }
+      }
+      return next;
+    });
     emitProfileLayoutPulse();
   };
 
@@ -1898,7 +1916,7 @@ export function AppShell() {
           ) : null}
         </div>
       ) : null}
-      {!isMobileViewport && !isMapExpanded && !isProfileExpanded && shouldRenderNavigatorPanel && (accessState === "granted" || accessState === "readonly" || isAnonymousBootstrapShell) ? (
+      {!isMobileViewport && !isMapExpanded && shouldRenderNavigatorPanel && (accessState === "granted" || accessState === "readonly" || isAnonymousBootstrapShell) ? (
           <Sidebar
             authBootstrapPending={accessState === "checking"}
             hideLibraryBrowsing={isReadOnlyShell}
@@ -1973,7 +1991,7 @@ export function AppShell() {
             shouldRenderInspectorPanel &&
             (isMobileViewport
               ? mobileActivePanel === "inspector" && shouldRenderMobileBottomPanel
-              : !isProfileExpanded)
+              : true)
           }
           showMultiSelectToggle={isMobileViewport}
           canPersist={canPersistWorkspace}

--- a/src/index.css
+++ b/src/index.css
@@ -845,7 +845,7 @@ input {
 }
 
 .collapsed-panel-btn-profile {
-  left: 50%;
+  left: calc((100% + var(--sidebar-overlay-width) - var(--inspector-overlay-width)) / 2);
   bottom: 70px;
   transform: translateX(-50%);
   animation: panel-toggle-bounce 200ms ease-out 50ms both;
@@ -858,7 +858,7 @@ input {
 }
 
 .collapsed-panel-btn-profile {
-  left: 50%;
+  left: calc((100% + var(--sidebar-overlay-width) - var(--inspector-overlay-width)) / 2);
   bottom: 70px;
   transform: translateX(-50%);
   z-index: 109;
@@ -924,7 +924,7 @@ input {
 }
 
 .workspace-panel.is-profile-expanded {
-  grid-template-rows: minmax(0, 1fr);
+  grid-template-rows: minmax(0, 0fr) minmax(0, 1fr);
   padding-right: 0;
   z-index: 101;
 }
@@ -1948,14 +1948,6 @@ input {
   position: relative;
   z-index: 35;
   grid-row: 2;
-}
-
-.workspace-panel.is-profile-expanded .chart-panel {
-  grid-row: 1;
-}
-
-.workspace-panel.is-profile-expanded .map-inspector {
-  display: none;
 }
 
 .chart-panel-empty {


### PR DESCRIPTION
## Summary
- center desktop floating profile restore control relative to workspace area instead of full app shell width
- animate desktop profile expand/collapse as true vertical resize by keeping chart in row 2 and transitioning row weights
- synchronize side panel hide/show with profile expand/collapse using remembered pre-expand hidden state
- keep inspector rendered for exit animation during profile expand (instead of immediate cut)

Closes #532