### PR TITLE
fix(ui): align user-chip-row with panel-toolbar-row on mobile (#616)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -3370,13 +3370,16 @@ html.panorama-gesture-lock body {
   display: flex;
   align-items: center;
   gap: 8px;
+  min-height: var(--panel-header-row-min-height);
+  padding-bottom: var(--panel-header-row-padding-bottom);
+  border-bottom: 1px solid var(--panel-shell-divider);
 }
 
 .user-chip-actions {
   margin-left: auto;
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: var(--panel-action-row-gap);
 }
 
 .user-chip-row .user-chip {
@@ -3432,8 +3435,8 @@ html.panorama-gesture-lock body {
   border: 0;
   background: transparent;
   border-radius: 0;
-  width: 30px;
-  height: 30px;
+  width: 34px;
+  height: 34px;
   padding: 0;
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary

When switching between panels on mobile (Navigator / Profile / Inspector), the Navigator top row looked inconsistent because it had no divider, different icon button sizes, and a wider action gap.

- Add `border-bottom`, `min-height`, `padding-bottom` to `.user-chip-row` using the same `--panel-header-row-*` tokens as `.panel-toolbar-row`
- `.user-chip-actions` gap: `12px` → `var(--panel-action-row-gap)` (8px)
- `.user-icon-button` size: `30px` → `34px` (matches `btn-icon`)

LinkSim title row (`.sidebar-title-row`) is intentionally left as-is.

## Test plan
- [ ] Mobile: switch between Navigator / Profile / Inspector — top rows should look consistent (same divider, same icon size)
- [ ] Desktop: user chip row in sidebar still renders correctly
- [ ] Sync, settings, and help icon buttons in user chip row are 34px

🤖 Generated with [Claude Code](https://claude.com/claude-code)