### PR TITLE
chore(ui): remove legacy NotificationBanner and OfflineBanner (#616)

### DIFF
--- a/src/components/UiGalleryPage.tsx
+++ b/src/components/UiGalleryPage.tsx
@@ -47,9 +47,7 @@ const SOURCE_PATHS: Record<string, string> = {
   "UI Slider": "src/components/UiSlider.tsx",
   "SiteBeamVisualizer": "src/components/SiteBeamVisualizer.tsx",
   "NotificationStack": "src/components/NotificationStack.tsx",
-  "NotificationBanner": "src/components/NotificationBanner.tsx",
   "MapInlineNotice": "src/components/MapInlineNotice.tsx",
-  "OfflineBanner": "src/components/OfflineBanner.tsx",
   "NotificationBell": "src/components/NotificationBell.tsx",
   "EmptyState": "src/components/ui/EmptyState.tsx",
   "LoadingState": "src/components/ui/LoadingState.tsx",
@@ -584,27 +582,10 @@ export function UiGalleryPage() {
                 </div>
               </div>
             </PatternCard>
-            <PatternCard name="NotificationBanner" status="legacy">
-              <div className="notification-banner" role="status">
-                <strong>2 moderator notifications</strong> need review.
-              </div>
-              <div className="notification-banner" role="status">
-                <strong>Schema warning:</strong> missing optional index metadata.
-              </div>
-            </PatternCard>
             <PatternCard name="MapInlineNotice" status="exception">
               <div className="ui-gallery-map-notice-stage">
                 <div className="map-inline-notice map-inline-notice-warning" role="status">
                   <span>Offline mode active. Changes will sync later.</span>
-                  <ActionButton>Dismiss</ActionButton>
-                </div>
-              </div>
-            </PatternCard>
-            <PatternCard name="OfflineBanner" status="legacy">
-              <div className="offline-banner" role="status">
-                <span>Offline. Changes are saved locally and will sync when connection returns.</span>
-                <div className="chip-group">
-                  <ActionButton>Open Sync Status</ActionButton>
                   <ActionButton>Dismiss</ActionButton>
                 </div>
               </div>

--- a/src/index.css
+++ b/src/index.css
@@ -3552,29 +3552,6 @@ html.panorama-gesture-lock body {
   word-break: break-word;
 }
 
-.offline-banner {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  flex-wrap: nowrap;
-  gap: 0.75rem;
-  margin-bottom: 0.75rem;
-  padding: 0.65rem 0.8rem;
-  border-radius: 10px;
-  border: 1px solid color-mix(in srgb, var(--warning) 40%, var(--border));
-  background: color-mix(in srgb, var(--warning) 14%, var(--surface));
-  color: var(--text);
-}
-
-.offline-banner > span {
-  white-space: nowrap;
-}
-
-.offline-banner .chip-group {
-  margin-left: auto;
-  flex-wrap: nowrap;
-}
-
 .resource-edit-fieldset {
   border: 0;
   margin: 0;
@@ -3918,15 +3895,6 @@ html.panorama-gesture-lock body {
   font-size: 0.72rem;
   font-weight: 700;
   padding: 0 6px;
-}
-
-.notification-banner {
-  border: 1px solid color-mix(in srgb, var(--warning) 52%, var(--border));
-  background: var(--warning-soft);
-  color: var(--text);
-  border-radius: 10px;
-  padding: 8px 10px;
-  font-size: 0.78rem;
 }
 
 .notifications-popover {
@@ -4699,10 +4667,6 @@ html.panorama-gesture-lock body {
 .ui-gallery-page .chart-panel {
   padding: 12px;
   gap: 10px;
-}
-
-.ui-gallery-page .offline-banner {
-  position: relative;
 }
 
 .ui-gallery-page .map-controls {


### PR DESCRIPTION
## Summary

Both patterns are dead — nothing in the live app renders `.notification-banner` or `.offline-banner`. The offline notice moved to `NotificationStack` and the moderator banner was never wired up.

- Removes `.offline-banner`, `.offline-banner > span`, `.offline-banner .chip-group` CSS rules
- Removes `.notification-banner` CSS rule
- Removes `.ui-gallery-page .offline-banner` gallery override
- Removes `NotificationBanner` and `OfflineBanner` PatternCards from gallery
- Removes their `SOURCE_PATHS` entries

## Test plan

- [ ] UI Gallery → Notifications tab: `NotificationBanner` and `OfflineBanner` cards are gone
- [ ] App renders normally — no visual regressions
- [ ] `tsc -b config/tsconfig.json --noEmit` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)