### PR TITLE
fix(ui): migrate Navigator toolbar to PanelToolbar — all four panels unified (#616)

### DIFF
--- a/src/components/UserAdminPanel.tsx
+++ b/src/components/UserAdminPanel.tsx
@@ -37,6 +37,7 @@ import { InfoTip } from "./InfoTip";
 import { InlineCloseIconButton } from "./InlineCloseIconButton";
 import { ModalOverlay } from "./ModalOverlay";
 import { SettingsIcon, SyncStatusIcon } from "./icons/AppIcons";
+import { PanelToolbar } from "./ui/PanelToolbar";
 
 const fmtDate = (iso: string | null | undefined): string => {
   if (!iso) return "-";
@@ -1124,55 +1125,59 @@ export function UserAdminPanel({
 
   return (
     <>
-      <div className="user-chip-row">
-        {isSignedIn && displayUser ? (
-          <button aria-label="Open user settings" className="user-chip" onClick={() => (onOpenSettings ? onOpenSettings() : setOpen(true))} type="button">
-            <ProfileAvatar avatarUrl={displayUser.avatarUrl ?? ""} name={displayUser.username ?? "User"} />
-            {canModerate && unreadNotifications.length > 0 ? (
-              <span className="notification-badge">{unreadNotifications.length}</span>
-            ) : null}
-          </button>
-        ) : authBootstrapPending ? (
-          <div aria-label="Loading account" className="user-chip user-chip-loading" role="status" title="Checking account access">
-            <div className="map-progress-track">
-              <div className="map-progress-fill map-progress-fill-indeterminate" />
-            </div>
-          </div>
-        ) : (
-          <button aria-label="Sign in or sign up" className="user-chip user-chip-signup" onClick={handleSignUp} type="button">
-            <CircleUserRound aria-hidden="true" strokeWidth={1.8} />
-            <span>Sign in / Sign up</span>
-          </button>
-        )}
-        <div className="user-chip-actions">
-          {isSignedIn ? (
-            <>
-              <button
-                aria-label={syncIndicator.label}
-                className={`user-icon-button sync-indicator-button ${syncIndicator.className}`}
-                onClick={handleSyncIndicatorClick}
-                title={syncIndicator.title}
-                type="button"
-              >
-                <SyncStatusIcon
-                  className={syncIndicator.state === "syncing" ? "sync-icon-pulsing" : undefined}
-                  state={syncIndicator.state}
-                  title={syncIndicator.label}
-                />
-              </button>
-              <button aria-label="Open user settings" className="user-icon-button" onClick={() => (onOpenSettings ? onOpenSettings() : setOpen(true))} type="button">
-                <SettingsIcon title="Settings" />
-              </button>
-            </>
-          ) : null}
-          {onOpenHelp ? (
-            <button aria-label="Open onboarding" className="user-icon-button" onClick={onOpenHelp} type="button">
-              <CircleQuestionMark aria-hidden="true" strokeWidth={1.8} />
+      <PanelToolbar
+        title={
+          isSignedIn && displayUser ? (
+            <button aria-label="Open user settings" className="user-chip" onClick={() => (onOpenSettings ? onOpenSettings() : setOpen(true))} type="button">
+              <ProfileAvatar avatarUrl={displayUser.avatarUrl ?? ""} name={displayUser.username ?? "User"} />
+              {canModerate && unreadNotifications.length > 0 ? (
+                <span className="notification-badge">{unreadNotifications.length}</span>
+              ) : null}
             </button>
-          ) : null}
-          {extraActions}
-        </div>
-      </div>
+          ) : authBootstrapPending ? (
+            <div aria-label="Loading account" className="user-chip user-chip-loading" role="status" title="Checking account access">
+              <div className="map-progress-track">
+                <div className="map-progress-fill map-progress-fill-indeterminate" />
+              </div>
+            </div>
+          ) : (
+            <button aria-label="Sign in or sign up" className="user-chip user-chip-signup" onClick={handleSignUp} type="button">
+              <CircleUserRound aria-hidden="true" strokeWidth={1.8} />
+              <span>Sign in / Sign up</span>
+            </button>
+          )
+        }
+        actions={
+          <>
+            {isSignedIn ? (
+              <>
+                <button
+                  aria-label={syncIndicator.label}
+                  className={`user-icon-button sync-indicator-button ${syncIndicator.className}`}
+                  onClick={handleSyncIndicatorClick}
+                  title={syncIndicator.title}
+                  type="button"
+                >
+                  <SyncStatusIcon
+                    className={syncIndicator.state === "syncing" ? "sync-icon-pulsing" : undefined}
+                    state={syncIndicator.state}
+                    title={syncIndicator.label}
+                  />
+                </button>
+                <button aria-label="Open user settings" className="user-icon-button" onClick={() => (onOpenSettings ? onOpenSettings() : setOpen(true))} type="button">
+                  <SettingsIcon title="Settings" />
+                </button>
+              </>
+            ) : null}
+            {onOpenHelp ? (
+              <button aria-label="Open onboarding" className="user-icon-button" onClick={onOpenHelp} type="button">
+                <CircleQuestionMark aria-hidden="true" strokeWidth={1.8} />
+              </button>
+            ) : null}
+            {extraActions}
+          </>
+        }
+      />
 
       {syncModalOpen ? (
         <ModalOverlay aria-label="Sync Status" onClose={() => setSyncModalOpen(false)}>

--- a/src/index.css
+++ b/src/index.css
@@ -2258,19 +2258,6 @@ input {
   border-bottom: 1px solid var(--panel-shell-divider);
 }
 
-.chart-action-row-controls {
-  margin-left: auto;
-  display: inline-flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: var(--panel-action-row-gap);
-  flex: 0 0 auto;
-}
-
-
-.chart-action-row-controls .panel-size-controls {
-  justify-content: flex-end;
-}
 
 .ui-slider {
   display: flex;
@@ -3367,26 +3354,12 @@ html.panorama-gesture-lock body {
   color: var(--text);
 }
 
-.user-chip-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  min-height: var(--panel-header-row-min-height);
-  padding-bottom: var(--panel-header-row-padding-bottom);
-  border-bottom: 1px solid var(--panel-shell-divider);
-}
+/* user-chip-row and user-chip-actions removed — Navigator now uses PanelToolbar */
 
-.user-chip-actions {
-  margin-left: auto;
-  display: flex;
-  align-items: center;
-  gap: var(--panel-action-row-gap);
-}
-
-.user-chip-row .user-chip {
-  width: 38px;
-  height: 38px;
-  min-width: 38px;
+.user-chip {
+  width: 34px;
+  height: 34px;
+  min-width: 34px;
   padding: 0;
   justify-content: center;
   gap: 0;
@@ -3394,7 +3367,7 @@ html.panorama-gesture-lock body {
   flex: 0 0 auto;
 }
 
-.user-chip-row .user-chip.user-chip-signup {
+.user-chip.user-chip-signup {
   width: auto;
   min-width: 0;
   height: 34px;
@@ -3408,17 +3381,17 @@ html.panorama-gesture-lock body {
   white-space: nowrap;
 }
 
-.user-chip-row .user-chip.user-chip-signup:hover {
+.user-chip.user-chip-signup:hover {
   color: var(--accent);
   border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
 }
 
-.user-chip-row .user-chip.user-chip-signup svg {
+.user-chip.user-chip-signup svg {
   width: 16px;
   height: 16px;
 }
 
-.user-chip-row .user-chip.user-chip-loading {
+.user-chip.user-chip-loading {
   width: 132px;
   min-width: 132px;
   height: 34px;
@@ -3428,7 +3401,7 @@ html.panorama-gesture-lock body {
   background: color-mix(in srgb, var(--panel) 86%, var(--bg));
 }
 
-.user-chip-row .user-chip.user-chip-loading .map-progress-track {
+.user-chip.user-chip-loading .map-progress-track {
   height: 6px;
 }
 


### PR DESCRIPTION
## Summary

Navigator (UserAdminPanel) was the last panel still using a bespoke `user-chip-row` div instead of `PanelToolbar`, causing visible inconsistencies on mobile when switching panels:

- Different `min-height` formula (old 34 px border-box vs corrected 44 px)
- Avatar chip was 38 px while btn-icon is 34 px — making Navigator toolbar 4 px taller
- Different gap (8 px vs 10 px) and separate alignment CSS

**Changes:**
- `UserAdminPanel.tsx`: replace `user-chip-row` + `user-chip-actions` divs with `<PanelToolbar title={chip} actions={…} />` — all four panel toolbars now use the same component and CSS path
- `index.css`: remove dead `.user-chip-row` and `.user-chip-actions` layout rules; drop `user-chip-row` parent-prefix from all `.user-chip` sub-rules; resize avatar chip 38 px → 34 px to match `btn-icon`
- `index.css`: remove dead `.chart-action-row-controls` rules (no longer in any component after PanelToolbar migration)

## Test plan

- [ ] Mobile: switch Navigator / Profile / Inspector — all three toolbar rows should be **identical height** with action buttons consistently right-aligned
- [ ] Avatar button (signed-in): renders at 34 × 34 px, visually centered in the toolbar
- [ ] Sign-in / loading states: still look correct
- [ ] Desktop sidebar: no visual regression
- [ ] TypeScript: no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)