### PR TITLE
fix(agents): clarify worktree branch, ban local deploys, improve D1 auth error

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,10 +20,19 @@
   - Only promote to production after explicit user approval, using the same verified commit.
 - Branch workflow:
   - Use per-issue branches: `issue/<id>-<slug>`.
+  - **Always branch from `origin/staging`**, not `origin/main`. Creating a branch from `main` will cause merge conflicts when opening a PR to `staging`.
   - Merge issue branches into `staging` first.
   - For normal releases, promote to production only via a direct PR from `staging` into `main` (no release branch needed — the branch policy allows `staging` → `main` directly).
   - Use `hotfix/<slug>` only for explicitly approved incidents.
   - This staging-integration model is the default unless the user explicitly overrides it.
+- Worktree branch vs. issue branch:
+  - When working inside a Claude Code worktree, the session branch is named `claude/<name>` — this is the worktree's own bookkeeping branch, **not** your working branch.
+  - Always create a new `issue/<id>-<slug>` branch from `origin/staging` before making any changes: `git checkout -b issue/<id>-<slug> origin/staging`
+  - Never commit to the `claude/*` session branch. All work goes on the `issue/<id>-<slug>` branch.
+- Deploy policy:
+  - **Never run `npm run deploy:staging`, `npm run deploy:prod:main`, or any deploy script locally.** CI automatically deploys when code merges to `staging` or `main` — you do not need to trigger a deploy.
+  - Local deploy attempts will fail: Cloudflare credentials (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`) are only available in the CI environment.
+  - If you encounter a Cloudflare authentication error while running a deploy script, stop immediately — you are running a command that belongs in CI, not locally.
 - Branch/worktree cleanup routine (default after each completed pass):
   - Keep only long-lived branches locally/remotely: `main`, `staging` (unless an active pass needs additional branches).
   - After merge/deploy, prune refs: `git fetch --prune origin`.

--- a/scripts/deploy-pages-safe.mjs
+++ b/scripts/deploy-pages-safe.mjs
@@ -217,11 +217,25 @@ async function verifyRemoteSchema(targetName, databaseName) {
   // Skip in CI: schema correctness is enforced by the PR/migration review process.
   // The check requires D1 API access beyond what the deploy token provides.
   if (process.env.GITHUB_ACTIONS === "true") return;
-  const { stdout } = await run(
-    wrangler,
-    ["d1", "execute", databaseName, "--remote", "--command", "PRAGMA table_info(resource_changes);"],
-    { capture: true },
-  );
+  let d1Result;
+  try {
+    d1Result = await run(
+      wrangler,
+      ["d1", "execute", databaseName, "--remote", "--command", "PRAGMA table_info(resource_changes);"],
+      { capture: true },
+    );
+  } catch (err) {
+    const msg = String(err?.message ?? "");
+    if (msg.includes("Authentication") || msg.includes("code: 10000") || msg.includes("code: 9106") || msg.includes("Authentication failed")) {
+      throw new Error(
+        "D1 preflight failed: Cloudflare authentication error. " +
+        "Deploy scripts require CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID. " +
+        "Do NOT run deploy scripts locally — CI handles all deploys automatically on merge to staging or main.",
+      );
+    }
+    throw err;
+  }
+  const { stdout } = d1Result;
   const parsed = parseWranglerJsonPayload(stdout);
   assert(Array.isArray(parsed) && parsed.length > 0, "Preflight failed: unable to parse D1 schema output.");
   const first = parsed[0];


### PR DESCRIPTION
## Summary
Fixes three agent traps that caused a deployment failure on issue #647:

- **Branch from staging, not main**: Added explicit rule that issue branches must start from `origin/staging`. Branching from `main` causes merge conflicts when PRing to staging.
- **Worktree branch ≠ issue branch**: Agents in Claude Code worktrees get a `claude/<name>` session branch. AGENTS.md now explicitly explains this is not the working branch — always create `issue/<id>-<slug>` from `origin/staging` first.
- **No local deploys**: Added explicit ban on running deploy scripts locally. CI handles all deploys on merge. Cloudflare credentials are CI-only.
- **Clearer D1 auth error**: When a local deploy fails with Cloudflare auth, the error now identifies the root cause and tells the agent to stop and use CI.