### PR TITLE
fix(ui): scope chart svg rule to .chart-svg-wrap (#616)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2142,7 +2142,7 @@ input {
   letter-spacing: 0.01em;
 }
 
-.chart-panel svg {
+.chart-svg-wrap svg {
   display: block;
   width: 100%;
   height: 100%;
@@ -2170,7 +2170,7 @@ input {
   min-height: clamp(280px, 62vh, 760px);
 }
 
-.chart-panel.is-expanded svg {
+.chart-panel.is-expanded .chart-svg-wrap svg {
   max-height: none;
   min-height: clamp(280px, 62vh, 760px);
 }
@@ -3094,7 +3094,7 @@ html.panorama-gesture-lock body {
     min-height: 0;
   }
 
-  .mobile-workspace-panel .chart-panel svg {
+  .mobile-workspace-panel .chart-svg-wrap svg {
     min-height: 0;
     max-height: none;
   }


### PR DESCRIPTION
## Summary

- `.chart-panel svg` was hitting all SVGs inside the chart panel — including Lucide icons inside toolbar buttons — overriding `.btn-icon svg { width: 18px; height: 18px }` with `width: 100%; height: 100%`, making icons fill their button containers
- Scoped to `.chart-svg-wrap svg` so only the actual D3/canvas-overlay SVG gets the full-bleed treatment
- Same change applied to `.chart-panel.is-expanded svg` and the mobile variant

## Test plan

- [ ] Panorama chart renders correctly (key risk — was broken locally last attempt)
- [ ] Path profile renders correctly  
- [ ] Chart toolbar icon buttons are correctly sized (18px icons, not filling button)
- [ ] Peak labels still render correctly in panorama

🤖 Generated with [Claude Code](https://claude.com/claude-code)