### PR TITLE
fix(ui): align badge icon and text with flexbox

### DIFF
--- a/functions/_lib/buildInfo.ts
+++ b/functions/_lib/buildInfo.ts
@@ -1,5 +1,5 @@
 export const APP_VERSION = "0.16.0";
-export const APP_COMMIT = "f56ab4ee";
+export const APP_COMMIT = "52ff4b30";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -27,8 +27,8 @@ export function Badge({ variant, className, children, ...rest }: BadgeProps) {
   const Icon = variantIcon[variant];
   return (
     <span className={`${variantClassName[variant]} ${className ?? ''}`} {...rest}>
-      <Icon aria-hidden size={10} strokeWidth={2.2} style={{ display: 'inline-flex', marginRight: 4, verticalAlign: 'text-bottom', flexShrink: 0 }} />
-      <span style={{ verticalAlign: 'middle' }}>{children}</span>
+      <Icon aria-hidden size={10} strokeWidth={2.2} style={{ marginRight: 4 }} />
+      {children}
     </span>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -4089,9 +4089,11 @@ html.panorama-gesture-lock body {
 }
 
 .access-badge {
+  display: inline-flex;
+  align-items: center;
   border: 1px solid color-mix(in srgb, var(--border) 75%, transparent);
   border-radius: var(--radius-pill);
-  padding: 2px 8px;
+  padding: 2px 6px;
   font-size: 0.68rem;
   color: var(--muted);
   text-transform: capitalize;

--- a/src/lib/buildInfo.ts
+++ b/src/lib/buildInfo.ts
@@ -1,5 +1,5 @@
 export const APP_VERSION = "0.16.0";
-export const APP_COMMIT = "f56ab4ee";
+export const APP_COMMIT = "52ff4b30";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {


### PR DESCRIPTION
CSS: add display:inline-flex and align-items:center to .access-badge, reduce padding to 2px 6px
Component: simplify Badge by removing inline vertical-align styles (handled by CSS)