### PR TITLE
fix: fetch tags in prod release workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -52,6 +52,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
Fetch the full history and tags in the prod release job so validate-prod-release.mjs can see the v0.16.1 tag on HEAD and inspect HEAD^ during the release gate.