### PR TITLE
ci(#426): auto-deploy on staging/main merge + fix branch policy and guardrails

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,6 +1,10 @@
 name: Deploy LinkSim Pages
 
 on:
+  push:
+    branches:
+      - staging
+      - main
   workflow_dispatch:
     inputs:
       target:
@@ -14,7 +18,9 @@ on:
 
 jobs:
   deploy-staging:
-    if: ${{ github.event.inputs.target == 'staging' }}
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/staging') ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'staging')
     runs-on: ubuntu-latest
     environment: staging
     permissions:
@@ -42,7 +48,9 @@ jobs:
         run: npm run deploy:staging
 
   deploy-prod-main:
-    if: ${{ github.event.inputs.target == 'prod-main' }}
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'prod-main')
     runs-on: ubuntu-latest
     environment: production
     permissions:

--- a/.github/workflows/pr-branch-policy.yml
+++ b/.github/workflows/pr-branch-policy.yml
@@ -27,10 +27,10 @@ jobs:
             exit 1
           fi
           if [ "$BASE_REF" = "main" ]; then
-            if [[ "$HEAD_REF" =~ ^release/v[0-9]+\.[0-9]+\.[0-9]+$ ]] || [[ "$HEAD_REF" =~ ^hotfix/[a-z0-9-]+$ ]]; then
+            if [ "$HEAD_REF" = "staging" ] || [[ "$HEAD_REF" =~ ^release/v[0-9]+\.[0-9]+\.[0-9]+$ ]] || [[ "$HEAD_REF" =~ ^hotfix/[a-z0-9-]+$ ]]; then
               exit 0
             fi
-            echo "PR to main must come from release/vX.Y.Z or hotfix/<slug>."
+            echo "PR to main must come from staging, release/vX.Y.Z, or hotfix/<slug>."
             exit 1
           fi
       - name: Set commit status on success
@@ -57,5 +57,5 @@ jobs:
               sha: context.payload.pull_request.head.sha,
               state: 'failure',
               context: 'PR Branch Policy / enforce',
-              description: 'Branch naming policy violation',
+              description: 'Branch naming policy violation — PR to main must come from staging, release/vX.Y.Z, or hotfix/<slug>',
             });

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@
 - Branch workflow:
   - Use per-issue branches: `issue/<id>-<slug>`.
   - Merge issue branches into `staging` first.
-  - For normal releases, promote to production only via a direct PR from `staging` into `main` (no release branch).
+  - For normal releases, promote to production only via a direct PR from `staging` into `main` (no release branch needed — the branch policy allows `staging` → `main` directly).
   - Use `hotfix/<slug>` only for explicitly approved incidents.
   - This staging-integration model is the default unless the user explicitly overrides it.
 - Branch/worktree cleanup routine (default after each completed pass):
@@ -49,7 +49,7 @@
 - For user-added issues:
   - Keep them labeled `pending-discussion` until discussed.
   - Do not move them to in-progress automatically.
-- After every live deploy, monitor Cloudflare Pages deployment status (`wrangler pages deployment list --project-name linksim`) and explicitly notify the user when deployment is complete.
+- After every merge to `staging` or `main`, CI auto-deploys via the `Deploy LinkSim Pages` GitHub Actions workflow. Monitor the workflow run in GitHub Actions and report the commit SHA and build label when the deploy job completes. Do not run `npm run deploy:staging` or `npm run deploy:prod:main` manually after a merge — CI handles it. Manual deploys via `workflow_dispatch` are reserved for overrides only.
 - Follow and maintain `docs/release-flow.md` as the source of truth for release promotion steps.
 - Follow `docs/release-flow.md` versioning policy (SemVer + explicit bump rules) for all releases.
 - Maintain a human-readable `CHANGELOG.md` for every release; do not use raw commit dumps as release notes.
@@ -96,6 +96,7 @@
   - Maintain explicit status labels: `pending-discussion` -> `in-progress` -> `in-staging` (while open) -> issue closed after staging sign-off -> `released` label applied during milestone production release sweep.
   - After every staging merge/deploy, automatically update the related GitHub Issue(s) label from `in-progress` to `in-staging`. Do not wait for the user to ask.
   - Milestone release policy: at production release time, apply `released` to the milestone's shipped issues (including already-closed staging-verified issues).
