### PR TITLE
tweak heltec baseline assumption and copy

### DIFF
--- a/src/components/SiteBeamVisualizer.test.tsx
+++ b/src/components/SiteBeamVisualizer.test.tsx
@@ -54,7 +54,7 @@ describe("SiteBeamVisualizerPopover", () => {
 
     await userEvent.click(screen.getByLabelText("Tx power"));
     expect(await screen.findByText("Beam preview")).toBeInTheDocument();
-    expect(screen.getByText(/Gray outline: Heltec v3 baseline/)).toBeInTheDocument();
+    expect(screen.getByText("Gray outline: Typical Heltec V3 setup")).toBeInTheDocument();
     expect(screen.getByText("Not to scale, illustration only.")).toBeInTheDocument();
   });
 

--- a/src/components/SiteBeamVisualizer.tsx
+++ b/src/components/SiteBeamVisualizer.tsx
@@ -34,13 +34,13 @@ export function SiteBeamVisualizer({ values }: SiteBeamVisualizerProps) {
   const heltecBaselineMetrics = useMemo(
     () =>
       computeBeamPreviewMetrics({
-        antennaHeightM: values.antennaHeightM,
+        antennaHeightM: 2,
         txPowerDbm: 22,
         txGainDbi: 2,
         rxGainDbi: 2,
         cableLossDb: 1,
       }),
-    [values.antennaHeightM],
+    [],
   );
   const cx = 110;
   const cy = 116;
@@ -83,7 +83,7 @@ export function SiteBeamVisualizer({ values }: SiteBeamVisualizerProps) {
         </li>
       </ul>
       <p className="field-help beam-visualizer-baseline-note">
-        Gray outline: Heltec v3 baseline (22 dBm, 2 dBi, 1 dB cable loss).
+        Gray outline: Typical Heltec V3 setup
       </p>
       <p className="field-help beam-visualizer-note">Not to scale, illustration only.</p>
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -2510,7 +2510,7 @@ input {
 .beam-visualizer-baseline {
   fill: none;
   stroke: color-mix(in srgb, var(--muted) 72%, var(--surface));
-  stroke-width: 1.4;
+  stroke-width: 0.9;
   stroke-dasharray: 4 3;
 }
 


### PR DESCRIPTION
## Summary
- Set the Heltec baseline assumption to a fixed 2 m antenna height in the beam visualizer
- Update baseline caption to `Gray outline: Typical Heltec V3 setup`
- Make the baseline outline thinner

## Tests
- npm test -- --run src/components/SiteBeamVisualizer.test.tsx src/lib/beamVisualizer.test.ts
- npm run build

Refs #107
