### PR TITLE
Fix deploy script syntax

### DIFF
--- a/scripts/deploy-pages-safe.mjs
+++ b/scripts/deploy-pages-safe.mjs
@@ -376,6 +376,9 @@ async function main() {
     console.log(
       `[deploy-pages-safe] Success: target=${targetName} project=${target.projectName} branch=${deployBranch} commit=${commit}`,
     );
+  } catch (error) {
+    console.error(`[deploy-pages-safe] ${error instanceof Error ? error.message : String(error)}`);
+    throw error;
   }
 }
 


### PR DESCRIPTION
Fixes a syntax error in scripts/deploy-pages-safe.mjs that blocked the staging deploy job.\n\nVerification:\n- node --check scripts/deploy-pages-safe.mjs