### PR TITLE
feat(ui): unify button system — btn/btn-ghost/btn-icon CSS + Button component (#616)

### DIFF
--- a/src/components/ActionButton.tsx
+++ b/src/components/ActionButton.tsx
@@ -1,25 +1,11 @@
 import type { ButtonHTMLAttributes, ReactNode } from "react";
-import clsx from "clsx";
+import { Button } from "./ui/Button";
 
 type ActionButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   children: ReactNode;
   variant?: "default" | "danger";
 };
 
-export function ActionButton({
-  children,
-  className,
-  type = "button",
-  variant = "default",
-  ...buttonProps
-}: ActionButtonProps) {
-  return (
-    <button
-      {...buttonProps}
-      className={clsx("inline-action", "action-button", variant === "danger" && "danger", className)}
-      type={type}
-    >
-      {children}
-    </button>
-  );
+export function ActionButton({ variant = "default", ...props }: ActionButtonProps) {
+  return <Button variant={variant} {...props} />;
 }

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -29,6 +29,7 @@ import { useAppStore } from "../store/appStore";
 import { LinkProfileChart } from "./LinkProfileChart";
 import { PanoramaChart } from "./PanoramaChart";
 import { ActionButton } from "./ActionButton";
+import { MapControlButton } from "./ui/MapControlButton";
 import { InlineCloseIconButton } from "./InlineCloseIconButton";
 import { MapView } from "./MapView";
 import { ModalOverlay } from "./ModalOverlay";
@@ -1784,38 +1785,32 @@ export function AppShell() {
   }, [activeSimulation, clearNotifications, copyCurrentLink, publishAppNotice]);
 
   const panelSizeControls = useCallback(
-    (labelPrefix: string, variant: "map" | "chart" = "map") => (
+    (labelPrefix: string) => (
       <div className="panel-size-controls">
         {mobileBottomPanelMode === "full" ? (
-          <button
+          <MapControlButton
             aria-label={`Set ${labelPrefix} panel to normal size`}
-            className={variant === "chart" ? "chart-endpoint-swap chart-endpoint-icon" : "map-control-btn map-control-btn-icon"}
             onClick={() => setMobileBottomPanelVisibility("normal")}
             title="Normal size"
-            type="button"
           >
             <PanelBottomClose aria-hidden="true" strokeWidth={1.8} />
-          </button>
+          </MapControlButton>
         ) : (
           <>
-            <button
+            <MapControlButton
               aria-label={`Hide ${labelPrefix} panel`}
-              className={variant === "chart" ? "chart-endpoint-swap chart-endpoint-icon" : "map-control-btn map-control-btn-icon"}
               onClick={() => setMobileBottomPanelVisibility("hidden")}
               title="Hide panel"
-              type="button"
             >
               <PanelBottomClose aria-hidden="true" strokeWidth={1.8} />
-            </button>
-            <button
+            </MapControlButton>
+            <MapControlButton
               aria-label={`Expand ${labelPrefix} panel to full height`}
-              className={variant === "chart" ? "chart-endpoint-swap chart-endpoint-icon" : "map-control-btn map-control-btn-icon"}
               onClick={() => setMobileBottomPanelVisibility("full")}
               title="Full size"
-              type="button"
             >
               <PanelBottomOpen aria-hidden="true" strokeWidth={1.8} />
-            </button>
+            </MapControlButton>
           </>
         )}
       </div>
@@ -1951,37 +1946,34 @@ export function AppShell() {
       {!isMobileViewport && !isMapExpanded && !isProfileExpanded && (isNavigatorHidden || isInspectorHidden || isProfileHidden) ? (
         <div className="collapsed-panel-controls" aria-label="Restore hidden panels">
           {isNavigatorHidden ? (
-            <button
+            <MapControlButton
               aria-label="Show Navigator panel"
-              className="map-control-btn map-control-btn-icon collapsed-panel-btn collapsed-panel-btn-navigator"
+              className="collapsed-panel-btn collapsed-panel-btn-navigator"
               onClick={showNavigatorPanel}
               title="Show Navigator"
-              type="button"
             >
-<PanelLeftOpen aria-hidden="true" strokeWidth={1.8} />
-            </button>
+              <PanelLeftOpen aria-hidden="true" strokeWidth={1.8} />
+            </MapControlButton>
           ) : null}
           {isInspectorHidden ? (
-            <button
+            <MapControlButton
               aria-label="Show Inspector panel"
-              className="map-control-btn map-control-btn-icon collapsed-panel-btn collapsed-panel-btn-inspector"
+              className="collapsed-panel-btn collapsed-panel-btn-inspector"
               onClick={showInspectorPanel}
               title="Show Inspector"
-              type="button"
             >
-<PanelRightOpen aria-hidden="true" strokeWidth={1.8} />
-            </button>
+              <PanelRightOpen aria-hidden="true" strokeWidth={1.8} />
+            </MapControlButton>
           ) : null}
           {isProfileHidden ? (
-            <button
+            <MapControlButton
               aria-label="Show Profile panel"
-              className="map-control-btn map-control-btn-icon collapsed-panel-btn collapsed-panel-btn-profile"
+              className="collapsed-panel-btn collapsed-panel-btn-profile"
               onClick={showProfilePanel}
               title="Show Profile"
-              type="button"
             >
-<PanelBottomOpen aria-hidden="true" strokeWidth={1.8} />
-            </button>
+              <PanelBottomOpen aria-hidden="true" strokeWidth={1.8} />
+            </MapControlButton>
           ) : null}
         </div>
       ) : null}
@@ -2068,9 +2060,8 @@ export function AppShell() {
           inspectorHeaderActions={
             <div className="map-inspector-header-actions">
               {!isMobileViewport ? (
-                <button
+                <MapControlButton
                   aria-label={isInspectorHidden ? "Show Inspector panel" : "Hide Inspector panel"}
-                  className="map-control-btn map-control-btn-icon"
                   onClick={() => {
                     if (isInspectorHidden) {
                       showInspectorPanel();
@@ -2079,22 +2070,19 @@ export function AppShell() {
                     hideInspectorPanel();
                   }}
                   title={isInspectorHidden ? "Show Inspector" : "Hide Inspector"}
-                  type="button"
                 >
                   {isInspectorHidden ? <PanelRightOpen aria-hidden="true" strokeWidth={1.8} /> : <PanelRightClose aria-hidden="true" strokeWidth={1.8} />}
-                </button>
+                </MapControlButton>
               ) : null}
               <div className="map-inspector-header-actions-right">
                 {accessState === "granted" ? (
-                  <button
+                  <MapControlButton
                     aria-label="Share"
-                    className="map-control-btn map-control-btn-icon"
                     onClick={openShareModalOrCopy}
                     title="Share"
-                    type="button"
                   >
                     <Share aria-hidden="true" strokeWidth={1.8} />
-                  </button>
+                  </MapControlButton>
                 ) : null}
                 {isMobileViewport ? panelSizeControls("Inspector") : null}
               </div>
@@ -2130,9 +2118,8 @@ export function AppShell() {
             onToggleExpanded={toggleProfileExpanded}
             rowControls={
               isProfileExpanded ? null :
-              <button
+              <MapControlButton
                 aria-label={isProfileHidden ? "Show Profile panel" : "Hide Profile panel"}
-                className="chart-endpoint-swap chart-endpoint-icon"
                 onClick={() => {
                   if (isProfileHidden) {
                     showProfilePanel();
@@ -2142,10 +2129,9 @@ export function AppShell() {
                   hideProfilePanel();
                 }}
                 title={isProfileHidden ? "Show Profile" : "Hide Profile"}
-                type="button"
               >
                 {isProfileHidden ? <PanelBottomOpen aria-hidden="true" strokeWidth={1.8} /> : <PanelBottomClose aria-hidden="true" strokeWidth={1.8} />}
-              </button>
+              </MapControlButton>
             }
             panelClassName={profilePanelMotionClass}
             showExpandToggle
@@ -2156,9 +2142,8 @@ export function AppShell() {
             onToggleExpanded={toggleProfileExpanded}
             rowControls={
               isProfileExpanded ? null :
-              <button
+              <MapControlButton
                 aria-label={isProfileHidden ? "Show Profile panel" : "Hide Profile panel"}
-                className="chart-endpoint-swap chart-endpoint-icon"
                 onClick={() => {
                   if (isProfileHidden) {
                     showProfilePanel();
@@ -2168,10 +2153,9 @@ export function AppShell() {
                   hideProfilePanel();
                 }}
                 title={isProfileHidden ? "Show Profile" : "Hide Profile"}
-                type="button"
               >
                 {isProfileHidden ? <PanelBottomOpen aria-hidden="true" strokeWidth={1.8} /> : <PanelBottomClose aria-hidden="true" strokeWidth={1.8} />}
-              </button>
+              </MapControlButton>
             }
             panelClassName={profilePanelMotionClass}
             showExpandToggle
@@ -2189,14 +2173,14 @@ export function AppShell() {
               <PanoramaChart
                 isExpanded={mobileBottomPanelMode === "full"}
                 onToggleExpanded={toggleProfileExpanded}
-                rowControls={panelSizeControls("Profile", "chart")}
+                rowControls={panelSizeControls("Profile")}
                 showExpandToggle={false}
               />
             ) : (
               <LinkProfileChart
                 isExpanded={mobileBottomPanelMode === "full"}
                 onToggleExpanded={toggleProfileExpanded}
-                rowControls={panelSizeControls("Profile", "chart")}
+                rowControls={panelSizeControls("Profile")}
                 showExpandToggle={false}
               />
             )}
@@ -2327,15 +2311,13 @@ export function AppShell() {
                 <p className="field-help">This link opens the same simulation, selected path, map view, and overlay mode.</p>
                 <div style={{ display: "flex", gap: "0.5em", alignItems: "center" }}>
                   <input className="locale-select" readOnly style={{ flex: 1, minWidth: 0 }} value={currentShareLink} />
-                  <button
+                  <MapControlButton
                     aria-label="Copy link"
-                    className="inline-action inline-action-icon"
                     onClick={() => void copyCurrentLink()}
                     title="Copy link"
-                    type="button"
                   >
                     <Copy aria-hidden="true" strokeWidth={1.8} />
-                  </button>
+                  </MapControlButton>
                 </div>
                 {toVisibility(activeSimulation.visibility) === "private" ? (
                   <div className="panel-section compact-panel">

--- a/src/components/InlineCloseIconButton.tsx
+++ b/src/components/InlineCloseIconButton.tsx
@@ -1,4 +1,5 @@
 import { CircleX } from "lucide-react";
+import { Button } from "./ui/Button";
 
 type InlineCloseIconButtonProps = {
   onClick: () => void;
@@ -6,8 +7,8 @@ type InlineCloseIconButtonProps = {
 
 export function InlineCloseIconButton({ onClick }: InlineCloseIconButtonProps) {
   return (
-    <button aria-label="Close" className="inline-action inline-action-icon" onClick={onClick} title="Close" type="button">
+    <Button aria-label="Close" size="icon" onClick={onClick} title="Close">
       <CircleX aria-hidden="true" strokeWidth={1.8} />
-    </button>
+    </Button>
   );
 }

--- a/src/components/LinkProfileChart.tsx
+++ b/src/components/LinkProfileChart.tsx
@@ -2,6 +2,7 @@ import { extent, max } from "d3-array";
 import { scaleLinear } from "d3-scale";
 import { ArrowLeftRight, PanelBottomClose, PanelBottomOpen } from "lucide-react";
 import { FloatingPopover } from "./ui/FloatingPopover";
+import { MapControlButton } from "./ui/MapControlButton";
 import type { MouseEvent } from "react";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
@@ -727,25 +728,23 @@ export function LinkProfileChart({
           <span className="chart-endpoint chart-endpoint-right">{toSiteName}</span>
         </div>
         <div className="chart-action-row-controls">
-          <button
+          <MapControlButton
             aria-label="Reverse path direction for this view"
-            className={`chart-endpoint-swap chart-endpoint-icon ${temporaryDirectionReversed ? "is-active" : ""}`}
+            isSelected={temporaryDirectionReversed}
             onClick={toggleTemporaryDirectionReversed}
             title="Temporarily reverse path direction"
-            type="button"
           >
             <ArrowLeftRight aria-hidden="true" strokeWidth={1.8} />
-          </button>
+          </MapControlButton>
           {showExpandToggle ? (
-            <button
+            <MapControlButton
               aria-label={isExpanded ? "Exit full screen" : "Full screen"}
-              className={`chart-endpoint-swap chart-endpoint-icon ${isExpanded ? "is-active" : ""}`}
+              isSelected={isExpanded}
               onClick={onToggleExpanded}
               title={isExpanded ? "Exit full screen" : "Full screen"}
-              type="button"
             >
               {isExpanded ? <PanelBottomClose aria-hidden="true" strokeWidth={1.8} /> : <PanelBottomOpen aria-hidden="true" strokeWidth={1.8} />}
-            </button>
+            </MapControlButton>
           ) : null}
           {rowControls}
         </div>

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent, type ReactNode } from "react";
 import { Egg, Fullscreen, Maximize2, Minimize2, Rabbit, RefreshCw, SquareStack, ZoomIn, ZoomOut } from "lucide-react";
 import { CompactDetails, CompactDetailsSummary } from "./ui/CompactDetails";
+import { MapControlButton } from "./ui/MapControlButton";
 import { Surface } from "./ui/Surface";
 import Map, {
   Layer,
@@ -2398,40 +2399,37 @@ export function MapView({
       <div className="map-controls map-controls-unified map-controls-icon-only">
         <div className="map-controls-group map-controls-group-utility map-controls-utility-pill ui-surface-pill">
           {showMultiSelectToggle ? (
-            <button
+            <MapControlButton
               aria-label={isMultiSelectMode ? "Disable multi-select" : "Enable multi-select"}
-              className={`map-control-btn map-control-btn-icon ${isMultiSelectMode ? "is-selected" : ""}`}
+              isSelected={isMultiSelectMode}
               onClick={() => setIsMultiSelectMode((current) => !current)}
               title={isMultiSelectMode ? "Multi-select On" : "Multi-select Off"}
-              type="button"
             >
               <SquareStack aria-hidden="true" strokeWidth={1.8} />
-            </button>
+            </MapControlButton>
           ) : null}
-          <button aria-label="Zoom out" className="map-control-btn map-control-btn-icon" onClick={() => zoomBy(-1)} title="Zoom out" type="button">
+          <MapControlButton aria-label="Zoom out" onClick={() => zoomBy(-1)} title="Zoom out">
             <ZoomOut aria-hidden="true" strokeWidth={1.8} />
-          </button>
-          <button aria-label="Zoom in" className="map-control-btn map-control-btn-icon" onClick={() => zoomBy(1)} title="Zoom in" type="button">
+          </MapControlButton>
+          <MapControlButton aria-label="Zoom in" onClick={() => zoomBy(1)} title="Zoom in">
             <ZoomIn aria-hidden="true" strokeWidth={1.8} />
-          </button>
-          <button
+          </MapControlButton>
+          <MapControlButton
             aria-label="Fit map to sites"
-            className={`map-control-btn map-control-btn-icon ${fitControlActive ? "is-selected" : ""}`}
+            isSelected={fitControlActive}
             onClick={fitToNodes}
             title="Fit"
-            type="button"
           >
             <Fullscreen aria-hidden="true" strokeWidth={1.8} />
-          </button>
-          <button
+          </MapControlButton>
+          <MapControlButton
             aria-label={isMapExpanded ? "Show panels" : "Hide panels"}
-            className={`map-control-btn map-control-btn-icon ${isMapExpanded ? "is-selected" : ""}`}
+            isSelected={isMapExpanded}
             onClick={onToggleMapExpanded}
             title={isMapExpanded ? "Show panels" : "Hide panels"}
-            type="button"
           >
             {isMapExpanded ? <Minimize2 aria-hidden="true" strokeWidth={1.8} /> : <Maximize2 aria-hidden="true" strokeWidth={1.8} />}
-          </button>
+          </MapControlButton>
         </div>
       </div>
       {notice ? (
@@ -2786,20 +2784,19 @@ export function MapView({
                 <div className="overlay-inline-controls">
                   <span>Style</span>
                   <div className="chip-group">
-                    <button
-                      className="map-control-btn is-selected"
+                    <MapControlButton
+                      isSelected
                       onClick={() => setCoverageVizMode("heatmap")}
-                      type="button"
+                      variant="labeled"
                     >
                       Smooth
-                    </button>
-                    <button
-                      className="map-control-btn"
+                    </MapControlButton>
+                    <MapControlButton
                       onClick={() => setCoverageVizMode("contours")}
-                      type="button"
+                      variant="labeled"
                     >
                       Bands
-                    </button>
+                    </MapControlButton>
                   </div>
                 </div>
                 <div className="overlay-scale">
@@ -2818,20 +2815,19 @@ export function MapView({
                 <div className="overlay-inline-controls">
                   <span>Style</span>
                   <div className="chip-group">
-                    <button
-                      className="map-control-btn"
+                    <MapControlButton
                       onClick={() => setCoverageVizMode("heatmap")}
-                      type="button"
+                      variant="labeled"
                     >
                       Smooth
-                    </button>
-                    <button
-                      className="map-control-btn is-selected"
+                    </MapControlButton>
+                    <MapControlButton
+                      isSelected
                       onClick={() => setCoverageVizMode("contours")}
-                      type="button"
+                      variant="labeled"
                     >
                       Bands
-                    </button>
+                    </MapControlButton>
                   </div>
                 </div>
                 <div className="overlay-inline-controls">

--- a/src/components/PanoramaChart.tsx
+++ b/src/components/PanoramaChart.tsx
@@ -1,5 +1,6 @@
 import { scaleLinear } from "d3-scale";
 import { FloatingPopover } from "./ui/FloatingPopover";
+import { MapControlButton } from "./ui/MapControlButton";
 import { StateDot } from "./StateDot";
 import { Info, MapPinned, Paintbrush, PanelBottomClose, PanelBottomOpen, Mountain, MountainSnow, RadioTower, Settings, Tags } from "lucide-react";
 import type { CSSProperties, MouseEvent as ReactMouseEvent, ReactNode } from "react";
@@ -1413,36 +1414,33 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
       <div className="chart-top-row">
         <h3 className="panorama-header-title">Panorama from {selectedSiteEffective.name}</h3>
         <div className="chart-action-row-controls">
-          <button
+          <MapControlButton
             aria-label="Panorama settings"
-            className={`chart-endpoint-swap chart-endpoint-icon ${settingsPopoverOpen ? "is-active" : ""}`}
+            isSelected={settingsPopoverOpen}
             onClick={() => setSettingsPopoverOpen((v) => !v)}
             ref={settingsButtonRef}
             title="Settings"
-            type="button"
           >
             <Settings aria-hidden="true" strokeWidth={1.8} />
-          </button>
-          <button
+          </MapControlButton>
+          <MapControlButton
             aria-label="Legend"
-            className={`chart-endpoint-swap chart-endpoint-icon ${legendPopoverOpen ? "is-active" : ""}`}
+            isSelected={legendPopoverOpen}
             onClick={() => setLegendPopoverOpen((v) => !v)}
             ref={legendButtonRef}
             title="Legend"
-            type="button"
           >
             <Info aria-hidden="true" strokeWidth={1.8} />
-          </button>
+          </MapControlButton>
           {showExpandToggle ? (
-            <button
+            <MapControlButton
               aria-label={isExpanded ? "Exit full screen" : "Full screen"}
-              className={`chart-endpoint-swap chart-endpoint-icon ${isExpanded ? "is-active" : ""}`}
+              isSelected={isExpanded}
               onClick={onToggleExpanded}
               title={isExpanded ? "Exit full screen" : "Full screen"}
-              type="button"
             >
               {isExpanded ? <PanelBottomClose aria-hidden="true" strokeWidth={1.8} /> : <PanelBottomOpen aria-hidden="true" strokeWidth={1.8} />}
-            </button>
+            </MapControlButton>
           ) : null}
           {rowControls}
         </div>

--- a/src/components/UiGalleryPage.tsx
+++ b/src/components/UiGalleryPage.tsx
@@ -4,6 +4,8 @@ import { ActionButton } from "./ActionButton";
 import { StateDot } from "./StateDot";
 import { Surface } from "./ui/Surface";
 import { Badge } from "./ui/Badge";
+import { Button } from "./ui/Button";
+import { MapControlButton } from "./ui/MapControlButton";
 import { UiSlider } from "./UiSlider";
 import { SiteBeamVisualizer } from "./SiteBeamVisualizer";
 import { useThemeVariant } from "../hooks/useThemeVariant";
@@ -26,8 +28,9 @@ const GALLERY_TABS: Array<{ id: GalleryTab; label: string }> = [
 ];
 
 const SOURCE_PATHS: Record<string, string> = {
+  "Button": "src/components/ui/Button.tsx",
   "ActionButton": "src/components/ActionButton.tsx",
-  "MapControlButton": "src/components/MapControlButton.tsx",
+  "MapControlButton": "src/components/ui/MapControlButton.tsx",
   "LinkButton": "src/components/LinkButton.tsx",
   "PanelShell.LeftSidePanel": "src/components/app-shell/LeftSidePanel.tsx",
   "PanelShell.RightSidePanel": "src/components/app-shell/RightSidePanel.tsx",
@@ -284,26 +287,28 @@ export function UiGalleryPage() {
         <section className="ui-gallery-section">
           <h3>Actions</h3>
           <div className="ui-pattern-grid">
-            <PatternCard name="ActionButton" status="under migration">
+            <PatternCard name="Button" status="standard">
               <div className="chip-group">
-                <ActionButton>Save Selected Path</ActionButton>
-                <ActionButton>Details</ActionButton>
-                <ActionButton variant="danger">Remove From Simulation</ActionButton>
+                <Button>Save Selected Path</Button>
+                <Button>Details</Button>
+                <Button variant="danger">Remove From Simulation</Button>
               </div>
-              <VariantList variants={["default", "variant=\"danger\""]} />
-            </PatternCard>
-            <PatternCard name="MapControlButton" status="standard">
               <div className="chip-group">
-                <button aria-label="Zoom out" className="map-control-btn map-control-btn-icon" title="Zoom out" type="button">
+                <Button variant="ghost">Smooth</Button>
+                <Button variant="ghost" isSelected>Bands</Button>
+              </div>
+              <div className="chip-group">
+                <Button size="icon" aria-label="Zoom out" title="Zoom out">
                   <Minus aria-hidden="true" size={16} strokeWidth={1.8} />
-                </button>
-                <button aria-label="Zoom in" className="map-control-btn map-control-btn-icon" title="Zoom in" type="button">
+                </Button>
+                <Button size="icon" aria-label="Zoom in" title="Zoom in">
                   <Plus aria-hidden="true" size={16} strokeWidth={1.8} />
-                </button>
-                <button aria-label="Fit bounds" className="map-control-btn map-control-btn-icon" title="Fit bounds" type="button">
+                </Button>
+                <Button size="icon" isSelected aria-label="Fit bounds" title="Fit bounds (selected)">
                   <Maximize2 aria-hidden="true" size={16} strokeWidth={1.8} />
-                </button>
+                </Button>
               </div>
+              <VariantList variants={["default", "variant=\"ghost\"", "variant=\"danger\"", "size=\"icon\"", "isSelected"]} />
             </PatternCard>
             <PatternCard name="LinkButton" status="exception">
               <button className="inline-link-button" type="button">
@@ -344,9 +349,9 @@ export function UiGalleryPage() {
                   <div className="map-inspector-header-actions">
                     <strong>Inspector</strong>
                     <div className="map-inspector-header-actions-right">
-                      <button className="map-control-btn map-control-btn-icon" title="Hide panel" type="button">
+                      <MapControlButton title="Hide panel">
                         <PanelRightClose aria-hidden="true" size={16} strokeWidth={1.8} />
-                      </button>
+                      </MapControlButton>
                     </div>
                   </div>
                 </div>
@@ -362,9 +367,9 @@ export function UiGalleryPage() {
                     <span>Path Profile</span>
                   </div>
                   <div className="chart-action-row-controls">
-                    <button className="chart-endpoint-swap chart-endpoint-icon" title="Full size" type="button">
+                    <MapControlButton title="Full size">
                       <Maximize2 aria-hidden="true" size={16} strokeWidth={1.8} />
-                    </button>
+                    </MapControlButton>
                   </div>
                 </div>
                 <div className="chart-action-row">
@@ -580,12 +585,12 @@ export function UiGalleryPage() {
             <PatternCard name="MapControls" status="standard">
               <div className="map-controls map-controls-unified">
                 <div className="map-controls-group">
-                  <button className="map-control-btn map-control-btn-icon" title="Layers" type="button">
+                  <MapControlButton title="Layers">
                     <Layers aria-hidden="true" size={16} strokeWidth={1.8} />
-                  </button>
-                  <button className="map-control-btn map-control-btn-icon" title="Refresh" type="button">
+                  </MapControlButton>
+                  <MapControlButton title="Refresh">
                     <RefreshCw aria-hidden="true" size={16} strokeWidth={1.8} />
-                  </button>
+                  </MapControlButton>
                 </div>
               </div>
             </PatternCard>

--- a/src/components/UserAdminPanel.tsx
+++ b/src/components/UserAdminPanel.tsx
@@ -1281,7 +1281,7 @@ export function UserAdminPanel({
             <div className="user-settings-layout">
               <div className="user-settings-avatar-column">
                 <ProfileAvatar avatarUrl={avatarDraft} name={nameDraft || "User"} size="large" />
-                <label className="upload-button">
+                <label className="btn-ghost upload-button">
                   Upload Picture
                   <input accept="image/*" onChange={(event) => void onUploadAvatar(event)} type="file" />
                 </label>

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,37 @@
+import clsx from "clsx";
+import { forwardRef } from "react";
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+
+type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  /** "default" = accent-filled CTA. "ghost" = glass-surface toggle. "danger" = destructive action. */
+  variant?: "default" | "ghost" | "danger";
+  /** "default" = labeled button. "icon" = 34×34 transparent icon-only (no variant base styles). */
+  size?: "default" | "icon";
+  /** Applies .is-selected: accent-soft bg, accent-tinted border. */
+  isSelected?: boolean;
+  children: ReactNode;
+};
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ variant = "default", size = "default", isSelected = false, className, type = "button", children, ...rest }, ref) => (
+    <button
+      ref={ref}
+      type={type}
+      className={clsx(
+        size === "icon"
+          ? "btn-icon"
+          : variant === "ghost"
+            ? "btn-ghost"
+            : "btn",
+        variant === "danger" && size !== "icon" && "btn-danger",
+        isSelected && "is-selected",
+        className,
+      )}
+      {...rest}
+    >
+      {children}
+    </button>
+  ),
+);
+
+Button.displayName = "Button";

--- a/src/components/ui/MapControlButton.tsx
+++ b/src/components/ui/MapControlButton.tsx
@@ -1,0 +1,25 @@
+import { forwardRef } from "react";
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import { Button } from "./Button";
+
+type MapControlButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  /** "icon" = 34×34 transparent icon-only (default). "labeled" = ghost-style with border. */
+  variant?: "icon" | "labeled";
+  /** Applies .is-selected: accent-soft bg, accent-tinted border. */
+  isSelected?: boolean;
+  children: ReactNode;
+};
+
+export const MapControlButton = forwardRef<HTMLButtonElement, MapControlButtonProps>(
+  ({ variant = "icon", isSelected, ...rest }, ref) => (
+    <Button
+      ref={ref}
+      size={variant === "icon" ? "icon" : "default"}
+      variant={variant === "labeled" ? "ghost" : "default"}
+      isSelected={isSelected}
+      {...rest}
+    />
+  ),
+);
+
+MapControlButton.displayName = "MapControlButton";

--- a/src/index.css
+++ b/src/index.css
@@ -513,24 +513,6 @@ input {
   justify-content: flex-end;
 }
 
-.chip-button {
-  border: 1px solid var(--border);
-  background: var(--surface);
-  border-radius: var(--radius-pill);
-  padding: 5px 12px;
-  color: var(--text);
-  cursor: pointer;
-}
-
-.chip-button:disabled {
-  opacity: 0.55;
-  cursor: not-allowed;
-}
-
-.chip-button.is-selected {
-  border-color: var(--accent);
-  background: var(--accent-soft);
-}
 
 .field-grid {
   display: grid;
@@ -575,21 +557,20 @@ input {
   min-width: 0;
 }
 
-.field-inline-btn {
+.field-inline .btn {
   padding: 6px 8px;
   min-height: 32px;
 }
 
+/* Upload label piggybacks off btn-ghost; only overrides live here */
 .upload-button {
-  border: 1px dashed var(--border);
-  border-radius: 10px;
+  border-style: dashed;
   background: var(--surface);
-  color: var(--text);
   display: inline-flex;
   justify-content: center;
   align-items: center;
   min-height: 38px;
-  cursor: pointer;
+  height: auto;
 }
 
 .upload-button input {
@@ -834,7 +815,7 @@ input {
   pointer-events: auto;
 }
 
-.collapsed-panel-btn.map-control-btn-icon {
+.collapsed-panel-btn.btn-icon {
   width: 36px;
   height: 36px;
   min-width: 36px;
@@ -849,8 +830,8 @@ input {
   justify-content: center;
 }
 
-.collapsed-panel-btn.map-control-btn-icon:hover,
-.collapsed-panel-btn.map-control-btn-icon:focus-visible {
+.collapsed-panel-btn.btn-icon:hover,
+.collapsed-panel-btn.btn-icon:focus-visible {
   border: 1px solid var(--accent);
   background: color-mix(in srgb, var(--surface-2) var(--glass-panel-opacity), transparent);
 }
@@ -1098,7 +1079,7 @@ input {
   border-color: color-mix(in srgb, var(--text) 34%, var(--border));
 }
 
-.map-inline-notice .inline-action {
+.map-inline-notice .btn {
   white-space: nowrap;
   padding: 4px 10px;
 }
@@ -1793,7 +1774,7 @@ input {
   font-size: 0.74rem;
 }
 
-.overlay-inline-controls .map-control-btn {
+.overlay-inline-controls .btn-ghost {
   height: 28px;
   min-width: 72px;
   font-size: 0.72rem;
@@ -1937,7 +1918,7 @@ input {
   border-top: 1px solid color-mix(in srgb, var(--border) 84%, transparent);
 }
 
-.map-control-btn {
+.btn-ghost {
   border: 1px solid var(--border);
   background: color-mix(in srgb, var(--surface-2) 88%, transparent);
   color: var(--text);
@@ -1949,7 +1930,7 @@ input {
   box-shadow: var(--shadow-elev-3);
 }
 
-.map-control-btn-icon {
+.btn-icon {
   min-width: 34px;
   width: 34px;
   height: 34px;
@@ -1960,29 +1941,30 @@ input {
   border: 0;
   background: transparent;
   box-shadow: none;
+  border-radius: var(--radius-pill);
 }
 
-.map-control-btn-icon svg {
+.btn-icon svg {
   width: 18px;
   height: 18px;
 }
 
-.map-control-btn-icon:hover,
-.map-control-btn-icon:focus-visible {
+.btn-icon:hover,
+.btn-icon:focus-visible {
   border: 0;
   background: transparent;
 }
 
-.map-control-btn-icon.is-selected {
+.btn-icon.is-selected {
   background: var(--accent-soft);
   color: color-mix(in srgb, var(--accent) 82%, var(--text));
 }
 
-.map-control-btn:hover {
+.btn-ghost:hover {
   border-color: var(--accent);
 }
 
-.map-control-btn.is-selected {
+.btn-ghost.is-selected {
   border-color: var(--accent);
   background: var(--accent-soft);
 }
@@ -2193,46 +2175,6 @@ input {
   min-height: clamp(280px, 62vh, 760px);
 }
 
-.chart-endpoint-swap {
-  border: 1px solid var(--border);
-  background: color-mix(in srgb, var(--surface-2) 88%, transparent);
-  color: var(--text);
-  border-radius: var(--radius-btn);
-  width: auto;
-  min-width: 118px;
-  height: 26px;
-  padding: 0 10px;
-  line-height: 1.1;
-  cursor: pointer;
-  font-weight: 600;
-  font-size: 0.74rem;
-}
-
-.chart-endpoint-swap:hover {
-  border-color: var(--accent);
-}
-
-.chart-endpoint-swap.is-active {
-  border-color: var(--accent);
-  background: var(--accent-soft);
-}
-
-.chart-endpoint-icon {
-  min-width: 34px;
-  width: 34px;
-  height: 34px;
-  padding: 0;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border: 0;
-  background: transparent;
-}
-
-.chart-endpoint-icon svg {
-  width: 18px;
-  height: 18px;
-}
 
 .chart-hover-state {
   display: flex;
@@ -2329,6 +2271,14 @@ input {
   justify-content: flex-end;
   gap: var(--panel-action-row-gap);
   flex: 0 0 auto;
+}
+
+/* Chart toolbar rows have padding-bottom: 9px, so btn-icon must fit in ~25px content area */
+.chart-top-row .btn-icon,
+.chart-action-row-controls .btn-icon {
+  width: 26px;
+  height: 26px;
+  min-width: 26px;
 }
 
 .chart-action-row-controls .panel-size-controls {
@@ -3369,7 +3319,7 @@ html.panorama-gesture-lock body {
   font-weight: 600;
 }
 
-.inline-action {
+.btn {
   border: 1px solid var(--accent);
   border-radius: var(--radius-btn);
   background: var(--accent-soft);
@@ -3379,9 +3329,6 @@ html.panorama-gesture-lock body {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-}
-
-.action-button {
   font-family: "Space Grotesk", "Avenir Next", sans-serif;
   font-size: 0.82rem;
   font-weight: 600;
@@ -3389,27 +3336,10 @@ html.panorama-gesture-lock body {
   min-height: 34px;
 }
 
-.inline-action.danger {
+.btn-danger {
   border-color: color-mix(in srgb, var(--danger) 78%, var(--border));
   background: var(--danger);
   color: var(--danger-on);
-}
-
-.inline-action-icon {
-  min-width: 34px;
-  width: 34px;
-  height: 34px;
-  padding: 0;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border: 0;
-  background: transparent;
-}
-
-.inline-action-icon svg {
-  width: 18px;
-  height: 18px;
 }
 
 .user-admin-panel {
@@ -3722,23 +3652,6 @@ html.panorama-gesture-lock body {
   font-size: 1.2rem;
 }
 
-.floating-help-button {
-  width: 52px;
-  height: 52px;
-  border-radius: var(--radius-pill);
-  border: 1px solid color-mix(in srgb, var(--accent) 58%, var(--border));
-  background: color-mix(in srgb, var(--accent-soft) 78%, var(--surface));
-  color: var(--text);
-  font-size: 1.4rem;
-  font-weight: 700;
-  line-height: 1;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  box-shadow: var(--shadow-elev-4);
-  z-index: 920;
-}
 
 .floating-help-cluster {
   position: fixed;
@@ -3762,14 +3675,6 @@ html.panorama-gesture-lock body {
   box-shadow: var(--shadow-elev-5);
 }
 
-.floating-help-button:hover {
-  background: color-mix(in srgb, var(--accent-soft) 88%, var(--surface));
-}
-
-.floating-help-button:focus-visible {
-  outline: 2px solid var(--focus-outline);
-  outline-offset: 2px;
-}
 
 .tutorial-report-cta {
   margin-top: 16px;
@@ -4770,7 +4675,7 @@ html.panorama-gesture-lock body {
   color: var(--muted);
 }
 
-.ui-gallery-theme-toggle .action-button[aria-pressed="true"] {
+.ui-gallery-theme-toggle .btn[aria-pressed="true"] {
   border-color: var(--accent);
   background: var(--accent-soft);
 }


### PR DESCRIPTION
## Summary

- Renames CSS classes: `.map-control-btn` → `.btn-ghost`, `.map-control-btn-icon` → `.btn-icon`, `.inline-action` + `.action-button` → `.btn`, `.inline-action.danger` → `.btn-danger`
- Deletes dead CSS: `.chip-button`, `.floating-help-button`, `.chart-endpoint-swap`
- Creates unified `Button` component (`variant=default|ghost|danger`, `size=default|icon`, `isSelected`)
- `ActionButton` and `MapControlButton` now delegate to `Button` internally — all call sites unchanged
- Fixes `InlineCloseIconButton` visual bug (had accidental accent border/background)
- Adds compact chart toolbar override so icon buttons fit the 34px row height
- Gallery updated: `Button` pattern card with all variants

## Visual changes to verify

- **Unchanged (should look identical):** all `ActionButton` call sites, all `MapControlButton` call sites, map controls overlay, sidebar panels
- **Fixed:** modal close buttons no longer have accent border/background — now transparent icon
- **Possibly affected:** panorama chart — investigate whether this was already broken on staging before this branch

## Test plan

- [ ] Path profile renders correctly
- [ ] Panorama chart renders (check if broken on staging *before* this branch too)
- [ ] Map controls (zoom/fit/expand/multiselect) work and show `isSelected` highlight
- [ ] Modal close buttons are plain icons (no filled background)
- [ ] Chart toolbar icon buttons are compact (26px) and don't overflow the header row
- [ ] Upload picture button (UserAdminPanel) looks correct
- [ ] UI Gallery Actions tab shows Button card with all variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)