### PR TITLE
feat(panorama): add distance-based terrain heatmap coloring

### DIFF
--- a/functions/_lib/buildInfo.ts
+++ b/functions/_lib/buildInfo.ts
@@ -1,5 +1,5 @@
 export const APP_VERSION = "0.15.0";
-export const APP_COMMIT = "4f65dd85";
+export const APP_COMMIT = "6b2d608a";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {

--- a/src/components/PanoramaChart.tsx
+++ b/src/components/PanoramaChart.tsx
@@ -1,6 +1,6 @@
 import { scaleLinear } from "d3-scale";
 import { Surface } from "./ui/Surface";
-import { Info, MapPinned, PanelBottomClose, PanelBottomOpen, Mountain, MountainSnow, MoveVertical, RadioTower, Tags, ZoomIn } from "lucide-react";
+import { Info, MapPinned, Paintbrush, PanelBottomClose, PanelBottomOpen, Mountain, MountainSnow, MoveVertical, RadioTower, Tags, ZoomIn } from "lucide-react";
 import { createPortal } from "react-dom";
 import type { CSSProperties, MouseEvent as ReactMouseEvent, ReactNode } from "react";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
@@ -23,13 +23,14 @@ import { resolveVisiblePanoramaLabels, type PanoramaLabelCandidate } from "../li
 import { loadPanoramaPeaks, type PanoramaPeakCandidate } from "../lib/panoramaPeaks";
 import { isPeakLosVisible, nearestSampleForDistance } from "../lib/panoramaLos";
 import { buildDepthBands, buildNearBiasedDepthFractions, resolveRenderedEndpoint } from "../lib/panoramaRender";
-import { cardinalLabelForAzimuth, formatAzimuthTick, fovScaleToSpanDeg, mod360, normalizeFovScale, resolvePanoramaWindow, unwrapAzimuthForWindow } from "../lib/panoramaView";
+import { cardinalLabelForAzimuth, formatAzimuthTick, fovScaleToSpanDeg, FOV_SCALE_DEFAULT, FOV_SCALE_MAX, FOV_SCALE_MIN, mod360, normalizeFovScale, resolvePanoramaWindow, unwrapAzimuthForWindow } from "../lib/panoramaView";
 import { centerForScaledWindow } from "../lib/panoramaViewport";
 import { passFailStateLabel } from "../lib/passFailState";
 import { sampleSrtmElevation } from "../lib/srtm";
 import { useAppStore } from "../store/appStore";
 import { useThemeVariant } from "../hooks/useThemeVariant";
 import { UiSlider } from "./UiSlider";
+import { interpolateHeatmapColor } from "../themes/heatmapColors";
 
 const M = { t: 22, r: 20, b: 32, l: 46 };
 const LABEL_RAIL_HEIGHT = 34;
@@ -140,7 +141,8 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
   const [exaggeration, setExaggeration] = useState(4);
   const [mapHoverZoomEnabled, setMapHoverZoomEnabled] = useState(false);
   const [showLabels, setShowLabels] = useState(true);
-  const [fovScale, setFovScale] = useState(3);
+  const [terrainDistanceHeatmap, setTerrainDistanceHeatmap] = useState(false);
+  const [fovScale, setFovScale] = useState(FOV_SCALE_DEFAULT);
   const [hoverTarget, setHoverTarget] = useState<HoverTarget | null>(null);
   const [pinnedTarget, setPinnedTarget] = useState<HoverTarget | null>(null);
   const [openSliderPopover, setOpenSliderPopover] = useState<"fov" | "vertical" | null>(null);
@@ -809,6 +811,8 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
         0.001,
         ...rays.map((entry) => (entry.ray.samples.length ? entry.ray.samples[entry.ray.samples.length - 1]?.distanceKm ?? entry.ray.maxDistanceKm : entry.ray.maxDistanceKm)),
       );
