### PR TITLE
chore: ignore local debug artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ dist-ssr
 .tmp/
 
 debug-logs/
+.playwright-mcp/
+artifacts/
+linksim-home.png
+opencode.json
 
 # Python
 __pycache__/


### PR DESCRIPTION
## Summary
- ignore local-only debug/runtime artifacts so they never pollute git status or deployment preflight
- add ignores for .playwright-mcp/, artifacts/, linksim-home.png, and opencode.json

## Verification
- npm test
- npm run build