### PR TITLE
User Settings UX overhaul: /settings panel with per-field auto-save (#125)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -2,7 +2,7 @@ import { type CSSProperties, useCallback, useEffect, useMemo, useRef, useState }
 import { CircleAlert, CircleCheck, CircleUserRound, CircleX, CloudAlert, Copy, Globe, Info, PanelBottomClose, PanelBottomOpen, PanelLeftClose, PanelLeftOpen, PanelRightClose, PanelRightOpen, Share, UserRoundPlus, UserRoundSearch, Users, X } from "lucide-react";
 import { type CollaboratorDirectoryUser, fetchCollaboratorDirectory, fetchDeepLinkStatus, fetchMe, setLocalDevRole } from "../lib/cloudUser";
 import { fetchCloudLibrary, fetchPublicSimulationLibrary, pushCloudLibrary } from "../lib/cloudLibrary";
-import { buildDeepLinkPathname, buildDeepLinkUrl, canonicalizeDeepLinkKey, parseDeepLinkFromLocation, slugifyName } from "../lib/deepLink";
+import { buildDeepLinkPathname, buildDeepLinkUrl, buildSettingsPath, canonicalizeDeepLinkKey, matchSettingsPath, parseDeepLinkFromLocation, slugifyName, type SettingsSectionId } from "../lib/deepLink";
 import { canRunDeepLinkApply } from "../lib/deepLinkApplyGate";
 import {
   formatPrivateSiteReferenceBlockMessage,
@@ -37,6 +37,7 @@ import SimulationLibraryPanel from "./SimulationLibraryPanel";
 import WelcomeModal from "./WelcomeModal";
 import { Sidebar } from "./Sidebar";
 import { UserAdminPanel } from "./UserAdminPanel";
+import { SettingsPanel } from "./settings/SettingsPanel";
 import { MobileWorkspaceTabs } from "./app-shell/MobileWorkspaceTabs";
 import { useOnboardingFlow } from "./app-shell/useOnboardingFlow";
 
@@ -188,6 +189,42 @@ export function AppShell() {
   const lockedNeedsSignIn = isAuthSignInRequiredMessage(accessDiagnosticMessage);
   const isAnonymousGuestReadonly = accessState === "readonly" && !currentUser;
   const [activeUserId, setActiveUserId] = useState("");
+  const [settingsRoute, setSettingsRoute] = useState<{ section: SettingsSectionId | null } | null>(() => {
+    if (typeof window === "undefined") return null;
+    const match = matchSettingsPath(window.location.pathname);
+    return match ? { section: match.section } : null;
+  });
+  const returnPathBeforeSettingsRef = useRef<string | null>(null);
+  const openSettings = useCallback((section: SettingsSectionId = "profile") => {
+    if (typeof window === "undefined") return;
+    const currentPath = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+    const match = matchSettingsPath(window.location.pathname);
+    if (!match) {
+      returnPathBeforeSettingsRef.current = currentPath;
+    }
+    window.history.pushState(null, "", buildSettingsPath(section));
+    setSettingsRoute({ section });
+  }, []);
+  const closeSettings = useCallback(() => {
+    const returnPath = returnPathBeforeSettingsRef.current;
+    returnPathBeforeSettingsRef.current = null;
+    setSettingsRoute(null);
+    if (typeof window === "undefined") return;
+    if (returnPath && returnPath !== window.location.pathname + window.location.search + window.location.hash) {
+      window.history.pushState(null, "", returnPath);
+    } else {
+      window.history.pushState(null, "", "/");
+    }
+  }, []);
+  useEffect(() => {
+    const onPop = () => {
+      if (typeof window === "undefined") return;
+      const match = matchSettingsPath(window.location.pathname);
+      setSettingsRoute(match ? { section: match.section } : null);
+    };
+    window.addEventListener("popstate", onPop);
+    return () => window.removeEventListener("popstate", onPop);
+  }, []);
   const [libraryAutoOpened, setLibraryAutoOpened] = useState(false);
   const [showShareModal, setShowShareModal] = useState(false);
   const [shareBusy, setShareBusy] = useState(false);
@@ -420,7 +457,7 @@ export function AppShell() {
       return;
     }
 
-    const reserved = ["api", "cdn-cgi", "assets", "meshmap"];
+    const reserved = ["api", "cdn-cgi", "assets", "meshmap", "settings"];
     const head = (window.location.pathname ?? "/").split("/").filter(Boolean)[0]?.toLowerCase() ?? "";
     if (reserved.includes(head)) return;
 
@@ -1791,7 +1828,7 @@ export function AppShell() {
     return (
       <main className="app-shell access-locked-shell">
         <section className="panel-section access-locked-panel">
-          <UserAdminPanel />
+          <UserAdminPanel onOpenSettings={() => openSettings("profile")} />
           <h2>Closed Beta: Access Pending Approval</h2>
           <p className="field-help">
             You can sign in and edit your profile, but simulation tools stay locked until a moderator or admin approves your access.
@@ -1954,6 +1991,7 @@ export function AppShell() {
             authBootstrapPending={accessState === "checking"}
             hideLibraryBrowsing={isReadOnlyShell}
             onOpenHelp={openOnboardingTutorial}
+            onOpenSettings={() => openSettings("profile")}
             readOnly={!canPersistWorkspace}
             panelToggleControl={
               isMobileViewport ? (
@@ -2177,6 +2215,7 @@ export function AppShell() {
                 authBootstrapPending={accessState === "checking"}
                 hideLibraryBrowsing={isReadOnlyShell}
                 onOpenHelp={openOnboardingTutorial}
+            onOpenSettings={() => openSettings("profile")}
                 readOnly={!canPersistWorkspace}
                 panelToggleControl={panelSizeControls("Navigator")}
               />
@@ -2413,6 +2452,9 @@ export function AppShell() {
             )}
           </div>
         </ModalOverlay>
+      ) : null}
+      {settingsRoute ? (
+        <SettingsPanel initialSection={settingsRoute.section} onClose={closeSettings} />
       ) : null}
     </main>
   );

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -222,6 +222,7 @@ const formatMqttSourceMeta = (value: unknown): string[] => {
 
 type SidebarProps = {
   onOpenHelp?: () => void;
+  onOpenSettings?: () => void;
   hideLibraryBrowsing?: boolean;
   readOnly?: boolean;
   authBootstrapPending?: boolean;
@@ -233,6 +234,7 @@ type SidebarProps = {
 
 export function Sidebar({
   onOpenHelp,
+  onOpenSettings,
   hideLibraryBrowsing = false,
   readOnly = false,
   authBootstrapPending = false,
@@ -1772,7 +1774,7 @@ export function Sidebar({
 
   return (
     <aside className={`sidebar-panel ${panelClassName ?? ""}`.trim()}>
-      <UserAdminPanel authBootstrapPending={authBootstrapPending} extraActions={panelToggleControl} onOpenHelp={onOpenHelp} />
+      <UserAdminPanel authBootstrapPending={authBootstrapPending} extraActions={panelToggleControl} onOpenHelp={onOpenHelp} onOpenSettings={onOpenSettings} />
       <header>
         <div className="sidebar-title-row">
           <h1>{t(locale, "appTitle")}</h1>

--- a/src/components/UserAdminPanel.tsx
+++ b/src/components/UserAdminPanel.tsx
@@ -123,9 +123,28 @@ type UserAdminPanelProps = {
   onOpenHelp?: () => void;
   authBootstrapPending?: boolean;
   extraActions?: ReactNode;
+  /**
+   * "chip" (default): render the header user chip, sync chip, sync modal, and
+   * the legacy user-settings modal.
+   * "admin-inline": render only the admin tools inline (no chip, no modal
+   * wrapper) — used by the Settings panel's Admin section.
+   */
+  renderMode?: "chip" | "admin-inline";
+  /**
+   * When provided, the settings-icon button (and user chip click) invoke this
+   * callback instead of opening the legacy User Settings modal. Used by
+   * AppShell to navigate to `/settings/profile`.
+   */
+  onOpenSettings?: () => void;
 };
 
-export function UserAdminPanel({ onOpenHelp, authBootstrapPending = false, extraActions }: UserAdminPanelProps) {
+export function UserAdminPanel({
+  onOpenHelp,
+  authBootstrapPending = false,
+  extraActions,
+  renderMode = "chip",
+  onOpenSettings,
+}: UserAdminPanelProps) {
   const runtimeEnvironment = getCurrentRuntimeEnvironment();
   const isLocalRuntime = runtimeEnvironment === "local";
   const uiThemePreference = useAppStore((state) => state.uiThemePreference);
@@ -698,6 +717,395 @@ export function UserAdminPanel({ onOpenHelp, authBootstrapPending = false, extra
     };
   }, []);
 
+  if (renderMode === "admin-inline") {
+    if (!canModerate) {
+      return (
+        <p className="field-help">You do not have access to admin tools.</p>
+      );
+    }
+    return (
+      <div className="user-admin-inline">
+        {canAdmin ? (
+          <div className="user-manager-list">
+            <div className="section-heading">
+              <p className="field-help">System diagnostics</p>
+              <div className="chip-group">
+                <ActionButton disabled={busy} onClick={() => void load()} type="button">
+                  Refresh
+                </ActionButton>
+                <ActionButton disabled={busy} onClick={() => void repairMetadata()} type="button">
+                  Repair Metadata
+                </ActionButton>
+              </div>
+            </div>
+            {authWarnings.length ? (
+              <div className="app-notification-item app-notification-item-warning app-notification-item-static" role="status">
+                <span className="app-notification-glyph" aria-hidden="true">
+                  <CircleAlert size={14} strokeWidth={2} />
+                </span>
+                <div className="app-notification-copy">
+                  <span>
+                    <strong>Auth warnings:</strong> {authWarnings.join(" | ")}
+                  </span>
+                </div>
+              </div>
+            ) : (
+              <p className="field-help">Auth configuration checks passed.</p>
+            )}
+            {schemaWarnings.length ? (
+              <div className="app-notification-item app-notification-item-warning app-notification-item-static" role="status">
+                <span className="app-notification-glyph" aria-hidden="true">
+                  <CircleAlert size={14} strokeWidth={2} />
+                </span>
+                <div className="app-notification-copy">
+                  <span>
+                    <strong>Schema warnings:</strong> {schemaWarnings.join(" | ")}
+                  </span>
+                </div>
+              </div>
+            ) : (
+              <p className="field-help">Schema diagnostics passed.</p>
+            )}
+            <p className="field-help">
+              Schema version: {schemaDiagnostics?.schema.version ?? "-"} | Auth source: {authDiagnostics?.auth.source ?? "-"} | JWT:{" "}
+              {authDiagnostics?.auth.signals.hasJwtAssertion ? "yes" : "no"} | Header email:{" "}
+              {authDiagnostics?.auth.signals.hasEmailHeader ? "yes" : "no"}
+            </p>
+          </div>
+        ) : null}
+
+        {canAdmin ? (
+          <div className="user-manager-list">
+            <div className="section-heading">
+              <p className="field-help">Admin ownership tools</p>
+              <div className="chip-group">
+                <ActionButton disabled={busy || auditBusy} onClick={() => void loadAdminAudit()} type="button">
+                  Refresh Audit
+                </ActionButton>
+              </div>
+            </div>
+            <label className="field-grid user-field-grid">
+              <span>Resource type</span>
+              <select
+                className="locale-select"
+                onChange={(event) => setOwnershipKind(event.target.value as "site" | "simulation")}
+                value={ownershipKind}
+              >
+                <option value="site">Site</option>
+                <option value="simulation">Simulation</option>
+              </select>
+            </label>
+            <label className="field-grid user-field-grid">
+              <span>Resource ID</span>
+              <input
+                onChange={(event) => setOwnershipResourceId(event.target.value)}
+                placeholder="site-id or simulation-id"
+                type="text"
+                value={ownershipResourceId}
+              />
+            </label>
+            <label className="field-grid user-field-grid">
+              <span>New owner ID</span>
+              <input
+                list="admin-user-ids-inline"
+                onChange={(event) => setOwnershipNewOwnerId(event.target.value)}
+                placeholder="target user ID"
+                type="text"
+                value={ownershipNewOwnerId}
+              />
+            </label>
+            <ActionButton disabled={busy} onClick={() => void runOwnerReassign()} type="button">
+              Reassign Owner
+            </ActionButton>
+
+            <label className="field-grid user-field-grid">
+              <span>Bulk from owner ID</span>
+              <input
+                list="admin-user-ids-inline"
+                onChange={(event) => setBulkFromOwnerId(event.target.value)}
+                placeholder="source owner user ID"
+                type="text"
+                value={bulkFromOwnerId}
+              />
+            </label>
+            <label className="field-grid user-field-grid">
+              <span>Bulk to owner ID</span>
+              <input
+                list="admin-user-ids-inline"
+                onChange={(event) => setBulkToOwnerId(event.target.value)}
+                placeholder="target owner user ID"
+                type="text"
+                value={bulkToOwnerId}
+              />
+            </label>
+            <ActionButton disabled={busy} onClick={() => void runBulkOwnerReassign()} type="button">
+              Bulk Reassign Ownership
+            </ActionButton>
+
+            <p className="field-help">Recent admin audit events</p>
+            {auditBusy ? <p className="field-help">Loading audit events…</p> : null}
+            <div className="notifications-list">
+              {auditEvents.slice(0, 12).map((event) => (
+                <div className="library-row" key={event.id}>
+                  <strong>{event.eventType}</strong>
+                  <p className="field-help">
+                    actor: {event.actorUserId ?? "-"} | target: {event.targetUserId}
+                  </p>
+                  <p className="field-help">
+                    source: {event.sourceUserId ?? "-"} | at: {fmtDate(event.createdAt)}
+                  </p>
+                </div>
+              ))}
+            </div>
+            {!auditEvents.length ? <p className="field-help">No admin audit events yet.</p> : null}
+            <datalist id="admin-user-ids-inline">
+              {users.map((user) => (
+                <option key={user.id} value={user.id}>
+                  {user.username}
+                </option>
+              ))}
+            </datalist>
+          </div>
+        ) : null}
+
+        {canModerate ? (
+          <div className="user-manager-list notifications-center">
+            {unreadNotifications.length > 0 ? (
+              <div className="app-notification-item app-notification-item-warning app-notification-item-static" role="status">
+                <span className="app-notification-glyph" aria-hidden="true">
+                  <CircleAlert size={14} strokeWidth={2} />
+                </span>
+                <div className="app-notification-copy">
+                  <span>
+                    <strong>{unreadNotifications.length} moderator/admin notification(s)</strong> need your review.
+                  </span>
+                </div>
+              </div>
+            ) : null}
+            <div className="section-heading">
+              <p className="field-help">Notification Center</p>
+              <div className="chip-group">
+                <ActionButton onClick={() => setNotificationOpen((prev) => !prev)} type="button">
+                  {notificationOpen ? "Hide" : "Open"}
+                </ActionButton>
+                <ActionButton onClick={() => void loadNotifications()} type="button">
+                  Refresh
+                </ActionButton>
+              </div>
+            </div>
+            {notificationOpen ? (
+              <>
+                {notificationBusy ? <p className="field-help">Loading notifications…</p> : null}
+                {notificationStatus ? <p className="field-help">{notificationStatus}</p> : null}
+                {notificationFeed.items.length ? (
+                  <div className="notifications-list">
+                    {notificationFeed.items.map((item) => {
+                      const isDismissed = dismissedNotifications.has(item.id);
+                      return (
+                        <div className="library-row" key={item.id}>
+                          <strong>{item.title}</strong>
+                          <p className="field-help">{item.message}</p>
+                          <p className="field-help">Updated: {fmtDate(item.createdAt)}</p>
+                          <div className="chip-group">
+                            <ActionButton
+                              disabled={isDismissed}
+                              onClick={() => dismissNotification(item.id)}
+                              type="button"
+                            >
+                              {isDismissed ? "Dismissed" : "Dismiss Badge"}
+                            </ActionButton>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <p className="field-help">No notifications yet.</p>
+                )}
+              </>
+            ) : null}
+          </div>
+        ) : null}
+
+        {canModerate ? (
+          <div className="user-manager-list">
+            <div className="section-heading">
+              <p className="field-help">Users: open a profile to review and moderate.</p>
+              <p className="field-help">Pending: {pendingUserCount} | Revoked: {revokedUserCount}</p>
+            </div>
+            <label className="field-grid user-field-grid">
+              <span>Filter</span>
+              <select
+                className="locale-select"
+                onChange={(event) => setUserFilter(event.target.value as "all" | "pending" | "approved" | "revoked")}
+                value={userFilter}
+              >
+                <option value="all">All users</option>
+                <option value="pending">Pending only</option>
+                <option value="approved">Approved only</option>
+                <option value="revoked">Revoked only</option>
+              </select>
+            </label>
+            <label className="field-grid user-field-grid">
+              <span>Search</span>
+              <input onChange={(event) => setUserSearch(event.target.value)} placeholder="Name, email, or user ID" type="text" value={userSearch} />
+            </label>
+            {filteredUserRows.map((user) => (
+              <button className="library-row user-list-row-btn" key={user.id} onClick={() => openManagedUser(user)} type="button">
+                <div className="user-list-row">
+                  <ProfileAvatar avatarUrl={user.avatarUrl} name={user.username} />
+                  <div>
+                    <p className="field-help">
+                      <strong>{user.username}</strong>
+                    </p>
+                    <p className="field-help">
+                      {user.accountState === "revoked"
+                        ? "Revoked"
+                        : user.isApproved
+                          ? "Approved"
+                          : "Pending"}
+                    </p>
+                    <p className="field-help">{user.email ?? "-"}</p>
+                  </div>
+                </div>
+              </button>
+            ))}
+            {!filteredUserRows.length ? <p className="field-help">No users match this filter.</p> : null}
+          </div>
+        ) : null}
+
+        {canAdmin ? (
+          <div className="user-manager-list">
+            <p className="field-help">Deleted users: remove lock to allow immediate re-creation.</p>
+            {deletedUsers.map((entry) => (
+              <div className="library-row" key={entry.id}>
+                <p className="field-help">
+                  <strong>{entry.id}</strong>
+                </p>
+                <p className="field-help">Deleted: {fmtDate(entry.deletedAt)}</p>
+                <p className="field-help">Deleted by: {entry.deletedByUserId ?? "-"}</p>
+                <div className="chip-group">
+                  <ActionButton onClick={() => void restoreDeletedUser(entry.id)} type="button">
+                    Restore
+                  </ActionButton>
+                </div>
+              </div>
+            ))}
+            {!deletedUsers.length ? <p className="field-help">No deleted-user locks.</p> : null}
+          </div>
+        ) : null}
+
+        {managedUser ? (
+          <ModalOverlay aria-label="Managed User Profile" onClose={closeManagedUser} tier="raised">
+            <div className="library-manager-card user-profile-popup">
+              <div className="library-manager-header">
+                <h2>User Profile</h2>
+                <InlineCloseIconButton onClick={closeManagedUser} />
+              </div>
+              <div className="user-list-row">
+                <ProfileAvatar avatarUrl={managedUser.avatarUrl} name={managedUser.username} size="large" />
+                <div>
+                  <p className="field-help">
+                    <strong>{managedUser.username}</strong> ({managedUser.id})
+                  </p>
+                  <p className="field-help">Created: {fmtDate(managedUser.createdAt)}</p>
+                  <p className="field-help">
+                    Access:{" "}
+                    {managedUser.accountState === "revoked"
+                      ? "Revoked"
+                      : managedUser.isApproved
+                        ? "Approved"
+                        : "Pending"}{" "}
+                    | Role: {managedUser.role ?? (managedUser.isAdmin ? "admin" : managedUser.isModerator ? "moderator" : managedUser.isApproved ? "user" : "pending")}
+                  </p>
+                </div>
+              </div>
+              <label className="field-grid user-field-grid">
+                <span>Name</span>
+                <input
+                  className={managedNameError ? "input-error" : ""}
+                  onChange={(event) => {
+                    setManagedNameDraft(event.target.value);
+                    if (managedNameError) setManagedNameError("");
+                  }}
+                  type="text"
+                  value={managedNameDraft}
+                />
+              </label>
+              {managedNameError ? <p className="field-help field-help-error">{managedNameError}</p> : null}
+              <label className="field-grid user-field-grid">
+                <span>Email</span>
+                <input
+                  className={managedEmailError ? "input-error" : ""}
+                  onChange={(event) => {
+                    setManagedEmailDraft(event.target.value);
+                    if (managedEmailError) setManagedEmailError("");
+                  }}
+                  type="email"
+                  value={managedEmailDraft}
+                />
+              </label>
+              {managedEmailError ? <p className="field-help field-help-error">{managedEmailError}</p> : null}
+              {managedUser.accessRequestNote ? (
+                <p className="field-help">Access request note: {managedUser.accessRequestNote}</p>
+              ) : (
+                <p className="field-help">No access request note.</p>
+              )}
+              <div className="chip-group">
+                <ActionButton
+                  onClick={() => void saveManagedProfile(managedUser, { username: managedNameDraft, email: managedEmailDraft })}
+                  type="button"
+                >
+                  Save Profile
+                </ActionButton>
+                <label className="field-grid user-field-grid">
+                  <span>
+                    Role{" "}
+                    <InfoTip text="Role changes are audited. Admins can assign all roles except their own. Moderators can only approve pending users to User, or move existing users back to Pending." />
+                  </span>
+                  <select
+                    className="locale-select"
+                    onChange={(event) => {
+                      const nextRole = event.target.value as "admin" | "moderator" | "user" | "pending";
+                      if (!canAssignManagedRole(managedUser, nextRole)) return;
+                      void updateRole(managedUser, nextRole);
+                    }}
+                    value={resolveRole(managedUser)}
+                  >
+                    <option disabled={!canAssignManagedRole(managedUser, "pending")} value="pending">Pending</option>
+                    <option disabled={!canAssignManagedRole(managedUser, "user")} value="user">User</option>
+                    <option disabled={!canAssignManagedRole(managedUser, "moderator")} value="moderator">Moderator</option>
+                    <option disabled={!canAssignManagedRole(managedUser, "admin")} value="admin">Admin</option>
+                  </select>
+                </label>
+                {!managedUser.isApproved ? (
+                  <ActionButton onClick={() => void updateRole(managedUser, "user")} type="button">
+                    Approve Access
+                  </ActionButton>
+                ) : null}
+                {canAdmin ? (
+                  <ActionButton
+                    disabled={managedUser.id === me?.id || resolveRole(managedUser) === "admin"}
+                    onClick={() => void deleteUserAccount(managedUser)}
+                    type="button"
+                    variant="danger"
+                  >
+                    Delete User
+                  </ActionButton>
+                ) : null}
+              </div>
+              <p className="field-help">
+                Role and approval changes are audited. Moderators can only approve pending users to User, or move existing users back to Pending.
+              </p>
+            </div>
+          </ModalOverlay>
+        ) : null}
+
+        {status ? <p className="field-help">{status}</p> : null}
+      </div>
+    );
+  }
+
   const syncIndicator = deriveSyncIndicator({
     isLocalRuntime,
     isOnline,
@@ -718,7 +1126,7 @@ export function UserAdminPanel({ onOpenHelp, authBootstrapPending = false, extra
     <>
       <div className="user-chip-row">
         {isSignedIn && displayUser ? (
-          <button aria-label="Open user settings" className="user-chip" onClick={() => setOpen(true)} type="button">
+          <button aria-label="Open user settings" className="user-chip" onClick={() => (onOpenSettings ? onOpenSettings() : setOpen(true))} type="button">
             <ProfileAvatar avatarUrl={displayUser.avatarUrl ?? ""} name={displayUser.username ?? "User"} />
             {canModerate && unreadNotifications.length > 0 ? (
               <span className="notification-badge">{unreadNotifications.length}</span>
@@ -752,7 +1160,7 @@ export function UserAdminPanel({ onOpenHelp, authBootstrapPending = false, extra
                   title={syncIndicator.label}
                 />
               </button>
-              <button aria-label="Open user settings" className="user-icon-button" onClick={() => setOpen(true)} type="button">
+              <button aria-label="Open user settings" className="user-icon-button" onClick={() => (onOpenSettings ? onOpenSettings() : setOpen(true))} type="button">
                 <SettingsIcon title="Settings" />
               </button>
             </>

--- a/src/components/settings/AutoSaveField.tsx
+++ b/src/components/settings/AutoSaveField.tsx
@@ -1,0 +1,156 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type InputHTMLAttributes,
+  type ReactNode,
+  type TextareaHTMLAttributes,
+} from "react";
+import { getUiErrorMessage } from "../../lib/uiError";
+import { AutoSaveIndicator, type AutoSaveState } from "../ui/AutoSaveIndicator";
+
+type BaseProps = {
+  id: string;
+  label: string;
+  value: string;
+  /**
+   * Commit handler — called on blur when the value differs from the initial value.
+   * Should return a promise that resolves on save success and rejects on failure.
+   */
+  onSave: (nextValue: string) => Promise<void>;
+  /** Client-side validation run before calling onSave. Return null/empty to accept. */
+  validate?: (nextValue: string) => string | null;
+  /** Optional inline help below the field. */
+  help?: ReactNode;
+  /** Optional external error to display (e.g., from server). Overrides local save error. */
+  externalError?: string | null;
+  className?: string;
+};
+
+type InputFieldProps = BaseProps & {
+  as?: "input";
+  inputProps?: Omit<InputHTMLAttributes<HTMLInputElement>, "id" | "value" | "onChange" | "onBlur">;
+};
+
+type TextareaFieldProps = BaseProps & {
+  as: "textarea";
+  textareaProps?: Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, "id" | "value" | "onChange" | "onBlur">;
+};
+
+export type AutoSaveFieldProps = InputFieldProps | TextareaFieldProps;
+
+const SAVED_FADE_MS = 1800;
+
+/**
+ * Auto-save-on-blur wrapper for a single text input or textarea.
+ * Renders label + input + inline AutoSaveIndicator.
+ * Does NOT manage network retries or debouncing; one save per blur.
+ */
+export function AutoSaveField(props: AutoSaveFieldProps) {
+  const { id, label, value, onSave, validate, help, externalError, className } = props;
+  const [draft, setDraft] = useState(value);
+  const [state, setState] = useState<AutoSaveState>("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const lastSavedRef = useRef(value);
+  const savedTimerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    // Sync external value changes when not actively editing or saving.
+    if (state === "saving") return;
+    setDraft(value);
+    lastSavedRef.current = value;
+  }, [value, state]);
+
+  useEffect(() => {
+    return () => {
+      if (savedTimerRef.current != null) {
+        window.clearTimeout(savedTimerRef.current);
+      }
+    };
+  }, []);
+
+  const commit = useCallback(
+    async (nextValue: string) => {
+      if (nextValue === lastSavedRef.current) return;
+      if (validate) {
+        const validationError = validate(nextValue);
+        if (validationError) {
+          setState("error");
+          setErrorMessage(validationError);
+          return;
+        }
+      }
+      setState("saving");
+      setErrorMessage(null);
+      try {
+        await onSave(nextValue);
+        lastSavedRef.current = nextValue;
+        setState("saved");
+        if (savedTimerRef.current != null) window.clearTimeout(savedTimerRef.current);
+        savedTimerRef.current = window.setTimeout(() => setState("idle"), SAVED_FADE_MS);
+      } catch (error) {
+        setState("error");
+        setErrorMessage(getUiErrorMessage(error));
+      }
+    },
+    [onSave, validate],
+  );
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    setDraft(event.target.value);
+    if (state === "error" || state === "saved") {
+      setState("idle");
+      setErrorMessage(null);
+    }
+  };
+
+  const handleBlur = () => {
+    void commit(draft);
+  };
+
+  const resolvedError = externalError ?? (state === "error" ? errorMessage : null);
+  const classes = ["autosave-field"];
+  if (resolvedError) classes.push("autosave-field-error");
+  if (className) classes.push(className);
+
+  return (
+    <div className={classes.join(" ")}>
+      <label htmlFor={id} className="autosave-field-label">
+        <span>{label}</span>
+        <AutoSaveIndicator state={state} errorMessage={errorMessage} fieldLabel={label} />
+      </label>
+      {props.as === "textarea" ? (
+        <textarea
+          id={id}
+          className={resolvedError ? "input-error" : undefined}
+          value={draft}
+          onChange={handleChange}
+          onBlur={handleBlur}
+          aria-invalid={resolvedError ? true : undefined}
+          aria-describedby={resolvedError ? `${id}-error` : undefined}
+          {...props.textareaProps}
+        />
+      ) : (
+        <input
+          id={id}
+          className={resolvedError ? "input-error" : undefined}
+          value={draft}
+          onChange={handleChange}
+          onBlur={handleBlur}
+          aria-invalid={resolvedError ? true : undefined}
+          aria-describedby={resolvedError ? `${id}-error` : undefined}
+          {...(props as InputFieldProps).inputProps}
+        />
+      )}
+      {resolvedError ? (
+        <div id={`${id}-error`} className="autosave-field-error-text" role="alert">
+          {resolvedError}
+        </div>
+      ) : help ? (
+        <div className="field-help">{help}</div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/settings/AvatarDropZone.tsx
+++ b/src/components/settings/AvatarDropZone.tsx
@@ -1,0 +1,269 @@
+import { useCallback, useRef, useState, type DragEvent, type KeyboardEvent } from "react";
+import { ImagePlus, Trash2 } from "lucide-react";
+import { updateMyProfile, uploadAvatar, type CloudUser } from "../../lib/cloudUser";
+import { getUiErrorMessage } from "../../lib/uiError";
+import { AvatarBadge } from "../AvatarBadge";
+import { ActionButton } from "../ActionButton";
+
+type AvatarDropZoneProps = {
+  name: string;
+  avatarUrl: string | null | undefined;
+  onUpdated: (user: CloudUser) => void;
+};
+
+type Step = "idle" | "processing" | "uploading" | "saved" | "error";
+
+const stepLabel: Record<Step, string> = {
+  idle: "",
+  processing: "Resizing image…",
+  uploading: "Uploading avatar…",
+  saved: "Avatar saved",
+  error: "",
+};
+
+const stepProgress: Record<Step, number | "indeterminate" | null> = {
+  idle: null,
+  processing: 35,
+  uploading: "indeterminate",
+  saved: 100,
+  error: null,
+};
+
+const loadImageFromFile = async (file: File): Promise<HTMLImageElement> => {
+  const objectUrl = URL.createObjectURL(file);
+  try {
+    return await new Promise<HTMLImageElement>((resolve, reject) => {
+      const img = new Image();
+      img.onload = () => resolve(img);
+      img.onerror = () => reject(new Error("Unable to decode image."));
+      img.src = objectUrl;
+    });
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
+};
+
+const resizeAvatarFileToDataUrl = async (
+  file: File,
+): Promise<{ originalDataUrl: string; thumbDataUrl: string }> => {
+  const image = await loadImageFromFile(file);
+  const maxOriginal = 2048;
+  const maxThumb = 320;
+  const originalScale = Math.min(1, maxOriginal / Math.max(image.width, image.height));
+  const thumbScale = Math.min(1, maxThumb / Math.max(image.width, image.height));
+  const originalWidth = Math.max(1, Math.round(image.width * originalScale));
+  const originalHeight = Math.max(1, Math.round(image.height * originalScale));
+  const thumbWidth = Math.max(1, Math.round(image.width * thumbScale));
+  const thumbHeight = Math.max(1, Math.round(image.height * thumbScale));
+
+  const originalCanvas = document.createElement("canvas");
+  originalCanvas.width = originalWidth;
+  originalCanvas.height = originalHeight;
+  const originalCtx = originalCanvas.getContext("2d");
+  if (!originalCtx) throw new Error("Canvas unavailable for image resize.");
+  originalCtx.drawImage(image, 0, 0, originalWidth, originalHeight);
+
+  const thumbCanvas = document.createElement("canvas");
+  thumbCanvas.width = thumbWidth;
+  thumbCanvas.height = thumbHeight;
+  const thumbCtx = thumbCanvas.getContext("2d");
+  if (!thumbCtx) throw new Error("Canvas unavailable for thumbnail resize.");
+  thumbCtx.drawImage(image, 0, 0, thumbWidth, thumbHeight);
+
+  const originalDataUrl = originalCanvas.toDataURL("image/webp", 0.86);
+  const thumbDataUrl = thumbCanvas.toDataURL("image/webp", 0.8);
+  if (originalDataUrl.length > 7_000_000) {
+    throw new Error("Profile image is still too large after resize.");
+  }
+  if (thumbDataUrl.length > 1_400_000) {
+    throw new Error("Profile thumbnail is still too large after resize.");
+  }
+  return { originalDataUrl, thumbDataUrl };
+};
+
+export function AvatarDropZone({ name, avatarUrl, onUpdated }: AvatarDropZoneProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [step, setStep] = useState<Step>("idle");
+  const [errorMessage, setErrorMessage] = useState("");
+  const [isDragOver, setIsDragOver] = useState(false);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+
+  const busy = step === "processing" || step === "uploading";
+
+  const handleFile = useCallback(
+    async (file: File) => {
+      setStep("processing");
+      setErrorMessage("");
+      // Local preview for immediate feedback.
+      const localPreview = URL.createObjectURL(file);
+      setPreviewUrl(localPreview);
+      try {
+        const resized = await resizeAvatarFileToDataUrl(file);
+        setStep("uploading");
+        const uploaded = await uploadAvatar(resized.originalDataUrl, resized.thumbDataUrl);
+        onUpdated(uploaded.user);
+        setStep("saved");
+        window.setTimeout(() => {
+          setStep((current) => (current === "saved" ? "idle" : current));
+        }, 1800);
+      } catch (error) {
+        setStep("error");
+        setErrorMessage(getUiErrorMessage(error));
+        setPreviewUrl(null);
+      } finally {
+        URL.revokeObjectURL(localPreview);
+      }
+    },
+    [onUpdated],
+  );
+
+  const openPicker = () => {
+    if (busy) return;
+    inputRef.current?.click();
+  };
+
+  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      openPicker();
+    }
+  };
+
+  const onDragOver = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    if (busy) return;
+    setIsDragOver(true);
+  };
+
+  const onDragLeave = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsDragOver(false);
+  };
+
+  const onDrop = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsDragOver(false);
+    if (busy) return;
+    const file = event.dataTransfer?.files?.[0];
+    if (!file) return;
+    if (!file.type.startsWith("image/")) {
+      setStep("error");
+      setErrorMessage("Please drop an image file.");
+      return;
+    }
+    void handleFile(file);
+  };
+
+  const removeAvatar = async () => {
+    if (busy) return;
+    setStep("uploading");
+    setErrorMessage("");
+    try {
+      const updated = await updateMyProfile({ avatarUrl: "" });
+      setPreviewUrl(null);
+      onUpdated(updated);
+      setStep("saved");
+      window.setTimeout(() => {
+        setStep((current) => (current === "saved" ? "idle" : current));
+      }, 1800);
+    } catch (error) {
+      setStep("error");
+      setErrorMessage(getUiErrorMessage(error));
+    }
+  };
+
+  const displayUrl = previewUrl ?? avatarUrl ?? undefined;
+  const progress = stepProgress[step];
+
+  const zoneClasses = ["avatar-dropzone"];
+  if (isDragOver) zoneClasses.push("avatar-dropzone-drag-over");
+  if (busy) zoneClasses.push("avatar-dropzone-busy");
+  if (step === "error") zoneClasses.push("avatar-dropzone-error");
+
+  return (
+    <div className="avatar-dropzone-wrapper">
+      <div
+        className={zoneClasses.join(" ")}
+        role="button"
+        tabIndex={0}
+        aria-label="Upload profile picture — click or drop an image"
+        aria-busy={busy || undefined}
+        onClick={openPicker}
+        onKeyDown={onKeyDown}
+        onDragOver={onDragOver}
+        onDragLeave={onDragLeave}
+        onDrop={onDrop}
+      >
+        <div className="avatar-dropzone-preview">
+          <AvatarBadge
+            name={name}
+            avatarUrl={displayUrl}
+            imageClassName="avatar-dropzone-image"
+            fallbackClassName="avatar-dropzone-image avatar-dropzone-initials"
+            fallbackAs="div"
+          />
+        </div>
+        <div className="avatar-dropzone-copy">
+          <div className="avatar-dropzone-title">
+            <ImagePlus size={16} strokeWidth={2} aria-hidden="true" />
+            <span>Drop an image or click to upload</span>
+          </div>
+          <div className="avatar-dropzone-hint">PNG, JPG, or WebP · resized automatically</div>
+        </div>
+        <input
+          ref={inputRef}
+          type="file"
+          accept="image/*"
+          className="avatar-dropzone-input"
+          onChange={(event) => {
+            const file = event.target.files?.[0];
+            event.target.value = "";
+            if (file) void handleFile(file);
+          }}
+        />
+      </div>
+
+      {progress != null ? (
+        <div className="avatar-dropzone-progress" aria-live="polite">
+          <div className="map-progress-label">{stepLabel[step]}</div>
+          <div
+            className="map-progress-track"
+            role="progressbar"
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={typeof progress === "number" ? progress : undefined}
+          >
+            {progress === "indeterminate" ? (
+              <div className="map-progress-fill map-progress-fill-indeterminate" />
+            ) : (
+              <div className="map-progress-fill" style={{ width: `${progress}%` }} />
+            )}
+          </div>
+        </div>
+      ) : null}
+
+      {step === "error" && errorMessage ? (
+        <div className="avatar-dropzone-error-text" role="alert">
+          {errorMessage}
+        </div>
+      ) : null}
+
+      <div className="avatar-dropzone-actions">
+        <ActionButton type="button" onClick={openPicker} disabled={busy}>
+          Upload image
+        </ActionButton>
+        {(avatarUrl || previewUrl) && !busy ? (
+          <button
+            type="button"
+            className="avatar-dropzone-remove"
+            onClick={() => void removeAvatar()}
+            aria-label="Remove profile picture"
+          >
+            <Trash2 size={14} strokeWidth={2} aria-hidden="true" />
+            <span>Remove</span>
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/SettingsNav.tsx
+++ b/src/components/settings/SettingsNav.tsx
@@ -1,0 +1,61 @@
+import { ChevronRight, ShieldCheck, SlidersHorizontal, UserRound } from "lucide-react";
+import type { SettingsSectionId } from "../../lib/deepLink";
+
+export type SettingsNavItem = {
+  id: SettingsSectionId;
+  label: string;
+  description: string;
+  icon: typeof UserRound;
+};
+
+type SettingsNavProps = {
+  items: SettingsNavItem[];
+  activeSection: SettingsSectionId;
+  onSelect: (section: SettingsSectionId) => void;
+  layout: "sidebar" | "list";
+};
+
+export function SettingsNav({ items, activeSection, onSelect, layout }: SettingsNavProps) {
+  return (
+    <nav
+      className={`settings-nav settings-nav-${layout}`}
+      aria-label="Settings sections"
+    >
+      <ul>
+        {items.map((item) => {
+          const Icon = item.icon;
+          const isActive = item.id === activeSection;
+          return (
+            <li key={item.id}>
+              <button
+                type="button"
+                className={`settings-nav-item${isActive ? " settings-nav-item-active" : ""}`}
+                aria-current={isActive ? "page" : undefined}
+                onClick={() => onSelect(item.id)}
+              >
+                <span className="settings-nav-item-icon" aria-hidden="true">
+                  <Icon size={18} strokeWidth={2} />
+                </span>
+                <span className="settings-nav-item-copy">
+                  <span className="settings-nav-item-label">{item.label}</span>
+                  {layout === "list" ? (
+                    <span className="settings-nav-item-description">{item.description}</span>
+                  ) : null}
+                </span>
+                {layout === "list" ? (
+                  <ChevronRight className="settings-nav-item-chevron" size={18} aria-hidden="true" />
+                ) : null}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}
+
+export const settingsNavIcons = {
+  profile: UserRound,
+  preferences: SlidersHorizontal,
+  admin: ShieldCheck,
+};

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -1,0 +1,258 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ArrowLeft, X } from "lucide-react";
+import { buildSettingsPath, matchSettingsPath, type SettingsSectionId } from "../../lib/deepLink";
+import { useAppStore } from "../../store/appStore";
+import { fetchMe, type CloudUser } from "../../lib/cloudUser";
+import { getUiErrorMessage } from "../../lib/uiError";
+import { ProfileSection } from "./sections/ProfileSection";
+import { PreferencesSection } from "./sections/PreferencesSection";
+import { SettingsNav, settingsNavIcons, type SettingsNavItem } from "./SettingsNav";
+import { UserAdminPanel } from "../UserAdminPanel";
+
+const MOBILE_BREAKPOINT_PX = 980;
+
+type SettingsPanelProps = {
+  /** Active section resolved from the URL; null → default to "profile". */
+  initialSection: SettingsSectionId | null;
+  onClose: () => void;
+};
+
+const useIsNarrow = () => {
+  const [isNarrow, setIsNarrow] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT_PX - 1}px)`).matches;
+  });
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mq = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT_PX - 1}px)`);
+    const listener = (event: MediaQueryListEvent) => setIsNarrow(event.matches);
+    mq.addEventListener("change", listener);
+    return () => mq.removeEventListener("change", listener);
+  }, []);
+  return isNarrow;
+};
+
+export function SettingsPanel({ initialSection, onClose }: SettingsPanelProps) {
+  const currentUser = useAppStore((state) => state.currentUser);
+  const setCurrentUser = useAppStore((state) => state.setCurrentUser);
+  const authState = useAppStore((state) => state.authState);
+  const setAuthState = useAppStore((state) => state.setAuthState);
+
+  const [me, setMe] = useState<CloudUser | null>(currentUser);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [activeSection, setActiveSection] = useState<SettingsSectionId>(initialSection ?? "profile");
+  const [mobileDetailOpen, setMobileDetailOpen] = useState<boolean>(initialSection !== null);
+  const isNarrow = useIsNarrow();
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  // Load/refresh "me" when signed in.
+  useEffect(() => {
+    if (authState !== "signed_in") return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const current = await fetchMe();
+        if (cancelled) return;
+        setMe(current);
+        setCurrentUser(current);
+      } catch (error) {
+        if (cancelled) return;
+        setLoadError(getUiErrorMessage(error));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [authState, setCurrentUser]);
+
+  // Sync active section to URL (without adding history entries).
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const targetPath = buildSettingsPath(activeSection);
+    if (window.location.pathname !== targetPath) {
+      window.history.replaceState(null, "", `${targetPath}${window.location.search}${window.location.hash}`);
+    }
+  }, [activeSection]);
+
+  // React to browser back/forward while the panel is open.
+  useEffect(() => {
+    const onPopState = () => {
+      const match = matchSettingsPath(window.location.pathname);
+      if (!match) {
+        onClose();
+        return;
+      }
+      setActiveSection(match.section ?? "profile");
+      setMobileDetailOpen(match.section !== null);
+    };
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, [onClose]);
+
+  // Escape key closes the panel.
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  useEffect(() => {
+    // Focus the close button when opening for a11y.
+    closeButtonRef.current?.focus();
+  }, []);
+
+  const handleMeUpdated = useCallback(
+    (user: CloudUser) => {
+      setMe(user);
+      setCurrentUser(user);
+      setAuthState("signed_in");
+    },
+    [setAuthState, setCurrentUser],
+  );
+
+  const navItems = useMemo<SettingsNavItem[]>(() => {
+    const items: SettingsNavItem[] = [
+      {
+        id: "profile",
+        label: "Profile",
+        description: "Name, email, bio, avatar",
+        icon: settingsNavIcons.profile,
+      },
+      {
+        id: "preferences",
+        label: "Preferences",
+        description: "Theme, defaults, access request",
+        icon: settingsNavIcons.preferences,
+      },
+    ];
+    if (me?.isAdmin || me?.isModerator) {
+      items.push({
+        id: "admin",
+        label: "Admin",
+        description: "Users, audit, diagnostics",
+        icon: settingsNavIcons.admin,
+      });
+    }
+    return items;
+  }, [me?.isAdmin, me?.isModerator]);
+
+  // If user navigates to /settings/admin but loses admin rights, fall back.
+  useEffect(() => {
+    if (activeSection === "admin" && !(me?.isAdmin || me?.isModerator)) {
+      setActiveSection("profile");
+    }
+  }, [activeSection, me?.isAdmin, me?.isModerator]);
+
+  const onSelectSection = (section: SettingsSectionId) => {
+    setActiveSection(section);
+    setMobileDetailOpen(true);
+    if (typeof window !== "undefined") {
+      window.history.pushState(null, "", buildSettingsPath(section));
+    }
+  };
+
+  const onBackToList = () => {
+    setMobileDetailOpen(false);
+    if (typeof window !== "undefined") {
+      window.history.pushState(null, "", buildSettingsPath(null));
+    }
+  };
+
+  const renderSection = () => {
+    if (loadError) {
+      return (
+        <section className="settings-section">
+          <h2>Profile unavailable</h2>
+          <p className="field-help field-help-error">{loadError}</p>
+        </section>
+      );
+    }
+    switch (activeSection) {
+      case "profile":
+        return <ProfileSection me={me} onMeUpdated={handleMeUpdated} />;
+      case "preferences":
+        return <PreferencesSection me={me} onMeUpdated={handleMeUpdated} />;
+      case "admin":
+        return (
+          <section className="settings-section" aria-labelledby="settings-admin-heading">
+            <header className="settings-section-header">
+              <h2 id="settings-admin-heading">Admin</h2>
+              <p className="field-help">
+                User management, audit events, and diagnostics. Changes made here are audited.
+              </p>
+            </header>
+            <div className="settings-admin-embed">
+              <UserAdminPanel renderMode="admin-inline" />
+            </div>
+          </section>
+        );
+      default:
+        return null;
+    }
+  };
+
+  const showList = !isNarrow || !mobileDetailOpen;
+  const showDetail = !isNarrow || mobileDetailOpen;
+
+  return (
+    <div
+      className="settings-panel"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="settings-panel-title"
+    >
+      <header className="settings-panel-header">
+        <div className="settings-panel-header-lead">
+          {isNarrow && mobileDetailOpen ? (
+            <button
+              type="button"
+              className="settings-panel-back"
+              aria-label="Back to settings"
+              onClick={onBackToList}
+            >
+              <ArrowLeft size={18} strokeWidth={2} aria-hidden="true" />
+              <span>Back</span>
+            </button>
+          ) : null}
+          <h1 id="settings-panel-title" className="settings-panel-title">
+            {isNarrow && mobileDetailOpen
+              ? navItems.find((item) => item.id === activeSection)?.label ?? "Settings"
+              : "Settings"}
+          </h1>
+        </div>
+        <button
+          ref={closeButtonRef}
+          type="button"
+          className="settings-panel-close"
+          aria-label="Close settings"
+          onClick={onClose}
+        >
+          <X size={20} strokeWidth={2} aria-hidden="true" />
+        </button>
+      </header>
+
+      <div className="settings-panel-body">
+        {showList ? (
+          <aside className="settings-panel-sidebar">
+            <SettingsNav
+              items={navItems}
+              activeSection={activeSection}
+              onSelect={onSelectSection}
+              layout={isNarrow ? "list" : "sidebar"}
+            />
+          </aside>
+        ) : null}
+        {showDetail ? (
+          <main className="settings-panel-content" tabIndex={-1}>
+            {renderSection()}
+          </main>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/sections/PreferencesSection.tsx
+++ b/src/components/settings/sections/PreferencesSection.tsx
@@ -1,0 +1,180 @@
+import { useCallback, useState } from "react";
+import { updateMyProfile, type CloudUser } from "../../../lib/cloudUser";
+import { FREQUENCY_PRESETS, frequencyPresetGroups } from "../../../lib/frequencyPlans";
+import { getUiErrorMessage } from "../../../lib/uiError";
+import { useAppStore } from "../../../store/appStore";
+import { useThemeVariant } from "../../../hooks/useThemeVariant";
+import type { UiColorTheme } from "../../../themes/types";
+import { AutoSaveField } from "../AutoSaveField";
+import { AutoSaveIndicator, type AutoSaveState } from "../../ui/AutoSaveIndicator";
+import { InfoTip } from "../../InfoTip";
+
+type PreferencesSectionProps = {
+  me: CloudUser | null;
+  onMeUpdated: (user: CloudUser) => void;
+};
+
+type SelectFieldState = {
+  state: AutoSaveState;
+  error: string | null;
+};
+
+const IDLE_SELECT: SelectFieldState = { state: "idle", error: null };
+
+export function PreferencesSection({ me, onMeUpdated }: PreferencesSectionProps) {
+  const uiThemePreference = useAppStore((state) => state.uiThemePreference);
+  const setUiThemePreference = useAppStore((state) => state.setUiThemePreference);
+  const uiColorTheme = useAppStore((state) => state.uiColorTheme);
+  const setUiColorTheme = useAppStore((state) => state.setUiColorTheme);
+  const setCurrentUser = useAppStore((state) => state.setCurrentUser);
+  const setAuthState = useAppStore((state) => state.setAuthState);
+  const { activeHolidayTheme } = useThemeVariant();
+
+  const [presetState, setPresetState] = useState<SelectFieldState>(IDLE_SELECT);
+
+  const canModerate = Boolean(me?.isAdmin || me?.isModerator);
+  const canEditAccessRequestNote = Boolean(canModerate || !me?.isApproved);
+  const showAccessRequestNoteField = Boolean(canModerate || !me?.isApproved);
+
+  const savePreset = useCallback(
+    async (value: string | null) => {
+      setPresetState({ state: "saving", error: null });
+      try {
+        const updated = await updateMyProfile({ defaultFrequencyPresetId: value });
+        onMeUpdated(updated);
+        setCurrentUser(updated);
+        setAuthState("signed_in");
+        setPresetState({ state: "saved", error: null });
+        window.setTimeout(() => {
+          setPresetState((current) => (current.state === "saved" ? IDLE_SELECT : current));
+        }, 1800);
+      } catch (error) {
+        setPresetState({ state: "error", error: getUiErrorMessage(error) });
+      }
+    },
+    [onMeUpdated, setAuthState, setCurrentUser],
+  );
+
+  const saveNote = useCallback(
+    async (value: string) => {
+      const updated = await updateMyProfile({ accessRequestNote: value });
+      onMeUpdated(updated);
+      setCurrentUser(updated);
+      setAuthState("signed_in");
+    },
+    [onMeUpdated, setAuthState, setCurrentUser],
+  );
+
+  return (
+    <section className="settings-section" aria-labelledby="settings-preferences-heading">
+      <header className="settings-section-header">
+        <h2 id="settings-preferences-heading">Preferences</h2>
+        <p className="field-help">Theme preferences apply to this device. Other preferences sync to your account.</p>
+      </header>
+
+      <div className="settings-preferences-fields">
+        <div className="autosave-field">
+          <label className="autosave-field-label" htmlFor="pref-ui-theme">
+            <span>
+              UI theme{" "}
+              <InfoTip text="Choose whether LinkSim follows your system theme, or force light/dark mode." />
+            </span>
+          </label>
+          <select
+            id="pref-ui-theme"
+            className="locale-select"
+            value={uiThemePreference}
+            onChange={(event) =>
+              setUiThemePreference(event.target.value as "system" | "light" | "dark")
+            }
+          >
+            <option value="system">System</option>
+            <option value="dark">Dark</option>
+            <option value="light">Light</option>
+          </select>
+          <div className="field-help">Device-only preference — not synced across devices.</div>
+        </div>
+
+        <div className="autosave-field">
+          <label className="autosave-field-label" htmlFor="pref-color-theme">
+            <span>
+              Color theme <InfoTip text="Select the app accent palette." />
+            </span>
+          </label>
+          <select
+            id="pref-color-theme"
+            className="locale-select"
+            value={uiColorTheme}
+            onChange={(event) => setUiColorTheme(event.target.value as UiColorTheme)}
+          >
+            <option value="blue">Blue</option>
+            <option value="pink">Pink</option>
+            <option value="red">Red</option>
+            <option value="green">Green</option>
+            {activeHolidayTheme ? (
+              <option value="yellow">{activeHolidayTheme.title.replace(" Theme", "")}</option>
+            ) : null}
+          </select>
+        </div>
+
+        <div className="autosave-field">
+          <label className="autosave-field-label" htmlFor="pref-default-preset">
+            <span>
+              Default preset for new simulations{" "}
+              <InfoTip text="This cloud setting applies when you create a new simulation. Existing simulations keep their own saved channel settings." />
+            </span>
+            <AutoSaveIndicator
+              state={presetState.state}
+              errorMessage={presetState.error}
+              fieldLabel="Default preset"
+            />
+          </label>
+          <select
+            id="pref-default-preset"
+            className="locale-select"
+            value={me?.defaultFrequencyPresetId ?? ""}
+            onChange={(event) => {
+              const next = event.target.value ? event.target.value : null;
+              void savePreset(next);
+            }}
+          >
+            <option value="">App default (Oslo Local 869.618)</option>
+            {frequencyPresetGroups(FREQUENCY_PRESETS).map((groupEntry) => (
+              <optgroup key={groupEntry.group} label={groupEntry.group}>
+                {groupEntry.presets.map((preset) => (
+                  <option key={preset.id} value={preset.id}>
+                    {preset.label}
+                  </option>
+                ))}
+              </optgroup>
+            ))}
+          </select>
+        </div>
+
+        {showAccessRequestNoteField ? (
+          <AutoSaveField
+            as="textarea"
+            id="pref-access-request-note"
+            label="Access request note"
+            value={me?.accessRequestNote ?? ""}
+            onSave={saveNote}
+            textareaProps={{
+              maxLength: 1200,
+              rows: 5,
+              readOnly: !canEditAccessRequestNote,
+              disabled: !canEditAccessRequestNote,
+              placeholder: canEditAccessRequestNote
+                ? "Optional private note to moderators/admins."
+                : "Request note is locked after approval.",
+            }}
+            help={
+              canEditAccessRequestNote
+                ? "Visible to moderators and admins. Up to 1200 characters."
+                : "Request note is locked after approval."
+            }
+          />
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/src/components/settings/sections/ProfileSection.tsx
+++ b/src/components/settings/sections/ProfileSection.tsx
@@ -1,0 +1,205 @@
+import { useCallback, useEffect, useState } from "react";
+import { fetchMe, updateMyProfile, type CloudUser } from "../../../lib/cloudUser";
+import { getUiErrorMessage } from "../../../lib/uiError";
+import { useAppStore } from "../../../store/appStore";
+import { formatDate } from "../../../lib/locale";
+import { AutoSaveField } from "../AutoSaveField";
+import { AvatarDropZone } from "../AvatarDropZone";
+import { AutoSaveIndicator, type AutoSaveState } from "../../ui/AutoSaveIndicator";
+
+type ProfileSectionProps = {
+  me: CloudUser | null;
+  onMeUpdated: (user: CloudUser) => void;
+};
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function ProfileSection({ me, onMeUpdated }: ProfileSectionProps) {
+  const setCurrentUser = useAppStore((state) => state.setCurrentUser);
+  const setAuthState = useAppStore((state) => state.setAuthState);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [emailPublicState, setEmailPublicState] = useState<AutoSaveState>("idle");
+  const [emailPublicError, setEmailPublicError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (me) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const current = await fetchMe();
+        if (cancelled) return;
+        onMeUpdated(current);
+        setCurrentUser(current);
+        setAuthState("signed_in");
+      } catch (error) {
+        if (cancelled) return;
+        setLoadError(getUiErrorMessage(error));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [me, onMeUpdated, setAuthState, setCurrentUser]);
+
+  const applyUpdate = useCallback(
+    (user: CloudUser) => {
+      onMeUpdated(user);
+      setCurrentUser(user);
+      setAuthState("signed_in");
+    },
+    [onMeUpdated, setAuthState, setCurrentUser],
+  );
+
+  const saveField = useCallback(
+    async (patch: Parameters<typeof updateMyProfile>[0]) => {
+      const updated = await updateMyProfile(patch);
+      applyUpdate(updated);
+    },
+    [applyUpdate],
+  );
+
+  const saveEmailPublic = useCallback(
+    async (nextValue: boolean) => {
+      setEmailPublicState("saving");
+      setEmailPublicError(null);
+      try {
+        const updated = await updateMyProfile({ emailPublic: nextValue });
+        applyUpdate(updated);
+        setEmailPublicState("saved");
+        window.setTimeout(() => {
+          setEmailPublicState((current) => (current === "saved" ? "idle" : current));
+        }, 1800);
+      } catch (error) {
+        setEmailPublicState("error");
+        setEmailPublicError(getUiErrorMessage(error));
+      }
+    },
+    [applyUpdate],
+  );
+
+  if (loadError) {
+    return (
+      <section className="settings-section" aria-labelledby="settings-profile-heading">
+        <h2 id="settings-profile-heading">Profile</h2>
+        <p className="field-help field-help-error">Could not load profile: {loadError}</p>
+      </section>
+    );
+  }
+
+  if (!me) {
+    return (
+      <section className="settings-section" aria-labelledby="settings-profile-heading">
+        <h2 id="settings-profile-heading">Profile</h2>
+        <p className="field-help">Loading profile…</p>
+      </section>
+    );
+  }
+
+  const displayName = me.username || "User";
+
+  return (
+    <section className="settings-section" aria-labelledby="settings-profile-heading">
+      <header className="settings-section-header">
+        <h2 id="settings-profile-heading">Profile</h2>
+        <p className="field-help">
+          Changes save automatically as you leave each field. Account settings are separate from simulation sync.
+        </p>
+      </header>
+
+      <div className="settings-profile-grid">
+        <div className="settings-profile-avatar">
+          <AvatarDropZone name={displayName} avatarUrl={me.avatarUrl} onUpdated={applyUpdate} />
+          <dl className="settings-profile-meta">
+            <div>
+              <dt>ID</dt>
+              <dd>{me.id}</dd>
+            </div>
+            <div>
+              <dt>Role</dt>
+              <dd>
+                {me.role ??
+                  (me.isAdmin
+                    ? "admin"
+                    : me.isModerator
+                      ? "moderator"
+                      : me.isApproved
+                        ? "user"
+                        : "pending")}
+              </dd>
+            </div>
+            <div>
+              <dt>Access</dt>
+              <dd>
+                {me.accountState === "revoked"
+                  ? "Revoked"
+                  : me.isApproved
+                    ? "Approved"
+                    : "Pending approval"}
+              </dd>
+            </div>
+            {me.createdAt ? (
+              <div>
+                <dt>Member since</dt>
+                <dd>{formatDate(me.createdAt)}</dd>
+              </div>
+            ) : null}
+          </dl>
+        </div>
+
+        <div className="settings-profile-fields">
+          <AutoSaveField
+            id="profile-name"
+            label="Name"
+            value={me.username ?? ""}
+            validate={(value) => (value.trim() ? null : "A name is required.")}
+            onSave={(value) => saveField({ username: value.trim() })}
+            inputProps={{ type: "text", autoComplete: "name", maxLength: 60 }}
+          />
+
+          <AutoSaveField
+            id="profile-email"
+            label="Email"
+            value={me.email ?? ""}
+            validate={(value) => {
+              const trimmed = value.trim();
+              if (!trimmed) return "A valid email is required.";
+              if (!EMAIL_PATTERN.test(trimmed)) return "Enter a valid email address.";
+              return null;
+            }}
+            onSave={(value) => saveField({ email: value.trim() })}
+            inputProps={{ type: "email", autoComplete: "email" }}
+          />
+
+          <div className="autosave-field">
+            <div className="autosave-field-label">
+              <span>Email visibility</span>
+              <AutoSaveIndicator
+                state={emailPublicState}
+                errorMessage={emailPublicError}
+                fieldLabel="Email visibility"
+              />
+            </div>
+            <label className="checkbox-field">
+              <input
+                type="checkbox"
+                checked={me.emailPublic ?? true}
+                onChange={(event) => void saveEmailPublic(event.target.checked)}
+              />
+              <span>Visible to all users in profile popover (admins always see it)</span>
+            </label>
+          </div>
+
+          <AutoSaveField
+            as="textarea"
+            id="profile-bio"
+            label="Bio"
+            value={me.bio ?? ""}
+            onSave={(value) => saveField({ bio: value })}
+            textareaProps={{ maxLength: 300, rows: 4, placeholder: "A short bio (up to 300 characters)." }}
+            help={<>Up to 300 characters.</>}
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/ui/AutoSaveIndicator.tsx
+++ b/src/components/ui/AutoSaveIndicator.tsx
@@ -1,0 +1,45 @@
+import { Check, CircleAlert, Loader2 } from "lucide-react";
+
+export type AutoSaveState = "idle" | "saving" | "saved" | "error";
+
+type AutoSaveIndicatorProps = {
+  state: AutoSaveState;
+  errorMessage?: string | null;
+  /** Optional label announced for screen readers alongside field status. */
+  fieldLabel?: string;
+  className?: string;
+};
+
+/**
+ * Small, reusable save-status chip for auto-saving form fields.
+ * Visually shows idle (invisible), saving (spinner), saved (check), or error (icon + text).
+ * Announces status changes via an `aria-live="polite"` region.
+ * Intentionally decoupled from the Settings panel so future forms can reuse it.
+ */
+export function AutoSaveIndicator({ state, errorMessage, fieldLabel, className }: AutoSaveIndicatorProps) {
+  const classes = ["autosave-indicator", `autosave-indicator-${state}`];
+  if (className) classes.push(className);
+
+  const liveMessage = (() => {
+    if (state === "saving") return fieldLabel ? `Saving ${fieldLabel}…` : "Saving…";
+    if (state === "saved") return fieldLabel ? `${fieldLabel} saved` : "Saved";
+    if (state === "error") return errorMessage ?? "Save failed";
+    return "";
+  })();
+
+  return (
+    <span className={classes.join(" ")}>
+      <span className="autosave-indicator-visual" aria-hidden="true">
+        {state === "saving" ? <Loader2 className="autosave-spin" size={14} strokeWidth={2} /> : null}
+        {state === "saved" ? <Check size={14} strokeWidth={2.5} /> : null}
+        {state === "error" ? <CircleAlert size={14} strokeWidth={2} /> : null}
+      </span>
+      {state === "error" && errorMessage ? (
+        <span className="autosave-indicator-text">{errorMessage}</span>
+      ) : null}
+      <span className="sr-only" role="status" aria-live="polite">
+        {liveMessage}
+      </span>
+    </span>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -4594,3 +4594,408 @@ html.panorama-gesture-lock body {
     width: min(460px, calc(100% - 16px));
   }
 }
+
+/* ---------- Settings panel (issue #125) ---------- */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.settings-panel {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  display: flex;
+  flex-direction: column;
+  background: var(--surface);
+  color: var(--text);
+  overflow: hidden;
+}
+
+.settings-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 20px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.settings-panel-header-lead {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.settings-panel-title {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.settings-panel-back,
+.settings-panel-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-btn);
+  padding: 6px 10px;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.settings-panel-back:hover,
+.settings-panel-close:hover {
+  background: var(--surface-2);
+  border-color: var(--border);
+}
+
+.settings-panel-close {
+  padding: 6px;
+}
+
+.settings-panel-body {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.settings-panel-sidebar {
+  flex: 0 0 280px;
+  border-right: 1px solid var(--border);
+  background: var(--surface-2);
+  overflow-y: auto;
+  padding: 12px;
+}
+
+.settings-panel-content {
+  flex: 1;
+  min-width: 0;
+  overflow-y: auto;
+  padding: 24px 28px 48px;
+  outline: none;
+}
+
+@media (max-width: 980px) {
+  .settings-panel-sidebar {
+    flex: 1 1 auto;
+    border-right: none;
+    padding: 8px;
+  }
+  .settings-panel-content {
+    padding: 16px 16px 36px;
+  }
+}
+
+/* Settings nav */
+.settings-nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.settings-nav-item {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-btn);
+  padding: 10px 12px;
+  color: var(--text);
+  cursor: pointer;
+  text-align: left;
+}
+
+.settings-nav-item:hover {
+  background: var(--surface);
+  border-color: var(--border);
+}
+
+.settings-nav-item-active,
+.settings-nav-item-active:hover {
+  background: var(--accent-soft);
+  border-color: var(--border);
+}
+
+.settings-nav-item-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
+}
+
+.settings-nav-item-active .settings-nav-item-icon {
+  color: var(--text);
+}
+
+.settings-nav-item-copy {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1;
+}
+
+.settings-nav-item-label {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.settings-nav-item-description {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.settings-nav-item-chevron {
+  color: var(--muted);
+  flex-shrink: 0;
+}
+
+/* Settings sections */
+.settings-section {
+  max-width: 860px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.settings-section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.settings-section-header h2 {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.settings-preferences-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.settings-profile-grid {
+  display: grid;
+  grid-template-columns: minmax(220px, 260px) 1fr;
+  gap: 32px;
+}
+
+@media (max-width: 980px) {
+  .settings-profile-grid {
+    grid-template-columns: 1fr;
+    gap: 24px;
+  }
+}
+
+.settings-profile-avatar {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.settings-profile-meta {
+  margin: 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 12px;
+  row-gap: 6px;
+  font-size: 0.85rem;
+}
+
+.settings-profile-meta > div {
+  display: contents;
+}
+
+.settings-profile-meta dt {
+  color: var(--muted);
+}
+
+.settings-profile-meta dd {
+  margin: 0;
+  color: var(--text);
+  word-break: break-all;
+}
+
+.settings-profile-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.settings-admin-embed {
+  border-top: 1px solid var(--border);
+  padding-top: 16px;
+}
+
+/* Auto-save field */
+.autosave-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.autosave-field-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.autosave-field-error-text {
+  color: var(--danger, #c2410c);
+  font-size: 0.85rem;
+}
+
+/* Auto-save indicator */
+.autosave-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.8rem;
+  color: var(--muted);
+  min-height: 18px;
+}
+
+.autosave-indicator-saved {
+  color: var(--text);
+}
+
+.autosave-indicator-error {
+  color: var(--danger, #c2410c);
+}
+
+.autosave-spin {
+  animation: autosave-spin 0.9s linear infinite;
+}
+
+@keyframes autosave-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Avatar drop zone */
+.avatar-dropzone {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.avatar-dropzone-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px;
+  border: 1.5px dashed var(--border);
+  border-radius: var(--radius-btn);
+  background: var(--surface-2);
+  cursor: pointer;
+  transition: border-color 120ms ease, background 120ms ease;
+}
+
+.avatar-dropzone-wrapper:hover,
+.avatar-dropzone-wrapper:focus-visible {
+  border-color: var(--text);
+  outline: none;
+}
+
+.avatar-dropzone-wrapper.is-dragover {
+  border-style: solid;
+  background: var(--accent-soft);
+}
+
+.avatar-dropzone-preview {
+  flex-shrink: 0;
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--surface);
+  border: 1px solid var(--border);
+}
+
+.avatar-dropzone-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.avatar-dropzone-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 0.85rem;
+  color: var(--muted);
+  min-width: 0;
+}
+
+.avatar-dropzone-copy strong {
+  color: var(--text);
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.avatar-dropzone-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.avatar-dropzone-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.avatar-dropzone-remove {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-btn);
+  padding: 4px 10px;
+  color: var(--text);
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.avatar-dropzone-remove:hover {
+  background: var(--surface-2);
+}
+
+.avatar-dropzone-remove[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Admin inline embed */
+.user-admin-inline {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}

--- a/src/lib/deepLink.test.ts
+++ b/src/lib/deepLink.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { buildDeepLinkPathname, buildDeepLinkUrl, canonicalizeDeepLinkKey, parseDeepLinkFromLocation, slugifyName } from "./deepLink";
+import {
+  buildDeepLinkPathname,
+  buildDeepLinkUrl,
+  buildSettingsPath,
+  canonicalizeDeepLinkKey,
+  matchSettingsPath,
+  parseDeepLinkFromLocation,
+  slugifyName,
+} from "./deepLink";
 
 describe("deepLink", () => {
   it("parses old v1 deep link payload and converts to v2", () => {
@@ -256,5 +264,56 @@ describe("deepLink", () => {
       selectedSiteSlugs: ["남산-서울-타워", "평양텔레비죤탑"],
     });
     expect(pathname).toBe("/한국조선/남산-서울-타워+평양텔레비죤탑");
+  });
+
+  it("treats /settings as a reserved path head (no simulation parsed)", () => {
+    const parsed = parseDeepLinkFromLocation({ pathname: "/settings", search: "" });
+    expect(parsed).toEqual({ ok: false, reason: "missing_sim" });
+  });
+
+  it("treats /settings/profile as a reserved path head (no simulation parsed)", () => {
+    const parsed = parseDeepLinkFromLocation({ pathname: "/settings/profile", search: "" });
+    expect(parsed).toEqual({ ok: false, reason: "missing_sim" });
+  });
+
+  describe("matchSettingsPath", () => {
+    it("returns null for unrelated paths", () => {
+      expect(matchSettingsPath("/")).toBeNull();
+      expect(matchSettingsPath("/Høgevarde")).toBeNull();
+      expect(matchSettingsPath("/Høgevarde/site")).toBeNull();
+    });
+
+    it("matches /settings without a section", () => {
+      expect(matchSettingsPath("/settings")).toEqual({ matched: true, section: null });
+      expect(matchSettingsPath("/settings/")).toEqual({ matched: true, section: null });
+    });
+
+    it("matches /settings/<known-section>", () => {
+      expect(matchSettingsPath("/settings/profile")).toEqual({ matched: true, section: "profile" });
+      expect(matchSettingsPath("/settings/preferences")).toEqual({ matched: true, section: "preferences" });
+      expect(matchSettingsPath("/settings/admin")).toEqual({ matched: true, section: "admin" });
+    });
+
+    it("matches /settings/<unknown-section> as settings with null section", () => {
+      expect(matchSettingsPath("/settings/unknown")).toEqual({ matched: true, section: null });
+    });
+
+    it("is case-insensitive on the settings head", () => {
+      expect(matchSettingsPath("/Settings")).toEqual({ matched: true, section: null });
+      expect(matchSettingsPath("/SETTINGS/Profile")).toEqual({ matched: true, section: "profile" });
+    });
+  });
+
+  describe("buildSettingsPath", () => {
+    it("returns /settings without a section", () => {
+      expect(buildSettingsPath()).toBe("/settings");
+      expect(buildSettingsPath(null)).toBe("/settings");
+    });
+
+    it("returns /settings/<section> when provided", () => {
+      expect(buildSettingsPath("profile")).toBe("/settings/profile");
+      expect(buildSettingsPath("preferences")).toBe("/settings/preferences");
+      expect(buildSettingsPath("admin")).toBe("/settings/admin");
+    });
   });
 });

--- a/src/lib/deepLink.ts
+++ b/src/lib/deepLink.ts
@@ -23,7 +23,55 @@ const trimToUndefined = (value: string | null): string | undefined => {
 
 const isReservedPathHead = (head: string): boolean => {
   const value = head.toLowerCase();
-  return value === "api" || value === "cdn-cgi" || value === "assets" || value === "meshmap";
+  return (
+    value === "api" ||
+    value === "cdn-cgi" ||
+    value === "assets" ||
+    value === "meshmap" ||
+    value === "settings"
+  );
+};
+
+export const SETTINGS_PATH_HEAD = "settings";
+
+export type SettingsSectionId = "profile" | "preferences" | "admin";
+
+const SETTINGS_SECTIONS: ReadonlySet<SettingsSectionId> = new Set<SettingsSectionId>([
+  "profile",
+  "preferences",
+  "admin",
+]);
+
+export type SettingsRouteMatch = {
+  matched: true;
+  section: SettingsSectionId | null;
+};
+
+/**
+ * Detects whether a pathname points at the Settings panel (`/settings` or
+ * `/settings/<section>`). Returns the matched section id when valid, or `null`
+ * when the pathname is `/settings` with no section (caller should default to
+ * `profile`).
+ */
+export const matchSettingsPath = (pathname: string | null | undefined): SettingsRouteMatch | null => {
+  const segments = (pathname ?? "/")
+    .split("/")
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+  if (!segments.length) return null;
+  if (segments[0].toLowerCase() !== SETTINGS_PATH_HEAD) return null;
+  const next = segments[1]?.toLowerCase();
+  if (!next) return { matched: true, section: null };
+  if (SETTINGS_SECTIONS.has(next as SettingsSectionId)) {
+    return { matched: true, section: next as SettingsSectionId };
+  }
+  // Unknown section — still match Settings route but report null so caller can redirect.
+  return { matched: true, section: null };
+};
+
+export const buildSettingsPath = (section?: SettingsSectionId | null): string => {
+  if (!section) return `/${SETTINGS_PATH_HEAD}`;
+  return `/${SETTINGS_PATH_HEAD}/${section}`;
 };
 
 const safeDecodeURIComponent = (value: string): string => {


### PR DESCRIPTION
## Summary
- New `/settings` route (added to deepLink reserved heads) renders a full-viewport panel over the app with left-nav sections **Profile / Preferences / Admin** on desktop and master-detail at the existing 980px breakpoint on mobile.
- All editable fields auto-save on blur via a new reusable `AutoSaveField` + `AutoSaveIndicator` primitive (idle → spinner → check → fades; inline error via `getUiErrorMessage`).
- Avatar upload replaced by a drag-and-drop + click zone with preview, remove action, and stepped progress reusing the existing `.map-progress-*` track.
- Sync UI is fully removed from Settings; the header sync chip remains the only sync surface.
- Admin tools move into `/settings/admin` as a top-level nav section — implemented via a new `renderMode="admin-inline"` on the existing `UserAdminPanel` (no content duplication).

Closes #125.

## Test plan
- [ ] `npm run test` — 361 tests pass (verified locally, including 35 deepLink tests covering the new `/settings` routes and `matchSettingsPath`/`buildSettingsPath`).
- [ ] `npm run build` — clean build locally.
- [ ] Navigate directly to `/settings` — panel opens, simulation state preserved underneath.
- [ ] Open via user chip — URL becomes `/settings/profile`; browser back closes panel; forward reopens.
- [ ] Edit username → blur → spinner → check → persists after reload.
- [ ] Invalid email → blur → inline error.
- [ ] Avatar drag-drop and click-to-upload both work; progress animates; Remove clears avatar.
- [ ] Resize <980px: master-detail; back button returns to list.
- [ ] Admin user sees Admin nav; non-admin does not.
- [ ] Existing deep links (`/<sim>`, `/<sim>/<site>`, etc.) still work.
- [ ] Staging verification at https://staging.linksim.link after auto-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)