### PR TITLE
feat: add site beam visualizer popover

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode, type RefObject } from "react";
 import clsx from "clsx";
 import { Funnel, Handshake, HatGlasses, RefreshCw } from "lucide-react";
 import { CompactDetails, CompactDetailsSummary } from "./ui/CompactDetails";
@@ -81,6 +81,7 @@ import {
 import { AvatarBadge } from "./AvatarBadge";
 import { InlineCloseIconButton } from "./InlineCloseIconButton";
 import { ModalOverlay } from "./ModalOverlay";
+import { SiteBeamVisualizerPopover } from "./SiteBeamVisualizer";
 import SimulationLibraryPanel from "./SimulationLibraryPanel";
 import { Badge } from "./ui/Badge";
 import { Surface } from "./ui/Surface";
@@ -167,6 +168,17 @@ const ALL_VISIBILITY_FILTERS = VISIBILITY_FILTER_OPTIONS.map((option) => option.
 const ALL_SITE_SOURCE_FILTERS = SITE_SOURCE_FILTER_OPTIONS.map((option) => option.key);
 
 type SiteFilterGroupKey = "role" | "visibility" | "source";
+type BeamPreviewFieldKey =
+  | "add-antenna"
+  | "add-tx-power"
+  | "add-tx-gain"
+  | "add-rx-gain"
+  | "add-cable-loss"
+  | "edit-antenna"
+  | "edit-tx-power"
+  | "edit-tx-gain"
+  | "edit-rx-gain"
+  | "edit-cable-loss";
 
 const formatChangeSummary = (action: string, note: string | null): string => {
   if (note && note.trim()) return note;
@@ -553,6 +565,17 @@ export function Sidebar({
   const [resourceTxGainDraft, setResourceTxGainDraft] = useState(STANDARD_SITE_RADIO.txGainDbi);
   const [resourceRxGainDraft, setResourceRxGainDraft] = useState(STANDARD_SITE_RADIO.rxGainDbi);
   const [resourceCableLossDraft, setResourceCableLossDraft] = useState(STANDARD_SITE_RADIO.cableLossDb);
+  const [activeBeamPreviewField, setActiveBeamPreviewField] = useState<BeamPreviewFieldKey | null>(null);
+  const addAntennaBeamRef = useRef<HTMLInputElement | null>(null);
+  const addTxPowerBeamRef = useRef<HTMLInputElement | null>(null);
+  const addTxGainBeamRef = useRef<HTMLInputElement | null>(null);
+  const addRxGainBeamRef = useRef<HTMLInputElement | null>(null);
+  const addCableLossBeamRef = useRef<HTMLInputElement | null>(null);
+  const editAntennaBeamRef = useRef<HTMLInputElement | null>(null);
+  const editTxPowerBeamRef = useRef<HTMLInputElement | null>(null);
+  const editTxGainBeamRef = useRef<HTMLInputElement | null>(null);
+  const editRxGainBeamRef = useRef<HTMLInputElement | null>(null);
+  const editCableLossBeamRef = useRef<HTMLInputElement | null>(null);
   const [resourceCollaboratorUserIds, setResourceCollaboratorUserIds] = useState<string[]>([]);
   const [resourceCollaboratorRoles, setResourceCollaboratorRoles] = useState<Record<string, "viewer" | "editor">>({});
   const [resourceCollaboratorDirectory, setResourceCollaboratorDirectory] = useState<CollaboratorDirectoryUser[]>([]);
@@ -565,6 +588,37 @@ export function Sidebar({
     targetVisibility: "public" | "shared";
     referencedPrivateSiteIds: string[];
   } | null>(null);
+
+  const beamPreviewTriggerRefs: Record<BeamPreviewFieldKey, RefObject<HTMLInputElement | null>> = {
+    "add-antenna": addAntennaBeamRef,
+    "add-tx-power": addTxPowerBeamRef,
+    "add-tx-gain": addTxGainBeamRef,
+    "add-rx-gain": addRxGainBeamRef,
+    "add-cable-loss": addCableLossBeamRef,
+    "edit-antenna": editAntennaBeamRef,
+    "edit-tx-power": editTxPowerBeamRef,
+    "edit-tx-gain": editTxGainBeamRef,
+    "edit-rx-gain": editRxGainBeamRef,
+    "edit-cable-loss": editCableLossBeamRef,
+  };
+  const activeBeamPreviewValues = activeBeamPreviewField?.startsWith("edit-")
+    ? {
+        antennaHeightM: resourceAntennaDraft,
+        txPowerDbm: resourceTxPowerDraft,
+        txGainDbi: resourceTxGainDraft,
+        rxGainDbi: resourceRxGainDraft,
+        cableLossDb: resourceCableLossDraft,
+      }
+    : {
+        antennaHeightM: newLibraryAntennaM,
+        txPowerDbm: newLibraryTxPowerDbm,
+        txGainDbi: newLibraryTxGainDbi,
+        rxGainDbi: newLibraryRxGainDbi,
+        cableLossDb: newLibraryCableLossDb,
+      };
+  const activeBeamPreviewTriggerRef = activeBeamPreviewField
+    ? (beamPreviewTriggerRefs[activeBeamPreviewField] as RefObject<HTMLElement | null>)
+    : undefined;
 
 
   const [deleteConfirm, setDeleteConfirm] = useState<{
@@ -2340,11 +2394,23 @@ export function Sidebar({
       ) : null}
 
       {resourceDetailsPopup ? (
-        <ModalOverlay aria-label="Resource Edit" onClose={() => setResourceDetailsPopup(null)} tier="raised">
+        <ModalOverlay
+          aria-label="Resource Edit"
+          onClose={() => {
+            setResourceDetailsPopup(null);
+            setActiveBeamPreviewField(null);
+          }}
+          tier="raised"
+        >
           <div className="library-manager-card user-profile-popup resource-details-card">
             <div className="library-manager-header">
               <h2>Edit · {resourceDetailsPopup.label}</h2>
-              <InlineCloseIconButton onClick={() => setResourceDetailsPopup(null)} />
+              <InlineCloseIconButton
+                onClick={() => {
+                  setResourceDetailsPopup(null);
+                  setActiveBeamPreviewField(null);
+                }}
+              />
             </div>
             <p className="field-help">Type: {resourceDetailsPopup.kind === "site" ? "Site" : "Simulation"}</p>
             <p className="field-help">ID: {resourceDetailsPopup.resourceId}</p>
@@ -2467,9 +2533,11 @@ export function Sidebar({
                     <span>Antenna (m)</span>
                     <input
                       onChange={(event) => setResourceAntennaDraft(parseNumber(event.target.value))}
+                      onFocus={() => setActiveBeamPreviewField("edit-antenna")}
                       onBlur={() => {
                         void persistResourceAccessSettings();
                       }}
+                      ref={editAntennaBeamRef}
                       type="number"
                       value={resourceAntennaDraft}
                     />
@@ -2478,9 +2546,11 @@ export function Sidebar({
                     <span>Tx power (dBm)</span>
                     <input
                       onChange={(event) => setResourceTxPowerDraft(parseNumber(event.target.value))}
+                      onFocus={() => setActiveBeamPreviewField("edit-tx-power")}
                       onBlur={() => {
                         void persistResourceAccessSettings();
                       }}
+                      ref={editTxPowerBeamRef}
                       type="number"
                       value={resourceTxPowerDraft}
                     />
@@ -2489,9 +2559,11 @@ export function Sidebar({
                     <span>Tx gain (dBi)</span>
                     <input
                       onChange={(event) => setResourceTxGainDraft(parseNumber(event.target.value))}
+                      onFocus={() => setActiveBeamPreviewField("edit-tx-gain")}
                       onBlur={() => {
                         void persistResourceAccessSettings();
                       }}
+                      ref={editTxGainBeamRef}
                       type="number"
                       value={resourceTxGainDraft}
                     />
@@ -2500,9 +2572,11 @@ export function Sidebar({
                     <span>Rx gain (dBi)</span>
                     <input
                       onChange={(event) => setResourceRxGainDraft(parseNumber(event.target.value))}
+                      onFocus={() => setActiveBeamPreviewField("edit-rx-gain")}
                       onBlur={() => {
                         void persistResourceAccessSettings();
                       }}
+                      ref={editRxGainBeamRef}
                       type="number"
                       value={resourceRxGainDraft}
                     />
@@ -2511,9 +2585,11 @@ export function Sidebar({
                     <span>Cable loss (dB)</span>
                     <input
                       onChange={(event) => setResourceCableLossDraft(parseNumber(event.target.value))}
+                      onFocus={() => setActiveBeamPreviewField("edit-cable-loss")}
                       onBlur={() => {
                         void persistResourceAccessSettings();
                       }}
+                      ref={editCableLossBeamRef}
                       type="number"
                       value={resourceCableLossDraft}
                     />
@@ -3275,6 +3351,7 @@ export function Sidebar({
                 onClick={() => {
                   setShowAddLibraryForm((current) => !current);
                   if (showAddLibraryForm) {
+                    setActiveBeamPreviewField(null);
                     setPendingDraftAutoInsert(false);
                     setNewLibraryDescription("");
                     setNewLibraryVisibility("private");
@@ -3412,6 +3489,8 @@ export function Sidebar({
                   <span>Antenna (m)</span>
                   <input
                     onChange={(event) => setNewLibraryAntennaM(parseNumber(event.target.value))}
+                    onFocus={() => setActiveBeamPreviewField("add-antenna")}
+                    ref={addAntennaBeamRef}
                     type="number"
                     value={newLibraryAntennaM}
                   />
@@ -3420,6 +3499,8 @@ export function Sidebar({
                   <span>Tx power (dBm)</span>
                   <input
                     onChange={(event) => setNewLibraryTxPowerDbm(parseNumber(event.target.value))}
+                    onFocus={() => setActiveBeamPreviewField("add-tx-power")}
+                    ref={addTxPowerBeamRef}
                     type="number"
                     value={newLibraryTxPowerDbm}
                   />
@@ -3428,6 +3509,8 @@ export function Sidebar({
                   <span>Tx gain (dBi)</span>
                   <input
                     onChange={(event) => setNewLibraryTxGainDbi(parseNumber(event.target.value))}
+                    onFocus={() => setActiveBeamPreviewField("add-tx-gain")}
+                    ref={addTxGainBeamRef}
                     type="number"
                     value={newLibraryTxGainDbi}
                   />
@@ -3436,6 +3519,8 @@ export function Sidebar({
                   <span>Rx gain (dBi)</span>
                   <input
                     onChange={(event) => setNewLibraryRxGainDbi(parseNumber(event.target.value))}
+                    onFocus={() => setActiveBeamPreviewField("add-rx-gain")}
+                    ref={addRxGainBeamRef}
                     type="number"
                     value={newLibraryRxGainDbi}
                   />
@@ -3444,6 +3529,8 @@ export function Sidebar({
                   <span>Cable loss (dB)</span>
                   <input
                     onChange={(event) => setNewLibraryCableLossDb(parseNumber(event.target.value))}
+                    onFocus={() => setActiveBeamPreviewField("add-cable-loss")}
+                    ref={addCableLossBeamRef}
                     type="number"
                     value={newLibraryCableLossDb}
                   />
@@ -3804,6 +3891,12 @@ export function Sidebar({
           </div>
         </ModalOverlay>
       ) : null}
+      <SiteBeamVisualizerPopover
+        onClose={() => setActiveBeamPreviewField(null)}
+        open={Boolean(activeBeamPreviewField && activeBeamPreviewTriggerRef?.current)}
+        triggerRef={activeBeamPreviewTriggerRef}
+        values={activeBeamPreviewValues}
+      />
       {deleteConfirm ? (
         <ModalOverlay aria-label="Confirm Delete" onClose={() => setDeleteConfirm(null)} tier="raised">
           <div className="library-manager-card user-profile-popup">

--- a/src/components/SiteBeamVisualizer.test.tsx
+++ b/src/components/SiteBeamVisualizer.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useRef, useState } from "react";
+import { describe, expect, it } from "vitest";
+import { SiteBeamVisualizerPopover } from "./SiteBeamVisualizer";
+
+const initialValues = {
+  antennaHeightM: 2,
+  txPowerDbm: 20,
+  txGainDbi: 2,
+  rxGainDbi: 2,
+  cableLossDb: 1,
+};
+
+function Harness() {
+  const [open, setOpen] = useState(false);
+  const [txPowerDbm, setTxPowerDbm] = useState(initialValues.txPowerDbm);
+  const triggerRef = useRef<HTMLInputElement | null>(null);
+
+  return (
+    <div>
+      <label>
+        Site name
+        <input aria-label="Site name" />
+      </label>
+      <label>
+        Tx power
+        <input
+          aria-label="Tx power"
+          onChange={(event) => setTxPowerDbm(Number(event.target.value))}
+          onFocus={() => setOpen(true)}
+          ref={triggerRef}
+          type="number"
+          value={txPowerDbm}
+        />
+      </label>
+      <SiteBeamVisualizerPopover
+        onClose={() => setOpen(false)}
+        open={open}
+        triggerRef={triggerRef}
+        values={{ ...initialValues, txPowerDbm }}
+      />
+    </div>
+  );
+}
+
+describe("SiteBeamVisualizerPopover", () => {
+  it("opens from relevant field focus and ignores unrelated fields", async () => {
+    render(<Harness />);
+
+    await userEvent.click(screen.getByLabelText("Site name"));
+    expect(screen.queryByText("Beam preview")).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByLabelText("Tx power"));
+    expect(await screen.findByText("Beam preview")).toBeInTheDocument();
+    expect(screen.getByText("Educational only. Terrain, line of sight, and selected Path target are not evaluated here.")).toBeInTheDocument();
+  });
+
+  it("updates the educational budget when form values change", async () => {
+    render(<Harness />);
+
+    const input = screen.getByLabelText("Tx power");
+    await userEvent.click(input);
+    expect(await screen.findByText("Budget 23.0 dB")).toBeInTheDocument();
+
+    await userEvent.clear(input);
+    await userEvent.type(input, "28");
+    expect(await screen.findByText("Budget 31.0 dB")).toBeInTheDocument();
+  });
+});

--- a/src/components/SiteBeamVisualizer.tsx
+++ b/src/components/SiteBeamVisualizer.tsx
@@ -1,0 +1,101 @@
+import { useMemo } from "react";
+import { computeBeamPreviewMetrics, type BeamPreviewInput } from "../lib/beamVisualizer";
+import { StateDot } from "./StateDot";
+import { FloatingPopover } from "./ui/FloatingPopover";
+import type { RefObject } from "react";
+
+type SiteBeamVisualizerProps = {
+  values: BeamPreviewInput;
+};
+
+type SiteBeamVisualizerPopoverProps = SiteBeamVisualizerProps & {
+  open: boolean;
+  onClose: () => void;
+  triggerRef?: RefObject<HTMLElement | null>;
+};
+
+const polarToPoint = (cx: number, cy: number, radius: number, angleDeg: number): { x: number; y: number } => {
+  const angleRad = (angleDeg * Math.PI) / 180;
+  return {
+    x: cx + Math.cos(angleRad) * radius,
+    y: cy + Math.sin(angleRad) * radius,
+  };
+};
+
+const sectorPath = (cx: number, cy: number, radius: number, widthDeg: number): string => {
+  const start = polarToPoint(cx, cy, radius, -90 - widthDeg / 2);
+  const end = polarToPoint(cx, cy, radius, -90 + widthDeg / 2);
+  const largeArc = widthDeg > 180 ? 1 : 0;
+  return `M ${cx} ${cy} L ${start.x.toFixed(2)} ${start.y.toFixed(2)} A ${radius} ${radius} 0 ${largeArc} 1 ${end.x.toFixed(2)} ${end.y.toFixed(2)} Z`;
+};
+
+export function SiteBeamVisualizer({ values }: SiteBeamVisualizerProps) {
+  const metrics = useMemo(() => computeBeamPreviewMetrics(values), [values]);
+  const cx = 110;
+  const cy = 116;
+  const maxRadius = 96 * metrics.rangeScore;
+
+  return (
+    <div
+      className="beam-visualizer"
+      role="img"
+      aria-label={`Educational beam preview: ${metrics.rangeLabel.toLowerCase()} relative range, ${metrics.beamWidthDeg} deg relative beam width.`}
+    >
+      <div className="beam-visualizer-header">
+        <strong>Beam preview</strong>
+        <span>{metrics.rangeLabel} range</span>
+      </div>
+      <svg className="beam-visualizer-chart" viewBox="0 0 220 132" aria-hidden="true" focusable="false">
+        <line className="beam-visualizer-axis" x1={cx} x2={cx} y1="18" y2={cy} />
+        {metrics.bands.map((band) => (
+          <path
+            className={`beam-visualizer-band beam-visualizer-band-${band.state}`}
+            d={sectorPath(cx, cy, maxRadius * (band.radiusPercent / 100), metrics.beamWidthDeg)}
+            key={band.state}
+          />
+        ))}
+        <circle className="beam-visualizer-origin" cx={cx} cy={cy} r="5" />
+      </svg>
+      <div className="beam-visualizer-stats">
+        <span>Width {metrics.beamWidthDeg} deg</span>
+        <span>Budget {metrics.linkBudgetScoreDb.toFixed(1)} dB</span>
+      </div>
+      <ul className="beam-visualizer-legend">
+        <li>
+          <StateDot state="pass_clear" />
+          <span>Strong core</span>
+        </li>
+        <li>
+          <StateDot state="pass_blocked" />
+          <span>Usable</span>
+        </li>
+        <li>
+          <StateDot state="fail_clear" />
+          <span>Marginal</span>
+        </li>
+        <li>
+          <StateDot state="fail_blocked" />
+          <span>Weak edge</span>
+        </li>
+      </ul>
+      <p className="field-help beam-visualizer-note">
+        Educational only. Terrain, line of sight, and selected Path target are not evaluated here.
+      </p>
+    </div>
+  );
+}
+
+export function SiteBeamVisualizerPopover({ open, onClose, triggerRef, values }: SiteBeamVisualizerPopoverProps) {
+  return (
+    <FloatingPopover
+      className="beam-visualizer-popover"
+      estimatedHeight={290}
+      estimatedWidth={300}
+      onClose={onClose}
+      open={open}
+      triggerRef={triggerRef}
+    >
+      <SiteBeamVisualizer values={values} />
+    </FloatingPopover>
+  );
+}

--- a/src/components/UiGalleryPage.tsx
+++ b/src/components/UiGalleryPage.tsx
@@ -5,6 +5,7 @@ import { StateDot } from "./StateDot";
 import { Surface } from "./ui/Surface";
 import { Badge } from "./ui/Badge";
 import { UiSlider } from "./UiSlider";
+import { SiteBeamVisualizer } from "./SiteBeamVisualizer";
 import { useThemeVariant } from "../hooks/useThemeVariant";
 import { useAppStore } from "../store/appStore";
 import type { UiColorTheme } from "../themes/types";
@@ -36,6 +37,7 @@ const SOURCE_PATHS: Record<string, string> = {
   "Select": "src/components/ui/Select.tsx",
   "Badge": "src/components/ui/Badge.tsx",
   "UI Slider": "src/components/UiSlider.tsx",
+  "SiteBeamVisualizer": "src/components/SiteBeamVisualizer.tsx",
   "NotificationStack": "src/components/NotificationStack.tsx",
   "NotificationBanner": "src/components/NotificationBanner.tsx",
   "MapInlineNotice": "src/components/MapInlineNotice.tsx",
@@ -438,6 +440,17 @@ export function UiGalleryPage() {
                   value={0.75}
                 />
               </div>
+            </PatternCard>
+            <PatternCard name="SiteBeamVisualizer" status="standard">
+              <SiteBeamVisualizer
+                values={{
+                  antennaHeightM: 8,
+                  txPowerDbm: 22,
+                  txGainDbi: 9,
+                  rxGainDbi: 9,
+                  cableLossDb: 1.8,
+                }}
+              />
             </PatternCard>
           </div>
         </section>

--- a/src/index.css
+++ b/src/index.css
@@ -2445,6 +2445,100 @@ input {
   border-top: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
 }
 
+.beam-visualizer-popover {
+  width: min(300px, calc(100vw - 24px));
+  pointer-events: none;
+}
+
+.beam-visualizer {
+  display: grid;
+  gap: 8px;
+  padding: 10px 12px;
+  color: var(--text);
+}
+
+.beam-visualizer-header,
+.beam-visualizer-stats {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.beam-visualizer-header span,
+.beam-visualizer-stats {
+  color: var(--muted);
+  font-size: 0.75rem;
+}
+
+.beam-visualizer-stats {
+  font-family: "IBM Plex Mono", monospace;
+}
+
+.beam-visualizer-chart {
+  width: 100%;
+  height: 132px;
+  border-radius: var(--radius-card);
+  background:
+    radial-gradient(circle at 50% 88%, color-mix(in srgb, var(--accent-soft) 46%, transparent), transparent 38%),
+    color-mix(in srgb, var(--surface-2) 72%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+}
+
+.beam-visualizer-axis {
+  stroke: color-mix(in srgb, var(--muted) 42%, transparent);
+  stroke-width: 1;
+  stroke-dasharray: 3 4;
+}
+
+.beam-visualizer-band {
+  stroke: color-mix(in srgb, var(--surface) 42%, transparent);
+  stroke-width: 1;
+}
+
+.beam-visualizer-band-pass_clear {
+  fill: color-mix(in srgb, var(--state-pass-clear) 72%, transparent);
+}
+
+.beam-visualizer-band-pass_blocked {
+  fill: color-mix(in srgb, var(--state-pass-blocked) 58%, transparent);
+}
+
+.beam-visualizer-band-fail_clear {
+  fill: color-mix(in srgb, var(--state-fail-clear) 50%, transparent);
+}
+
+.beam-visualizer-band-fail_blocked {
+  fill: color-mix(in srgb, var(--state-fail-blocked) 42%, transparent);
+}
+
+.beam-visualizer-origin {
+  fill: var(--text);
+  stroke: var(--surface);
+  stroke-width: 2;
+}
+
+.beam-visualizer-legend {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 5px 10px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-size: 0.75rem;
+}
+
+.beam-visualizer-legend li {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+}
+
+.beam-visualizer-note {
+  margin: 0;
+}
+
 .ui-settings-row-slider {
   display: flex;
   flex-direction: column;

--- a/src/lib/beamVisualizer.test.ts
+++ b/src/lib/beamVisualizer.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { computeBeamPreviewMetrics } from "./beamVisualizer";
+
+const base = {
+  antennaHeightM: 2,
+  txPowerDbm: 20,
+  txGainDbi: 2,
+  rxGainDbi: 2,
+  cableLossDb: 1,
+};
+
+describe("computeBeamPreviewMetrics", () => {
+  it("increases relative range when tx power increases", () => {
+    const low = computeBeamPreviewMetrics({ ...base, txPowerDbm: 12 });
+    const high = computeBeamPreviewMetrics({ ...base, txPowerDbm: 28 });
+
+    expect(high.rangeScore).toBeGreaterThan(low.rangeScore);
+  });
+
+  it("decreases relative range when cable loss increases", () => {
+    const lowLoss = computeBeamPreviewMetrics({ ...base, cableLossDb: 0.5 });
+    const highLoss = computeBeamPreviewMetrics({ ...base, cableLossDb: 8 });
+
+    expect(highLoss.rangeScore).toBeLessThan(lowLoss.rangeScore);
+  });
+
+  it("narrows beam width and increases range when gain increases", () => {
+    const lowGain = computeBeamPreviewMetrics({ ...base, txGainDbi: 1, rxGainDbi: 1 });
+    const highGain = computeBeamPreviewMetrics({ ...base, txGainDbi: 9, rxGainDbi: 9 });
+
+    expect(highGain.rangeScore).toBeGreaterThan(lowGain.rangeScore);
+    expect(highGain.beamWidthDeg).toBeLessThan(lowGain.beamWidthDeg);
+  });
+
+  it("modestly increases relative range when antenna height increases", () => {
+    const low = computeBeamPreviewMetrics({ ...base, antennaHeightM: 2 });
+    const high = computeBeamPreviewMetrics({ ...base, antennaHeightM: 24 });
+
+    expect(high.rangeScore).toBeGreaterThan(low.rangeScore);
+    expect(high.rangeScore - low.rangeScore).toBeLessThan(0.2);
+  });
+
+  it("clamps invalid and extreme values to stable display bounds", () => {
+    const metrics = computeBeamPreviewMetrics({
+      antennaHeightM: Number.NaN,
+      txPowerDbm: Infinity,
+      txGainDbi: 999,
+      rxGainDbi: -999,
+      cableLossDb: 999,
+    });
+
+    expect(metrics.rangeScore).toBeGreaterThanOrEqual(0.16);
+    expect(metrics.rangeScore).toBeLessThanOrEqual(0.96);
+    expect(metrics.beamWidthDeg).toBeGreaterThanOrEqual(32);
+    expect(metrics.beamWidthDeg).toBeLessThanOrEqual(150);
+    expect(metrics.bands).toHaveLength(4);
+  });
+});

--- a/src/lib/beamVisualizer.ts
+++ b/src/lib/beamVisualizer.ts
@@ -1,0 +1,68 @@
+import type { PassFailState } from "./passFailState";
+
+export type BeamPreviewInput = {
+  antennaHeightM: number;
+  txPowerDbm: number;
+  txGainDbi: number;
+  rxGainDbi: number;
+  cableLossDb: number;
+};
+
+export type BeamPreviewBand = {
+  state: PassFailState;
+  label: string;
+  radiusPercent: number;
+};
+
+export type BeamPreviewMetrics = {
+  beamWidthDeg: number;
+  beamSpreadPercent: number;
+  rangeScore: number;
+  rangeLabel: "Short" | "Moderate" | "Long" | "Extended";
+  linkBudgetScoreDb: number;
+  bands: BeamPreviewBand[];
+};
+
+const clamp = (value: number, min: number, max: number): number => Math.min(max, Math.max(min, value));
+
+const finiteOr = (value: number, fallback: number): number => (Number.isFinite(value) ? value : fallback);
+
+export const computeBeamPreviewMetrics = ({
+  antennaHeightM,
+  txPowerDbm,
+  txGainDbi,
+  rxGainDbi,
+  cableLossDb,
+}: BeamPreviewInput): BeamPreviewMetrics => {
+  const antenna = clamp(finiteOr(antennaHeightM, 2), 0, 80);
+  const txPower = clamp(finiteOr(txPowerDbm, 0), 0, 40);
+  const txGain = clamp(finiteOr(txGainDbi, 0), 0, 30);
+  const rxGain = clamp(finiteOr(rxGainDbi, 0), 0, 30);
+  const cableLoss = clamp(finiteOr(cableLossDb, 0), 0, 30);
+  const gainSum = txGain + rxGain;
+  const linkBudgetScoreDb = txPower + gainSum - cableLoss;
+
+  const powerFactor = clamp((txPower - 10) / 20, 0, 1);
+  const gainFactor = clamp((gainSum - 2) / 22, 0, 1);
+  const antennaFactor = clamp((antenna - 2) / 28, 0, 1);
+  const lossFactor = clamp(cableLoss / 10, 0, 1);
+  const rangeScore = clamp(0.26 + powerFactor * 0.34 + gainFactor * 0.32 + antennaFactor * 0.14 - lossFactor * 0.24, 0.16, 0.96);
+  const beamWidthDeg = Math.round(clamp(150 - gainSum * 4.2, 32, 150));
+  const beamSpreadPercent = Math.round((beamWidthDeg / 150) * 100);
+  const rangeLabel =
+    rangeScore >= 0.82 ? "Extended" : rangeScore >= 0.62 ? "Long" : rangeScore >= 0.38 ? "Moderate" : "Short";
+
+  return {
+    beamWidthDeg,
+    beamSpreadPercent,
+    rangeScore,
+    rangeLabel,
+    linkBudgetScoreDb,
+    bands: [
+      { state: "fail_blocked", label: "Weak edge", radiusPercent: 100 },
+      { state: "fail_clear", label: "Marginal", radiusPercent: 78 },
+      { state: "pass_blocked", label: "Usable", radiusPercent: 56 },
+      { state: "pass_clear", label: "Strong core", radiusPercent: 34 },
+    ],
+  };
+};


### PR DESCRIPTION
## Summary
- Add a focus-triggered educational beam visualizer for Site RF fields in Add Site and Edit Site flows.
- Use only current form parameters: antenna height, Tx power, Tx gain, Rx gain, and cable loss.
- Reuse existing FloatingPopover and app pass/fail color tokens as relative signal bands; no schema or simulation behavior changes.
- Add UI-gallery coverage plus helper/component tests.

## Verification
- npm test
- npm run build
- Playwright UI-gallery visual check at /ui-gallery

Refs #107