### PR TITLE
chore(ui): gallery cleanup — dead class refs, SOURCE_PATHS, PanelToolbar + CompactDetails cards (#616)

### DIFF
--- a/src/components/LinkProfileChart.tsx
+++ b/src/components/LinkProfileChart.tsx
@@ -721,7 +721,6 @@ export function LinkProfileChart({
   return (
     <section className={`chart-panel ${isExpanded ? "is-expanded" : ""} ${panelClassName ?? ""}`.trim()} data-profile-revision={profileRevision} ref={chartPanelRef}>
       <PanelToolbar
-        className="chart-top-row"
         title={
           <div className="chart-endpoints" aria-live="polite">
             <span className="chart-endpoint chart-endpoint-left">{fromSiteName}</span>

--- a/src/components/PanoramaChart.tsx
+++ b/src/components/PanoramaChart.tsx
@@ -1413,7 +1413,6 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
   return (
     <section className={`chart-panel ${isExpanded ? "is-expanded" : ""} ${panelClassName ?? ""}`.trim()} ref={chartPanelRef}>
       <PanelToolbar
-        className="chart-top-row"
         title={<h3 className="panorama-header-title">Panorama from {selectedSiteEffective.name}</h3>}
         actions={
           <>

--- a/src/components/UiGalleryPage.tsx
+++ b/src/components/UiGalleryPage.tsx
@@ -7,6 +7,7 @@ import { Badge } from "./ui/Badge";
 import { Button } from "./ui/Button";
 import { MapControlButton } from "./ui/MapControlButton";
 import { PanelToolbar } from "./ui/PanelToolbar";
+import { CompactDetails, CompactDetailsSummary } from "./ui/CompactDetails";
 import { UiSlider } from "./UiSlider";
 import { SiteBeamVisualizer } from "./SiteBeamVisualizer";
 import { useThemeVariant } from "../hooks/useThemeVariant";
@@ -35,9 +36,10 @@ const SOURCE_PATHS: Record<string, string> = {
   "MapControlButton": "src/components/ui/MapControlButton.tsx",
   "PanelToolbar": "src/components/ui/PanelToolbar.tsx",
   "LinkButton": "src/components/LinkButton.tsx",
-  "PanelShell.LeftSidePanel": "src/components/app-shell/LeftSidePanel.tsx",
-  "PanelShell.RightSidePanel": "src/components/app-shell/RightSidePanel.tsx",
-  "PanelShell.BottomPanel": "src/components/app-shell/BottomPanel.tsx",
+  "CompactDetails": "src/components/ui/CompactDetails.tsx",
+  "PanelShell.LeftSidePanel": "src/components/Sidebar.tsx",
+  "PanelShell.RightSidePanel": "src/components/MapView.tsx",
+  "PanelShell.BottomPanel": "src/components/LinkProfileChart.tsx",
   "FormActionRow": "src/components/FormActionRow.tsx",
   "Input": "src/components/ui/Input.tsx",
   "Select": "src/components/ui/Select.tsx",
@@ -358,7 +360,34 @@ export function UiGalleryPage() {
         <section className="ui-gallery-section">
           <h3>Panels</h3>
           <div className="ui-pattern-grid ui-pattern-grid-shells">
-            <PatternCard name="PanelShell.LeftSidePanel" status="under migration">
+            <PatternCard name="PanelToolbar" status="standard">
+              <div className="panel-section">
+                <PanelToolbar
+                  title={<h2>Title + Actions</h2>}
+                  actions={
+                    <MapControlButton title="Settings">
+                      <RefreshCw aria-hidden="true" size={16} strokeWidth={1.8} />
+                    </MapControlButton>
+                  }
+                />
+                <PanelToolbar
+                  title={<h2>Title Only</h2>}
+                />
+                <PanelToolbar
+                  actions={
+                    <>
+                      <MapControlButton title="Close">
+                        <X aria-hidden="true" size={16} strokeWidth={1.8} />
+                      </MapControlButton>
+                      <MapControlButton title="Settings">
+                        <RefreshCw aria-hidden="true" size={16} strokeWidth={1.8} />
+                      </MapControlButton>
+                    </>
+                  }
+                />
+              </div>
+            </PatternCard>
+            <PatternCard name="PanelShell.LeftSidePanel" status="standard">
               <aside className="sidebar-panel">
                 <section className="panel-section">
                   <PanelToolbar
@@ -372,7 +401,7 @@ export function UiGalleryPage() {
                 </section>
               </aside>
             </PatternCard>
-            <PatternCard name="PanelShell.RightSidePanel" status="under migration">
+            <PatternCard name="PanelShell.RightSidePanel" status="standard">
               <aside className="map-inspector">
                 <PanelToolbar
                   title={
@@ -386,10 +415,9 @@ export function UiGalleryPage() {
                 </div>
               </aside>
             </PatternCard>
-            <PatternCard name="PanelShell.BottomPanel" status="under migration">
+            <PatternCard name="PanelShell.BottomPanel" status="standard">
               <section className="chart-panel">
                 <PanelToolbar
-                  className="chart-top-row"
                   title={<span className="field-help">Path Profile A → B</span>}
                   actions={
                     <MapControlButton title="Full size">
@@ -401,11 +429,21 @@ export function UiGalleryPage() {
                   <div className="chart-hover-state">
                     <span>Action row cadence aligned with shell family.</span>
                   </div>
-                  <div className="chart-action-row-controls">
-                    <ActionButton>Save</ActionButton>
-                  </div>
+                  <ActionButton>Save</ActionButton>
                 </div>
               </section>
+            </PatternCard>
+            <PatternCard name="CompactDetails" status="standard">
+              <div className="panel-section">
+                <CompactDetails>
+                  <CompactDetailsSummary>Collapsed by default</CompactDetailsSummary>
+                  <p className="map-inspector-line">Content revealed when expanded.</p>
+                </CompactDetails>
+                <CompactDetails open>
+                  <CompactDetailsSummary>Open by default</CompactDetailsSummary>
+                  <p className="map-inspector-line">Content visible on load.</p>
+                </CompactDetails>
+              </div>
             </PatternCard>
           </div>
         </section>


### PR DESCRIPTION
## Summary

- Removes dead `className="chart-top-row"` from `LinkProfileChart`, `PanoramaChart`, and gallery specimen (CSS rule was deleted in #756)
- Removes dead `chart-action-row-controls` wrapper div from the BottomPanel gallery specimen
- Fixes three `SOURCE_PATHS` entries that pointed to a non-existent `app-shell/` subdirectory
- Marks all three `PanelShell.*` PatternCards as `status="standard"` — migration is complete
- Adds a standalone `PanelToolbar` PatternCard (title+actions, title-only, actions-only specimens)
- Adds a `CompactDetails` PatternCard (collapsed + open states) + `SOURCE_PATHS` entry

## Test plan

- [ ] Open UI Gallery → Panels tab: verify `PanelToolbar` card shows 3 rows with correct alignment
- [ ] Verify `PanelShell.*` cards show `standard` badge and correct source file links
- [ ] Verify `CompactDetails` card shows both collapsed and expanded states
- [ ] Open Link Profile and Panorama charts — toolbar renders unchanged (dead class removal is visual no-op)
- [ ] `tsc -b config/tsconfig.json --noEmit` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)