### PR TITLE
feat(ui): add local/staging variants to Badge (#616)

### DIFF
--- a/functions/_lib/buildInfo.ts
+++ b/functions/_lib/buildInfo.ts
@@ -1,5 +1,5 @@
 export const APP_VERSION = "0.16.0";
-export const APP_COMMIT = "52ff4b30";
+export const APP_COMMIT = "e098e898";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1775,7 +1775,7 @@ export function Sidebar({
       <header>
         <div className="sidebar-title-row">
           <h1>{t(locale, "appTitle")}</h1>
-          {envBadgeLabel ? <span className="sidebar-env-badge">{envBadgeLabel}</span> : null}
+          {envBadgeLabel ? <Badge variant={envBadgeLabel === 'LOCAL' ? 'local' : 'staging'}>{envBadgeLabel}</Badge> : null}
         </div>
       </header>
       <section className="panel-section section-scenario">

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -1,7 +1,7 @@
-import { Globe, Lock, EthernetPort, Globe2 } from 'lucide-react';
+import { Globe, Lock, EthernetPort, Globe2, GlobeOff, FlaskConical } from 'lucide-react';
 import type { HTMLAttributes } from 'react';
 
-type BadgeVariant = 'private' | 'public' | 'shared' | 'mqtt';
+type BadgeVariant = 'private' | 'public' | 'shared' | 'mqtt' | 'local' | 'staging';
 
 type BadgeProps = {
   variant: BadgeVariant;
@@ -14,13 +14,17 @@ const variantIcon = {
   public: Globe2,
   shared: Globe,
   mqtt: EthernetPort,
+  local: GlobeOff,
+  staging: FlaskConical,
 };
 
-const variantClassName = {
+const variantClassName: Record<BadgeVariant, string> = {
   private: 'access-badge',
   public: 'access-badge',
   shared: 'access-badge',
   mqtt: 'access-badge mqtt-source-badge',
+  local: 'access-badge',
+  staging: 'access-badge',
 };
 
 export function Badge({ variant, className, children, ...rest }: BadgeProps) {

--- a/src/lib/buildInfo.ts
+++ b/src/lib/buildInfo.ts
@@ -1,5 +1,5 @@
 export const APP_VERSION = "0.16.0";
-export const APP_COMMIT = "52ff4b30";
+export const APP_COMMIT = "e098e898";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {


### PR DESCRIPTION
Add local and staging variants to Badge component with GlobeOff and FlaskConical icons
Migrate sidebar-env-badge to use Badge component