### PR TITLE
release: v0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project are documented here in a human-readable format.
 
+## [0.16.1] - 2026-04-17
+
+### Fixed
+- Newly created Sites now stay in cloud sync after reload because the new site-library entry is marked dirty before the next delta push.
+
 ## [0.16.0] - 2026-04-12
 
 ### Added

--- a/functions/_lib/buildInfo.ts
+++ b/functions/_lib/buildInfo.ts
@@ -1,5 +1,5 @@
-export const APP_VERSION = "0.16.0";
-export const APP_COMMIT = "c88d7c63";
+export const APP_VERSION = "0.16.1";
+export const APP_COMMIT = "ea1d5149";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linksim",
-  "version": "0.12.1",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linksim",
-      "version": "0.12.1",
+      "version": "0.16.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "linksim",
   "private": true,
-  "version": "0.16.0",
+  "version": "0.16.1",
   "license": "GPL-3.0-only",
   "type": "module",
   "scripts": {

--- a/src/lib/buildInfo.ts
+++ b/src/lib/buildInfo.ts
@@ -1,5 +1,5 @@
-export const APP_VERSION = "0.16.0";
-export const APP_COMMIT = "c88d7c63";
+export const APP_VERSION = "0.16.1";
+export const APP_COMMIT = "ea1d5149";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {


### PR DESCRIPTION
Production release for the site sync hotfix.

Includes:
- v0.16.1 version bump
- changelog entry
- generated build-info updates

Verification:
- `npm test`
- `npm run build`

Release tag `v0.16.1` already exists and will be aligned with the merged release commit if needed.