### PR TITLE
chore: rename heltec baseline label

### DIFF
--- a/src/components/SiteBeamVisualizer.test.tsx
+++ b/src/components/SiteBeamVisualizer.test.tsx
@@ -54,7 +54,7 @@ describe("SiteBeamVisualizerPopover", () => {
 
     await userEvent.click(screen.getByLabelText("Tx power"));
     expect(await screen.findByText("Beam preview")).toBeInTheDocument();
-    expect(screen.getByText("Gray outline: Typical Heltec V3 setup")).toBeInTheDocument();
+    expect(screen.getByText("Outline: Typical Heltec V3 setup")).toBeInTheDocument();
     expect(screen.getByText("Not to scale, illustration only.")).toBeInTheDocument();
   });
 

--- a/src/components/SiteBeamVisualizer.tsx
+++ b/src/components/SiteBeamVisualizer.tsx
@@ -82,9 +82,7 @@ export function SiteBeamVisualizer({ values }: SiteBeamVisualizerProps) {
           <span>Fail</span>
         </li>
       </ul>
-      <p className="field-help beam-visualizer-baseline-note">
-        Gray outline: Typical Heltec V3 setup
-      </p>
+      <p className="field-help beam-visualizer-baseline-note">Outline: Typical Heltec V3 setup</p>
       <p className="field-help beam-visualizer-note">Not to scale, illustration only.</p>
     </div>
   );


### PR DESCRIPTION
## Summary
- Rename baseline caption from `Gray outline: ...` to `Outline: Typical Heltec V3 setup`
- Keep behavior and rendering unchanged

## Tests
- npm test -- --run src/components/SiteBeamVisualizer.test.tsx
- npm run build

Refs #107
