### PR TITLE
fix(ui): match chart-panel side padding to sidebar/inspector (#616)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2039,7 +2039,7 @@ input {
 
 .chart-panel {
   overflow: hidden;
-  padding: 10px 10px 8px;
+  padding: 10px 18px 8px;
   display: flex;
   flex-direction: column;
   gap: 8px;


### PR DESCRIPTION
## Summary

`.chart-panel` had `padding: 10px` on all sides. `.sidebar-panel` and `.map-inspector` both use `18px` side padding. This made toolbar buttons sit much closer to the panel edges on the Profile panel — especially noticeable on mobile where all three panels occupy the same position.

Change: `padding: 10px 10px 8px` → `padding: 10px 18px 8px` (left/right only, top/bottom unchanged).

## Test plan
- [ ] Mobile: Profile panel toolbar buttons have the same visual inset from the edges as Navigator and Inspector
- [ ] Desktop: chart panel still renders correctly (the extra 8px each side is within the panel width)
- [ ] Chart content (path profile graph, panorama canvas) renders correctly at the new width

🤖 Generated with [Claude Code](https://claude.com/claude-code)