### PR TITLE
Standardize sidebar headers v2

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent, type ReactNode } from "react";
 import { Egg, Fullscreen, Maximize2, Minimize2, Rabbit, RefreshCw, SquareStack, ZoomIn, ZoomOut } from "lucide-react";
-import { CompactDetails } from "./ui/CompactDetails";
+import { CompactDetails, CompactDetailsSummary } from "./ui/CompactDetails";
 import Map, {
   Layer,
   type MapRef,
@@ -2588,14 +2588,12 @@ export function MapView({
             </div>
           ) : null}
           <CompactDetails
-            className="compact-details map-inspector-details"
-            onToggle={(event) => { const v = event.currentTarget.open; writeSectionBool(UI_SECTION_KEYS.mapViewOverlayGuide, v); setShowOverlayGuide(v); }}
-            open={showOverlayGuide}
-          >
-            <div className="section-heading">
-              <h2>Map</h2>
-            </div>
-            <div className="map-inspector-map-settings">
+              className="compact-details map-inspector-details"
+              onToggle={(event) => { const v = event.currentTarget.open; writeSectionBool(UI_SECTION_KEYS.mapViewOverlayGuide, v); setShowOverlayGuide(v); }}
+              open={showOverlayGuide}
+            >
+              <CompactDetailsSummary>Map</CompactDetailsSummary>
+              <div className="map-inspector-map-settings">
               <label className="map-inspector-map-setting">
                 <span>Map Provider</span>
                 <select
@@ -2884,25 +2882,21 @@ export function MapView({
               </>
             ) : null}
           </CompactDetails>
-          <CompactDetails
-            className="compact-details map-inspector-details"
-            onToggle={(event) => { const v = event.currentTarget.open; writeSectionBool(UI_SECTION_KEYS.mapViewResults, v); setShowResultsSummary(v); }}
-            open={showResultsSummary}
-          >
-            <div className="section-heading">
-              <h2>Results</h2>
-            </div>
-            <SimulationResultsSection />
-          </CompactDetails>
-          <CompactDetails
-            className="compact-details map-inspector-details"
-            onToggle={(event) => { const v = event.currentTarget.open; writeSectionBool(UI_SECTION_KEYS.mapViewSimSummary, v); setShowSimulationSummary(v); }}
-            open={showSimulationSummary}
-          >
-            <div className="section-heading">
-              <h2>Simulation Sources</h2>
-            </div>
-            <p>
+            <CompactDetails
+              className="compact-details map-inspector-details"
+              onToggle={(event) => { const v = event.currentTarget.open; writeSectionBool(UI_SECTION_KEYS.mapViewResults, v); setShowResultsSummary(v); }}
+              open={showResultsSummary}
+            >
+              <CompactDetailsSummary infoTipText="Computed link budget summary for the selected path and current channel/model settings.">Results</CompactDetailsSummary>
+              <SimulationResultsSection />
+            </CompactDetails>
+            <CompactDetails
+              className="compact-details map-inspector-details"
+              onToggle={(event) => { const v = event.currentTarget.open; writeSectionBool(UI_SECTION_KEYS.mapViewSimSummary, v); setShowSimulationSummary(v); }}
+              open={showSimulationSummary}
+            >
+              <CompactDetailsSummary>Simulation Sources</CompactDetailsSummary>
+              <p>
               Model: {propagationModel} / {selectedCoverageResolution} / View: {coverageVizMode}
             </p>
             <p>

--- a/src/components/ui/CompactDetails.tsx
+++ b/src/components/ui/CompactDetails.tsx
@@ -1,5 +1,6 @@
 import { CircleChevronDown, CircleChevronRight } from 'lucide-react';
 import type { HTMLAttributes, ReactNode } from 'react';
+import { InfoTip } from "../InfoTip";
 
 type CompactDetailsProps = {
   children: ReactNode;
@@ -19,14 +20,18 @@ export function CompactDetails({ children, className, open, onToggle, ...rest }:
 type CompactDetailsSummaryProps = {
   children: ReactNode;
   className?: string;
+  infoTipText?: string;
 };
 
-export function CompactDetailsSummary({ children, className }: CompactDetailsSummaryProps) {
+export function CompactDetailsSummary({ children, className, infoTipText }: CompactDetailsSummaryProps) {
   return (
-    <summary className={className}>
-      <CircleChevronRight className="compact-details-icon collapsed" aria-hidden size={16} strokeWidth={2} />
-      <CircleChevronDown className="compact-details-icon expanded" aria-hidden size={16} strokeWidth={2} />
-      <span>{children}</span>
+    <summary className={`section-heading ${className ?? ''}`}>
+      <span className="compact-details-header">
+        <CircleChevronRight className="compact-details-icon collapsed" aria-hidden size={16} strokeWidth={2} />
+        <CircleChevronDown className="compact-details-icon expanded" aria-hidden size={16} strokeWidth={2} />
+        <h2>{children}</h2>
+      </span>
+      {infoTipText ? <InfoTip text={infoTipText} /> : null}
     </summary>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -713,15 +713,34 @@ input {
 .compact-details > summary {
   cursor: pointer;
   list-style: none;
-  font-size: 0.82rem;
-  font-weight: 600;
   color: var(--text);
   display: flex;
   align-items: center;
 }
 
+.compact-details > summary.section-heading {
+  min-height: unset;
+  padding-bottom: 0;
+}
+
 .compact-details > summary::-webkit-details-marker {
   display: none;
+}
+
+.compact-details > summary h2 {
+  font-size: 0.96rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.compact-details-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.compact-details:not([open]) > summary.section-heading {
+  border-bottom: none;
 }
 
 .compact-details > summary .compact-details-icon {


### PR DESCRIPTION
## Summary
- Right sidebar now uses h2-style headers matching left sidebar in expandable sections
- CompactDetailsSummary now has section-heading class + h2 + optional infoTip
- Border hidden when collapsed, visible when expanded
- Fixed vertical alignment in collapsed headers

Testing: https://staging.linksim.link