### PR TITLE
feat(ui): componentize badge patterns (#616)

### DIFF
--- a/functions/_lib/buildInfo.ts
+++ b/functions/_lib/buildInfo.ts
@@ -1,5 +1,5 @@
 export const APP_VERSION = "0.16.0";
-export const APP_COMMIT = "b5696044";
+export const APP_COMMIT = "f56ab4ee";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -68,6 +68,7 @@ import { AvatarBadge } from "./AvatarBadge";
 import { InlineCloseIconButton } from "./InlineCloseIconButton";
 import { ModalOverlay } from "./ModalOverlay";
 import SimulationLibraryPanel from "./SimulationLibraryPanel";
+import { Badge } from "./ui/Badge";
 import { UserAdminPanel } from "./UserAdminPanel";
 
 const parseNumber = (value: string): number => {
@@ -3705,9 +3706,9 @@ export function Sidebar({
                     {entry.name} ({entry.position.lat.toFixed(5)}, {entry.position.lon.toFixed(5)})
                   </span>
                   <span className="library-row-meta">
-                    <span className="access-badge">{toAccessVisibility((entry as { visibility?: unknown }).visibility)}</span>
+                    {(() => { const v = toAccessVisibility((entry as { visibility?: unknown }).visibility); return <Badge variant={v as "private" | "public" | "shared"}>{v}</Badge>; })()}
                     {(entry as { sourceMeta?: { sourceType?: string } }).sourceMeta?.sourceType === "mqtt-feed" ? (
-                      <span className="access-badge mqtt-source-badge">MQTT</span>
+                      <Badge variant="mqtt">MQTT</Badge>
                     ) : null}
                     <button
                       className="row-avatar owner-avatar"

--- a/src/components/SimulationLibraryPanel.tsx
+++ b/src/components/SimulationLibraryPanel.tsx
@@ -18,6 +18,7 @@ import {
 } from "../lib/libraryFilterUi";
 import { formatDate } from "../lib/locale";
 import { toAccessVisibility } from "../lib/uiFormatting";
+import { Badge } from "./ui/Badge";
 import { duplicateSimulationNameMessage, hasDuplicateSimulationNameForOwner } from "../lib/simulationNameValidation";
 import { useAppStore } from "../store/appStore";
 import { ActionButton } from "./ActionButton";
@@ -429,9 +430,7 @@ export default function SimulationLibraryPanel({
                   Updated {formatDate(preset.updatedAt)}
                 </span>
                 <span className="library-row-meta">
-                  <span className="access-badge">
-                    {toAccessVisibility((preset as { visibility?: unknown }).visibility)}
-                  </span>
+                  {((v: string) => <Badge variant={v as "private" | "public" | "shared"}>{v}</Badge>)(toAccessVisibility((preset as { visibility?: unknown }).visibility))}
                   <span className="row-avatar owner-avatar" title={`Owner: ${owner.name}`}>
                     <AvatarBadge
                       avatarUrl={owner.avatarUrl}

--- a/src/components/UiGalleryPage.tsx
+++ b/src/components/UiGalleryPage.tsx
@@ -3,6 +3,7 @@ import { CircleAlert, CircleCheck, CircleX, Info, Layers, Maximize2, Minus, Pane
 import { ActionButton } from "./ActionButton";
 import { StateDot } from "./StateDot";
 import { Surface } from "./ui/Surface";
+import { Badge } from "./ui/Badge";
 import { UiSlider } from "./UiSlider";
 import { useThemeVariant } from "../hooks/useThemeVariant";
 import { useAppStore } from "../store/appStore";
@@ -259,8 +260,8 @@ export function UiGalleryPage() {
             </PatternCard>
             <PatternCard name="Badges/Chips/Pills" status="standard">
               <div className="chip-group ui-gallery-chip-specimen">
-                <span className="access-badge">shared</span>
-                <span className="access-badge mqtt-source-badge">MQTT</span>
+                <Badge variant="shared">shared</Badge>
+                <Badge variant="mqtt">MQTT</Badge>
                 <span className="map-band-chip">Mesh</span>
               </div>
             </PatternCard>

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -1,0 +1,34 @@
+import { Globe, Lock, EthernetPort, Globe2 } from 'lucide-react';
+import type { HTMLAttributes } from 'react';
+
+type BadgeVariant = 'private' | 'public' | 'shared' | 'mqtt';
+
+type BadgeProps = {
+  variant: BadgeVariant;
+  className?: string;
+  children: string;
+} & HTMLAttributes<HTMLSpanElement>;
+
+const variantIcon = {
+  private: Lock,
+  public: Globe2,
+  shared: Globe,
+  mqtt: EthernetPort,
+};
+
+const variantClassName = {
+  private: 'access-badge',
+  public: 'access-badge',
+  shared: 'access-badge',
+  mqtt: 'access-badge mqtt-source-badge',
+};
+
+export function Badge({ variant, className, children, ...rest }: BadgeProps) {
+  const Icon = variantIcon[variant];
+  return (
+    <span className={`${variantClassName[variant]} ${className ?? ''}`} {...rest}>
+      <Icon aria-hidden size={10} strokeWidth={2.2} style={{ display: 'inline-flex', marginRight: 4, verticalAlign: 'middle' }} />
+      {children}
+    </span>
+  );
+}

--- a/src/lib/buildInfo.ts
+++ b/src/lib/buildInfo.ts
@@ -1,5 +1,5 @@
 export const APP_VERSION = "0.16.0";
-export const APP_COMMIT = "b5696044";
+export const APP_COMMIT = "f56ab4ee";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {


### PR DESCRIPTION
## Summary
- Create Badge component with semantic variants: private, public, shared, mqtt
- Icons: Lock (private), Globe2 (public), Globe (shared), EthernetPort (mqtt)
- Migrate 4 access-badge usages in Sidebar.tsx, SimulationLibraryPanel.tsx, UiGalleryPage.tsx
- Keep class compatibility with existing CSS (access-badge, mqtt-source-badge)