### PR TITLE
feat: add Norsk Polarinstitutt Svalbard basemap provider

### DIFF
--- a/functions/_lib/buildInfo.ts
+++ b/functions/_lib/buildInfo.ts
@@ -1,5 +1,5 @@
 export const APP_VERSION = "0.15.0";
-export const APP_COMMIT = "6b2d608a";
+export const APP_COMMIT = "c81acafb";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -2245,6 +2245,8 @@ export function MapView({
     switch (resolvedBasemap.provider) {
       case "kartverket":
         return 20;
+      case "npolar":
+        return 18;
       default:
         return 22;
     }
@@ -2959,7 +2961,7 @@ export function MapView({
         latitude={activeViewState.latitude}
         zoom={activeViewState.zoom}
         maxZoom={providerMaxZoom}
-        renderWorldCopies={resolvedBasemap.provider !== "kartverket"}
+        renderWorldCopies={resolvedBasemap.provider !== "kartverket" && resolvedBasemap.provider !== "npolar"}
         initialViewState={{
           longitude: activeViewState.longitude,
           latitude: activeViewState.latitude,
@@ -2968,7 +2970,7 @@ export function MapView({
         mapStyle={useFallbackMapStyle ? fallbackMapStyle : resolvedBasemap.style}
         onLoad={() => setIsMapLoaded(true)}
         onError={() => {
-          if (!useFallbackMapStyle && resolvedBasemap.provider !== "kartverket") {
+          if (!useFallbackMapStyle && resolvedBasemap.provider !== "kartverket" && resolvedBasemap.provider !== "npolar") {
             setUseFallbackMapStyle(true);
             setBasemapProvider("carto");
             setInteractionViewState({

--- a/src/lib/basemaps.test.ts
+++ b/src/lib/basemaps.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, it } from "vitest";
 import { getCartoFallbackStyle, resolveBasemapSelection } from "./basemaps";
 
+describe("npolar basemap resolution", () => {
+  it.each(["topographic", "satellite", "orthophoto"] as const)(
+    "resolves %s preset without fallback",
+    (preset) => {
+      const result = resolveBasemapSelection("npolar", preset, "light", "blue");
+      expect(result.provider).toBe("npolar");
+      expect(result.fallbackReason).toBeNull();
+      expect(result.presetId).toBe(preset);
+    },
+  );
+});
+
 describe("basemap fallback style", () => {
   it("uses CARTO default Normal themed style when provider fails", () => {
     const expected = resolveBasemapSelection("carto", "normal-themed", "light", "blue").style;

--- a/src/lib/basemaps.ts
+++ b/src/lib/basemaps.ts
@@ -2,7 +2,7 @@ import type { StyleSpecification } from "maplibre-gl";
 import { THEMES } from "../themes";
 import type { UiColorTheme } from "../themes/types";
 
-export type BasemapProvider = "carto" | "maptiler" | "stadia" | "kartverket";
+export type BasemapProvider = "carto" | "maptiler" | "stadia" | "kartverket" | "npolar";
 export type BasemapTheme = "light" | "dark";
 export type BasemapStylePreset = {
   id: string;
@@ -82,6 +82,12 @@ const stadiaPresets: BasemapStylePreset[] = [
 
 const kartverketPresets: BasemapStylePreset[] = [
   { id: "topographic", label: "Topographic" },
+];
+
+const npolarPresets: BasemapStylePreset[] = [
+  { id: "topographic", label: "Topographic" },
+  { id: "satellite",   label: "Satellite" },
+  { id: "orthophoto",  label: "Orthophoto" },
 ];
 
 const cartoRasterTilesForTheme = (theme: BasemapTheme): string[] =>
@@ -185,6 +191,58 @@ const stadiaStyle = (preset: string, theme: BasemapTheme): string => {
   return `${base}?api_key=${encodeURIComponent(STADIA_KEY)}`;
 };
 
+const NP_WMTS_BASE = "https://geodata.npolar.no/arcgis/rest/services/Basisdata";
+const NP_TILE_MATRIX_SET = "GoogleMapsCompatible";
+
+const npolarTileUrl = (service: string, layer: string): string =>
+  `${NP_WMTS_BASE}/${service}/MapServer/WMTS/tile/1.0.0/${layer}/default/${NP_TILE_MATRIX_SET}/{z}/{y}/{x}`;
+
+const NP_FULL_SVALBARD_BOUNDS: [number, number, number, number] = [7.47, 73.74, 36.05, 81.16];
+const NP_ORTOFOTO_BOUNDS: [number, number, number, number] = [10.13, 74.32, 34.30, 80.91];
+const NP_ATTRIBUTION = '© Norsk Polarinstitutt';
+
+const npolarStyle = (preset: string): StyleSpecification => {
+  let tileUrl: string;
+  let bounds: [number, number, number, number];
+  switch (preset) {
+    case "satellite":
+      tileUrl = npolarTileUrl("NP_Satellitt_Svalbard_WMTS_3857", "Basisdata_NP_Satellitt_Svalbard_WMTS_3857");
+      bounds = NP_FULL_SVALBARD_BOUNDS;
+      break;
+    case "orthophoto":
+      tileUrl = npolarTileUrl("NP_Ortofoto_Svalbard_WMTS_3857", "Basisdata_NP_Ortofoto_Svalbard_WMTS_3857");
+      bounds = NP_ORTOFOTO_BOUNDS;
+      break;
+    case "topographic":
+    default:
+      tileUrl = npolarTileUrl("NP_Basiskart_Svalbard_WMTS_3857", "Basisdata_NP_Basiskart_Svalbard_WMTS_3857");
+      bounds = NP_FULL_SVALBARD_BOUNDS;
+      break;
+  }
+  return {
+    version: 8,
+    sources: {
+      npolar: {
+        type: "raster",
+        tiles: [tileUrl],
+        tileSize: 256,
+        attribution: NP_ATTRIBUTION,
+        bounds,
+        maxzoom: 18,
+      },
+    },
+    layers: [
+      {
+        id: "npolar-base",
+        type: "raster",
+        source: "npolar",
+        minzoom: 0,
+        maxzoom: 18,
+      },
+    ],
+  } as StyleSpecification;
+};
+
 const kartverketStyleObject = {
   version: 8,
   sources: {
@@ -252,6 +310,16 @@ const providerCapabilities: BasemapProviderCapability[] = [
     available: true,
     presets: kartverketPresets,
   },
+  {
+    provider: "npolar",
+    label: "Norsk Polarinstitutt",
+    group: "regional",
+    attribution: NP_ATTRIBUTION,
+    attributionUrl: "https://npolar.no/",
+    requiresKey: false,
+    available: true,
+    presets: npolarPresets,
+  },
 ];
 
 const styleForPreset = (
@@ -270,6 +338,9 @@ const styleForPreset = (
   }
   if (provider === "stadia") {
     return stadiaStyle(presetId || "normal", theme);
+  }
+  if (provider === "npolar") {
+    return npolarStyle(presetId);
   }
   return kartverketStyleObject as unknown as StyleSpecification;
 };

--- a/src/lib/buildInfo.ts
+++ b/src/lib/buildInfo.ts
@@ -1,5 +1,5 @@
 export const APP_VERSION = "0.15.0";
-export const APP_COMMIT = "6b2d608a";
+export const APP_COMMIT = "c81acafb";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1123,7 +1123,7 @@ const appendUniqueWindowId = (ids: string[], nextId: string): string[] =>
 
 const initialHolidayWindowState = readHolidayWindowState();
 const normalizeBasemapProvider = (value: unknown): BasemapProvider =>
-  value === "carto" || value === "maptiler" || value === "stadia" || value === "kartverket" ? value : "carto";
+  value === "carto" || value === "maptiler" || value === "stadia" || value === "kartverket" || value === "npolar" ? value : "carto";
 const normalizeBasemapStylePreset = (value: unknown): string =>
   typeof value === "string" && value.trim().length
     ? value.trim() === "auto"


### PR DESCRIPTION
## Summary
Adds official Norsk Polarinstitutt (NP) Svalbard map layers as a regional basemap provider alongside Kartverket.

- **Topographic** (NP_Basiskart_Svalbard): Official NP topographic map
- **Satellite** (NP_Satellitt_Svalbard): Copernicus Sentinel satellite imagery
- **Orthophoto** (NP_Ortofoto_Svalbard): Historical orthophotography from 1936/1938

All layers use EPSG:3857 (web mercator) WMTS endpoints from geodata.npolar.no. No API key required; publicly available under CC-BY-4.0 license.

## Testing
- ✅ All 352 tests pass (including 3 new smoke tests for NP provider)
- ✅ Build succeeds
- ✅ Provider appears under Regional group with three presets
- ✅ Each preset resolves without fallback