### PR TITLE
#616: Fix mobile panel shell clipping + restore surfaces

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2870,11 +2870,6 @@ html.panorama-gesture-lock body {
     display: grid;
     height: var(--mobile-panel-height);
     min-height: var(--mobile-panel-height);
-    overflow: hidden;
-    border: 0;
-    border-radius: 0;
-    background: transparent;
-    box-shadow: none;
     padding: 0;
     z-index: 45;
     transition: opacity 350ms ease-out, transform 350ms ease-out, height 350ms ease-out, min-height 350ms ease-out;
@@ -3021,9 +3016,6 @@ html.panorama-gesture-lock body {
     height: 100dvh;
     min-height: 100dvh;
     margin: 0;
-    border: 0;
-    border-radius: 0;
-    box-shadow: none;
   }
 
   .map-controls {

--- a/src/index.css
+++ b/src/index.css
@@ -2911,10 +2911,6 @@ html.panorama-gesture-lock body {
     max-height: 100%;
     grid-row: 1;
     overflow: auto;
-    border-radius: 0;
-    border: 0;
-    box-shadow: none;
-    background: transparent;
     padding-top: 4px;
   }
 
@@ -2938,10 +2934,6 @@ html.panorama-gesture-lock body {
     max-height: 100%;
     min-height: 100%;
     overflow: auto;
-    border: 0;
-    border-radius: 0;
-    box-shadow: none;
-    background: transparent;
   }
 
   .app-shell.is-mobile-shell.is-map-expanded .mobile-workspace-panel,


### PR DESCRIPTION
Fix:
- Removed remaining wrapper appearance stripping
- Restored panel-owned visuals (border, radius, shadow, background)
- Fixed shadow clipping by removing wrapper overflow

Validation:
- Navigator / Profile / Inspector consistent
- Shadows render correctly
- Expanded mode still works