### PR TITLE
fix(settings): layout fixes, avatar zone, access request note, RTL tests

### DIFF
--- a/config/test-setup.ts
+++ b/config/test-setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/config/test-setup.ts
+++ b/config/test-setup.ts
@@ -1,1 +1,19 @@
 import "@testing-library/jest-dom/vitest";
+
+// jsdom does not implement window.matchMedia. Provide a no-op stub so
+// components that call it at render time (e.g. useSystemTheme, useIsNarrow)
+// don't throw. Tests that need specific match results can override this
+// per-test with vi.mocked(window.matchMedia).mockReturnValue(...).
+if (typeof window !== "undefined") {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}

--- a/config/tsconfig.app.json
+++ b/config/tsconfig.app.json
@@ -5,7 +5,7 @@
     "useDefineForClassFields": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "types": ["vite/client"],
+    "types": ["vite/client", "@testing-library/jest-dom", "vitest/globals"],
     "skipLibCheck": true,
 
     /* Bundler mode */

--- a/config/vitest.config.ts
+++ b/config/vitest.config.ts
@@ -1,9 +1,17 @@
 import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
 
 export default defineConfig({
+  plugins: [react()],
   test: {
+    globals: true,
     environment: "node",
-    include: ["src/**/*.test.ts", "functions/**/*.test.ts"],
+    include: [
+      "src/**/*.test.ts",
+      "src/**/*.test.tsx",
+      "functions/**/*.test.ts",
+    ],
+    setupFiles: ["config/test-setup.ts"],
     coverage: {
       provider: "v8",
       reporter: ["text", "html"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linksim",
-  "version": "0.12.1",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linksim",
-      "version": "0.12.1",
+      "version": "0.16.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "clsx": "^2.1.1",
@@ -28,6 +28,9 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/d3-array": "^3.2.2",
         "@types/d3-scale": "^4.0.9",
         "@types/node": "^24.10.1",
@@ -52,6 +55,13 @@
       "version": "0.9.31",
       "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
       "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
       "dev": true,
       "license": "MIT"
     },
@@ -345,6 +355,16 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2442,6 +2462,104 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -3208,6 +3326,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -3230,6 +3359,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/arr-union": {
       "version": "3.1.0",
@@ -3593,6 +3732,13 @@
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssstyle": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
@@ -3796,6 +3942,14 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/earcut": {
       "version": "3.0.2",
@@ -4480,6 +4634,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
@@ -4876,6 +5040,17 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -5825,6 +6000,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/miniflare": {
       "version": "4.20260312.0",
       "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260312.0.tgz",
@@ -6205,6 +6390,36 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/property-information": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
@@ -6270,6 +6485,14 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-map-gl": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/react-map-gl/-/react-map-gl-8.1.0.tgz",
@@ -6329,6 +6552,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/remark-gfm": {
@@ -6746,6 +6983,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,9 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/d3-array": "^3.2.2",
     "@types/d3-scale": "^4.0.9",
     "@types/node": "^24.10.1",

--- a/src/components/UserAdminPanel.chip.test.tsx
+++ b/src/components/UserAdminPanel.chip.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+// Tests for the UserAdminPanel chip's onOpenSettings integration.
+// Only covers the chip-row UI; the full modal and admin-inline mode are
+// better suited to Playwright given their network and canvas dependencies.
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { CloudUser } from "../lib/cloudUser";
+import { UserAdminPanel } from "./UserAdminPanel";
+
+// --- Module mocks ----------------------------------------------------------
+
+vi.mock("../lib/cloudUser", () => ({
+  fetchMe: vi.fn().mockResolvedValue(null),
+  fetchUsers: vi.fn().mockResolvedValue([]),
+  fetchAdminAuditEvents: vi.fn().mockResolvedValue([]),
+  fetchAuthDiagnostics: vi.fn().mockResolvedValue({}),
+  fetchSchemaDiagnostics: vi.fn().mockResolvedValue({}),
+  fetchDeletedUsers: vi.fn().mockResolvedValue([]),
+  updateMyProfile: vi.fn().mockResolvedValue(null),
+  updateUserRole: vi.fn().mockResolvedValue(null),
+  updateUserProfile: vi.fn().mockResolvedValue(null),
+  uploadAvatar: vi.fn().mockResolvedValue(null),
+  deleteUser: vi.fn().mockResolvedValue(null),
+  restoreDeletedCloudUser: vi.fn().mockResolvedValue(null),
+  reassignResourceOwner: vi.fn().mockResolvedValue(null),
+  bulkReassignOwnership: vi.fn().mockResolvedValue(null),
+  runMetadataRepair: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../lib/cloudNotifications", () => ({
+  fetchNotifications: vi.fn().mockResolvedValue({ items: [] }),
+}));
+
+vi.mock("../lib/environment", () => ({
+  getCurrentRuntimeEnvironment: vi.fn().mockReturnValue("production"),
+}));
+
+const signedInUser: CloudUser = {
+  id: "u1",
+  username: "Alice",
+  email: "alice@example.com",
+  isAdmin: false,
+  isModerator: false,
+  isApproved: true,
+  accountState: "active",
+} as CloudUser;
+
+const { mockStoreState } = vi.hoisted(() => {
+  const mockStoreState = {
+    currentUser: null as CloudUser | null,
+    authState: "signed_out" as "checking" | "signed_in" | "signed_out",
+    setCurrentUser: vi.fn(),
+    setAuthState: vi.fn(),
+    uiThemePreference: "system" as const,
+    setUiThemePreference: vi.fn(),
+    uiColorTheme: "blue" as const,
+    setUiColorTheme: vi.fn(),
+    syncStatus: "idle" as const,
+    syncPending: false,
+    pendingChangesCount: 0,
+    isOnline: true,
+    lastSyncedAt: null,
+    syncErrorMessage: null,
+    performManualCloudSync: vi.fn(),
+    holidayWindowState: { reverted: [], dismissed: [] },
+    revertHolidayThemeForWindow: vi.fn(),
+    dismissHolidayThemeNotice: vi.fn(),
+  };
+  return { mockStoreState };
+});
+
+vi.mock("../store/appStore", () => ({
+  useAppStore: (selector: (s: typeof mockStoreState) => unknown) =>
+    selector(mockStoreState),
+}));
+
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockStoreState.currentUser = signedInUser;
+  mockStoreState.authState = "signed_in";
+});
+
+describe("UserAdminPanel chip — onOpenSettings", () => {
+  it("calls onOpenSettings when the user chip is clicked (signed in)", async () => {
+    const onOpenSettings = vi.fn();
+    render(<UserAdminPanel onOpenSettings={onOpenSettings} />);
+    // Both the chip and the settings icon share the same aria-label; chip is first.
+    const buttons = screen.getAllByRole("button", { name: /open user settings/i });
+    expect(buttons.length).toBeGreaterThanOrEqual(2);
+    await userEvent.click(buttons[0]); // user chip
+    expect(onOpenSettings).toHaveBeenCalledOnce();
+  });
+
+  it("calls onOpenSettings from the settings icon button when signed in", async () => {
+    const onOpenSettings = vi.fn();
+    render(<UserAdminPanel onOpenSettings={onOpenSettings} />);
+    const buttons = screen.getAllByRole("button", { name: /open user settings/i });
+    expect(buttons.length).toBeGreaterThanOrEqual(2);
+    await userEvent.click(buttons[1]); // settings icon is second
+    expect(onOpenSettings).toHaveBeenCalledOnce();
+  });
+
+  it("shows the sign-in button instead of the chip when signed out", () => {
+    mockStoreState.authState = "signed_out";
+    mockStoreState.currentUser = null;
+    render(<UserAdminPanel />);
+    expect(screen.getByRole("button", { name: /sign in/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /open user settings/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/UserAdminPanel.chip.test.tsx
+++ b/src/components/UserAdminPanel.chip.test.tsx
@@ -36,7 +36,7 @@ vi.mock("../lib/environment", () => ({
   getCurrentRuntimeEnvironment: vi.fn().mockReturnValue("production"),
 }));
 
-const signedInUser: CloudUser = {
+const signedInUser = {
   id: "u1",
   username: "Alice",
   email: "alice@example.com",
@@ -44,7 +44,11 @@ const signedInUser: CloudUser = {
   isModerator: false,
   isApproved: true,
   accountState: "active",
-} as CloudUser;
+  bio: null,
+  avatarUrl: null,
+  createdAt: null,
+  updatedAt: null,
+} as unknown as CloudUser;
 
 const { mockStoreState } = vi.hoisted(() => {
   const mockStoreState = {

--- a/src/components/settings/AutoSaveField.test.tsx
+++ b/src/components/settings/AutoSaveField.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { AutoSaveField } from "./AutoSaveField";
+
+describe("AutoSaveField", () => {
+  it("renders the label and input", () => {
+    render(<AutoSaveField id="test" label="Username" value="alice" onSave={vi.fn()} />);
+    expect(screen.getByLabelText("Username")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveValue("alice");
+  });
+
+  it("does not call onSave when blurred without changing the value", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(<AutoSaveField id="test" label="Username" value="alice" onSave={onSave} />);
+    const input = screen.getByRole("textbox");
+    await userEvent.click(input);
+    await userEvent.tab(); // blur
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("calls onSave with the updated value after the user edits and blurs", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(<AutoSaveField id="test" label="Username" value="alice" onSave={onSave} />);
+    const input = screen.getByRole("textbox");
+    await userEvent.clear(input);
+    await userEvent.type(input, "bob");
+    await userEvent.tab(); // blur
+    expect(onSave).toHaveBeenCalledOnce();
+    expect(onSave).toHaveBeenCalledWith("bob");
+  });
+
+  it("shows a validation error and does not call onSave when validate returns a message", async () => {
+    const onSave = vi.fn();
+    const validate = (v: string) => (v.trim() ? null : "A name is required.");
+    render(
+      <AutoSaveField id="test" label="Username" value="alice" onSave={onSave} validate={validate} />,
+    );
+    const input = screen.getByRole("textbox");
+    await userEvent.clear(input);
+    await userEvent.tab(); // blur with empty value
+    expect(await screen.findByRole("alert")).toHaveTextContent("A name is required.");
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("shows the save-error message when onSave rejects", async () => {
+    const onSave = vi.fn().mockRejectedValue(new Error("Server error"));
+    render(<AutoSaveField id="test" label="Bio" value="hello" onSave={onSave} />);
+    const input = screen.getByRole("textbox");
+    await userEvent.clear(input);
+    await userEvent.type(input, "updated bio");
+    await userEvent.tab();
+    expect(await screen.findByRole("alert")).toHaveTextContent("Server error");
+  });
+});

--- a/src/components/settings/SettingsNav.test.tsx
+++ b/src/components/settings/SettingsNav.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { SettingsNav, settingsNavIcons } from "./SettingsNav";
+import type { SettingsNavItem } from "./SettingsNav";
+
+const items: SettingsNavItem[] = [
+  { id: "profile", label: "Profile", description: "Name, email, avatar", icon: settingsNavIcons.profile },
+  { id: "preferences", label: "Preferences", description: "Theme, defaults", icon: settingsNavIcons.preferences },
+  { id: "admin", label: "Admin", description: "Users, audit", icon: settingsNavIcons.admin },
+];
+
+describe("SettingsNav", () => {
+  it("renders one button per nav item", () => {
+    render(
+      <SettingsNav items={items} activeSection="profile" onSelect={vi.fn()} layout="sidebar" />,
+    );
+    expect(screen.getAllByRole("button")).toHaveLength(3);
+    expect(screen.getByRole("button", { name: /Profile/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Preferences/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Admin/i })).toBeInTheDocument();
+  });
+
+  it("marks only the active item with aria-current", () => {
+    render(
+      <SettingsNav items={items} activeSection="preferences" onSelect={vi.fn()} layout="sidebar" />,
+    );
+    expect(screen.getByRole("button", { name: /Preferences/i })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    expect(screen.getByRole("button", { name: /Profile/i })).not.toHaveAttribute("aria-current");
+    expect(screen.getByRole("button", { name: /Admin/i })).not.toHaveAttribute("aria-current");
+  });
+
+  it("calls onSelect with the clicked section id", async () => {
+    const onSelect = vi.fn();
+    render(
+      <SettingsNav items={items} activeSection="profile" onSelect={onSelect} layout="sidebar" />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /Admin/i }));
+    expect(onSelect).toHaveBeenCalledOnce();
+    expect(onSelect).toHaveBeenCalledWith("admin");
+  });
+
+  it("shows item descriptions in list layout", () => {
+    render(
+      <SettingsNav items={items} activeSection="profile" onSelect={vi.fn()} layout="list" />,
+    );
+    expect(screen.getByText("Name, email, avatar")).toBeInTheDocument();
+    expect(screen.getByText("Theme, defaults")).toBeInTheDocument();
+  });
+
+  it("hides item descriptions in sidebar layout", () => {
+    render(
+      <SettingsNav items={items} activeSection="profile" onSelect={vi.fn()} layout="sidebar" />,
+    );
+    expect(screen.queryByText("Name, email, avatar")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/settings/SettingsPanel.test.tsx
+++ b/src/components/settings/SettingsPanel.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { CloudUser } from "../../lib/cloudUser";
+import { SettingsPanel } from "./SettingsPanel";
+
+// Stub sub-sections so SettingsPanel tests focus on panel-level behaviour.
+vi.mock("./sections/ProfileSection", () => ({
+  ProfileSection: () => <div data-testid="profile-section">Profile Section</div>,
+}));
+vi.mock("./sections/PreferencesSection", () => ({
+  PreferencesSection: () => <div data-testid="preferences-section">Preferences Section</div>,
+}));
+vi.mock("../UserAdminPanel", () => ({
+  UserAdminPanel: () => <div data-testid="admin-panel">Admin Panel</div>,
+}));
+vi.mock("../../lib/cloudUser", () => ({
+  fetchMe: vi.fn().mockResolvedValue(null),
+}));
+
+// Shared mock state — mutate currentUser per test for admin/non-admin scenarios.
+const { mockState } = vi.hoisted(() => {
+  const mockState: {
+    currentUser: CloudUser | null;
+    setCurrentUser: ReturnType<typeof vi.fn>;
+    authState: "checking" | "signed_in" | "signed_out";
+    setAuthState: ReturnType<typeof vi.fn>;
+  } = {
+    currentUser: null,
+    setCurrentUser: vi.fn(),
+    authState: "checking",
+    setAuthState: vi.fn(),
+  };
+  return { mockState };
+});
+
+vi.mock("../../store/appStore", () => ({
+  useAppStore: (selector: (s: typeof mockState) => unknown) => selector(mockState),
+}));
+
+beforeEach(() => {
+  // Reset to non-admin, signed-out state.
+  mockState.currentUser = null;
+  mockState.authState = "checking";
+
+  // Stub history methods to avoid jsdom URL errors.
+  vi.spyOn(window.history, "replaceState").mockImplementation(() => {});
+  vi.spyOn(window.history, "pushState").mockImplementation(() => {});
+});
+
+describe("SettingsPanel", () => {
+  it("renders the Settings dialog with a close button", () => {
+    render(<SettingsPanel initialSection={null} onClose={vi.fn()} />);
+    expect(screen.getByRole("dialog", { name: /settings/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /close settings/i })).toBeInTheDocument();
+  });
+
+  it("shows the Profile section by default (initialSection = null)", () => {
+    render(<SettingsPanel initialSection={null} onClose={vi.fn()} />);
+    expect(screen.getByTestId("profile-section")).toBeInTheDocument();
+    expect(screen.queryByTestId("preferences-section")).not.toBeInTheDocument();
+  });
+
+  it("shows the Preferences section when initialSection = 'preferences'", () => {
+    render(<SettingsPanel initialSection="preferences" onClose={vi.fn()} />);
+    expect(screen.getByTestId("preferences-section")).toBeInTheDocument();
+    expect(screen.queryByTestId("profile-section")).not.toBeInTheDocument();
+  });
+
+  it("does not show the Admin nav item for a non-admin user", () => {
+    mockState.currentUser = {
+      id: "u1",
+      username: "Alice",
+      email: "alice@example.com",
+      isAdmin: false,
+      isModerator: false,
+      isApproved: true,
+    } as CloudUser;
+    mockState.authState = "signed_in";
+    render(<SettingsPanel initialSection={null} onClose={vi.fn()} />);
+    expect(screen.queryByRole("button", { name: /admin/i })).not.toBeInTheDocument();
+  });
+
+  it("shows the Admin nav item for an admin user", () => {
+    mockState.currentUser = {
+      id: "u2",
+      username: "Bob",
+      email: "bob@example.com",
+      isAdmin: true,
+      isModerator: false,
+      isApproved: true,
+    } as CloudUser;
+    mockState.authState = "signed_in";
+    render(<SettingsPanel initialSection={null} onClose={vi.fn()} />);
+    expect(screen.getByRole("button", { name: /admin/i })).toBeInTheDocument();
+  });
+
+  it("calls onClose when the close button is clicked", () => {
+    const onClose = vi.fn();
+    render(<SettingsPanel initialSection={null} onClose={onClose} />);
+    fireEvent.click(screen.getByRole("button", { name: /close settings/i }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("calls onClose when the Escape key is pressed", () => {
+    const onClose = vi.fn();
+    render(<SettingsPanel initialSection={null} onClose={onClose} />);
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("switches to Preferences section when its nav item is clicked", () => {
+    render(<SettingsPanel initialSection={null} onClose={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: /preferences/i }));
+    expect(screen.getByTestId("preferences-section")).toBeInTheDocument();
+    expect(screen.queryByTestId("profile-section")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/settings/sections/PreferencesSection.tsx
+++ b/src/components/settings/sections/PreferencesSection.tsx
@@ -32,9 +32,7 @@ export function PreferencesSection({ me, onMeUpdated }: PreferencesSectionProps)
 
   const [presetState, setPresetState] = useState<SelectFieldState>(IDLE_SELECT);
 
-  const canModerate = Boolean(me?.isAdmin || me?.isModerator);
-  const canEditAccessRequestNote = Boolean(canModerate || !me?.isApproved);
-  const showAccessRequestNoteField = Boolean(canModerate || !me?.isApproved);
+  const showAccessRequestNoteField = Boolean(me && !me.isApproved);
 
   const savePreset = useCallback(
     async (value: string | null) => {
@@ -161,17 +159,9 @@ export function PreferencesSection({ me, onMeUpdated }: PreferencesSectionProps)
             textareaProps={{
               maxLength: 1200,
               rows: 5,
-              readOnly: !canEditAccessRequestNote,
-              disabled: !canEditAccessRequestNote,
-              placeholder: canEditAccessRequestNote
-                ? "Optional private note to moderators/admins."
-                : "Request note is locked after approval.",
+              placeholder: "Optional private note to moderators/admins.",
             }}
-            help={
-              canEditAccessRequestNote
-                ? "Visible to moderators and admins. Up to 1200 characters."
-                : "Request note is locked after approval."
-            }
+            help="Visible to moderators and admins. Up to 1200 characters."
           />
         ) : null}
       </div>

--- a/src/components/settings/sections/ProfileSection.tsx
+++ b/src/components/settings/sections/ProfileSection.tsx
@@ -102,7 +102,7 @@ export function ProfileSection({ me, onMeUpdated }: ProfileSectionProps) {
       <header className="settings-section-header">
         <h2 id="settings-profile-heading">Profile</h2>
         <p className="field-help">
-          Changes save automatically as you leave each field. Account settings are separate from simulation sync.
+          Changes save automatically as you leave each field.
         </p>
       </header>
 

--- a/src/index.css
+++ b/src/index.css
@@ -4685,6 +4685,7 @@ html.panorama-gesture-lock body {
 .settings-panel-content {
   flex: 1;
   min-width: 0;
+  overflow-x: hidden;
   overflow-y: auto;
   padding: 24px 28px 48px;
   outline: none;
@@ -4797,8 +4798,9 @@ html.panorama-gesture-lock body {
 
 .settings-profile-grid {
   display: grid;
-  grid-template-columns: minmax(220px, 260px) 1fr;
+  grid-template-columns: minmax(0, 260px) 1fr;
   gap: 32px;
+  min-width: 0;
 }
 
 @media (max-width: 980px) {
@@ -4896,15 +4898,18 @@ html.panorama-gesture-lock body {
 }
 
 /* Avatar drop zone */
-.avatar-dropzone {
+
+/* Outer wrapper: vertical stack of [zone] + [progress] + [actions] */
+.avatar-dropzone-wrapper {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 8px;
 }
 
-.avatar-dropzone-wrapper {
-  position: relative;
+/* The interactive drop zone: avatar preview on the left, copy text on the right */
+.avatar-dropzone {
   display: flex;
+  flex-direction: row;
   align-items: center;
   gap: 14px;
   padding: 14px;
@@ -4913,23 +4918,24 @@ html.panorama-gesture-lock body {
   background: var(--surface-2);
   cursor: pointer;
   transition: border-color 120ms ease, background 120ms ease;
+  overflow: hidden;
 }
 
-.avatar-dropzone-wrapper:hover,
-.avatar-dropzone-wrapper:focus-visible {
+.avatar-dropzone:hover,
+.avatar-dropzone:focus-visible {
   border-color: var(--text);
   outline: none;
 }
 
-.avatar-dropzone-wrapper.is-dragover {
+.avatar-dropzone.avatar-dropzone-drag-over {
   border-style: solid;
   background: var(--accent-soft);
 }
 
 .avatar-dropzone-preview {
   flex-shrink: 0;
-  width: 64px;
-  height: 64px;
+  width: 56px;
+  height: 56px;
   border-radius: 50%;
   overflow: hidden;
   display: flex;
@@ -4948,16 +4954,28 @@ html.panorama-gesture-lock body {
 .avatar-dropzone-copy {
   display: flex;
   flex-direction: column;
-  gap: 2px;
-  font-size: 0.85rem;
-  color: var(--muted);
+  gap: 3px;
   min-width: 0;
+  overflow: hidden;
 }
 
-.avatar-dropzone-copy strong {
-  color: var(--text);
+.avatar-dropzone-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.9rem;
   font-weight: 600;
-  font-size: 0.95rem;
+  color: var(--text);
+  white-space: normal;
+  word-break: break-word;
+}
+
+.avatar-dropzone-hint {
+  font-size: 0.8rem;
+  color: var(--muted);
+  white-space: normal;
+  word-break: break-word;
+  overflow-wrap: break-word;
 }
 
 .avatar-dropzone-progress {
@@ -4968,17 +4986,26 @@ html.panorama-gesture-lock body {
   color: var(--muted);
 }
 
+.avatar-dropzone-error-text {
+  font-size: 0.85rem;
+  color: var(--danger, #c2410c);
+}
+
 .avatar-dropzone-actions {
   display: flex;
   gap: 8px;
   align-items: center;
+  flex-wrap: wrap;
 }
 
 .avatar-dropzone-remove {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
   background: transparent;
   border: 1px solid var(--border);
   border-radius: var(--radius-btn);
-  padding: 4px 10px;
+  padding: 5px 10px;
   color: var(--text);
   cursor: pointer;
   font-size: 0.85rem;
@@ -4998,4 +5025,11 @@ html.panorama-gesture-lock body {
   display: flex;
   flex-direction: column;
   gap: 16px;
+}
+
+/* In the settings panel, the user list should not scroll internally — the
+   settings-panel-content pane already scrolls the whole page. */
+.user-admin-inline .user-manager-list {
+  max-height: none;
+  overflow: visible;
 }


### PR DESCRIPTION
## Summary
Follow-up fixes for the settings panel (all on top of #686):

- **Avatar drop zone**: corrected flex layout — wrapper is now a vertical column, the interactive zone is a horizontal row (preview | copy). Text no longer overflows its container on narrow viewports.
- **Profile header**: removed "Account settings are separate from simulation sync."
- **Access request note**: shown only to pending users (`!isApproved`). Admin/moderator users no longer see it.
- **Admin user list**: removed the 260 px `max-height` scroll cap in inline mode — the whole settings panel scrolls instead of a sub-container.
- **Mobile horizontal scrollbar**: `overflow-x: hidden` on the content pane; left grid column uses `minmax(0, 260px)` so it can compress on narrow screens.
- **RTL / component tests**: adds `@testing-library/react` + jsdom setup, plus tests for `AutoSaveField`, `SettingsNav`, `SettingsPanel`, and `UserAdminPanel` chip.

## Test plan
- [ ] 382 tests pass (`npm run test`)
- [ ] Build clean (`npm run build`)
- [ ] Settings panel opens without horizontal scrollbar at any viewport width
- [ ] Avatar drop zone renders correctly (preview left, text right, buttons below)
- [ ] Access request note hidden for approved and admin users; visible for pending
- [ ] Admin user list scrolls with the page, not in a sub-container

🤖 Generated with [Claude Code](https://claude.com/claude-code)