### PR TITLE
Standardize sidebar headers

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent, type ReactNode } from "react";
 import { Egg, Fullscreen, Maximize2, Minimize2, Rabbit, RefreshCw, SquareStack, ZoomIn, ZoomOut } from "lucide-react";
-import { CompactDetails, CompactDetailsSummary } from "./ui/CompactDetails";
+import { CompactDetails } from "./ui/CompactDetails";
 import Map, {
   Layer,
   type MapRef,
@@ -2592,7 +2592,9 @@ export function MapView({
             onToggle={(event) => { const v = event.currentTarget.open; writeSectionBool(UI_SECTION_KEYS.mapViewOverlayGuide, v); setShowOverlayGuide(v); }}
             open={showOverlayGuide}
           >
-            <CompactDetailsSummary>Map</CompactDetailsSummary>
+            <div className="section-heading">
+              <h2>Map</h2>
+            </div>
             <div className="map-inspector-map-settings">
               <label className="map-inspector-map-setting">
                 <span>Map Provider</span>
@@ -2887,7 +2889,9 @@ export function MapView({
             onToggle={(event) => { const v = event.currentTarget.open; writeSectionBool(UI_SECTION_KEYS.mapViewResults, v); setShowResultsSummary(v); }}
             open={showResultsSummary}
           >
-            <CompactDetailsSummary>Results</CompactDetailsSummary>
+            <div className="section-heading">
+              <h2>Results</h2>
+            </div>
             <SimulationResultsSection />
           </CompactDetails>
           <CompactDetails
@@ -2895,7 +2899,9 @@ export function MapView({
             onToggle={(event) => { const v = event.currentTarget.open; writeSectionBool(UI_SECTION_KEYS.mapViewSimSummary, v); setShowSimulationSummary(v); }}
             open={showSimulationSummary}
           >
-            <CompactDetailsSummary>Simulation Sources</CompactDetailsSummary>
+            <div className="section-heading">
+              <h2>Simulation Sources</h2>
+            </div>
             <p>
               Model: {propagationModel} / {selectedCoverageResolution} / View: {coverageVizMode}
             </p>

--- a/src/components/SimulationResultsSection.tsx
+++ b/src/components/SimulationResultsSection.tsx
@@ -292,23 +292,11 @@ export function SimulationResultsSection() {
         : selectionCount >= 3
           ? "Select exactly two sites to see link analysis."
           : "Select two sites or choose a saved link.";
-    return (
-      <>
-        <div className="section-heading">
-          <h2>Results</h2>
-          <InfoTip text="Computed link budget summary for the selected path and current channel/model settings." />
-        </div>
-        <div className="chart-empty">{message}</div>
-      </>
-    );
+    return <div className="chart-empty">{message}</div>;
   }
 
   return (
     <>
-      <div className="section-heading">
-        <h2>Results</h2>
-        <InfoTip text="Computed link budget summary for the selected path and current channel/model settings." />
-      </div>
       <div className="metrics">
         {metric("Network", selectedNetwork.name)}
         {metric(


### PR DESCRIPTION
## Summary
- Replace plain text section headers in MapView inspector with h2-style headers matching left sidebar
- Remove duplicate "Results" header from SimulationResultsSection (now handled by expandable header in MapView)
- Keep expandable sections with chevrons intact

Changes:
- MapView.tsx: "Map", "Results", "Simulation Sources" sections now use `<div className="section-heading"><h2>...</h2></div>`
- SimulationResultsSection.tsx: Removed duplicate h2 headers