### PR TITLE
fix: allow tagged prod release checkout

### DIFF
--- a/scripts/deploy-pages-safe.mjs
+++ b/scripts/deploy-pages-safe.mjs
@@ -260,11 +260,10 @@ async function preflight(targetName, target) {
     console.log(`[deploy-pages-safe] Allowing expected dirty files: ${dirtyPaths.join(", ")}`);
   }
   if (target.requiredBranch) {
-    const isTaggedProdCheckout =
-      targetName === "prod-main" && branch === "HEAD" && headTags.includes(expectedReleaseTag);
+    const isTaggedProdCheckout = targetName === "prod-main" && headTags.includes(expectedReleaseTag);
     assert(
       branch === target.requiredBranch || isTaggedProdCheckout,
-      `Preflight failed: target ${targetName} requires current branch '${target.requiredBranch}'.`,
+      `Preflight failed: target ${targetName} requires current branch '${target.requiredBranch}' or the tagged release commit.`,
     );
   }
 


### PR DESCRIPTION
Accept the tagged release commit in the prod deploy guard even if Git still reports the checkout as main. The workflow already checks out v0.16.1, so this lets the guarded deploy proceed without weakening staging.