### PR TITLE
fix(slider): simplify shared theme styling

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2244,7 +2244,8 @@ input {
   flex: 1 1 0;
   min-width: 0;
   height: 44px;
-  accent-color: var(--accent);
+  -webkit-appearance: none;
+  appearance: none;
   outline: none;
   cursor: pointer;
   touch-action: none;
@@ -2253,8 +2254,8 @@ input {
 .ui-slider-input::-webkit-slider-runnable-track {
   height: 7px;
   border-radius: var(--radius-pill);
-  background: color-mix(in srgb, var(--accent-soft) 34%, var(--surface-2));
-  border: 1px solid color-mix(in srgb, var(--accent) 24%, var(--border));
+  background: var(--surface-2);
+  border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border));
 }
 
 .ui-slider-input::-webkit-slider-thumb {
@@ -2272,14 +2273,8 @@ input {
 .ui-slider-input::-moz-range-track {
   height: 7px;
   border-radius: var(--radius-pill);
-  background: color-mix(in srgb, var(--accent-soft) 34%, var(--surface-2));
-  border: 1px solid color-mix(in srgb, var(--accent) 24%, var(--border));
-}
-
-.ui-slider-input::-moz-range-progress {
-  height: 7px;
-  border-radius: var(--radius-pill);
-  background: linear-gradient(90deg, color-mix(in srgb, var(--accent) 82%, var(--surface)), var(--accent));
+  background: var(--surface-2);
+  border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border));
 }
 
 .ui-slider-input::-moz-range-thumb {


### PR DESCRIPTION
Simplifies the shared slider styling to keep theme colors without progressive fill.

Verification:
- `npm test`
- `npm run build`