### PR TITLE
feat(ui): add PanelToolbar component, unify panel toolbar CSS (#616)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -2057,36 +2057,36 @@ export function AppShell() {
           }
           showMultiSelectToggle={isMobileViewport}
           canPersist={canPersistWorkspace}
-          inspectorHeaderActions={
-            <div className="map-inspector-header-actions">
-              {!isMobileViewport ? (
+          inspectorPanelToggle={
+            !isMobileViewport ? (
+              <MapControlButton
+                aria-label={isInspectorHidden ? "Show Inspector panel" : "Hide Inspector panel"}
+                onClick={() => {
+                  if (isInspectorHidden) {
+                    showInspectorPanel();
+                    return;
+                  }
+                  hideInspectorPanel();
+                }}
+                title={isInspectorHidden ? "Show Inspector" : "Hide Inspector"}
+              >
+                {isInspectorHidden ? <PanelRightOpen aria-hidden="true" strokeWidth={1.8} /> : <PanelRightClose aria-hidden="true" strokeWidth={1.8} />}
+              </MapControlButton>
+            ) : undefined
+          }
+          inspectorActions={
+            <>
+              {accessState === "granted" ? (
                 <MapControlButton
-                  aria-label={isInspectorHidden ? "Show Inspector panel" : "Hide Inspector panel"}
-                  onClick={() => {
-                    if (isInspectorHidden) {
-                      showInspectorPanel();
-                      return;
-                    }
-                    hideInspectorPanel();
-                  }}
-                  title={isInspectorHidden ? "Show Inspector" : "Hide Inspector"}
+                  aria-label="Share"
+                  onClick={openShareModalOrCopy}
+                  title="Share"
                 >
-                  {isInspectorHidden ? <PanelRightOpen aria-hidden="true" strokeWidth={1.8} /> : <PanelRightClose aria-hidden="true" strokeWidth={1.8} />}
+                  <Share aria-hidden="true" strokeWidth={1.8} />
                 </MapControlButton>
               ) : null}
-              <div className="map-inspector-header-actions-right">
-                {accessState === "granted" ? (
-                  <MapControlButton
-                    aria-label="Share"
-                    onClick={openShareModalOrCopy}
-                    title="Share"
-                  >
-                    <Share aria-hidden="true" strokeWidth={1.8} />
-                  </MapControlButton>
-                ) : null}
-                {isMobileViewport ? panelSizeControls("Inspector") : null}
-              </div>
-            </div>
+              {isMobileViewport ? panelSizeControls("Inspector") : null}
+            </>
           }
           readOnly={!canPersistWorkspace}
           inspectorPanelClassName={`${inspectorPanelMotionClass} ${

--- a/src/components/LinkProfileChart.tsx
+++ b/src/components/LinkProfileChart.tsx
@@ -3,6 +3,7 @@ import { scaleLinear } from "d3-scale";
 import { ArrowLeftRight, PanelBottomClose, PanelBottomOpen } from "lucide-react";
 import { FloatingPopover } from "./ui/FloatingPopover";
 import { MapControlButton } from "./ui/MapControlButton";
+import { PanelToolbar } from "./ui/PanelToolbar";
 import type { MouseEvent } from "react";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
@@ -719,36 +720,39 @@ export function LinkProfileChart({
 
   return (
     <section className={`chart-panel ${isExpanded ? "is-expanded" : ""} ${panelClassName ?? ""}`.trim()} data-profile-revision={profileRevision} ref={chartPanelRef}>
-      <div className="chart-top-row">
-        <div className="chart-endpoints" aria-live="polite">
-          <span className="chart-endpoint chart-endpoint-left">{fromSiteName}</span>
-          <span className="chart-endpoint-sep" aria-hidden>
-            →
-          </span>
-          <span className="chart-endpoint chart-endpoint-right">{toSiteName}</span>
-        </div>
-        <div className="chart-action-row-controls">
-          <MapControlButton
-            aria-label="Reverse path direction for this view"
-            isSelected={temporaryDirectionReversed}
-            onClick={toggleTemporaryDirectionReversed}
-            title="Temporarily reverse path direction"
-          >
-            <ArrowLeftRight aria-hidden="true" strokeWidth={1.8} />
-          </MapControlButton>
-          {showExpandToggle ? (
+      <PanelToolbar
+        className="chart-top-row"
+        title={
+          <div className="chart-endpoints" aria-live="polite">
+            <span className="chart-endpoint chart-endpoint-left">{fromSiteName}</span>
+            <span className="chart-endpoint-sep" aria-hidden>→</span>
+            <span className="chart-endpoint chart-endpoint-right">{toSiteName}</span>
+          </div>
+        }
+        actions={
+          <>
             <MapControlButton
-              aria-label={isExpanded ? "Exit full screen" : "Full screen"}
-              isSelected={isExpanded}
-              onClick={onToggleExpanded}
-              title={isExpanded ? "Exit full screen" : "Full screen"}
+              aria-label="Reverse path direction for this view"
+              isSelected={temporaryDirectionReversed}
+              onClick={toggleTemporaryDirectionReversed}
+              title="Temporarily reverse path direction"
             >
-              {isExpanded ? <PanelBottomClose aria-hidden="true" strokeWidth={1.8} /> : <PanelBottomOpen aria-hidden="true" strokeWidth={1.8} />}
+              <ArrowLeftRight aria-hidden="true" strokeWidth={1.8} />
             </MapControlButton>
-          ) : null}
-          {rowControls}
-        </div>
-      </div>
+            {showExpandToggle ? (
+              <MapControlButton
+                aria-label={isExpanded ? "Exit full screen" : "Full screen"}
+                isSelected={isExpanded}
+                onClick={onToggleExpanded}
+                title={isExpanded ? "Exit full screen" : "Full screen"}
+              >
+                {isExpanded ? <PanelBottomClose aria-hidden="true" strokeWidth={1.8} /> : <PanelBottomOpen aria-hidden="true" strokeWidth={1.8} />}
+              </MapControlButton>
+            ) : null}
+            {rowControls}
+          </>
+        }
+      />
       <div className="chart-action-row">
         <div className="chart-hover-state">
           {cursorPoint && footerCursorState ? (

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -70,6 +70,7 @@ import { SimulationResultsSection } from "./SimulationResultsSection";
 import { ActionButton } from "./ActionButton";
 import { StateDot } from "./StateDot";
 import { useMapControls } from "./map/useMapControls";
+import { PanelToolbar } from "./ui/PanelToolbar";
 
 const UI_SECTION_KEYS = {
   mapViewResults: "linksim-ui-mapview-results-v1",
@@ -492,8 +493,10 @@ type MapViewProps = {
   readOnly?: boolean;
   canPersist?: boolean;
   onToggleMapExpanded: () => void;
-  // Legacy prop name retained for stability; this renders in the RightSidePanel shell.
-  inspectorHeaderActions?: ReactNode;
+  /** Left-side element in the inspector toolbar (e.g. panel toggle button). */
+  inspectorPanelToggle?: ReactNode;
+  /** Right-side actions in the inspector toolbar (e.g. share button, mobile size controls). */
+  inspectorActions?: ReactNode;
   notice?: {
     message: string;
     tone: "info" | "warning" | "error";
@@ -589,7 +592,8 @@ export function MapView({
   readOnly = false,
   canPersist = true,
   onToggleMapExpanded,
-  inspectorHeaderActions,
+  inspectorPanelToggle,
+  inspectorActions,
   notice,
   fitBottomInset = 30,
   fitChromePadding = FIT_CHROME_PADDING,
@@ -2456,8 +2460,8 @@ export function MapView({
       ) : null}
       {showInspector ? (
         <aside className={`map-inspector ${inspectorPanelClassName ?? ""}`.trim()} aria-live="polite">
-          {inspectorHeaderActions ? (
-            <div className="map-inspector-header-row">{inspectorHeaderActions}</div>
+          {(inspectorPanelToggle != null || inspectorActions != null) ? (
+            <PanelToolbar title={inspectorPanelToggle} actions={inspectorActions} />
           ) : null}
           {simulationBusyIndicator ? (
             <div className="map-inspector-section">

--- a/src/components/PanoramaChart.tsx
+++ b/src/components/PanoramaChart.tsx
@@ -1,6 +1,7 @@
 import { scaleLinear } from "d3-scale";
 import { FloatingPopover } from "./ui/FloatingPopover";
 import { MapControlButton } from "./ui/MapControlButton";
+import { PanelToolbar } from "./ui/PanelToolbar";
 import { StateDot } from "./StateDot";
 import { Info, MapPinned, Paintbrush, PanelBottomClose, PanelBottomOpen, Mountain, MountainSnow, RadioTower, Settings, Tags } from "lucide-react";
 import type { CSSProperties, MouseEvent as ReactMouseEvent, ReactNode } from "react";
@@ -1411,40 +1412,43 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
 
   return (
     <section className={`chart-panel ${isExpanded ? "is-expanded" : ""} ${panelClassName ?? ""}`.trim()} ref={chartPanelRef}>
-      <div className="chart-top-row">
-        <h3 className="panorama-header-title">Panorama from {selectedSiteEffective.name}</h3>
-        <div className="chart-action-row-controls">
-          <MapControlButton
-            aria-label="Panorama settings"
-            isSelected={settingsPopoverOpen}
-            onClick={() => setSettingsPopoverOpen((v) => !v)}
-            ref={settingsButtonRef}
-            title="Settings"
-          >
-            <Settings aria-hidden="true" strokeWidth={1.8} />
-          </MapControlButton>
-          <MapControlButton
-            aria-label="Legend"
-            isSelected={legendPopoverOpen}
-            onClick={() => setLegendPopoverOpen((v) => !v)}
-            ref={legendButtonRef}
-            title="Legend"
-          >
-            <Info aria-hidden="true" strokeWidth={1.8} />
-          </MapControlButton>
-          {showExpandToggle ? (
+      <PanelToolbar
+        className="chart-top-row"
+        title={<h3 className="panorama-header-title">Panorama from {selectedSiteEffective.name}</h3>}
+        actions={
+          <>
             <MapControlButton
-              aria-label={isExpanded ? "Exit full screen" : "Full screen"}
-              isSelected={isExpanded}
-              onClick={onToggleExpanded}
-              title={isExpanded ? "Exit full screen" : "Full screen"}
+              aria-label="Panorama settings"
+              isSelected={settingsPopoverOpen}
+              onClick={() => setSettingsPopoverOpen((v) => !v)}
+              ref={settingsButtonRef}
+              title="Settings"
             >
-              {isExpanded ? <PanelBottomClose aria-hidden="true" strokeWidth={1.8} /> : <PanelBottomOpen aria-hidden="true" strokeWidth={1.8} />}
+              <Settings aria-hidden="true" strokeWidth={1.8} />
             </MapControlButton>
-          ) : null}
-          {rowControls}
-        </div>
-      </div>
+            <MapControlButton
+              aria-label="Legend"
+              isSelected={legendPopoverOpen}
+              onClick={() => setLegendPopoverOpen((v) => !v)}
+              ref={legendButtonRef}
+              title="Legend"
+            >
+              <Info aria-hidden="true" strokeWidth={1.8} />
+            </MapControlButton>
+            {showExpandToggle ? (
+              <MapControlButton
+                aria-label={isExpanded ? "Exit full screen" : "Full screen"}
+                isSelected={isExpanded}
+                onClick={onToggleExpanded}
+                title={isExpanded ? "Exit full screen" : "Full screen"}
+              >
+                {isExpanded ? <PanelBottomClose aria-hidden="true" strokeWidth={1.8} /> : <PanelBottomOpen aria-hidden="true" strokeWidth={1.8} />}
+              </MapControlButton>
+            ) : null}
+            {rowControls}
+          </>
+        }
+      />
 
       {legendPopover}
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -85,6 +85,7 @@ import { ModalOverlay } from "./ModalOverlay";
 import { SiteBeamVisualizerPopover } from "./SiteBeamVisualizer";
 import SimulationLibraryPanel from "./SimulationLibraryPanel";
 import { Badge } from "./ui/Badge";
+import { PanelToolbar } from "./ui/PanelToolbar";
 import { Surface } from "./ui/Surface";
 import { UserAdminPanel } from "./UserAdminPanel";
 
@@ -1903,10 +1904,10 @@ export function Sidebar({
         </div>
       </header>
       <section className="panel-section section-scenario">
-        <div className="section-heading">
-          <h2>Simulation: {simulationDisplayLabel ?? activeSimulationLabel}</h2>
-          <InfoTip text="Open a simulation from the library or create a new one. A simulation is a workspace where you can add sites and tweak settings. They can be private or shared." />
-        </div>
+        <PanelToolbar
+          title={<h2>Simulation: {simulationDisplayLabel ?? activeSimulationLabel}</h2>}
+          actions={<InfoTip text="Open a simulation from the library or create a new one. A simulation is a workspace where you can add sites and tweak settings. They can be private or shared." />}
+        />
         <div className="chip-group simulation-buttons">
           {!hideLibraryBrowsing ? (
             <>
@@ -1946,10 +1947,10 @@ export function Sidebar({
       </section>
 
       <section className="panel-section section-sites">
-        <div className="section-heading">
-          <h2>Sites</h2>
-          <InfoTip text="Add a site from the site library or create a new site. You can also create or add sites from the map. A site can be private or shared." />
-        </div>
+        <PanelToolbar
+          title={<h2>Sites</h2>}
+          actions={<InfoTip text="Add a site from the site library or create a new site. You can also create or add sites from the map. A site can be private or shared." />}
+        />
         {!siteLibrary.length ? <p className="field-help">No saved library sites yet.</p> : null}
         <div className="site-list">
           {sites.map((site) => (
@@ -2003,10 +2004,10 @@ export function Sidebar({
       </section>
 
       <section className="panel-section section-path">
-        <div className="section-heading">
-          <h2>Links</h2>
-          <InfoTip text={`Select multiple sites by ${isMac ? "Cmd" : "Ctrl"}+Clicking to instantly view a link. When a link is active on the map, you can save it permanently to this simulation by pressing "Save" in the inspector.`} />
-        </div>
+        <PanelToolbar
+          title={<h2>Links</h2>}
+          actions={<InfoTip text={`Select multiple sites by ${isMac ? "Cmd" : "Ctrl"}+Clicking to instantly view a link. When a link is active on the map, you can save it permanently to this simulation by pressing "Save" in the inspector.`} />}
+        />
         <div className="link-list">
           {visibleLinks.map((link) => (
             <button

--- a/src/components/UiGalleryPage.tsx
+++ b/src/components/UiGalleryPage.tsx
@@ -6,6 +6,7 @@ import { Surface } from "./ui/Surface";
 import { Badge } from "./ui/Badge";
 import { Button } from "./ui/Button";
 import { MapControlButton } from "./ui/MapControlButton";
+import { PanelToolbar } from "./ui/PanelToolbar";
 import { UiSlider } from "./UiSlider";
 import { SiteBeamVisualizer } from "./SiteBeamVisualizer";
 import { useThemeVariant } from "../hooks/useThemeVariant";
@@ -32,6 +33,7 @@ const SOURCE_PATHS: Record<string, string> = {
   "Button": "src/components/ui/Button.tsx",
   "ActionButton": "src/components/ActionButton.tsx",
   "MapControlButton": "src/components/ui/MapControlButton.tsx",
+  "PanelToolbar": "src/components/ui/PanelToolbar.tsx",
   "LinkButton": "src/components/LinkButton.tsx",
   "PanelShell.LeftSidePanel": "src/components/app-shell/LeftSidePanel.tsx",
   "PanelShell.RightSidePanel": "src/components/app-shell/RightSidePanel.tsx",
@@ -358,17 +360,11 @@ export function UiGalleryPage() {
           <div className="ui-pattern-grid ui-pattern-grid-shells">
             <PatternCard name="PanelShell.LeftSidePanel" status="under migration">
               <aside className="sidebar-panel">
-                <header>
-                  <div className="section-heading">
-                    <h2>Simulation</h2>
-                    <span className="field-help">left shell</span>
-                  </div>
-                </header>
                 <section className="panel-section">
-                  <div className="section-heading">
-                    <h2>Sites</h2>
-                    <span className="field-help">header rhythm</span>
-                  </div>
+                  <PanelToolbar
+                    title={<h2>Sites</h2>}
+                    actions={<span className="field-help">InfoTip slot</span>}
+                  />
                   <div className="chip-group">
                     <ActionButton>Library</ActionButton>
                     <ActionButton>New</ActionButton>
@@ -378,16 +374,13 @@ export function UiGalleryPage() {
             </PatternCard>
             <PatternCard name="PanelShell.RightSidePanel" status="under migration">
               <aside className="map-inspector">
-                <div className="map-inspector-header-row">
-                  <div className="map-inspector-header-actions">
-                    <strong>Inspector</strong>
-                    <div className="map-inspector-header-actions-right">
-                      <MapControlButton title="Hide panel">
-                        <PanelRightClose aria-hidden="true" size={16} strokeWidth={1.8} />
-                      </MapControlButton>
-                    </div>
-                  </div>
-                </div>
+                <PanelToolbar
+                  title={
+                    <MapControlButton title="Hide panel">
+                      <PanelRightClose aria-hidden="true" size={16} strokeWidth={1.8} />
+                    </MapControlButton>
+                  }
+                />
                 <div className="map-inspector-section">
                   <p className="map-inspector-line">Section/divider cadence shared with panel shell family.</p>
                 </div>
@@ -395,16 +388,15 @@ export function UiGalleryPage() {
             </PatternCard>
             <PatternCard name="PanelShell.BottomPanel" status="under migration">
               <section className="chart-panel">
-                <div className="chart-top-row">
-                  <div className="chart-hover-state">
-                    <span>Path Profile</span>
-                  </div>
-                  <div className="chart-action-row-controls">
+                <PanelToolbar
+                  className="chart-top-row"
+                  title={<span className="field-help">Path Profile A → B</span>}
+                  actions={
                     <MapControlButton title="Full size">
                       <Maximize2 aria-hidden="true" size={16} strokeWidth={1.8} />
                     </MapControlButton>
-                  </div>
-                </div>
+                  }
+                />
                 <div className="chart-action-row">
                   <div className="chart-hover-state">
                     <span>Action row cadence aligned with shell family.</span>

--- a/src/components/ui/PanelToolbar.tsx
+++ b/src/components/ui/PanelToolbar.tsx
@@ -1,0 +1,19 @@
+import clsx from "clsx";
+import type { ReactNode } from "react";
+
+type PanelToolbarProps = {
+  /** Left-aligned content: section title, endpoint grid, or left-side action button. */
+  title?: ReactNode;
+  /** Right-aligned icon buttons or controls. */
+  actions?: ReactNode;
+  className?: string;
+};
+
+export function PanelToolbar({ title, actions, className }: PanelToolbarProps) {
+  return (
+    <div className={clsx("panel-toolbar-row", className)}>
+      {title != null ? <div className="panel-toolbar-title">{title}</div> : null}
+      {actions != null ? <div className="panel-toolbar-actions">{actions}</div> : null}
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -451,6 +451,31 @@ input {
   border-bottom: 1px solid var(--panel-shell-divider);
 }
 
+/* Unified panel toolbar row — used by PanelToolbar component */
+.panel-toolbar-row {
+  display: flex;
+  align-items: center;
+  gap: var(--panel-header-row-gap);
+  min-height: var(--panel-header-row-min-height);
+  padding-bottom: var(--panel-header-row-padding-bottom);
+  border-bottom: 1px solid var(--panel-shell-divider);
+}
+
+.panel-toolbar-title {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--panel-header-row-gap);
+}
+
+.panel-toolbar-actions {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--panel-action-row-gap);
+}
+
 .info-tip {
   width: 18px;
   height: 18px;
@@ -1513,37 +1538,12 @@ input {
   font-family: "Space Grotesk", "Avenir Next", sans-serif;
 }
 
-.map-inspector-header-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--panel-header-row-gap);
-  min-height: var(--panel-header-row-min-height);
-  padding-bottom: var(--panel-header-row-padding-bottom);
-  border-bottom: 1px solid var(--panel-shell-divider);
-}
-
-.map-inspector-header-actions {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  width: 100%;
-  gap: 6px;
-}
-
 .panel-size-controls {
   display: inline-flex;
   align-items: center;
   gap: 6px;
 }
 
-.map-inspector-header-actions-right {
-  margin-left: auto;
-  display: inline-flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 6px;
-}
 
 .workspace-panel:not(.is-map-expanded):not(.is-profile-expanded) .map-panel .maplibregl-ctrl-bottom-right,
 .workspace-panel:not(.is-map-expanded):not(.is-profile-expanded) .map-panel .maplibregl-ctrl-bottom-left {
@@ -2093,14 +2093,6 @@ input {
   font-size: 0.83rem;
 }
 
-.chart-top-row {
-  display: flex;
-  align-items: center;
-  gap: var(--panel-header-row-gap);
-  min-height: var(--panel-header-row-min-height);
-  padding: 0 0 var(--panel-header-row-padding-bottom);
-  border-bottom: 1px solid var(--panel-shell-divider);
-}
 
 .chart-endpoints {
   display: grid;
@@ -2273,13 +2265,6 @@ input {
   flex: 0 0 auto;
 }
 
-/* Chart toolbar rows have padding-bottom: 9px, so btn-icon must fit in ~25px content area */
-.chart-top-row .btn-icon,
-.chart-action-row-controls .btn-icon {
-  width: 26px;
-  height: 26px;
-  min-width: 26px;
-}
 
 .chart-action-row-controls .panel-size-controls {
   justify-content: flex-end;


### PR DESCRIPTION
## Summary

- **New component** `src/components/ui/PanelToolbar.tsx` — typed `title` and `actions` slots, outputs `.panel-toolbar-row` with the standard flex/gap/border-bottom pattern
- **CSS unification** — three near-identical rules (`.section-heading`, `.map-inspector-header-row`, `.chart-top-row` base) collapsed into `.panel-toolbar-row` / `.panel-toolbar-title` / `.panel-toolbar-actions`. The redundant `.map-inspector-header-actions` wrapper rules removed.
- **Height model fix** — removed the 26px compact `btn-icon` override on chart toolbar rows. All panel toolbars now consistently expand to ~43px (34px button + 9px padding-bottom), matching the sidebar.
- **Migrations**: Sidebar.tsx (3 sections), MapView.tsx inspector header, LinkProfileChart.tsx, PanoramaChart.tsx, UiGalleryPage panel shell specimens
- **Inspector prop refactor**: `inspectorHeaderActions` split into `inspectorPanelToggle` (left slot) + `inspectorActions` (right slot) — eliminates the nested wrapper divs

## Test plan
- [ ] Sidebar section headings (Simulation / Sites / Links) render correctly with divider and InfoTip
- [ ] Inspector toolbar: toggle button on left, share on right (desktop); mobile size controls on right (mobile)
- [ ] Link profile chart toolbar: endpoint grid left, reverse+expand buttons right — same row height as sidebar
- [ ] Panorama chart toolbar: site name title left, settings+legend+expand right
- [ ] Chart toolbar buttons are now standard 34px, visually matching sidebar
- [ ] `tsc -b config/tsconfig.json --noEmit` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)