+      const validHorizonDistances = rays.map((r) => r.ray.horizonDistanceKm).filter((d): d is number => Number.isFinite(d) && d > 0);
+      const maxHorizonDistanceKm = validHorizonDistances.length > 0 ? Math.max(...validHorizonDistances) : maxDistanceKm;
       const maxSampleCount = Math.max(2, ...rays.map((entry) => entry.ray.samples.length));
       const light = { x: -0.62, y: -0.36, z: 0.7 };
       const lightNorm = Math.hypot(light.x, light.y, light.z) || 1;
@@ -832,7 +836,7 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
         oCtx.clip();
 
         // Helper: draw one terrain pass onto oCtx using the given color function.
-        const drawTerrainPass = (colorFn: (haze: number, lambert: number) => Rgb) => {
+        const drawTerrainPass = (colorFn: (haze: number, lambert: number, distanceKm?: number) => Rgb) => {
           oCtx.clearRect(0, 0, cw, ch);
           oCtx.save();
           oCtx.beginPath();
@@ -867,7 +871,7 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
               const depth = clamp(avgDistanceKm / maxDistanceKm, 0, 1);
               const haze = Math.pow(depth, 1.15);
 
-              oCtx.fillStyle = toCanvasColor(colorFn(haze, lambert), 1);
+              oCtx.fillStyle = toCanvasColor(colorFn(haze, lambert, avgDistanceKm), 1);
               oCtx.beginPath();
               oCtx.moveTo(x0, y00);
               oCtx.lineTo(x1 + 0.5, y10);
@@ -881,8 +885,14 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
         };
 
         // Pass 1: Relief shading (always rendered).
-        drawTerrainPass((haze, lambert) => {
-          const base = blendRgb(terrainColor, surfaceColor, shadingHazeStart + haze * 0.55);
+        drawTerrainPass((haze, lambert, avgDistanceKm) => {
+          let base: Rgb;
+          if (terrainDistanceHeatmap && maxHorizonDistanceKm > 0 && avgDistanceKm !== undefined) {
+            const normalizedDistance = 1 - avgDistanceKm / maxHorizonDistanceKm;
+            base = interpolateHeatmapColor(normalizedDistance);
+          } else {
+            base = blendRgb(terrainColor, surfaceColor, shadingHazeStart + haze * 0.55);
+          }
           const lighten = lambert > 0.4 ? ((lambert - 0.4) / 0.6) * 1.0 : 0;
           const darken = lambert < 0.4 ? ((0.4 - lambert) / 0.4) * 0.7 : 0;
           return brightenRgb(base, lighten - darken);
@@ -977,7 +987,7 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
       ctx.lineTo(label.x, label.y);
       ctx.stroke();
     }
-  }, [geometry, chartSize, shadingHazeStart]);
+  }, [geometry, chartSize, shadingHazeStart, terrainDistanceHeatmap]);
 
   const focusTarget = hoverTarget ?? pinnedTarget;
   const focusAzimuthDeg = focusTarget?.azimuthDeg ?? null;
@@ -1381,8 +1391,8 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
                 <UiSlider
                   ariaLabel="Panorama field of view"
                   label="FOV"
-                  max={4}
-                  min={1}
+                  max={FOV_SCALE_MAX}
+                  min={FOV_SCALE_MIN}
                   onChange={(value) => setFovScale(normalizeFovScale(value))}
                   orientation="vertical"
                   step={0.1}
@@ -1425,6 +1435,16 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
               <li><span className="state-dot state-dot-fail_clear" aria-hidden /><span>Visible + fail</span></li>
               <li><span className="state-dot state-dot-fail_blocked" aria-hidden /><span>Blocked + fail</span></li>
             </ul>
+            {terrainDistanceHeatmap ? (
+              <div className="panorama-legend-heatmap">
+                <p className="panorama-legend-heatmap-title">Terrain distance</p>
+                <div className="panorama-legend-heatmap-bar" />
+                <div className="panorama-legend-heatmap-labels">
+                  <span>Far</span>
+                  <span>Near</span>
+                </div>
+              </div>
+            ) : null}
           </Surface>,
           document.body,
         )
