### PR TITLE
fix(ui): restore panel shadows, add expanded opaque state

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -2066,7 +2066,7 @@ export function AppShell() {
           readOnly={!canPersistWorkspace}
           inspectorPanelClassName={`${inspectorPanelMotionClass} ${
             isMobileViewport && mobileActivePanel === "inspector" ? mobileBottomPanelMotionClass : ""
-          }`.trim()}
+          } ${isMobileViewport && mobileActivePanel === "inspector" && mobileBottomPanelMode === "full" ? "is-expanded" : ""}`.trim()}
           onToggleMapExpanded={toggleMapExpanded}
           fitBottomInset={mapFitBottomInset}
           fitChromePadding={mapFitChromePadding}
@@ -2178,6 +2178,7 @@ export function AppShell() {
                 hideLibraryBrowsing={isReadOnlyShell}
                 onOpenHelp={openOnboardingTutorial}
                 readOnly={!canPersistWorkspace}
+                panelClassName={mobileBottomPanelMode === "full" ? "is-expanded" : undefined}
                 panelToggleControl={panelSizeControls("Navigator")}
               />
             ) : null}

--- a/src/index.css
+++ b/src/index.css
@@ -308,7 +308,15 @@ input {
   -webkit-backdrop-filter: blur(var(--glass-panel-blur));
   backdrop-filter: blur(var(--glass-panel-blur));
   box-shadow: var(--shadow);
-  transition: transform 350ms ease-out, box-shadow 350ms ease-out;
+  transition: transform 350ms ease-out, box-shadow 350ms ease-out, background 350ms ease-out, backdrop-filter 350ms ease-out;
+}
+
+.sidebar-panel.is-expanded,
+.map-inspector.is-expanded,
+.chart-panel.is-expanded {
+  background: var(--surface-2);
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
 }
 
 .sidebar-panel {
@@ -2870,7 +2878,6 @@ html.panorama-gesture-lock body {
     display: grid;
     height: var(--mobile-panel-height);
     min-height: var(--mobile-panel-height);
-    overflow: hidden;
     border: 0;
     border-radius: 0;
     background: transparent;
@@ -2903,12 +2910,6 @@ html.panorama-gesture-lock body {
 
   .mobile-workspace-panel-shell {
     grid-template-rows: minmax(0, 1fr);
-    border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
-    border-radius: 14px;
-    background: color-mix(in srgb, var(--surface-2) var(--glass-panel-opacity), transparent);
-    -webkit-backdrop-filter: blur(var(--glass-panel-blur));
-    backdrop-filter: blur(var(--glass-panel-blur));
-    box-shadow: var(--shadow-elev-2);
     overflow: hidden;
   }
 
@@ -2919,10 +2920,6 @@ html.panorama-gesture-lock body {
     max-height: 100%;
     grid-row: 1;
     overflow: auto;
-    border-radius: 0;
-    border: 0;
-    box-shadow: none;
-    background: transparent;
     padding-top: 4px;
   }
 
@@ -2946,10 +2943,6 @@ html.panorama-gesture-lock body {
     max-height: 100%;
     min-height: 100%;
     overflow: auto;
-    border: 0;
-    border-radius: 0;
-    box-shadow: none;
-    background: transparent;
   }
 
   .app-shell.is-mobile-shell.is-map-expanded .mobile-workspace-panel,


### PR DESCRIPTION
## Summary
- Remove `overflow:hidden` from `.mobile-workspace-panel` that was clipping shadows
- Add `.is-expanded` rules to base panel classes for opaque expanded state
- Transitions synced with 350ms expansion animation
- Add `is-expanded` class to Navigator Sidebar in mobile full mode
- Add `is-expanded` class to Inspector in mobile full mode  
- Profile panels already have `is-expanded` class from existing prop