### PR TITLE
refactor(ui): rename access-badge to ui-badge, add tone support (#616)

### DIFF
--- a/functions/_lib/buildInfo.ts
+++ b/functions/_lib/buildInfo.ts
@@ -1,5 +1,5 @@
 export const APP_VERSION = "0.16.0";
-export const APP_COMMIT = "e098e898";
+export const APP_COMMIT = "f2975aed";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -2,9 +2,11 @@ import { Globe, Lock, EthernetPort, Globe2, GlobeOff, FlaskConical } from 'lucid
 import type { HTMLAttributes } from 'react';
 
 type BadgeVariant = 'private' | 'public' | 'shared' | 'mqtt' | 'local' | 'staging';
+type BadgeTone = 'subtle' | 'prominent';
 
 type BadgeProps = {
   variant: BadgeVariant;
+  tone?: BadgeTone;
   className?: string;
   children: string;
 } & HTMLAttributes<HTMLSpanElement>;
@@ -18,19 +20,21 @@ const variantIcon = {
   staging: FlaskConical,
 };
 
-const variantClassName: Record<BadgeVariant, string> = {
-  private: 'access-badge',
-  public: 'access-badge',
-  shared: 'access-badge',
-  mqtt: 'access-badge mqtt-source-badge',
-  local: 'access-badge',
-  staging: 'access-badge',
+const defaultTone: Record<BadgeVariant, BadgeTone> = {
+  private: 'subtle',
+  public: 'subtle',
+  shared: 'subtle',
+  mqtt: 'subtle',
+  local: 'prominent',
+  staging: 'prominent',
 };
 
-export function Badge({ variant, className, children, ...rest }: BadgeProps) {
+export function Badge({ variant, tone, className, children, ...rest }: BadgeProps) {
   const Icon = variantIcon[variant];
+  const effectiveTone = tone ?? defaultTone[variant];
+  const isMqtt = variant === 'mqtt';
   return (
-    <span className={`${variantClassName[variant]} ${className ?? ''}`} {...rest}>
+    <span className={`ui-badge ${effectiveTone === 'prominent' ? 'prominent' : ''} ${isMqtt ? 'mqtt-source-badge' : ''} ${className ?? ''}`} {...rest}>
       <Icon aria-hidden size={10} strokeWidth={2.2} style={{ marginRight: 4 }} />
       {children}
     </span>

--- a/src/index.css
+++ b/src/index.css
@@ -4088,7 +4088,7 @@ html.panorama-gesture-lock body {
   justify-self: end;
 }
 
-.access-badge {
+.ui-badge {
   display: inline-flex;
   align-items: center;
   border: 1px solid color-mix(in srgb, var(--border) 75%, transparent);
@@ -4098,6 +4098,12 @@ html.panorama-gesture-lock body {
   color: var(--muted);
   text-transform: capitalize;
   letter-spacing: 0.02em;
+}
+
+.ui-badge.prominent {
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+  background: color-mix(in srgb, var(--accent-soft) 50%, var(--surface));
+  color: var(--text);
 }
 
 .mqtt-source-badge {

--- a/src/lib/buildInfo.ts
+++ b/src/lib/buildInfo.ts
@@ -1,5 +1,5 @@
 export const APP_VERSION = "0.16.0";
-export const APP_COMMIT = "e098e898";
+export const APP_COMMIT = "f2975aed";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {


### PR DESCRIPTION
Rename .access-badge to .ui-badge, add tone support (subtle/prominent)
- Default tone is subtle (for private, public, shared, mqtt)
- Prominent tone for local, staging (uses accent colors)
- Update Badge component with tone prop