### PR TITLE
refine beam visualizer gain layout and copy

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2541,26 +2541,6 @@ export function Sidebar({
                         value={resourceTxPowerDraft}
                       />
                     </label>
-                    <div className="field-grid">
-                      <span>Gain mode</span>
-                      <label className="checkbox-field">
-                        <input
-                          checked={resourceSeparateGain}
-                          onChange={(event) => {
-                            const checked = event.target.checked;
-                            setResourceSeparateGain(checked);
-                            if (!checked) {
-                              const nextGain = collapseSiteGainToTx(resourceTxGainDraft);
-                              setResourceTxGainDraft(nextGain.txGainDbi);
-                              setResourceRxGainDraft(nextGain.rxGainDbi);
-                              void persistResourceAccessSettings(nextGain);
-                            }
-                          }}
-                          type="checkbox"
-                        />
-                        <span>Separate Tx/Rx gain</span>
-                      </label>
-                    </div>
                     {resourceSeparateGain ? (
                       <>
                         <label className="field-grid">
@@ -2606,6 +2586,24 @@ export function Sidebar({
                         />
                       </label>
                     )}
+                    <div className="field-grid gain-mode-toggle">
+                      <span>Separate RX/TX gain</span>
+                      <input
+                        aria-label="Separate RX/TX gain"
+                        checked={resourceSeparateGain}
+                        onChange={(event) => {
+                          const checked = event.target.checked;
+                          setResourceSeparateGain(checked);
+                          if (!checked) {
+                            const nextGain = collapseSiteGainToTx(resourceTxGainDraft);
+                            setResourceTxGainDraft(nextGain.txGainDbi);
+                            setResourceRxGainDraft(nextGain.rxGainDbi);
+                            void persistResourceAccessSettings(nextGain);
+                          }
+                        }}
+                        type="checkbox"
+                      />
+                    </div>
                     <label className="field-grid">
                       <span>Cable loss (dB)</span>
                       <input
@@ -3531,25 +3529,6 @@ export function Sidebar({
                       value={newLibraryTxPowerDbm}
                     />
                   </label>
-                  <div className="field-grid">
-                    <span>Gain mode</span>
-                    <label className="checkbox-field">
-                      <input
-                        checked={newLibrarySeparateGain}
-                        onChange={(event) => {
-                          const checked = event.target.checked;
-                          setNewLibrarySeparateGain(checked);
-                          if (!checked) {
-                            const nextGain = collapseSiteGainToTx(newLibraryTxGainDbi);
-                            setNewLibraryTxGainDbi(nextGain.txGainDbi);
-                            setNewLibraryRxGainDbi(nextGain.rxGainDbi);
-                          }
-                        }}
-                        type="checkbox"
-                      />
-                      <span>Separate Tx/Rx gain</span>
-                    </label>
-                  </div>
                   {newLibrarySeparateGain ? (
                     <>
                       <label className="field-grid">
@@ -3586,6 +3565,23 @@ export function Sidebar({
                       />
                     </label>
                   )}
+                  <div className="field-grid gain-mode-toggle">
+                    <span>Separate RX/TX gain</span>
+                    <input
+                      aria-label="Separate RX/TX gain"
+                      checked={newLibrarySeparateGain}
+                      onChange={(event) => {
+                        const checked = event.target.checked;
+                        setNewLibrarySeparateGain(checked);
+                        if (!checked) {
+                          const nextGain = collapseSiteGainToTx(newLibraryTxGainDbi);
+                          setNewLibraryTxGainDbi(nextGain.txGainDbi);
+                          setNewLibraryRxGainDbi(nextGain.rxGainDbi);
+                        }
+                      }}
+                      type="checkbox"
+                    />
+                  </div>
                   <label className="field-grid">
                     <span>Cable loss (dB)</span>
                     <input

--- a/src/components/SiteBeamVisualizer.test.tsx
+++ b/src/components/SiteBeamVisualizer.test.tsx
@@ -57,15 +57,19 @@ describe("SiteBeamVisualizerPopover", () => {
     expect(screen.getByText("Not to scale, illustration only.")).toBeInTheDocument();
   });
 
-  it("updates the educational budget when form values change", async () => {
+  it("keeps non-real numeric readouts out of the educational preview", async () => {
     render(<Harness />);
 
     const input = screen.getByLabelText("Tx power");
     await userEvent.click(input);
-    expect(await screen.findByText("Budget 23.0 dB")).toBeInTheDocument();
+    expect(await screen.findByText("Pass")).toBeInTheDocument();
+    expect(screen.getByText("Fail")).toBeInTheDocument();
+    expect(screen.queryByText(/Budget/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Width/i)).not.toBeInTheDocument();
 
     await userEvent.clear(input);
     await userEvent.type(input, "28");
-    expect(await screen.findByText("Budget 31.0 dB")).toBeInTheDocument();
+    expect(screen.queryByText(/Budget/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Width/i)).not.toBeInTheDocument();
   });
 });

--- a/src/components/SiteBeamVisualizer.tsx
+++ b/src/components/SiteBeamVisualizer.tsx
@@ -39,7 +39,7 @@ export function SiteBeamVisualizer({ values }: SiteBeamVisualizerProps) {
     <div
       className="beam-visualizer"
       role="img"
-      aria-label={`Educational beam preview: ${metrics.rangeLabel.toLowerCase()} relative range, ${metrics.beamWidthDeg} deg relative beam width.`}
+      aria-label={`Educational beam preview: ${metrics.rangeLabel.toLowerCase()} relative range with stronger and weaker illustrated beam areas.`}
     >
       <div className="beam-visualizer-header">
         <strong>Beam preview</strong>
@@ -56,26 +56,14 @@ export function SiteBeamVisualizer({ values }: SiteBeamVisualizerProps) {
         ))}
         <circle className="beam-visualizer-origin" cx={cx} cy={cy} r="5" />
       </svg>
-      <div className="beam-visualizer-stats">
-        <span>Width {metrics.beamWidthDeg} deg</span>
-        <span>Budget {metrics.linkBudgetScoreDb.toFixed(1)} dB</span>
-      </div>
       <ul className="beam-visualizer-legend">
         <li>
           <StateDot state="pass_clear" />
-          <span>Strong core</span>
-        </li>
-        <li>
-          <StateDot state="pass_blocked" />
-          <span>Usable</span>
-        </li>
-        <li>
-          <StateDot state="fail_clear" />
-          <span>Marginal</span>
+          <span>Pass</span>
         </li>
         <li>
           <StateDot state="fail_blocked" />
-          <span>Weak edge</span>
+          <span>Fail</span>
         </li>
       </ul>
       <p className="field-help beam-visualizer-note">Not to scale, illustration only.</p>

--- a/src/index.css
+++ b/src/index.css
@@ -551,6 +551,11 @@ input {
   font-family: "IBM Plex Mono", monospace;
 }
 
+.gain-mode-toggle input {
+  justify-self: end;
+  width: auto;
+}
+
 .field-grid textarea {
   border: 1px solid var(--border);
   background: var(--surface);
@@ -2469,22 +2474,16 @@ input {
   color: var(--text);
 }
 
-.beam-visualizer-header,
-.beam-visualizer-stats {
+.beam-visualizer-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 10px;
 }
 
-.beam-visualizer-header span,
-.beam-visualizer-stats {
+.beam-visualizer-header span {
   color: var(--muted);
   font-size: 0.75rem;
-}
-
-.beam-visualizer-stats {
-  font-family: "IBM Plex Mono", monospace;
 }
 
 .beam-visualizer-chart {


### PR DESCRIPTION
## Summary
- Move the separate RX/TX gain toggle below the gain input(s) in Add Site and Edit Site RF sections
- Rename toggle label to `Separate RX/TX gain` and keep the checkbox right-aligned
- Remove non-real numeric readouts (width/budget) from the beam popover
- Simplify legend copy to `Pass` and `Fail` to avoid implying hard thresholds

## Tests
- npm test
- npm run build

Refs #107
