### PR TITLE
fix: show beam visualizer above modals

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2447,6 +2447,7 @@ input {
 
 .beam-visualizer-popover {
   width: min(300px, calc(100vw - 24px));
+  z-index: 12050;
   pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary
- Raise only the beam visualizer popover above raised modal overlays.
- Keep the popover non-interactive and scoped to the existing educational preview.

## Verification
- npm test -- --run src/components/SiteBeamVisualizer.test.tsx src/lib/beamVisualizer.test.ts
- npm run build

Refs #107