### PR TITLE
fix(ui): right-align panel-toolbar actions and normalize toolbar height (#616)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -456,7 +456,8 @@ input {
   display: flex;
   align-items: center;
   gap: var(--panel-header-row-gap);
-  min-height: var(--panel-header-row-min-height);
+  /* min-height accounts for padding-bottom + border-bottom so all toolbars share the same total height */
+  min-height: calc(var(--panel-header-row-min-height) + var(--panel-header-row-padding-bottom) + 1px);
   padding-bottom: var(--panel-header-row-padding-bottom);
   border-bottom: 1px solid var(--panel-shell-divider);
 }
@@ -474,6 +475,7 @@ input {
   display: inline-flex;
   align-items: center;
   gap: var(--panel-action-row-gap);
+  margin-left: auto; /* push actions to the right even when no title is present */
 }
 
 .info-tip {


### PR DESCRIPTION
## Summary

- **Inspector icon alignment**: `panel-toolbar-actions` now has `margin-left: auto`, so when no `title` slot is provided (e.g. Inspector panel on mobile) the action buttons float to the right side as expected.
- **Consistent toolbar height**: `panel-toolbar-row` min-height was `34px` (`border-box`) which gave only 24px of actual content space — less than the 34px btn-icon. Changed to `calc(34px + 9px padding + 1px border)` so the content area is always at least 34px, making all four panel toolbars the same total height regardless of their content.

## Test plan

- [ ] Mobile: switch between Navigator / Profile / Inspector — all three panel toolbars should be visually the same height
- [ ] Mobile: Inspector toolbar action buttons should appear on the **right** side
- [ ] Desktop: sidebar section headings, inspector header, chart toolbar all look correct
- [ ] No TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)