### PR TITLE
fix: stabilize beam visualizer anchor

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type ReactNode, type RefObject } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import clsx from "clsx";
 import { Funnel, Handshake, HatGlasses, RefreshCw } from "lucide-react";
 import { CompactDetails, CompactDetailsSummary } from "./ui/CompactDetails";
@@ -168,17 +168,7 @@ const ALL_VISIBILITY_FILTERS = VISIBILITY_FILTER_OPTIONS.map((option) => option.
 const ALL_SITE_SOURCE_FILTERS = SITE_SOURCE_FILTER_OPTIONS.map((option) => option.key);
 
 type SiteFilterGroupKey = "role" | "visibility" | "source";
-type BeamPreviewFieldKey =
-  | "add-antenna"
-  | "add-tx-power"
-  | "add-tx-gain"
-  | "add-rx-gain"
-  | "add-cable-loss"
-  | "edit-antenna"
-  | "edit-tx-power"
-  | "edit-tx-gain"
-  | "edit-rx-gain"
-  | "edit-cable-loss";
+type BeamPreviewFieldKey = "add" | "edit";
 
 const formatChangeSummary = (action: string, note: string | null): string => {
   if (note && note.trim()) return note;
@@ -566,16 +556,8 @@ export function Sidebar({
   const [resourceRxGainDraft, setResourceRxGainDraft] = useState(STANDARD_SITE_RADIO.rxGainDbi);
   const [resourceCableLossDraft, setResourceCableLossDraft] = useState(STANDARD_SITE_RADIO.cableLossDb);
   const [activeBeamPreviewField, setActiveBeamPreviewField] = useState<BeamPreviewFieldKey | null>(null);
-  const addAntennaBeamRef = useRef<HTMLInputElement | null>(null);
-  const addTxPowerBeamRef = useRef<HTMLInputElement | null>(null);
-  const addTxGainBeamRef = useRef<HTMLInputElement | null>(null);
-  const addRxGainBeamRef = useRef<HTMLInputElement | null>(null);
-  const addCableLossBeamRef = useRef<HTMLInputElement | null>(null);
-  const editAntennaBeamRef = useRef<HTMLInputElement | null>(null);
-  const editTxPowerBeamRef = useRef<HTMLInputElement | null>(null);
-  const editTxGainBeamRef = useRef<HTMLInputElement | null>(null);
-  const editRxGainBeamRef = useRef<HTMLInputElement | null>(null);
-  const editCableLossBeamRef = useRef<HTMLInputElement | null>(null);
+  const addBeamPreviewAnchorRef = useRef<HTMLDivElement | null>(null);
+  const editBeamPreviewAnchorRef = useRef<HTMLDivElement | null>(null);
   const [resourceCollaboratorUserIds, setResourceCollaboratorUserIds] = useState<string[]>([]);
   const [resourceCollaboratorRoles, setResourceCollaboratorRoles] = useState<Record<string, "viewer" | "editor">>({});
   const [resourceCollaboratorDirectory, setResourceCollaboratorDirectory] = useState<CollaboratorDirectoryUser[]>([]);
@@ -589,19 +571,7 @@ export function Sidebar({
     referencedPrivateSiteIds: string[];
   } | null>(null);
 
-  const beamPreviewTriggerRefs: Record<BeamPreviewFieldKey, RefObject<HTMLInputElement | null>> = {
-    "add-antenna": addAntennaBeamRef,
-    "add-tx-power": addTxPowerBeamRef,
-    "add-tx-gain": addTxGainBeamRef,
-    "add-rx-gain": addRxGainBeamRef,
-    "add-cable-loss": addCableLossBeamRef,
-    "edit-antenna": editAntennaBeamRef,
-    "edit-tx-power": editTxPowerBeamRef,
-    "edit-tx-gain": editTxGainBeamRef,
-    "edit-rx-gain": editRxGainBeamRef,
-    "edit-cable-loss": editCableLossBeamRef,
-  };
-  const activeBeamPreviewValues = activeBeamPreviewField?.startsWith("edit-")
+  const activeBeamPreviewValues = activeBeamPreviewField === "edit"
     ? {
         antennaHeightM: resourceAntennaDraft,
         txPowerDbm: resourceTxPowerDraft,
@@ -616,9 +586,12 @@ export function Sidebar({
         rxGainDbi: newLibraryRxGainDbi,
         cableLossDb: newLibraryCableLossDb,
       };
-  const activeBeamPreviewTriggerRef = activeBeamPreviewField
-    ? (beamPreviewTriggerRefs[activeBeamPreviewField] as RefObject<HTMLElement | null>)
-    : undefined;
+  const activeBeamPreviewTriggerRef =
+    activeBeamPreviewField === "edit"
+      ? editBeamPreviewAnchorRef
+      : activeBeamPreviewField === "add"
+        ? addBeamPreviewAnchorRef
+        : undefined;
 
 
   const [deleteConfirm, setDeleteConfirm] = useState<{
@@ -2529,71 +2502,68 @@ export function Sidebar({
                       </ActionButton>
                     </div>
                   </label>
-                  <label className="field-grid">
-                    <span>Antenna (m)</span>
-                    <input
-                      onChange={(event) => setResourceAntennaDraft(parseNumber(event.target.value))}
-                      onFocus={() => setActiveBeamPreviewField("edit-antenna")}
-                      onBlur={() => {
-                        void persistResourceAccessSettings();
-                      }}
-                      ref={editAntennaBeamRef}
-                      type="number"
-                      value={resourceAntennaDraft}
-                    />
-                  </label>
-                  <label className="field-grid">
-                    <span>Tx power (dBm)</span>
-                    <input
-                      onChange={(event) => setResourceTxPowerDraft(parseNumber(event.target.value))}
-                      onFocus={() => setActiveBeamPreviewField("edit-tx-power")}
-                      onBlur={() => {
-                        void persistResourceAccessSettings();
-                      }}
-                      ref={editTxPowerBeamRef}
-                      type="number"
-                      value={resourceTxPowerDraft}
-                    />
-                  </label>
-                  <label className="field-grid">
-                    <span>Tx gain (dBi)</span>
-                    <input
-                      onChange={(event) => setResourceTxGainDraft(parseNumber(event.target.value))}
-                      onFocus={() => setActiveBeamPreviewField("edit-tx-gain")}
-                      onBlur={() => {
-                        void persistResourceAccessSettings();
-                      }}
-                      ref={editTxGainBeamRef}
-                      type="number"
-                      value={resourceTxGainDraft}
-                    />
-                  </label>
-                  <label className="field-grid">
-                    <span>Rx gain (dBi)</span>
-                    <input
-                      onChange={(event) => setResourceRxGainDraft(parseNumber(event.target.value))}
-                      onFocus={() => setActiveBeamPreviewField("edit-rx-gain")}
-                      onBlur={() => {
-                        void persistResourceAccessSettings();
-                      }}
-                      ref={editRxGainBeamRef}
-                      type="number"
-                      value={resourceRxGainDraft}
-                    />
-                  </label>
-                  <label className="field-grid">
-                    <span>Cable loss (dB)</span>
-                    <input
-                      onChange={(event) => setResourceCableLossDraft(parseNumber(event.target.value))}
-                      onFocus={() => setActiveBeamPreviewField("edit-cable-loss")}
-                      onBlur={() => {
-                        void persistResourceAccessSettings();
-                      }}
-                      ref={editCableLossBeamRef}
-                      type="number"
-                      value={resourceCableLossDraft}
-                    />
-                  </label>
+                  <div className="beam-visualizer-field-group" ref={editBeamPreviewAnchorRef}>
+                    <label className="field-grid">
+                      <span>Antenna (m)</span>
+                      <input
+                        onChange={(event) => setResourceAntennaDraft(parseNumber(event.target.value))}
+                        onFocus={() => setActiveBeamPreviewField("edit")}
+                        onBlur={() => {
+                          void persistResourceAccessSettings();
+                        }}
+                        type="number"
+                        value={resourceAntennaDraft}
+                      />
+                    </label>
+                    <label className="field-grid">
+                      <span>Tx power (dBm)</span>
+                      <input
+                        onChange={(event) => setResourceTxPowerDraft(parseNumber(event.target.value))}
+                        onFocus={() => setActiveBeamPreviewField("edit")}
+                        onBlur={() => {
+                          void persistResourceAccessSettings();
+                        }}
+                        type="number"
+                        value={resourceTxPowerDraft}
+                      />
+                    </label>
+                    <label className="field-grid">
+                      <span>Tx gain (dBi)</span>
+                      <input
+                        onChange={(event) => setResourceTxGainDraft(parseNumber(event.target.value))}
+                        onFocus={() => setActiveBeamPreviewField("edit")}
+                        onBlur={() => {
+                          void persistResourceAccessSettings();
+                        }}
+                        type="number"
+                        value={resourceTxGainDraft}
+                      />
+                    </label>
+                    <label className="field-grid">
+                      <span>Rx gain (dBi)</span>
+                      <input
+                        onChange={(event) => setResourceRxGainDraft(parseNumber(event.target.value))}
+                        onFocus={() => setActiveBeamPreviewField("edit")}
+                        onBlur={() => {
+                          void persistResourceAccessSettings();
+                        }}
+                        type="number"
+                        value={resourceRxGainDraft}
+                      />
+                    </label>
+                    <label className="field-grid">
+                      <span>Cable loss (dB)</span>
+                      <input
+                        onChange={(event) => setResourceCableLossDraft(parseNumber(event.target.value))}
+                        onFocus={() => setActiveBeamPreviewField("edit")}
+                        onBlur={() => {
+                          void persistResourceAccessSettings();
+                        }}
+                        type="number"
+                        value={resourceCableLossDraft}
+                      />
+                    </label>
+                  </div>
                 </div>
                 <div className="library-editor-map">
                   <div className="library-editor-map-controls">
@@ -3485,56 +3455,53 @@ export function Sidebar({
                     </ActionButton>
                   </div>
                 </label>
-                <label className="field-grid">
-                  <span>Antenna (m)</span>
-                  <input
-                    onChange={(event) => setNewLibraryAntennaM(parseNumber(event.target.value))}
-                    onFocus={() => setActiveBeamPreviewField("add-antenna")}
-                    ref={addAntennaBeamRef}
-                    type="number"
-                    value={newLibraryAntennaM}
-                  />
-                </label>
-                <label className="field-grid">
-                  <span>Tx power (dBm)</span>
-                  <input
-                    onChange={(event) => setNewLibraryTxPowerDbm(parseNumber(event.target.value))}
-                    onFocus={() => setActiveBeamPreviewField("add-tx-power")}
-                    ref={addTxPowerBeamRef}
-                    type="number"
-                    value={newLibraryTxPowerDbm}
-                  />
-                </label>
-                <label className="field-grid">
-                  <span>Tx gain (dBi)</span>
-                  <input
-                    onChange={(event) => setNewLibraryTxGainDbi(parseNumber(event.target.value))}
-                    onFocus={() => setActiveBeamPreviewField("add-tx-gain")}
-                    ref={addTxGainBeamRef}
-                    type="number"
-                    value={newLibraryTxGainDbi}
-                  />
-                </label>
-                <label className="field-grid">
-                  <span>Rx gain (dBi)</span>
-                  <input
-                    onChange={(event) => setNewLibraryRxGainDbi(parseNumber(event.target.value))}
-                    onFocus={() => setActiveBeamPreviewField("add-rx-gain")}
-                    ref={addRxGainBeamRef}
-                    type="number"
-                    value={newLibraryRxGainDbi}
-                  />
-                </label>
-                <label className="field-grid">
-                  <span>Cable loss (dB)</span>
-                  <input
-                    onChange={(event) => setNewLibraryCableLossDb(parseNumber(event.target.value))}
-                    onFocus={() => setActiveBeamPreviewField("add-cable-loss")}
-                    ref={addCableLossBeamRef}
-                    type="number"
-                    value={newLibraryCableLossDb}
-                  />
-                </label>
+                <div className="beam-visualizer-field-group" ref={addBeamPreviewAnchorRef}>
+                  <label className="field-grid">
+                    <span>Antenna (m)</span>
+                    <input
+                      onChange={(event) => setNewLibraryAntennaM(parseNumber(event.target.value))}
+                      onFocus={() => setActiveBeamPreviewField("add")}
+                      type="number"
+                      value={newLibraryAntennaM}
+                    />
+                  </label>
+                  <label className="field-grid">
+                    <span>Tx power (dBm)</span>
+                    <input
+                      onChange={(event) => setNewLibraryTxPowerDbm(parseNumber(event.target.value))}
+                      onFocus={() => setActiveBeamPreviewField("add")}
+                      type="number"
+                      value={newLibraryTxPowerDbm}
+                    />
+                  </label>
+                  <label className="field-grid">
+                    <span>Tx gain (dBi)</span>
+                    <input
+                      onChange={(event) => setNewLibraryTxGainDbi(parseNumber(event.target.value))}
+                      onFocus={() => setActiveBeamPreviewField("add")}
+                      type="number"
+                      value={newLibraryTxGainDbi}
+                    />
+                  </label>
+                  <label className="field-grid">
+                    <span>Rx gain (dBi)</span>
+                    <input
+                      onChange={(event) => setNewLibraryRxGainDbi(parseNumber(event.target.value))}
+                      onFocus={() => setActiveBeamPreviewField("add")}
+                      type="number"
+                      value={newLibraryRxGainDbi}
+                    />
+                  </label>
+                  <label className="field-grid">
+                    <span>Cable loss (dB)</span>
+                    <input
+                      onChange={(event) => setNewLibraryCableLossDb(parseNumber(event.target.value))}
+                      onFocus={() => setActiveBeamPreviewField("add")}
+                      type="number"
+                      value={newLibraryCableLossDb}
+                    />
+                  </label>
+                </div>
                 <label className="field-grid">
                   <span>Map Search</span>
                   <input

--- a/src/components/SiteBeamVisualizer.test.tsx
+++ b/src/components/SiteBeamVisualizer.test.tsx
@@ -54,7 +54,7 @@ describe("SiteBeamVisualizerPopover", () => {
 
     await userEvent.click(screen.getByLabelText("Tx power"));
     expect(await screen.findByText("Beam preview")).toBeInTheDocument();
-    expect(screen.getByText("Educational only. Terrain, line of sight, and selected Path target are not evaluated here.")).toBeInTheDocument();
+    expect(screen.getByText("Not to scale, illustration only.")).toBeInTheDocument();
   });
 
   it("updates the educational budget when form values change", async () => {

--- a/src/components/SiteBeamVisualizer.tsx
+++ b/src/components/SiteBeamVisualizer.tsx
@@ -78,9 +78,7 @@ export function SiteBeamVisualizer({ values }: SiteBeamVisualizerProps) {
           <span>Weak edge</span>
         </li>
       </ul>
-      <p className="field-help beam-visualizer-note">
-        Educational only. Terrain, line of sight, and selected Path target are not evaluated here.
-      </p>
+      <p className="field-help beam-visualizer-note">Not to scale, illustration only.</p>
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -2451,6 +2451,11 @@ input {
   pointer-events: none;
 }
 
+.beam-visualizer-field-group {
+  display: grid;
+  gap: 8px;
+}
+
 .beam-visualizer {
   display: grid;
   gap: 8px;


### PR DESCRIPTION
## Summary
- Anchor the Site beam visualizer popover to one stable RF field group in Add Site and one stable RF field group in Edit Site, instead of anchoring to each focused input.
- Update the visualizer footer copy to: Not to scale, illustration only.
- Keep the calculation educational and unchanged.

## Verification
- npm test
- npm run build

Refs #107