### PR TITLE
fix: deploy the tagged prod release commit

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -61,6 +61,13 @@ jobs:
           node-version: 22
           cache: npm
 
+      - name: Resolve release tag
+        id: release_tag
+        run: echo "tag=v$(node -p \"require('./package.json').version\")" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout release tag
+        run: git checkout --force "${{ steps.release_tag.outputs.tag }}"
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
Have the production workflow checkout the vX.Y.Z tag derived from package.json before validation and deploy. This keeps the release gate pointed at the tagged commit even after main advances.