### PR TITLE
chore: roll project to 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this project are documented here in a human-readable format.
 
+## [0.17.0] - 2026-04-17
+
+Rolls up all merged work since `0.16.0`, including the `0.16.2` shared-site sync hotfix and the release/deploy guardrail fixes.
+
+### Added
+- Panorama / single-site 360° mode with FOV controls, adaptive zoom sampling, peak labels, global peak tiles, and true shading/LOS-clipped terrain rendering. (#101)
+- A new `/settings` panel with per-field auto-save, plus settings layout, avatar drop-zone, and access-request refinements. (#125, #688, #689, #690, #691)
+- Norsk Polarinstitutt Svalbard basemap provider with topographic, satellite, and orthophoto presets. (#635)
+- The live in-app UI gallery plus continued componentization of badge, popover, state-dot, and ActionButton patterns across the shell. (#540, #616)
+- Mobile tabbed map overlays and expanded accessibility semantics for mobile tabs and markers. (#171, #430, #431, #433)
+
+### Changed
+- Bumped the app and release line to `0.17.0` so the next milestone train starts from the current staging baseline.
+- Standardized panel/sidebar headers, ActionButton usage, and iconography across the shell, inspector, sidebar, and settings surfaces.
+- Continued mobile map, panel, and attribution polish, including synchronized animation timing and viewport-fit behavior.
+- Hardened release and deploy automation, CI guardrails, and staging-main workflow rules.
+- Improved local test-server startup, change polling, and developer workflow reliability.
+
+### Fixed
+- Shared simulations now persist private Site references during sync and reload.
+- Deep-link handling is more stable for shared simulations, emoji/Korean names, and guest/public auth flows.
+- Panorama/profile sizing, path override handling, and overlay recompute/performance stability were improved.
+- Terrain loading, geocode throttling, meshmap MQTT/proxy caching, and other sync/network edge cases were hardened.
+- Production deploy verification now checks the correct release checkout and Pages project again, so tagged releases complete cleanly.
+- Rolled unfinished milestone work forward one step to keep the backlog aligned with the new release boundary.
+
 ## [0.16.2] - 2026-04-17
 
 ### Fixed

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -61,7 +61,7 @@
 
 ## Versioning Policy
 - SemVer is mandatory (`MAJOR.MINOR.PATCH`).
-- Current baseline: `0.9.14`.
+- Current baseline: `0.17.0`.
 - Bump level decision rules:
   - `PATCH` (`0.9.x`): bug fixes, polish, performance tuning, and non-breaking UX behavior fixes.
   - `MINOR` (`0.x.0`): new user-facing features or meaningful workflow additions that are backward-compatible.

--- a/functions/_lib/buildInfo.ts
+++ b/functions/_lib/buildInfo.ts
@@ -1,5 +1,5 @@
-export const APP_VERSION = "0.16.0";
-export const APP_COMMIT = "d67c0de0";
+export const APP_VERSION = "0.17.0";
+export const APP_COMMIT = "c04b3246";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linksim",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linksim",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "linksim",
   "private": true,
-  "version": "0.16.2",
+  "version": "0.17.0",
   "license": "GPL-3.0-only",
   "type": "module",
   "scripts": {

--- a/src/lib/buildInfo.ts
+++ b/src/lib/buildInfo.ts
@@ -1,5 +1,5 @@
-export const APP_VERSION = "0.16.0";
-export const APP_COMMIT = "d67c0de0";
+export const APP_VERSION = "0.17.0";
+export const APP_COMMIT = "c04b3246";
 export const APP_BUILD_LABEL = `v${APP_VERSION}+${APP_COMMIT}`;
 export type BuildChannel = "stable" | "beta" | "alpha";
 export const buildLabelForChannel = (channel: BuildChannel): string => {


### PR DESCRIPTION
## Summary\n- Bump the app/release version to 0.17.0.\n- Update the 0.17.0 changelog to cover all merged work since 0.16.0.\n- Shift open milestones forward one step: 0.17.0 -> 0.18.0, 0.18.0 -> 0.19.0, 0.20.0 -> 0.21.0.\n- Update release-flow docs baseline to 0.17.0.\n\n## Verification\n- npm test\n- npm run build\n\n## Notes\n- No issue history was rewritten; this is release bookkeeping plus versioning.