### PR TITLE
chore: remove unused ve2dbe proxy config (#672)

### DIFF
--- a/config/vite.config.ts
+++ b/config/vite.config.ts
@@ -31,11 +31,6 @@ export default defineConfig(({ command }) => {
           changeOrigin: true,
           rewrite: (path) => path.replace(/^\/meshmap/, ""),
         },
-        "/ve2dbe": {
-          target: "https://www.ve2dbe.com",
-          changeOrigin: true,
-          rewrite: (path) => path.replace(/^\/ve2dbe/, ""),
-        },
       },
     },
     preview: {
@@ -44,11 +39,6 @@ export default defineConfig(({ command }) => {
           target: "https://meshmap.net",
           changeOrigin: true,
           rewrite: (path) => path.replace(/^\/meshmap/, ""),
-        },
-        "/ve2dbe": {
-          target: "https://www.ve2dbe.com",
-          changeOrigin: true,
-          rewrite: (path) => path.replace(/^\/ve2dbe/, ""),
         },
       },
     },

--- a/functions/_lib/buildInfo.ts
+++ b/functions/_lib/buildInfo.ts
@@ -1,5 +1,5 @@
 export const APP_VERSION = "0.16.0";
-export const APP_COMMIT = "f2975aed";
+export const APP_COMMIT = "990d8ab6";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -17,13 +17,4 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
   }
-
-  location /ve2dbe/ {
-    proxy_pass https://www.ve2dbe.com/;
-    proxy_ssl_server_name on;
-    proxy_set_header Host www.ve2dbe.com;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
-  }
 }

--- a/src/lib/buildInfo.ts
+++ b/src/lib/buildInfo.ts
@@ -1,5 +1,5 @@
 export const APP_VERSION = "0.16.0";
-export const APP_COMMIT = "f2975aed";
+export const APP_COMMIT = "990d8ab6";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {


### PR DESCRIPTION
## Summary
- Removed unused `/ve2dbe` proxy from `vite.config.ts` (both server and preview configs)
- Removed unused `/ve2dbe` location block from `nginx/default.conf`
- Preserved attribution to ve2dbe.com (Radio Mobile by Roger Coudé) in `terrainCatalog.ts` and `CREDITS.md`

The proxy was dead code - no API calls were using it.