### PR TITLE
hotfix(ci): allow drift and approved close exceptions

### DIFF
--- a/.github/workflows/require-milestone-on-close.yml
+++ b/.github/workflows/require-milestone-on-close.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   enforce-milestone:
-    if: github.event.issue.state_reason == 'completed' && github.event.issue.milestone == null && !contains(toJson(github.event.issue.labels), '\"name\":\"no-milestone-close-ok\"')
+    if: github.event.issue.state_reason == 'completed' && github.event.issue.milestone == null
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -17,5 +17,9 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
         run: |
+          if jq -e '.issue.labels[]? | select(.name == "no-milestone-close-ok" or .name == "staging-drift")' "$GITHUB_EVENT_PATH" > /dev/null; then
+            echo "Skipping milestone enforcement due to exception label."
+            exit 0
+          fi
           gh issue reopen "$ISSUE_NUMBER" --repo "$REPO"
-          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "⚠️ Issues closed as completed must have a milestone assigned. Please assign a milestone before closing, or add label \`no-milestone-close-ok\` for an approved exception."
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "⚠️ Issues closed as completed must have a milestone assigned. Please assign a milestone before closing, or add label \`no-milestone-close-ok\` (approved exception) or \`staging-drift\` (drift chore issue)."


### PR DESCRIPTION
## Summary
- replace brittle expression-level label filtering with payload-based jq check
- allow milestone-close exception labels: no-milestone-close-ok and staging-drift
- keep enforcement only for issues closed as completed with no milestone

## Behavior
- duplicate / not planned / won't fix style closures are unaffected and remain allowed because this workflow only enforces when state_reason is completed.
