### PR TITLE
Fix access editor popover and row placement

### DIFF
--- a/src/components/AccessSettingsEditor.test.tsx
+++ b/src/components/AccessSettingsEditor.test.tsx
@@ -63,6 +63,7 @@ describe("AccessSettingsEditor", () => {
     const surface = popover.closest(".ui-surface-pill");
     expect(surface).toHaveClass("ui-surface-pill");
     expect(surface).toHaveClass("is-card");
+    expect(surface).toHaveClass("access-collaborator-popover");
     expect(within(popover).queryByRole("button", { name: /Add Alice/i })).not.toBeInTheDocument();
 
     await userEvent.type(within(popover).getByLabelText("Search users"), "ali");

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1814,6 +1814,28 @@ export function Sidebar({
     void persistResourceAccessSettings({ collaboratorRoles: nextRoles });
   };
 
+  const resourceAccessSettingsEditor = resourceDetailsPopup ? (
+    <AccessSettingsEditor
+      collaborators={resourceSelectedCollaboratorUsers}
+      directory={resourceCollaboratorDirectory}
+      directoryBusy={resourceCollaboratorDirectoryBusy}
+      directoryStatus={resourceCollaboratorDirectoryStatus}
+      disabled={!resourceCanWrite}
+      onAddCollaborator={addCollaborator}
+      onOpenUserProfile={(userId) => void openUserProfilePopup(userId)}
+      onRemoveCollaborator={removeCollaborator}
+      onRoleChange={setCollaboratorRole}
+      onVisibilityChange={(next) => {
+        setResourceAccessVisibility(next);
+        void persistResourceAccessSettings({ visibility: next });
+      }}
+      ownerUserId={currentResourceOwnerId}
+      showStatusFallback
+      status={resourceAccessStatus}
+      visibility={resourceAccessVisibility === "private" ? "private" : "shared"}
+    />
+  ) : null;
+
   const changeProfileRole = async (nextRole: "admin" | "moderator" | "user" | "pending") => {
     if (!profilePopupUser) return;
     setProfilePopupBusy(true);
@@ -2355,6 +2377,7 @@ export function Sidebar({
                     value={resourceDescriptionDraft}
                   />
                 </label>
+                {resourceAccessSettingsEditor}
               </>
             ) : null}
             {resourceDetailsPopup.kind === "site" ? (
@@ -2383,6 +2406,7 @@ export function Sidebar({
                       value={resourceDescriptionDraft}
                     />
                   </label>
+                  {resourceAccessSettingsEditor}
                   <label className="field-grid">
                     <span>Latitude</span>
                     <input
@@ -2640,25 +2664,6 @@ export function Sidebar({
                 </div>
               </CompactDetails>
             ) : null}
-            <AccessSettingsEditor
-              collaborators={resourceSelectedCollaboratorUsers}
-              directory={resourceCollaboratorDirectory}
-              directoryBusy={resourceCollaboratorDirectoryBusy}
-              directoryStatus={resourceCollaboratorDirectoryStatus}
-              disabled={!resourceCanWrite}
-              onAddCollaborator={addCollaborator}
-              onOpenUserProfile={(userId) => void openUserProfilePopup(userId)}
-              onRemoveCollaborator={removeCollaborator}
-              onRoleChange={setCollaboratorRole}
-              onVisibilityChange={(next) => {
-                setResourceAccessVisibility(next);
-                void persistResourceAccessSettings({ visibility: next });
-              }}
-              ownerUserId={currentResourceOwnerId}
-              showStatusFallback
-              status={resourceAccessStatus}
-              visibility={resourceAccessVisibility === "private" ? "private" : "shared"}
-            />
             </fieldset>
             {resourceDetailsPopup.kind === "simulation" ? (
               <div className="compact-details">
@@ -3346,6 +3351,15 @@ export function Sidebar({
                   />
                 </label>
                 {newLibraryNameError ? <p className="field-help field-help-error">{newLibraryNameError}</p> : null}
+                <label className="field-grid">
+                  <span>Description</span>
+                  <textarea
+                    onChange={(event) => setNewLibraryDescription(event.target.value)}
+                    placeholder="Optional site notes"
+                    rows={3}
+                    value={newLibraryDescription}
+                  />
+                </label>
                 <AccessSettingsEditor
                   collaborators={newLibrarySelectedCollaboratorUsers}
                   directory={resourceCollaboratorDirectory}
@@ -3360,15 +3374,6 @@ export function Sidebar({
                   ownerUserId={currentUser?.id ?? ""}
                   visibility={newLibraryVisibility}
                 />
-                <label className="field-grid">
-                  <span>Description</span>
-                  <textarea
-                    onChange={(event) => setNewLibraryDescription(event.target.value)}
-                    placeholder="Optional site notes"
-                    rows={3}
-                    value={newLibraryDescription}
-                  />
-                </label>
                 <label className="field-grid">
                   <span>Latitude</span>
                   <input

--- a/src/index.css
+++ b/src/index.css
@@ -3782,6 +3782,7 @@ html.panorama-gesture-lock body {
 }
 
 .access-collaborator-popover {
+  z-index: 12000;
   width: min(420px, calc(100vw - 24px));
 }
 


### PR DESCRIPTION
## Summary\n- Raise the access collaborator popover above modal overlays while preserving the existing FloatingPopover/Surface card path\n- Move Access level and Collaborators below Description in Add Site and resource details\n- Reuse the resource access editor JSX instead of duplicating details markup\n\n## Verification\n- npm test -- --run src/components/AccessSettingsEditor.test.tsx\n- npx tsc -b config/tsconfig.json --pretty false\n- npm test\n- npm run build\n- Local edge browser smoke: Add Site row order and popover z-index\n\nFixes follow-up QA for #408.