### PR TITLE
fix: verify prod deploy against workflow sha

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -84,4 +84,5 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           VITE_MAPTILER_KEY: ${{ secrets.VITE_MAPTILER_KEY }}
+          DEPLOY_VERIFY_COMMIT: ${{ github.sha }}
         run: npm run build:bundle && npm run build:verify && node "$GITHUB_WORKSPACE/scripts/deploy-pages-safe.mjs" --target prod-main

--- a/scripts/deploy-pages-safe.mjs
+++ b/scripts/deploy-pages-safe.mjs
@@ -251,7 +251,7 @@ async function getGitRef(args = ["rev-parse", "--abbrev-ref", "HEAD"]) {
 
 async function preflight(targetName, target) {
   const branch = await getGitRef();
-  const commit = await getGitRef(["rev-parse", "--short", "HEAD"]);
+  const commit = String(process.env.DEPLOY_VERIFY_COMMIT ?? "").trim() || (await getGitRef(["rev-parse", "--short", "HEAD"]));
   const pkg = JSON.parse(await readFile(path.join(root, "package.json"), "utf8"));
   const expectedReleaseTag = `v${String(pkg.version ?? "").trim()}`;
   const { stdout: headTagsStdout } = await run("git", ["tag", "--points-at", "HEAD"], { capture: true });


### PR DESCRIPTION
Carry the release-tag worktree flow and verify the Pages deployment against the workflow SHA, which is what Cloudflare records for the publish event. This keeps the tagged release build intact while making the final post-deploy check line up with the actual Pages deployment record.