@@ -1477,11 +1497,20 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
             <Tags aria-hidden="true" strokeWidth={1.8} />
           </button>
           <button
-            aria-label="Signal coverage legend"
+            aria-label={terrainDistanceHeatmap ? "Disable distance heatmap" : "Enable distance heatmap"}
+            className={`chart-endpoint-swap chart-endpoint-icon ${terrainDistanceHeatmap ? "is-active" : ""}`}
+            onClick={() => setTerrainDistanceHeatmap((value) => !value)}
+            title={terrainDistanceHeatmap ? "Distance heatmap on" : "Distance heatmap off"}
+            type="button"
+          >
+            <Paintbrush aria-hidden="true" strokeWidth={1.8} />
+          </button>
+          <button
+            aria-label="Legend"
             className={`chart-endpoint-swap chart-endpoint-icon ${legendPopoverOpen ? "is-active" : ""}`}
             onClick={() => setLegendPopoverOpen((v) => !v)}
             ref={legendButtonRef}
-            title="Coverage legend"
+            title="Legend"
             type="button"
           >
             <Info aria-hidden="true" strokeWidth={1.8} />

--- a/src/index.css
+++ b/src/index.css
@@ -2420,6 +2420,45 @@ input {
   color: var(--text);
 }
 
+.panorama-legend-heatmap {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border);
+}
+
+.panorama-legend-heatmap-title {
+  margin: 0 0 6px;
+  font-size: 0.7rem;
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.panorama-legend-heatmap-bar {
+  width: 100%;
+  height: 8px;
+  border-radius: var(--radius-pill);
+  border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
+  background: linear-gradient(
+    90deg,
+    rgb(105, 42, 45) 0%,
+    rgb(156, 63, 49) 35%,
+    rgb(201, 92, 45) 45%,
+    rgb(226, 127, 45) 55%,
+    rgb(218, 175, 55) 65%,
+    rgb(164, 193, 68) 75%,
+    rgb(95, 178, 95) 85%,
+    rgb(64, 150, 178) 100%
+  );
+}
+
+.panorama-legend-heatmap-labels {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 4px;
+  font-size: 0.68rem;
+  color: var(--muted);
+}
+
 
 .panorama-shade-band {
   fill: color-mix(in srgb, var(--terrain) 72%, var(--surface-2) 28%);

--- a/src/lib/buildInfo.ts
+++ b/src/lib/buildInfo.ts
@@ -1,5 +1,5 @@
 export const APP_VERSION = "0.15.0";
-export const APP_COMMIT = "4f65dd85";
+export const APP_COMMIT = "6b2d608a";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {

--- a/src/lib/overlayRaster.ts
+++ b/src/lib/overlayRaster.ts
@@ -1,6 +1,7 @@
 import { classifyPassFailState, computeSourceCentricRxMetrics } from "./passFailState";
 import { STANDARD_SITE_RADIO } from "./linkRadio";
 import type { Link, PropagationEnvironment, Site } from "../types/radio";
+import { interpolateHeatmapColor } from "../themes/heatmapColors";
 
 export type TerrainBounds = {
   minLat: number;
@@ -168,30 +169,9 @@ const precomputeGridAxes = (
 };
 
 const coverageColorForDbm = (valueDbm: number): [number, number, number] => {
-  const stops: Array<{ v: number; c: [number, number, number] }> = [
-    { v: -125, c: [105, 42, 45] },
-    { v: -114, c: [156, 63, 49] },
-    { v: -104, c: [201, 92, 45] },
-    { v: -95, c: [226, 127, 45] },
-    { v: -86, c: [218, 175, 55] },
-    { v: -78, c: [164, 193, 68] },
-    { v: -70, c: [95, 178, 95] },
-    { v: -62, c: [64, 150, 178] },
-  ];
-  if (valueDbm <= stops[0].v) return stops[0].c;
-  if (valueDbm >= stops[stops.length - 1].v) return stops[stops.length - 1].c;
-  for (let i = 0; i < stops.length - 1; i += 1) {
-    const a = stops[i];
-    const b = stops[i + 1];
-    if (valueDbm < a.v || valueDbm > b.v) continue;
-    const t = (valueDbm - a.v) / (b.v - a.v);
-    return [
-      Math.round(a.c[0] + (b.c[0] - a.c[0]) * t),
-      Math.round(a.c[1] + (b.c[1] - a.c[1]) * t),
-      Math.round(a.c[2] + (b.c[2] - a.c[2]) * t),
-    ];
-  }
-  return [255, 255, 255];
+  const normalized = (valueDbm + 125) / 63;
+  const color = interpolateHeatmapColor(normalized);
+  return [color.r, color.g, color.b];
 };
 
 const computeCoverageAdaptiveScale = (

--- a/src/lib/panorama.ts
+++ b/src/lib/panorama.ts
@@ -1,6 +1,6 @@
 import { computeSourceCentricRxMetrics, classifyPassFailState, type PassFailState } from "./passFailState";
 import { haversineDistanceKm } from "./geo";
-import { normalizeFovScale } from "./panoramaView";
+import { normalizeFovScale, FOV_SCALE_DEFAULT } from "./panoramaView";
 import type { Link, PropagationEnvironment, Site } from "../types/radio";
 
 const EARTH_RADIUS_M = 6_371_000;
@@ -90,7 +90,7 @@ export const qualityToSampling = (quality: PanoramaQuality): { azimuthStepDeg: n
 export const resolvePanoramaSampling = (quality: PanoramaQuality, options?: { zoomModeEnabled?: boolean; fovScale?: number }) => {
   const defaults = qualityToSampling(quality);
   if (!options?.zoomModeEnabled) return defaults;
-  const fovScale = normalizeFovScale(options.fovScale ?? 1);
+  const fovScale = normalizeFovScale(options.fovScale ?? FOV_SCALE_DEFAULT);
   return {
     azimuthStepDeg: Math.max(0.25, defaults.azimuthStepDeg / fovScale),
     radialSamples: defaults.radialSamples,

--- a/src/lib/panoramaView.test.ts
+++ b/src/lib/panoramaView.test.ts
@@ -28,9 +28,12 @@ describe("panoramaView", () => {
 
   it("maps FOV scale to panorama span", () => {
     expect(normalizeFovScale(0.3)).toBe(1);
-    expect(normalizeFovScale(5)).toBe(4);
+    expect(normalizeFovScale(5)).toBe(5);
+    expect(normalizeFovScale(24)).toBe(24);
+    expect(normalizeFovScale(30)).toBe(24);
     expect(fovScaleToSpanDeg(1)).toBe(360);
     expect(fovScaleToSpanDeg(4)).toBe(90);
+    expect(fovScaleToSpanDeg(24)).toBe(15);
     expect(fovScaleToSpanDeg(1.5)).toBeCloseTo(240);
   });
 

--- a/src/lib/panoramaView.ts
+++ b/src/lib/panoramaView.ts
@@ -1,6 +1,14 @@
 export const mod360 = (value: number): number => ((value % 360) + 360) % 360;
 const clamp = (value: number, min: number, max: number): number => Math.max(min, Math.min(max, value));
 
+export const FOV_SCALE_MIN = 1;
+export const FOV_SCALE_DEFAULT = 4;
+export const FOV_SCALE_MAX = 24;
+
+export const normalizeFovScale = (fovScale: number): number => clamp(fovScale, FOV_SCALE_MIN, FOV_SCALE_MAX);
+
+export const fovScaleToSpanDeg = (fovScale: number): number => 360 / normalizeFovScale(fovScale);
+
 export const cardinalLabelForAzimuth = (azimuthDeg: number): "N" | "E" | "S" | "W" | null => {
   const normalized = mod360(azimuthDeg);
   if (Math.abs(normalized - 0) < 0.0001 || Math.abs(normalized - 360) < 0.0001) return "N";
@@ -30,10 +38,6 @@ export const resolvePanoramaWindow = (centerDeg: number, spanDeg = 90): Panorama
   const endDeg = center + span / 2;
   return { centerDeg: center, spanDeg: span, startDeg, endDeg };
 };
-
-export const normalizeFovScale = (fovScale: number): number => clamp(fovScale, 1, 4);
-
-export const fovScaleToSpanDeg = (fovScale: number): number => 360 / normalizeFovScale(fovScale);
 
 export const chartXNormToAzimuthDeg = (xNorm: number): number => clamp(xNorm, 0, 1) * 360;
 

--- a/src/themes/heatmapColors.ts
+++ b/src/themes/heatmapColors.ts
@@ -1,0 +1,30 @@
+export type Rgb = { r: number; g: number; b: number };
+
+export const HEATMAP_STOPS: Array<{ v: number; c: Rgb }> = [
+  { v: 0, c: { r: 105, g: 42, b: 45 } },
+  { v: 0.35, c: { r: 156, g: 63, b: 49 } },
+  { v: 0.45, c: { r: 201, g: 92, b: 45 } },
+  { v: 0.55, c: { r: 226, g: 127, b: 45 } },
+  { v: 0.65, c: { r: 218, g: 175, b: 55 } },
+  { v: 0.75, c: { r: 164, g: 193, b: 68 } },
+  { v: 0.85, c: { r: 95, g: 178, b: 95 } },
+  { v: 1, c: { r: 64, g: 150, b: 178 } },
+];
+
+export const interpolateHeatmapColor = (t: number): Rgb => {
+  const normalized = Math.max(0, Math.min(1, t));
+  if (normalized <= HEATMAP_STOPS[0].v) return HEATMAP_STOPS[0].c;
+  if (normalized >= HEATMAP_STOPS[HEATMAP_STOPS.length - 1].v) return HEATMAP_STOPS[HEATMAP_STOPS.length - 1].c;
+  for (let i = 0; i < HEATMAP_STOPS.length - 1; i += 1) {
+    const a = HEATMAP_STOPS[i];
+    const b = HEATMAP_STOPS[i + 1];
+    if (normalized < a.v || normalized > b.v) continue;
+    const ratio = (normalized - a.v) / (b.v - a.v);
+    return {
+      r: Math.round(a.c.r + (b.c.r - a.c.r) * ratio),
+      g: Math.round(a.c.g + (b.c.g - a.c.g) * ratio),
+      b: Math.round(a.c.b + (b.c.b - a.c.b) * ratio),
+    };
+  }
+  return HEATMAP_STOPS[HEATMAP_STOPS.length - 1].c;
+};


### PR DESCRIPTION
## Summary
Add distance-based terrain shading to panorama mode where terrain is colored by distance using a heatmap gradient.

### Features
- Distance heatmap toggle in panorama toolbar (Paintbrush icon)
- Far terrain = red, near terrain = blue (matching existing heatmap color system)
- Centralized heatmap color palette shared between map coverage and panorama
- Heatmap legend in legend popover when toggle is active

### FOV Changes
- Default FOV changed from 120° to 90°
- FOV slider range extended from 360°→90° to 360°→15°
- Centralized FOV constants in panoramaView.ts

### Technical
- New shared heatmap colors file: `src/themes/heatmapColors.ts`
- Updated `overlayRaster.ts` to use shared colors
- Updated `PanoramaChart.tsx` with toggle and rendering logic
- Updated `panoramaView.ts` with FOV_SCALE_MIN/DEFAULT/MAX constants
- Tests updated in `panoramaView.test.ts`

### Files Changed
- `src/themes/heatmapColors.ts` (new)
- `src/lib/overlayRaster.ts`
- `src/lib/panoramaView.ts`
- `src/lib/panorama.ts`
- `src/components/PanoramaChart.tsx`
- `src/index.css`
- `src/lib/panoramaView.test.ts`
- `functions/_lib/buildInfo.ts`, `src/lib/buildInfo.ts` (auto-generated)

Closes #633