### PR TITLE
feat: add heltec baseline outline to beam preview

### DIFF
--- a/src/components/SiteBeamVisualizer.test.tsx
+++ b/src/components/SiteBeamVisualizer.test.tsx
@@ -54,6 +54,7 @@ describe("SiteBeamVisualizerPopover", () => {
 
     await userEvent.click(screen.getByLabelText("Tx power"));
     expect(await screen.findByText("Beam preview")).toBeInTheDocument();
+    expect(screen.getByText(/Gray outline: Heltec v3 baseline/)).toBeInTheDocument();
     expect(screen.getByText("Not to scale, illustration only.")).toBeInTheDocument();
   });
 

--- a/src/components/SiteBeamVisualizer.tsx
+++ b/src/components/SiteBeamVisualizer.tsx
@@ -31,9 +31,21 @@ const sectorPath = (cx: number, cy: number, radius: number, widthDeg: number): s
 
 export function SiteBeamVisualizer({ values }: SiteBeamVisualizerProps) {
   const metrics = useMemo(() => computeBeamPreviewMetrics(values), [values]);
+  const heltecBaselineMetrics = useMemo(
+    () =>
+      computeBeamPreviewMetrics({
+        antennaHeightM: values.antennaHeightM,
+        txPowerDbm: 22,
+        txGainDbi: 2,
+        rxGainDbi: 2,
+        cableLossDb: 1,
+      }),
+    [values.antennaHeightM],
+  );
   const cx = 110;
   const cy = 116;
   const maxRadius = 96 * metrics.rangeScore;
+  const baselineRadius = 96 * heltecBaselineMetrics.rangeScore;
 
   return (
     <div
@@ -54,6 +66,10 @@ export function SiteBeamVisualizer({ values }: SiteBeamVisualizerProps) {
             key={band.state}
           />
         ))}
+        <path
+          className="beam-visualizer-baseline"
+          d={sectorPath(cx, cy, baselineRadius, heltecBaselineMetrics.beamWidthDeg)}
+        />
         <circle className="beam-visualizer-origin" cx={cx} cy={cy} r="5" />
       </svg>
       <ul className="beam-visualizer-legend">
@@ -66,6 +82,9 @@ export function SiteBeamVisualizer({ values }: SiteBeamVisualizerProps) {
           <span>Fail</span>
         </li>
       </ul>
+      <p className="field-help beam-visualizer-baseline-note">
+        Gray outline: Heltec v3 baseline (22 dBm, 2 dBi, 1 dB cable loss).
+      </p>
       <p className="field-help beam-visualizer-note">Not to scale, illustration only.</p>
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -2507,6 +2507,13 @@ input {
   stroke-width: 1;
 }
 
+.beam-visualizer-baseline {
+  fill: none;
+  stroke: color-mix(in srgb, var(--muted) 72%, var(--surface));
+  stroke-width: 1.4;
+  stroke-dasharray: 4 3;
+}
+
 .beam-visualizer-band-pass_clear {
   fill: color-mix(in srgb, var(--state-pass-clear) 72%, transparent);
 }
@@ -2547,6 +2554,10 @@ input {
 }
 
 .beam-visualizer-note {
+  margin: 0;
+}
+
+.beam-visualizer-baseline-note {
   margin: 0;
 }
 


### PR DESCRIPTION
## Summary
- Add a gray dashed comparison outline in the educational beam visualizer for a Heltec v3 baseline
- Baseline parameters are fixed to 22 dBm TX power, 2 dBi TX/RX gain, and 1 dB cable loss
- Keep the baseline educational by drawing only a shape overlay and a short caption

## Tests
- npm test -- --run src/components/SiteBeamVisualizer.test.tsx src/lib/beamVisualizer.test.ts
- npm run build

Refs #107
