### PR TITLE
fix: resolve prod release tag safely

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -63,7 +63,9 @@ jobs:
 
       - name: Resolve release tag
         id: release_tag
-        run: echo "tag=v$(node -p \"require('./package.json').version\")" >> "$GITHUB_OUTPUT"
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout release tag
         run: git checkout --force "${{ steps.release_tag.outputs.tag }}"


### PR DESCRIPTION
Use a multiline shell step to derive the vX.Y.Z tag from package.json before checking out the tagged release commit in the prod workflow.