### PR TITLE
fix(slider): remove native input fill

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2246,6 +2246,7 @@ input {
   height: 44px;
   -webkit-appearance: none;
   appearance: none;
+  background: transparent;
   outline: none;
   cursor: pointer;
   touch-action: none;


### PR DESCRIPTION
Removes the native full-box fill from the shared slider input while keeping the theme-colored shared styling.

Verification:
- `npm test`
- `npm run build`