+  - **Milestone required before closing**: always assign a milestone to an issue before closing it as completed. Closing without a milestone triggers an automated workflow that reopens the issue with a warning. Exception: add label `no-milestone-close-ok` for approved exceptions (e.g., chore/housekeeping issues that don't belong to a release).
   - If a historical `docs/BACKLOG.md` file still exists, treat it as legacy reference only unless the user explicitly asks to maintain it.
 
 ## Staging-First Milestone Workflow (Single Source)
@@ -126,8 +127,8 @@
     - `/<simulation>/<site1>+<site2>`
     - `/<simulation>/<site1>~<site2>`
 - Merge and staging deploy sequence per issue:
-  - Open PR into `staging`, merge, then deploy with `npm run deploy:staging`.
-  - After deploy, always confirm completion with `wrangler pages deployment list --project-name linksim-staging --environment production` and report the commit SHA/build label.
+  - Open PR into `staging` and merge. CI auto-deploys to https://staging.linksim.link — do NOT run `npm run deploy:staging` manually.
+  - After merge, monitor the `Deploy LinkSim Pages / deploy-staging` GitHub Actions job and report the commit SHA and build label from the workflow output when it completes.
 - Milestone promotion model:
   - Complete and verify all milestone issues on `staging` first.
   - Promote to production in one batch with a direct PR from `staging` to `main`.

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -21,17 +21,15 @@
 
 2. Live test (staging)
 - Merge approved issue PR into `staging` (squash merge).
-- Deploy from branch `staging` using `npm run deploy:staging`.
-- Verify at https://staging.linksim.link.
-- Use explicit guarded commands only:
-  - Staging deploy: `npm run deploy:staging`.
-  - Preview URL: `npm run deploy:staging:preview` (separate preview URL for side-by-side comparison).
+- CI automatically deploys to https://staging.linksim.link on every merge to `staging`. Monitor the `Deploy LinkSim Pages / deploy-staging` GitHub Actions job and report the commit SHA/build label when complete.
+- Do not run `npm run deploy:staging` manually after a normal merge — CI handles it. Use `workflow_dispatch` only for override deploys.
+- Preview URL for side-by-side comparison (explicit request only): `npm run deploy:staging:preview`.
 
 3. Production
 - Promote only after explicit user approval.
-- Open PR `staging` -> `main`.
-- Deploy the exact verified staging commit to production (no extra code changes in between).
-- Use explicit guarded command only: `npm run deploy:prod:main`.
+- Open PR `staging` -> `main` (direct path — branch policy allows `staging` as head branch).
+- CI automatically deploys to production on every merge to `main`. Monitor the `Deploy LinkSim Pages / deploy-prod-main` GitHub Actions job and report the commit SHA when complete.
+- Note: the CI deploy job runs `validate-prod-release.mjs` which requires a SemVer version bump and git tag at HEAD — ensure these are in place before merging to `main`.
 - After production deploy, continue all new work from updated `origin/staging`.
 - If direct `staging` -> `main` promotion is blocked and a `hotfix/*` reconcile/snapshot PR to `main` is used, treat that as an exception path and immediately run main->staging sync before starting any new work.
 
@@ -55,8 +53,9 @@
   - `hotfix/<slug>`
   - `chore/<slug>`
 - PRs into `main` must come from:
-  - `staging` (default and only normal release path)
+  - `staging` (default and only normal release path — branch policy explicitly allows this)
   - `hotfix/<slug>` (approved production incidents only)
+  - `release/vX.Y.Z` (legacy exception path, not used for normal releases)
 - Merge strategy: squash merge only.
 - Auto-delete merged branches enabled.
 
@@ -115,11 +114,13 @@
 - Milestone production release policy: apply `released` label during the milestone release sweep for shipped issues.
 
 ## CI/CD Controls
-- GitHub Actions deploy workflow is manual (`workflow_dispatch`) with explicit target selection:
-  - `staging`
-  - `prod-main`
+- GitHub Actions deploy workflow triggers automatically on push to `staging` and `main`:
+  - Push to `staging` → `deploy-staging` job → https://staging.linksim.link
+  - Push to `main` → `deploy-prod-main` job → https://linksim.link
+- Manual override available via `workflow_dispatch` with explicit target selection (`staging` or `prod-main`).
 - `prod-main` job runs in the `production` GitHub environment (configure required reviewers in repo settings).
 - `staging` runs in the `staging` environment.
+- Both branches require CI quality gates (`CI Quality Gates / verify` + `PR Branch Policy / enforce`) to pass before merge.
 
 ## Drift prevention rules
 - Issue branches must be created from latest `origin/staging`.


### PR DESCRIPTION
## Summary
- **Auto-deploy on merge** (issue #426): `deploy-pages.yml` now triggers on push to `staging` and `main`. No more manual `npm run deploy:staging` after merging — CI handles it. `workflow_dispatch` preserved for overrides.
- **Fix branch policy trap**: `pr-branch-policy.yml` now allows `staging` → `main` PRs directly. Previous policy blocked the documented release path, forcing every release to use a workaround `release/vX.Y.Z` or `hotfix/` branch.
- **Required CI for staging**: staging branch protection now enforces `CI Quality Gates / verify` and `PR Branch Policy / enforce` before merge, matching `main`'s existing requirements.
- **AGENTS.md + release-flow.md updated**: reflect auto-deploy, correct release path, and add explicit milestone-before-close rule.

## Guardrail changes
| Before | After |
|--------|-------|
| Deploy manual only (`workflow_dispatch`) | Auto-deploy on push to `staging`/`main` |
| PRs to `main` blocked from `staging` head | `staging` → `main` explicitly allowed |
| Staging has no required CI checks | Staging requires CI + branch policy (same as `main`) |
| Milestone rule undocumented in AGENTS.md | Explicit rule added |

## Test plan
- [ ] Merge this PR to staging → `deploy-staging` job fires automatically
- [ ] Confirm staging branch protection shows required status checks
- [ ] Confirm `workflow_dispatch` still works for both targets
- [ ] Open a test PR `staging` → `main` and verify branch policy check passes

Closes #426

- [x] Milestone release checklist completed: docs/milestone-release-checklist.md