### PR TITLE
feat(ui): componentize floating popover patterns (#616)

### DIFF
--- a/functions/_lib/buildInfo.ts
+++ b/functions/_lib/buildInfo.ts
@@ -1,5 +1,5 @@
 export const APP_VERSION = "0.16.0";
-export const APP_COMMIT = "34f4fcca";
+export const APP_COMMIT = "b5696044";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {

--- a/src/components/LinkProfileChart.tsx
+++ b/src/components/LinkProfileChart.tsx
@@ -1,6 +1,7 @@
 import { extent, max } from "d3-array";
 import { scaleLinear } from "d3-scale";
 import { ArrowLeftRight, PanelBottomClose, PanelBottomOpen } from "lucide-react";
+import { FloatingPopover } from "./ui/FloatingPopover";
 import type { MouseEvent } from "react";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
@@ -62,6 +63,7 @@ export function LinkProfileChart({
   rowControls,
   panelClassName,
 }: LinkProfileChartProps) {
+  const chartPanelRef = useRef<HTMLElement | null>(null);
   const chartHostRef = useRef<HTMLDivElement | null>(null);
   const [hostAttachRevision, setHostAttachRevision] = useState(0);
   const segmentStateCacheRef = useRef<Map<string, PassFailState[]>>(new Map());
@@ -715,7 +717,7 @@ export function LinkProfileChart({
   }
 
   return (
-    <section className={`chart-panel ${isExpanded ? "is-expanded" : ""} ${panelClassName ?? ""}`.trim()} data-profile-revision={profileRevision}>
+    <section className={`chart-panel ${isExpanded ? "is-expanded" : ""} ${panelClassName ?? ""}`.trim()} data-profile-revision={profileRevision} ref={chartPanelRef}>
       <div className="chart-top-row">
         <div className="chart-endpoints" aria-live="polite">
           <span className="chart-endpoint chart-endpoint-left">{fromSiteName}</span>
@@ -856,13 +858,14 @@ export function LinkProfileChart({
           />
         </svg>
         {splitHoverPopoverPosition && cursorStates && cursorStates.length > 1 ? (
-          <div
-            className="chart-hover-popover"
-            role="status"
-            style={{
-              left: `${(splitHoverPopoverPosition.x / chartWidth) * 100}%`,
-              top: `${(splitHoverPopoverPosition.y / chartHeight) * 100}%`,
-            }}
+          <FloatingPopover
+            open={true}
+            onClose={() => {}}
+            containerRef={chartPanelRef}
+            placement="centered"
+            className="panorama-legend-popover"
+            estimatedHeight={160}
+            estimatedWidth={400}
           >
             {cursorStates.map((state) => (
               <div className="chart-hover-popover-row" key={state.key}>
@@ -872,7 +875,7 @@ export function LinkProfileChart({
                 </span>
               </div>
             ))}
-          </div>
+          </FloatingPopover>
         ) : null}
         </>
       ) : (

--- a/src/components/PanoramaChart.tsx
+++ b/src/components/PanoramaChart.tsx
@@ -1,8 +1,7 @@
 import { scaleLinear } from "d3-scale";
-import { Surface } from "./ui/Surface";
+import { FloatingPopover } from "./ui/FloatingPopover";
 import { StateDot } from "./StateDot";
 import { Info, MapPinned, Paintbrush, PanelBottomClose, PanelBottomOpen, Mountain, MountainSnow, RadioTower, Settings, Tags } from "lucide-react";
-import { createPortal } from "react-dom";
 import type { CSSProperties, MouseEvent as ReactMouseEvent, ReactNode } from "react";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { STANDARD_SITE_RADIO } from "../lib/linkRadio";
@@ -122,13 +121,12 @@ type HoverTarget =
 const pointerDistance = (a: { x: number; y: number }, b: { x: number; y: number }): number => Math.hypot(a.x - b.x, a.y - b.y);
 
 export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle = true, rowControls, panelClassName }: PanoramaChartProps) {
+  const chartPanelRef = useRef<HTMLElement | null>(null);
   const chartHostRef = useRef<HTMLDivElement | null>(null);
   const terrainCanvasRef = useRef<HTMLCanvasElement | null>(null);
   const scrollbarTrackRef = useRef<HTMLDivElement | null>(null);
   const settingsButtonRef = useRef<HTMLButtonElement | null>(null);
-  const settingsPopoverRef = useRef<HTMLDivElement | null>(null);
   const legendButtonRef = useRef<HTMLButtonElement | null>(null);
-  const legendPopoverRef = useRef<HTMLDivElement | null>(null);
   const pinchPointersRef = useRef<Map<number, { x: number; y: number }>>(new Map());
   const pinchStartRef = useRef<{ distance: number; fovScale: number; spanDeg: number; centerDeg: number } | null>(null);
   const panDragRef = useRef<{ pointerId: number; startX: number; startCenterDeg: number } | null>(null);
@@ -146,14 +144,12 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
   const [hoverTarget, setHoverTarget] = useState<HoverTarget | null>(null);
   const [pinnedTarget, setPinnedTarget] = useState<HoverTarget | null>(null);
   const [settingsPopoverOpen, setSettingsPopoverOpen] = useState(false);
-  const [settingsPopoverPos, setSettingsPopoverPos] = useState<{ left: number; top: number; direction: "up" | "down" } | null>(null);
   const [peakCandidates, setPeakCandidates] = useState<PanoramaPeakCandidate[]>([]);
   const [peakLoadStatus, setPeakLoadStatus] = useState<"idle" | "loading" | "ready" | "error">("idle");
   const [, setPeakLoadError] = useState<string | null>(null);
   const { theme: themeMode } = useThemeVariant();
   const shadingHazeStart = themeMode === "dark" ? 0.5 : 0;
   const [legendPopoverOpen, setLegendPopoverOpen] = useState(false);
-  const [legendPopoverPos, setLegendPopoverPos] = useState<{ left: number; top: number; direction: "up" | "down" } | null>(null);
   const peakErrorLogTsRef = useRef(0);
 
 
@@ -1248,87 +1244,6 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
     });
   };
 
-  useEffect(() => {
-    if (!settingsPopoverOpen) { setSettingsPopoverPos(null); return; }
-    const updatePosition = () => {
-      const rect = settingsButtonRef.current?.getBoundingClientRect();
-      if (!rect) return;
-      const estimatedHeight = 290;
-      const spaceAbove = rect.top;
-      const spaceBelow = window.innerHeight - rect.bottom;
-      const direction: "up" | "down" = spaceAbove >= estimatedHeight + 12 || spaceAbove >= spaceBelow ? "up" : "down";
-      const left = clamp(rect.left + rect.width / 2, 84, window.innerWidth - 84);
-      setSettingsPopoverPos({ left, top: direction === "up" ? rect.top - 8 : rect.bottom + 8, direction });
-    };
-    updatePosition();
-    window.addEventListener("resize", updatePosition);
-    window.addEventListener("scroll", updatePosition, true);
-    return () => {
-      window.removeEventListener("resize", updatePosition);
-      window.removeEventListener("scroll", updatePosition, true);
-    };
-  }, [settingsPopoverOpen]);
-
-  useEffect(() => {
-    if (!settingsPopoverOpen) return;
-    const onPointerDown = (event: MouseEvent | TouchEvent) => {
-      const target = event.target as Node | null;
-      if (settingsPopoverRef.current?.contains(target)) return;
-      if (settingsButtonRef.current?.contains(target)) return;
-      setSettingsPopoverOpen(false);
-    };
-    const onFocusIn = (event: FocusEvent) => {
-      const target = event.target as Node | null;
-      if (settingsPopoverRef.current?.contains(target)) return;
-      if (settingsButtonRef.current?.contains(target)) return;
-      setSettingsPopoverOpen(false);
-    };
-    document.addEventListener("mousedown", onPointerDown);
-    document.addEventListener("touchstart", onPointerDown, { passive: true });
-    document.addEventListener("focusin", onFocusIn);
-    return () => {
-      document.removeEventListener("mousedown", onPointerDown);
-      document.removeEventListener("touchstart", onPointerDown);
-      document.removeEventListener("focusin", onFocusIn);
-    };
-  }, [settingsPopoverOpen]);
-
-  useEffect(() => {
-    if (!legendPopoverOpen) { setLegendPopoverPos(null); return; }
-    const updatePosition = () => {
-      const rect = legendButtonRef.current?.getBoundingClientRect();
-      if (!rect) return;
-      const estimatedHeight = 120;
-      const spaceAbove = rect.top;
-      const direction: "up" | "down" = spaceAbove >= estimatedHeight + 12 ? "up" : "down";
-      const left = clamp(rect.left + rect.width / 2, 84, window.innerWidth - 84);
-      setLegendPopoverPos({ left, top: direction === "up" ? rect.top - 8 : rect.bottom + 8, direction });
-    };
-    updatePosition();
-    window.addEventListener("resize", updatePosition);
-    window.addEventListener("scroll", updatePosition, true);
-    return () => {
-      window.removeEventListener("resize", updatePosition);
-      window.removeEventListener("scroll", updatePosition, true);
-    };
-  }, [legendPopoverOpen]);
-
-  useEffect(() => {
-    if (!legendPopoverOpen) return;
-    const onPointerDown = (event: MouseEvent | TouchEvent) => {
-      const target = event.target as Node | null;
-      if (legendPopoverRef.current?.contains(target)) return;
-      if (legendButtonRef.current?.contains(target)) return;
-      setLegendPopoverOpen(false);
-    };
-    document.addEventListener("mousedown", onPointerDown);
-    document.addEventListener("touchstart", onPointerDown, { passive: true });
-    return () => {
-      document.removeEventListener("mousedown", onPointerDown);
-      document.removeEventListener("touchstart", onPointerDown);
-    };
-  }, [legendPopoverOpen]);
-
   if (!selectedSiteEffective) {
     return (
       <section className={`chart-panel chart-panel-empty ${panelClassName ?? ""}`.trim()}>
@@ -1361,128 +1276,140 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
     : null;
 
 
-  const settingsPopover =
-    settingsPopoverOpen && settingsPopoverPos && typeof document !== "undefined"
-      ? createPortal(
-          <Surface
-            variant="card"
-            className={`ui-action-popover panorama-settings-popover ${settingsPopoverPos.direction === "down" ? "is-down" : ""}`}
-            ref={settingsPopoverRef}
-            style={{ left: `${settingsPopoverPos.left}px`, top: `${settingsPopoverPos.top}px` }}
-          >
-            <ul className="ui-settings-popover-list">
-              <li className="ui-settings-popover-row">
-                <div className="ui-settings-row-slider">
-                  <div className="ui-settings-row-slider-header">
-                    <span className="ui-settings-toggle-label">Field of view</span>
-                    <span className="ui-settings-row-slider-value">{`${Math.round(fovScaleToSpanDeg(normalizedFovScale))}°`}</span>
-                  </div>
-                  <UiSlider
-                    ariaLabel="Panorama field of view"
-                    max={FOV_SCALE_MAX}
-                    min={FOV_SCALE_MIN}
-                    onChange={(value) => setFovScale(normalizeFovScale(value))}
-                    step={0.1}
-                    value={normalizedFovScale}
-                  />
-                </div>
-              </li>
-              <li className="ui-settings-popover-row">
-                <div className="ui-settings-row-slider">
-                  <div className="ui-settings-row-slider-header">
-                    <span className="ui-settings-toggle-label">Vertical exaggeration</span>
-                    <span className="ui-settings-row-slider-value">{`${exaggeration.toFixed(1)}x`}</span>
-                  </div>
-                  <UiSlider
-                    ariaLabel="Panorama vertical exaggeration"
-                    max={20}
-                    min={1}
-                    onChange={(value) => setExaggeration(clamp(value, 1, 20))}
-                    step={0.1}
-                    value={exaggeration}
-                  />
-                </div>
-              </li>
-              <li className="ui-settings-popover-row">
-                <button
-                  aria-pressed={mapHoverZoomEnabled}
-                  className="ui-settings-row-toggle"
-                  onClick={() => setMapHoverZoomEnabled((v) => !v)}
-                  type="button"
-                >
-                  <span className="ui-settings-toggle-label">Center map on hover</span>
-                  <span className={`ui-settings-toggle-icon ${mapHoverZoomEnabled ? "is-active" : ""}`}>
-                    <MapPinned aria-hidden="true" size={16} strokeWidth={1.8} />
-                  </span>
-                </button>
-              </li>
-              <li className="ui-settings-popover-row">
-                <button
-                  aria-pressed={showLabels}
-                  className="ui-settings-row-toggle"
-                  onClick={() => setShowLabels((v) => !v)}
-                  type="button"
-                >
-                  <span className="ui-settings-toggle-label">Labels</span>
-                  <span className={`ui-settings-toggle-icon ${showLabels ? "is-active" : ""}`}>
-                    <Tags aria-hidden="true" size={16} strokeWidth={1.8} />
-                  </span>
-                </button>
-              </li>
-              <li className="ui-settings-popover-row">
-                <button
-                  aria-pressed={terrainDistanceHeatmap}
-                  className="ui-settings-row-toggle"
-                  onClick={() => setTerrainDistanceHeatmap((v) => !v)}
-                  type="button"
-                >
-                  <span className="ui-settings-toggle-label">Distance heatmap</span>
-                  <span className={`ui-settings-toggle-icon ${terrainDistanceHeatmap ? "is-active" : ""}`}>
-                    <Paintbrush aria-hidden="true" size={16} strokeWidth={1.8} />
-                  </span>
-                </button>
-              </li>
-            </ul>
-          </Surface>,
-          document.body,
-        )
-      : null;
+  const hoverPopoverFloating =
+    hoverPopover && focusTarget ? (
+      <FloatingPopover
+        open={!!focusTarget}
+        onClose={() => {}}
+        containerRef={chartPanelRef}
+        placement="centered"
+        className="panorama-legend-popover"
+        estimatedHeight={200}
+        estimatedWidth={380}
+      >
+        <div className="chart-hover-popover-row"><strong>{hoverPopover.title}</strong></div>
+        {hoverPopover.rows.map((row) => (
+          <div className="chart-hover-popover-row" key={row}>{row}</div>
+        ))}
+      </FloatingPopover>
+    ) : null;
 
-  const legendPopover =
-    legendPopoverOpen && legendPopoverPos && typeof document !== "undefined"
-      ? createPortal(
-          <Surface
-            variant="card"
-            className={`ui-action-popover panorama-legend-popover ${legendPopoverPos.direction === "down" ? "is-down" : ""}`}
-            ref={legendPopoverRef}
-            style={{ left: `${legendPopoverPos.left}px`, top: `${legendPopoverPos.top}px` }}
+  const settingsPopover = (
+    <FloatingPopover
+      open={settingsPopoverOpen}
+      onClose={() => setSettingsPopoverOpen(false)}
+      triggerRef={settingsButtonRef}
+      className="panorama-settings-popover"
+      estimatedHeight={290}
+    >
+      <ul className="ui-settings-popover-list">
+        <li className="ui-settings-popover-row">
+          <div className="ui-settings-row-slider">
+            <div className="ui-settings-row-slider-header">
+              <span className="ui-settings-toggle-label">Field of view</span>
+              <span className="ui-settings-row-slider-value">{`${Math.round(fovScaleToSpanDeg(normalizedFovScale))}°`}</span>
+            </div>
+            <UiSlider
+              ariaLabel="Panorama field of view"
+              max={FOV_SCALE_MAX}
+              min={FOV_SCALE_MIN}
+              onChange={(value) => setFovScale(normalizeFovScale(value))}
+              step={0.1}
+              value={normalizedFovScale}
+            />
+          </div>
+        </li>
+        <li className="ui-settings-popover-row">
+          <div className="ui-settings-row-slider">
+            <div className="ui-settings-row-slider-header">
+              <span className="ui-settings-toggle-label">Vertical exaggeration</span>
+              <span className="ui-settings-row-slider-value">{`${exaggeration.toFixed(1)}x`}</span>
+            </div>
+            <UiSlider
+              ariaLabel="Panorama vertical exaggeration"
+              max={20}
+              min={1}
+              onChange={(value) => setExaggeration(clamp(value, 1, 20))}
+              step={0.1}
+              value={exaggeration}
+            />
+          </div>
+        </li>
+        <li className="ui-settings-popover-row">
+          <button
+            aria-pressed={mapHoverZoomEnabled}
+            className="ui-settings-row-toggle"
+            onClick={() => setMapHoverZoomEnabled((v) => !v)}
+            type="button"
           >
-            <ul className="panorama-legend-popover-list">
-              <li><StateDot state="pass_clear" /><span>Visible + pass</span></li>
-              <li><StateDot state="pass_blocked" /><span>Blocked + pass</span></li>
-              <li><StateDot state="fail_clear" /><span>Visible + fail</span></li>
-              <li><StateDot state="fail_blocked" /><span>Blocked + fail</span></li>
-            </ul>
-            {terrainDistanceHeatmap ? (
-              <div className="panorama-legend-heatmap">
-                <p className="panorama-legend-heatmap-title">Terrain distance</p>
-                <div className="panorama-legend-heatmap-bar" />
-                <div className="panorama-legend-heatmap-labels">
-                  <span>Far</span>
-                  <span>Near</span>
-                </div>
-              </div>
-            ) : null}
-          </Surface>,
-          document.body,
-        )
-      : null;
+            <span className="ui-settings-toggle-label">Center map on hover</span>
+            <span className={`ui-settings-toggle-icon ${mapHoverZoomEnabled ? "is-active" : ""}`}>
+              <MapPinned aria-hidden="true" size={16} strokeWidth={1.8} />
+            </span>
+          </button>
+        </li>
+        <li className="ui-settings-popover-row">
+          <button
+            aria-pressed={showLabels}
+            className="ui-settings-row-toggle"
+            onClick={() => setShowLabels((v) => !v)}
+            type="button"
+          >
+            <span className="ui-settings-toggle-label">Labels</span>
+            <span className={`ui-settings-toggle-icon ${showLabels ? "is-active" : ""}`}>
+              <Tags aria-hidden="true" size={16} strokeWidth={1.8} />
+            </span>
+          </button>
+        </li>
+        <li className="ui-settings-popover-row">
+          <button
+            aria-pressed={terrainDistanceHeatmap}
+            className="ui-settings-row-toggle"
+            onClick={() => setTerrainDistanceHeatmap((v) => !v)}
+            type="button"
+          >
+            <span className="ui-settings-toggle-label">Distance heatmap</span>
+            <span className={`ui-settings-toggle-icon ${terrainDistanceHeatmap ? "is-active" : ""}`}>
+              <Paintbrush aria-hidden="true" size={16} strokeWidth={1.8} />
+            </span>
+          </button>
+        </li>
+      </ul>
+    </FloatingPopover>
+  );
+
+  const legendPopover = (
+    <FloatingPopover
+      open={legendPopoverOpen}
+      onClose={() => setLegendPopoverOpen(false)}
+      triggerRef={legendButtonRef}
+      className="panorama-legend-popover"
+      estimatedHeight={120}
+    >
+      <ul className="panorama-legend-popover-list">
+        <li><StateDot state="pass_clear" /><span>Visible + pass</span></li>
+        <li><StateDot state="pass_blocked" /><span>Blocked + pass</span></li>
+        <li><StateDot state="fail_clear" /><span>Visible + fail</span></li>
+        <li><StateDot state="fail_blocked" /><span>Blocked + fail</span></li>
+      </ul>
+      {terrainDistanceHeatmap ? (
+        <div className="panorama-legend-heatmap">
+          <p className="panorama-legend-heatmap-title">Terrain distance</p>
+          <div className="panorama-legend-heatmap-bar" />
+          <div className="panorama-legend-heatmap-labels">
+            <span>Far</span>
+            <span>Near</span>
+          </div>
+        </div>
+      ) : null}
+    </FloatingPopover>
+  );
 
   const scrubberWidthPct = Math.max(8, (viewportSpanDeg / 360) * 100);
   const scrubberLeftPct = clamp((viewportCenterAzimuthDeg / 360) * 100 - scrubberWidthPct / 2, 0, 100 - scrubberWidthPct);
 
   return (
-    <section className={`chart-panel ${isExpanded ? "is-expanded" : ""} ${panelClassName ?? ""}`.trim()}>
+    <section className={`chart-panel ${isExpanded ? "is-expanded" : ""} ${panelClassName ?? ""}`.trim()} ref={chartPanelRef}>
       <div className="chart-top-row">
         <h3 className="panorama-header-title">Panorama from {selectedSiteEffective.name}</h3>
         <div className="chart-action-row-controls">
@@ -1599,20 +1526,6 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
                 );
               })}
             </div>
-            {hoverPopover && focusTarget ? (
-              <div
-                className="chart-hover-popover"
-                style={{
-                  left: `${clamp(focusTarget.x, 170, chartWidth - 170)}px`,
-                  top: `${clamp(focusTarget.y - 12, 46, chartHeight - 14)}px`,
-                }}
-              >
-                <div className="chart-hover-popover-row"><strong>{hoverPopover.title}</strong></div>
-                {hoverPopover.rows.map((row) => (
-                  <div className="chart-hover-popover-row" key={row}>{row}</div>
-                ))}
-              </div>
-            ) : null}
             {peakLoadStatus === "loading" && (
               <div className="ui-surface-pill panorama-peaks-loading">
                 <div className="map-progress-track">
@@ -1640,6 +1553,7 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
           }}
         />
       </div>
+      {hoverPopoverFloating}
       {settingsPopover}
     </section>
   );

--- a/src/components/ui/FloatingPopover.tsx
+++ b/src/components/ui/FloatingPopover.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { Surface } from "./Surface";
+import type { CSSProperties, ReactNode } from "react";
+
+type FloatingPopoverPlacement = "trigger" | "centered";
+
+type FloatingPopoverPosition = {
+  left: number;
+  top: number;
+  direction: "up" | "down";
+};
+
+type FloatingPopoverProps = {
+  open: boolean;
+  onClose: () => void;
+  triggerRef?: React.RefObject<HTMLElement | null>;
+  containerRef?: React.RefObject<HTMLElement | null>;
+  children: ReactNode;
+  placement?: FloatingPopoverPlacement;
+  className?: string;
+  style?: CSSProperties;
+  estimatedHeight?: number;
+  estimatedWidth?: number;
+};
+
+export function FloatingPopover({
+  open,
+  onClose,
+  triggerRef,
+  containerRef,
+  children,
+  placement = "trigger",
+  className,
+  style,
+  estimatedHeight = 200,
+  estimatedWidth = 360,
+}: FloatingPopoverProps) {
+  const popoverRef = useRef<HTMLDivElement | null>(null);
+  const [position, setPosition] = useState<FloatingPopoverPosition | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setPosition(null);
+      return;
+    }
+
+    const updatePosition = () => {
+      if (placement === "centered") {
+        const container = containerRef?.current;
+        if (!container) {
+          setPosition(null);
+          return;
+        }
+        const rect = container.getBoundingClientRect();
+        const containerWidth = rect.width;
+        const containerLeft = rect.left;
+        const containerTop = rect.top;
+        const left = Math.min(
+          Math.max(containerLeft + containerWidth / 2, estimatedWidth / 2 + 8),
+          window.innerWidth - estimatedWidth / 2 - 8,
+        );
+        const spaceAbove = containerTop;
+        const spaceBelow = window.innerHeight - rect.bottom;
+        const direction: "up" | "down" =
+          spaceAbove >= estimatedHeight + 12 || spaceAbove >= spaceBelow ? "up" : "down";
+        const top = direction === "up" ? containerTop - 12 : rect.bottom + 12;
+        setPosition({ left, top, direction });
+        return;
+      }
+
+      const trigger = triggerRef?.current;
+      if (!trigger) {
+        setPosition(null);
+        return;
+      }
+
+      const rect = trigger.getBoundingClientRect();
+      const spaceAbove = rect.top;
+      const spaceBelow = window.innerHeight - rect.bottom;
+      const direction: "up" | "down" =
+        spaceAbove >= estimatedHeight + 12 || spaceAbove >= spaceBelow ? "up" : "down";
+      const left = Math.min(
+        Math.max(rect.left + rect.width / 2, 84),
+        window.innerWidth - 84,
+      );
+      setPosition({
+        left,
+        top: direction === "up" ? rect.top - 8 : rect.bottom + 8,
+        direction,
+      });
+    };
+
+    updatePosition();
+    window.addEventListener("resize", updatePosition);
+    window.addEventListener("scroll", updatePosition, true);
+    return () => {
+      window.removeEventListener("resize", updatePosition);
+      window.removeEventListener("scroll", updatePosition, true);
+    };
+  }, [open, placement, triggerRef, containerRef, estimatedHeight, estimatedWidth]);
+
+  useEffect(() => {
+    if (!open) return;
+    const trigger = triggerRef?.current;
+    const container = containerRef?.current;
+    const onPointerDown = (event: Event) => {
+      const target = event.target as Node | null;
+      if (popoverRef.current?.contains(target)) return;
+      if (trigger?.contains(target)) return;
+      if (container?.contains(target)) return;
+      onClose();
+    };
+    const onFocusIn = (event: Event) => {
+      const target = event.target as Node | null;
+      if (popoverRef.current?.contains(target)) return;
+      if (trigger?.contains(target)) return;
+      if (container?.contains(target)) return;
+      onClose();
+    };
+    document.addEventListener("mousedown", onPointerDown);
+    document.addEventListener("touchstart", onPointerDown, { passive: true });
+    document.addEventListener("focusin", onFocusIn);
+    return () => {
+      document.removeEventListener("mousedown", onPointerDown);
+      document.removeEventListener("touchstart", onPointerDown);
+      document.removeEventListener("focusin", onFocusIn);
+    };
+  }, [open, onClose, triggerRef, containerRef]);
+
+  if (!open || !position) return null;
+
+  return createPortal(
+    <Surface
+      ref={popoverRef}
+      variant="card"
+      className={`ui-action-popover ${className ?? ""} ${position.direction === "down" ? "is-down" : ""}`}
+      style={{
+        left: position.left,
+        top: position.top,
+        ...style,
+      }}
+    >
+      {children}
+    </Surface>,
+    document.body,
+  );
+}

--- a/src/lib/buildInfo.ts
+++ b/src/lib/buildInfo.ts
@@ -1,5 +1,5 @@
 export const APP_VERSION = "0.16.0";
-export const APP_COMMIT = "34f4fcca";
+export const APP_COMMIT = "b5696044";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {


### PR DESCRIPTION
## Summary
- Create FloatingPopover component foundation with portal rendering, viewport edge handling
- Migrate 4 popovers to shared component: settings, legend (PanoramaChart x2), chart hover (PanoramaChart, LinkProfileChart)
- Fix chart popover positioning to use panel-level container, not chart-area container
- Style chart hover popovers to match legend popover glass-morphic Surface style