### PR TITLE
fix(ui): align chart-panel top padding with sidebar/inspector (#616)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2039,7 +2039,7 @@ input {
 
 .chart-panel {
   overflow: hidden;
-  padding: 10px 18px 8px;
+  padding: 18px 18px 8px;
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -3071,7 +3071,6 @@ html.panorama-gesture-lock body {
     max-height: 100%;
     grid-row: 1;
     overflow: auto;
-    padding-top: 4px;
   }
 
   .mobile-workspace-panel .chart-svg-wrap {


### PR DESCRIPTION
## Summary

`.chart-panel` had `padding-top: 10px` on desktop and a mobile override of `padding-top: 4px`. Both `.sidebar-panel` and `.map-inspector` use `18px` on all sides. This made the Profile panel toolbar visibly closer to the top edge than Navigator and Inspector when switching between them on mobile.

- `.chart-panel` base top padding: `10px` → `18px`
- Mobile override `padding-top: 4px` removed (now matches base, override was redundant)

Together with #753 (side padding), all three panels now have a consistent 18px inset on all sides.

## Test plan
- [ ] Mobile: all three panels (Navigator / Profile / Inspector) have the same distance from the top and sides to the toolbar icons
- [ ] Desktop: chart panel toolbar has slightly more breathing room above it (10px → 18px) — should look fine

🤖 Generated with [Claude Code](https://claude.com/claude-code)