### PR TITLE
feat: redesign Site access editor

### DIFF
--- a/src/components/AccessSettingsEditor.test.tsx
+++ b/src/components/AccessSettingsEditor.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { AccessSettingsEditor } from "./AccessSettingsEditor";
+import type { AccessVisibility } from "./AccessSettingsEditor";
+import type { AccessCollaborator } from "./AccessSettingsEditor";
+import type { CollaboratorDirectoryUser } from "../lib/cloudUser";
+
+const directory: CollaboratorDirectoryUser[] = [
+  { id: "user-1", username: "Alice", email: "alice@example.com", avatarUrl: "" },
+  { id: "user-2", username: "Bob", email: "bob@example.com", avatarUrl: "" },
+];
+
+const collaborators: AccessCollaborator[] = [
+  { id: "user-1", username: "Alice", email: "alice@example.com", avatarUrl: "", role: "viewer" },
+];
+
+describe("AccessSettingsEditor", () => {
+  it("shows the private caption by default and updates for shared visibility", async () => {
+    const onVisibilityChange = vi.fn();
+    function Harness() {
+      const [visibility, setVisibility] = useState<AccessVisibility>("private");
+      return (
+        <AccessSettingsEditor
+          collaborators={[]}
+          directory={directory}
+          onAddCollaborator={vi.fn()}
+          onRemoveCollaborator={vi.fn()}
+          onRoleChange={vi.fn()}
+          onVisibilityChange={(next) => {
+            onVisibilityChange(next);
+            setVisibility(next);
+          }}
+          visibility={visibility}
+        />
+      );
+    }
+    render(<Harness />);
+
+    expect(screen.getByText("Only visible to you and collaborators")).toBeInTheDocument();
+    await userEvent.selectOptions(screen.getByLabelText("Access level"), "shared");
+    expect(onVisibilityChange).toHaveBeenCalledWith("shared");
+    expect(screen.getByText("Visible in the library for all users")).toBeInTheDocument();
+  });
+
+  it("uses a surface card popover and hides suggestions until search input has text", async () => {
+    render(
+      <AccessSettingsEditor
+        collaborators={[]}
+        directory={directory}
+        onAddCollaborator={vi.fn()}
+        onRemoveCollaborator={vi.fn()}
+        onRoleChange={vi.fn()}
+        onVisibilityChange={vi.fn()}
+        visibility="private"
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Edit collaborators" }));
+    const popover = await screen.findByRole("dialog", { name: "Edit collaborators" });
+    const surface = popover.closest(".ui-surface-pill");
+    expect(surface).toHaveClass("ui-surface-pill");
+    expect(surface).toHaveClass("is-card");
+    expect(within(popover).queryByRole("button", { name: /Add Alice/i })).not.toBeInTheDocument();
+
+    await userEvent.type(within(popover).getByLabelText("Search users"), "ali");
+    expect(await within(popover).findByRole("button", { name: /Add Alice/i })).toBeInTheDocument();
+  });
+
+  it("adds, removes, and changes roles with accessible controls", async () => {
+    const onAddCollaborator = vi.fn();
+    const onRemoveCollaborator = vi.fn();
+    const onRoleChange = vi.fn();
+    render(
+      <AccessSettingsEditor
+        collaborators={collaborators}
+        directory={directory}
+        onAddCollaborator={onAddCollaborator}
+        onRemoveCollaborator={onRemoveCollaborator}
+        onRoleChange={onRoleChange}
+        onVisibilityChange={vi.fn()}
+        visibility="private"
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Edit collaborators" }));
+    const popover = await screen.findByRole("dialog", { name: "Edit collaborators" });
+    await userEvent.selectOptions(within(popover).getByLabelText("Role for Alice"), "editor");
+    expect(onRoleChange).toHaveBeenCalledWith("user-1", "editor");
+
+    const remove = within(popover).getByRole("button", { name: "Remove Alice" });
+    expect(remove).toHaveAttribute("title", "Remove Alice");
+    await userEvent.click(remove);
+    expect(onRemoveCollaborator).toHaveBeenCalledWith("user-1");
+
+    await userEvent.type(within(popover).getByLabelText("Search users"), "bob");
+    await waitFor(() => expect(within(popover).getByRole("button", { name: /Add Bob/i })).toBeInTheDocument());
+    await userEvent.click(within(popover).getByRole("button", { name: /Add Bob/i }));
+    expect(onAddCollaborator).toHaveBeenCalledWith("user-2");
+  });
+});

--- a/src/components/AccessSettingsEditor.tsx
+++ b/src/components/AccessSettingsEditor.tsx
@@ -1,0 +1,223 @@
+import { useMemo, useRef, useState } from "react";
+import { Trash2 } from "lucide-react";
+import type { CollaboratorDirectoryUser } from "../lib/cloudUser";
+import { AvatarBadge } from "./AvatarBadge";
+import { FloatingPopover } from "./ui/FloatingPopover";
+
+export type AccessVisibility = "private" | "shared";
+export type AccessRole = "viewer" | "editor";
+
+export type AccessCollaborator = {
+  id: string;
+  username: string;
+  email: string;
+  avatarUrl: string;
+  role: AccessRole;
+};
+
+type AccessSettingsEditorProps = {
+  visibility: AccessVisibility;
+  collaborators: AccessCollaborator[];
+  directory: CollaboratorDirectoryUser[];
+  onVisibilityChange: (visibility: AccessVisibility) => void;
+  onAddCollaborator: (userId: string) => void;
+  onRemoveCollaborator: (userId: string) => void;
+  onRoleChange: (userId: string, role: AccessRole) => void;
+  disabled?: boolean;
+  ownerUserId?: string;
+  directoryBusy?: boolean;
+  directoryStatus?: string;
+  status?: string;
+  showStatusFallback?: boolean;
+  onOpenUserProfile?: (userId: string) => void;
+};
+
+export const accessVisibilityCaption = (visibility: AccessVisibility): string =>
+  visibility === "shared" ? "Visible in the library for all users" : "Only visible to you and collaborators";
+
+export function AccessSettingsEditor({
+  visibility,
+  collaborators,
+  directory,
+  onVisibilityChange,
+  onAddCollaborator,
+  onRemoveCollaborator,
+  onRoleChange,
+  disabled = false,
+  ownerUserId = "",
+  directoryBusy = false,
+  directoryStatus = "",
+  status = "",
+  showStatusFallback = false,
+  onOpenUserProfile,
+}: AccessSettingsEditorProps) {
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const selectedIds = useMemo(() => new Set(collaborators.map((user) => user.id)), [collaborators]);
+  const trimmedQuery = query.trim().toLowerCase();
+  const candidates = useMemo(() => {
+    if (!trimmedQuery) return [];
+    return directory
+      .filter((user) => {
+        if (ownerUserId && user.id === ownerUserId) return false;
+        if (selectedIds.has(user.id)) return false;
+        return `${user.username} ${user.email}`.toLowerCase().includes(trimmedQuery);
+      })
+      .slice(0, 8);
+  }, [directory, ownerUserId, selectedIds, trimmedQuery]);
+
+  const openUserProfile = (userId: string) => {
+    if (!onOpenUserProfile) return;
+    onOpenUserProfile(userId);
+  };
+
+  return (
+    <>
+      <label className="field-grid access-settings-row">
+        <span>Access level</span>
+        <span className="access-settings-control">
+          <select
+            aria-label="Access level"
+            className="locale-select"
+            disabled={disabled}
+            onChange={(event) => onVisibilityChange(event.target.value as AccessVisibility)}
+            value={visibility}
+          >
+            <option value="private">Private</option>
+            <option value="shared">Shared</option>
+          </select>
+          <span className="field-help access-settings-caption">{accessVisibilityCaption(visibility)}</span>
+        </span>
+      </label>
+      <div className="field-grid access-settings-row access-collaborators-row">
+        <span>Collaborators</span>
+        <div className="access-collaborators-summary">
+          <div className="access-collaborator-avatars" aria-label="Selected collaborators">
+            {collaborators.length ? (
+              collaborators.slice(0, 5).map((user) => {
+                const label = user.username || user.id;
+                return (
+                  <button
+                    aria-label={label}
+                    className="row-avatar"
+                    disabled={!onOpenUserProfile}
+                    key={user.id}
+                    onClick={() => openUserProfile(user.id)}
+                    title={label}
+                    type="button"
+                  >
+                    <AvatarBadge avatarUrl={user.avatarUrl} fallbackRawText imageClassName="row-avatar-image" name={label} />
+                  </button>
+                );
+              })
+            ) : (
+              <span className="field-help access-collaborators-empty">No collaborators</span>
+            )}
+          </div>
+          <button
+            aria-label="Edit collaborators"
+            className="inline-action action-button"
+            ref={triggerRef}
+            disabled={disabled}
+            onClick={() => setPopoverOpen((open) => !open)}
+            type="button"
+          >
+            Edit
+          </button>
+        </div>
+      </div>
+      <FloatingPopover
+        className="access-collaborator-popover"
+        estimatedHeight={360}
+        estimatedWidth={420}
+        onClose={() => setPopoverOpen(false)}
+        open={popoverOpen}
+        triggerRef={triggerRef}
+      >
+        <div aria-label="Edit collaborators" className="access-collaborator-popover-content" role="dialog">
+          <label className="access-collaborator-search">
+            <span className="sr-only">Search users</span>
+            <input
+              aria-label="Search users"
+              disabled={disabled}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search users by name or email"
+              type="text"
+              value={query}
+            />
+          </label>
+          {trimmedQuery ? (
+            <div className="collaborator-candidate-list access-collaborator-candidates">
+              {directoryBusy ? (
+                <p className="field-help">Loading users…</p>
+              ) : candidates.length ? (
+                candidates.map((user) => (
+                  <button
+                    aria-label={`Add ${user.username}`}
+                    className="site-quick-item"
+                    disabled={disabled}
+                    key={user.id}
+                    onClick={() => {
+                      onAddCollaborator(user.id);
+                      setQuery("");
+                    }}
+                    type="button"
+                  >
+                    <UserBadge avatarUrl={user.avatarUrl} name={user.username} />
+                    <span className="field-help">{user.email}</span>
+                    <span className="inline-action">Add</span>
+                  </button>
+                ))
+              ) : (
+                <p className="field-help">No matching users.</p>
+              )}
+            </div>
+          ) : null}
+          <div className="access-collaborator-list">
+            {collaborators.length ? (
+              collaborators.map((user) => {
+                const label = user.username || user.id;
+                return (
+                  <div className="access-collaborator-row" key={user.id}>
+                    <UserBadge avatarUrl={user.avatarUrl} name={label} />
+                    <select
+                      aria-label={`Role for ${label}`}
+                      disabled={disabled}
+                      onChange={(event) => onRoleChange(user.id, event.target.value as AccessRole)}
+                      value={user.role}
+                    >
+                      <option value="viewer">Viewer</option>
+                      <option value="editor">Editor</option>
+                    </select>
+                    <button
+                      aria-label={`Remove ${label}`}
+                      className="inline-action inline-action-icon access-collaborator-remove"
+                      disabled={disabled}
+                      onClick={() => onRemoveCollaborator(user.id)}
+                      title={`Remove ${label}`}
+                      type="button"
+                    >
+                      <Trash2 aria-hidden="true" size={14} strokeWidth={2} />
+                    </button>
+                  </div>
+                );
+              })
+            ) : (
+              <p className="field-help">No collaborators yet.</p>
+            )}
+          </div>
+          {directoryStatus ? <p className="field-help">{directoryStatus}</p> : null}
+        </div>
+      </FloatingPopover>
+      {status ? <p className="field-help">{status}</p> : showStatusFallback ? <p className="field-help">Saved automatically.</p> : null}
+    </>
+  );
+}
+
+const UserBadge = ({ name, avatarUrl }: { name: string; avatarUrl?: string | null }) => (
+  <span className="user-list-row">
+    <AvatarBadge avatarUrl={avatarUrl} imageClassName="profile-avatar" name={name} />
+    <span>{name}</span>
+  </span>
+);

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -72,6 +72,12 @@ import type { RadioClimate } from "../types/radio";
 import { siGithub } from "simple-icons";
 import { InfoTip } from "./InfoTip";
 import { ActionButton } from "./ActionButton";
+import {
+  AccessSettingsEditor,
+  type AccessCollaborator,
+  type AccessRole,
+  type AccessVisibility,
+} from "./AccessSettingsEditor";
 import { AvatarBadge } from "./AvatarBadge";
 import { InlineCloseIconButton } from "./InlineCloseIconButton";
 import { ModalOverlay } from "./ModalOverlay";
@@ -420,6 +426,9 @@ export function Sidebar({
   const [newLibraryTxGainDbi, setNewLibraryTxGainDbi] = useState(STANDARD_SITE_RADIO.txGainDbi);
   const [newLibraryRxGainDbi, setNewLibraryRxGainDbi] = useState(STANDARD_SITE_RADIO.rxGainDbi);
   const [newLibraryCableLossDb, setNewLibraryCableLossDb] = useState(STANDARD_SITE_RADIO.cableLossDb);
+  const [newLibraryVisibility, setNewLibraryVisibility] = useState<AccessVisibility>("private");
+  const [newLibraryCollaboratorUserIds, setNewLibraryCollaboratorUserIds] = useState<string[]>([]);
+  const [newLibraryCollaboratorRoles, setNewLibraryCollaboratorRoles] = useState<Record<string, AccessRole>>({});
   const [librarySearchQuery, setLibrarySearchQuery] = useState("");
   const [librarySearchStatus, setLibrarySearchStatus] = useState("");
   const [librarySearchResults, setLibrarySearchResults] = useState<GeocodeResult[]>([]);
@@ -546,7 +555,6 @@ export function Sidebar({
   const [resourceCableLossDraft, setResourceCableLossDraft] = useState(STANDARD_SITE_RADIO.cableLossDb);
   const [resourceCollaboratorUserIds, setResourceCollaboratorUserIds] = useState<string[]>([]);
   const [resourceCollaboratorRoles, setResourceCollaboratorRoles] = useState<Record<string, "viewer" | "editor">>({});
-  const [resourceCollaboratorQuery, setResourceCollaboratorQuery] = useState("");
   const [resourceCollaboratorDirectory, setResourceCollaboratorDirectory] = useState<CollaboratorDirectoryUser[]>([]);
   const [resourceCollaboratorDirectoryBusy, setResourceCollaboratorDirectoryBusy] = useState(false);
   const [resourceCollaboratorDirectoryStatus, setResourceCollaboratorDirectoryStatus] = useState("");
@@ -720,6 +728,28 @@ export function Sidebar({
       }),
     [collaboratorDirectoryById, resourceCollaboratorUserIds],
   );
+  const newLibrarySelectedCollaboratorUsers = useMemo<AccessCollaborator[]>(
+    () =>
+      newLibraryCollaboratorUserIds.map((userId) => {
+        const user = collaboratorDirectoryById.get(userId);
+        return {
+          id: userId,
+          username: user?.username ?? userId,
+          email: user?.email ?? "",
+          avatarUrl: user?.avatarUrl ?? "",
+          role: newLibraryCollaboratorRoles[userId] ?? "viewer",
+        };
+      }),
+    [collaboratorDirectoryById, newLibraryCollaboratorRoles, newLibraryCollaboratorUserIds],
+  );
+  const resourceSelectedCollaboratorUsers = useMemo<AccessCollaborator[]>(
+    () =>
+      selectedCollaboratorUsers.map((user) => ({
+        ...user,
+        role: resourceCollaboratorRoles[user.id] ?? "viewer",
+      })),
+    [resourceCollaboratorRoles, selectedCollaboratorUsers],
+  );
   const resolveOwnerDisplay = (
     ownerUserId: string | undefined,
     fallbackName: string | undefined,
@@ -766,18 +796,6 @@ export function Sidebar({
     if (!resourceDetailsPopup) return false;
     return canWriteResource(resourceDetailsPopup.kind, resourceDetailsPopup.resourceId);
   }, [resourceDetailsPopup, siteLibrary, simulationPresets]);
-  const collaboratorCandidates = useMemo(() => {
-    const q = resourceCollaboratorQuery.trim().toLowerCase();
-    const selectedIds = new Set(resourceCollaboratorUserIds);
-    const filtered = resourceCollaboratorDirectory.filter((user) => {
-      if (currentResourceOwnerId && user.id === currentResourceOwnerId) return false;
-      if (selectedIds.has(user.id)) return false;
-      if (!q) return true;
-      const hay = `${user.username} ${user.email}`.toLowerCase();
-      return hay.includes(q);
-    });
-    return filtered.slice(0, 30);
-  }, [currentResourceOwnerId, resourceCollaboratorDirectory, resourceCollaboratorUserIds, resourceCollaboratorQuery]);
   useEffect(() => {
     if (selectedSimulationRef.startsWith("saved:")) {
       const presetId = selectedSimulationRef.replace("saved:", "");
@@ -914,6 +932,9 @@ export function Sidebar({
     setShowSiteLibraryManager(true);
     setShowAddLibraryForm(true);
     setNewLibraryNameError("");
+    setNewLibraryVisibility("private");
+    setNewLibraryCollaboratorUserIds([]);
+    setNewLibraryCollaboratorRoles({});
     setNewLibrarySourceMeta(pendingSiteLibraryDraft.sourceMeta);
     setPendingDraftAutoInsert(true);
     setNewLibraryName(pendingSiteLibraryDraft.suggestedName ?? "");
@@ -1206,6 +1227,9 @@ export function Sidebar({
     setShowAddLibraryForm(true);
     setNewLibraryName("");
     setNewLibraryDescription("");
+    setNewLibraryVisibility("private");
+    setNewLibraryCollaboratorUserIds([]);
+    setNewLibraryCollaboratorRoles({});
     setNewLibrarySourceMeta(undefined);
     setNewLibraryLat(selectedSite.position.lat);
     setNewLibraryLon(selectedSite.position.lon);
@@ -1239,13 +1263,19 @@ export function Sidebar({
       newLibraryRxGainDbi,
       newLibraryCableLossDb,
       (newLibrarySourceMeta as Parameters<typeof addSiteLibraryEntry>[9]) ?? undefined,
-      pendingDraftAutoInsert ? activeSimulationVisibility : "private",
+      newLibraryVisibility,
       newLibraryDescription,
     );
     if (!createdId) {
       setNewLibraryNameError("A name is required.");
       setLibrarySearchStatus("");
       return;
+    }
+    const sharedWith = newLibraryCollaboratorUserIds
+      .filter((userId) => userId !== currentUser.id)
+      .map((userId) => ({ userId, role: (newLibraryCollaboratorRoles[userId] ?? "viewer") as AccessRole }));
+    if (sharedWith.length) {
+      updateSiteLibraryEntry(createdId, { sharedWith });
     }
     if (pendingDraftAutoInsert && createdId) {
       insertSiteFromLibrary(createdId);
@@ -1259,6 +1289,9 @@ export function Sidebar({
     setNewLibraryTxGainDbi(STANDARD_SITE_RADIO.txGainDbi);
     setNewLibraryRxGainDbi(STANDARD_SITE_RADIO.rxGainDbi);
     setNewLibraryCableLossDb(STANDARD_SITE_RADIO.cableLossDb);
+    setNewLibraryVisibility("private");
+    setNewLibraryCollaboratorUserIds([]);
+    setNewLibraryCollaboratorRoles({});
     setShowAddLibraryForm(false);
   };
   const fetchGroundFromLoadedTerrain = (lat: number, lon: number): number | null => {
@@ -1542,7 +1575,6 @@ export function Sidebar({
         Object.fromEntries(simGrants.map((grant) => [grant.userId, grant.role === "editor" || grant.role === "admin" ? "editor" : "viewer"])),
       );
     }
-    setResourceCollaboratorQuery("");
     setResourceAccessStatus("");
     const resolvedCreatedAvatar =
       createdByAvatarUrl.trim() || (createdByUserId && createdByUserId === lastEditedByUserId ? lastEditedByAvatarUrl : "");
@@ -1703,6 +1735,29 @@ export function Sidebar({
     setResourceAccessStatus("Saved");
   };
 
+  const addNewLibraryCollaborator = (userId: string) => {
+    if (!userId.trim()) return;
+    if (currentUser?.id && userId === currentUser.id) {
+      setLibrarySearchStatus("Owner is implicit and cannot be added as collaborator.");
+      return;
+    }
+    setNewLibraryCollaboratorUserIds((current) => (current.includes(userId) ? current : [...current, userId]));
+    setNewLibraryCollaboratorRoles((current) => (current[userId] ? current : { ...current, [userId]: "viewer" }));
+  };
+
+  const removeNewLibraryCollaborator = (userId: string) => {
+    setNewLibraryCollaboratorUserIds((current) => current.filter((id) => id !== userId));
+    setNewLibraryCollaboratorRoles((current) => {
+      const next = { ...current };
+      delete next[userId];
+      return next;
+    });
+  };
+
+  const setNewLibraryCollaboratorRole = (userId: string, role: AccessRole) => {
+    setNewLibraryCollaboratorRoles((current) => ({ ...current, [userId]: role }));
+  };
+
   const addCollaborator = (userId: string) => {
     if (!resourceCanWrite) {
       setResourceAccessStatus("Read-only: you do not have edit permission for this resource.");
@@ -1721,7 +1776,6 @@ export function Sidebar({
       setResourceCollaboratorRoles((prev) => ({ ...prev, [userId]: "viewer" }));
     }
     void persistResourceAccessSettings({ collaboratorUserIds: nextCollaborators });
-    setResourceCollaboratorQuery("");
   };
 
   const removeCollaborator = (userId: string) => {
@@ -2586,93 +2640,25 @@ export function Sidebar({
                 </div>
               </CompactDetails>
             ) : null}
-            <CompactDetails>
-              <CompactDetailsSummary>Access</CompactDetailsSummary>
-              <label className="field-grid">
-                <span>
-                  Access level{" "}
-                  <InfoTip text="Private: visible to owner/admin. Shared: readable by everyone. Editing is limited to owner, admins, and explicit collaborators." />
-                </span>
-                <select
-                  className="locale-select"
-                    onChange={(event) =>
-                    {
-                      const next = event.target.value as "private" | "public" | "shared";
-                      setResourceAccessVisibility(next);
-                      void persistResourceAccessSettings({ visibility: next });
-                    }
-                  }
-                  value={resourceAccessVisibility}
-                >
-                  <option value="private">Private</option>
-                  <option value="shared">Shared</option>
-                </select>
-              </label>
-              <p className="field-help warning-text">
-                Access levels are not a confidential storage guarantee. Never place passwords, tokens, private keys, or
-                other secrets in resource content.
-              </p>
-              <div className="field-grid user-bio-field collaborator-picker-grid">
-                <span>
-                  Collaborators{" "}
-                  <InfoTip text="Add specific users and assign them viewer or editor access. Viewers can view and run; editors can also modify and add collaborators. Owners/admins can remove collaborators." />
-                </span>
-                <div className="collaborator-picker">
-                  <div className="chip-group collaborator-selected-list">
-                    {selectedCollaboratorUsers.length ? (
-                      selectedCollaboratorUsers.map((user) => (
-                        <span className="site-quick-item" key={user.id}>
-                          <UserBadge avatarUrl={user.avatarUrl} name={user.username} />
-                          <select
-                            aria-label={`Role for ${user.username}`}
-                            onChange={(e) => setCollaboratorRole(user.id, e.target.value as "viewer" | "editor")}
-                            value={resourceCollaboratorRoles[user.id] ?? "viewer"}
-                          >
-                            <option value="viewer">Viewer</option>
-                            <option value="editor">Editor</option>
-                          </select>
-                          <ActionButton onClick={() => removeCollaborator(user.id)} type="button">
-                            Remove
-                          </ActionButton>
-                        </span>
-                      ))
-                    ) : (
-                      <span className="field-help">No collaborators yet.</span>
-                    )}
-                  </div>
-                  <input
-                    onChange={(event) => setResourceCollaboratorQuery(event.target.value)}
-                    placeholder="Search users by name or email"
-                    type="text"
-                    value={resourceCollaboratorQuery}
-                  />
-                  <div className="collaborator-candidate-list">
-                    {resourceCollaboratorDirectoryBusy ? (
-                      <p className="field-help">Loading users…</p>
-                    ) : collaboratorCandidates.length ? (
-                      collaboratorCandidates.map((user) => (
-                        <button className="site-quick-item" key={user.id} onClick={() => addCollaborator(user.id)} type="button">
-                          <UserBadge avatarUrl={user.avatarUrl} name={user.username} />
-                          <span className="field-help">{user.email}</span>
-                          <span className="inline-action">Add</span>
-                        </button>
-                      ))
-                    ) : (
-                      <p className="field-help">No matching users.</p>
-                    )}
-                  </div>
-                  {resourceCollaboratorDirectoryStatus ? (
-                    <p className="field-help">{resourceCollaboratorDirectoryStatus}</p>
-                  ) : null}
-                </div>
-              </div>
-              <p className="field-help">
-                Viewers can view and run the simulation. Editors can also modify it and add collaborators. Owners/admins
-                can remove collaborators. Private simulations remain private — only added collaborators gain access via
-                the share link when logged in.
-              </p>
-              {resourceAccessStatus ? <p className="field-help">{resourceAccessStatus}</p> : <p className="field-help">Saved automatically.</p>}
-            </CompactDetails>
+            <AccessSettingsEditor
+              collaborators={resourceSelectedCollaboratorUsers}
+              directory={resourceCollaboratorDirectory}
+              directoryBusy={resourceCollaboratorDirectoryBusy}
+              directoryStatus={resourceCollaboratorDirectoryStatus}
+              disabled={!resourceCanWrite}
+              onAddCollaborator={addCollaborator}
+              onOpenUserProfile={(userId) => void openUserProfilePopup(userId)}
+              onRemoveCollaborator={removeCollaborator}
+              onRoleChange={setCollaboratorRole}
+              onVisibilityChange={(next) => {
+                setResourceAccessVisibility(next);
+                void persistResourceAccessSettings({ visibility: next });
+              }}
+              ownerUserId={currentResourceOwnerId}
+              showStatusFallback
+              status={resourceAccessStatus}
+              visibility={resourceAccessVisibility === "private" ? "private" : "shared"}
+            />
             </fieldset>
             {resourceDetailsPopup.kind === "simulation" ? (
               <div className="compact-details">
@@ -3286,6 +3272,9 @@ export function Sidebar({
                   if (showAddLibraryForm) {
                     setPendingDraftAutoInsert(false);
                     setNewLibraryDescription("");
+                    setNewLibraryVisibility("private");
+                    setNewLibraryCollaboratorUserIds([]);
+                    setNewLibraryCollaboratorRoles({});
                   }
                 }}
                 type="button"
@@ -3357,6 +3346,20 @@ export function Sidebar({
                   />
                 </label>
                 {newLibraryNameError ? <p className="field-help field-help-error">{newLibraryNameError}</p> : null}
+                <AccessSettingsEditor
+                  collaborators={newLibrarySelectedCollaboratorUsers}
+                  directory={resourceCollaboratorDirectory}
+                  directoryBusy={resourceCollaboratorDirectoryBusy}
+                  directoryStatus={resourceCollaboratorDirectoryStatus}
+                  disabled={!currentUser?.id}
+                  onAddCollaborator={addNewLibraryCollaborator}
+                  onOpenUserProfile={(userId) => void openUserProfilePopup(userId)}
+                  onRemoveCollaborator={removeNewLibraryCollaborator}
+                  onRoleChange={setNewLibraryCollaboratorRole}
+                  onVisibilityChange={setNewLibraryVisibility}
+                  ownerUserId={currentUser?.id ?? ""}
+                  visibility={newLibraryVisibility}
+                />
                 <label className="field-grid">
                   <span>Description</span>
                   <textarea
@@ -3683,9 +3686,12 @@ export function Sidebar({
                   onClick={() => {
                     setShowAddLibraryForm(false);
                     setNewLibraryNameError("");
-                      setNewLibraryDescription("");
-                      setNewLibrarySourceMeta(undefined);
-                      setPendingDraftAutoInsert(false);
+                    setNewLibraryDescription("");
+                    setNewLibraryVisibility("private");
+                    setNewLibraryCollaboratorUserIds([]);
+                    setNewLibraryCollaboratorRoles({});
+                    setNewLibrarySourceMeta(undefined);
+                    setPendingDraftAutoInsert(false);
                   }}
                   type="button"
                 >

--- a/src/index.css
+++ b/src/index.css
@@ -3742,6 +3742,93 @@ html.panorama-gesture-lock body {
   gap: 8px;
 }
 
+.access-settings-control {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.access-settings-caption {
+  margin: 0;
+}
+
+.access-collaborators-summary {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  min-width: 0;
+}
+
+.access-collaborator-avatars {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  min-width: 0;
+}
+
+.access-collaborator-avatars .row-avatar + .row-avatar {
+  margin-left: -7px;
+}
+
+.access-collaborator-avatars .row-avatar {
+  position: relative;
+  box-shadow: 0 0 0 2px var(--surface);
+}
+
+.access-collaborators-empty {
+  margin: 0;
+  white-space: nowrap;
+}
+
+.access-collaborator-popover {
+  width: min(420px, calc(100vw - 24px));
+}
+
+.access-collaborator-popover-content {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+}
+
+.access-collaborator-search input {
+  width: 100%;
+}
+
+.access-collaborator-candidates {
+  max-height: 150px;
+}
+
+.access-collaborator-list {
+  display: grid;
+  gap: 6px;
+  max-height: 190px;
+  overflow: auto;
+}
+
+.access-collaborator-row {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-btn);
+  background: color-mix(in srgb, var(--surface-2) 88%, transparent);
+  padding: 6px 8px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 8px;
+}
+
+.access-collaborator-row select {
+  max-width: 112px;
+}
+
+.access-collaborator-remove {
+  display: inline-grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+}
+
 .collaborator-selected-list {
   max-height: 148px;
   overflow: auto;


### PR DESCRIPTION
## Summary
- Add a reusable AccessSettingsEditor for Site access and collaborator management
- Move Add Site access level directly under Name with live Private/Shared captions
- Replace the existing expandable Access section in resource details with inline access and collaborator rows
- Use the existing FloatingPopover/Surface card path for collaborator editing

## Verification
- npm test
- npm run build
- npx tsc -b config/tsconfig.json --pretty false
- Local edge smoke via npm run dev:edge: verified Add Site default Private caption and collaborator popover opening as the shared Surface card popover

Closes #408