### PR TITLE
chore(ui): remove dead MapInlineNotice, MapControls, FormActionRow patterns (#616)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -706,8 +706,7 @@ export function AppShell() {
     }
   }, [accessState, initializeCloudSync]);
 
-  // Auto-load the Oslo demo workspace for anonymous visitors with no deeplink,
-  // and publish a persistent map notice (uses the existing map-inline-notice UI).
+  // Auto-load the Oslo demo workspace for anonymous visitors with no deeplink.
   useEffect(() => {
     const isAnonNoDeepLink = !deepLinkParse.ok && isAnonymousGuestReadonly;
     if (!isAnonNoDeepLink) return;

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -497,12 +497,7 @@ type MapViewProps = {
   inspectorPanelToggle?: ReactNode;
   /** Right-side actions in the inspector toolbar (e.g. share button, mobile size controls). */
   inspectorActions?: ReactNode;
-  notice?: {
-    message: string;
-    tone: "info" | "warning" | "error";
-    onDismiss?: () => void;
-  };
-  /** Pixel inset for the bottom edge when computing fitBounds, to avoid UI chrome. */
+/** Pixel inset for the bottom edge when computing fitBounds, to avoid UI chrome. */
   fitBottomInset?: number;
   /** Pixel insets reserved for map-internal chrome when fitting bounds. */
   fitChromePadding?: { top: number; right: number; bottom: number; left: number };
@@ -594,7 +589,6 @@ export function MapView({
   onToggleMapExpanded,
   inspectorPanelToggle,
   inspectorActions,
-  notice,
   fitBottomInset = 30,
   fitChromePadding = FIT_CHROME_PADDING,
 }: MapViewProps) {
@@ -2436,17 +2430,7 @@ export function MapView({
           </MapControlButton>
         </div>
       </div>
-      {notice ? (
-        <div className={`map-inline-notice map-inline-notice-${notice.tone}`} role={notice.tone === "error" ? "alert" : "status"}>
-          <span>{notice.message}</span>
-          {notice.onDismiss ? (
-            <ActionButton aria-label="Dismiss notice" onClick={notice.onDismiss} title="Dismiss">
-              Dismiss
-            </ActionButton>
-          ) : null}
-        </div>
-      ) : null}
-      {(coverageVizMode !== "none" &&
+{(coverageVizMode !== "none" &&
         (!hasHeatTopology ||
         (coverageVizMode === "relay" && !hasRelayTopology) ||
         ((coverageVizMode === "passfail" || coverageVizMode === "relay") && !hasPassFailTopology))) ? (

--- a/src/components/UiGalleryPage.tsx
+++ b/src/components/UiGalleryPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useMemo, type ReactNode } from "react";
-import { CircleAlert, CircleCheck, CircleX, Info, Layers, Maximize2, Minus, PanelRightClose, Plus, RefreshCw, X } from "lucide-react";
+import { CircleAlert, CircleCheck, CircleX, Info, Maximize2, Minus, PanelRightClose, Plus, RefreshCw, X } from "lucide-react";
 import { ActionButton } from "./ActionButton";
 import { StateDot } from "./StateDot";
 import { Surface } from "./ui/Surface";
@@ -47,12 +47,10 @@ const SOURCE_PATHS: Record<string, string> = {
   "UI Slider": "src/components/UiSlider.tsx",
   "SiteBeamVisualizer": "src/components/SiteBeamVisualizer.tsx",
   "NotificationStack": "src/components/NotificationStack.tsx",
-  "MapInlineNotice": "src/components/MapInlineNotice.tsx",
   "NotificationBell": "src/components/NotificationBell.tsx",
   "EmptyState": "src/components/ui/EmptyState.tsx",
   "LoadingState": "src/components/ui/LoadingState.tsx",
   "ErrorHelperStates": "src/components/ErrorHelperStates.tsx",
-  "MapControls": "src/components/MapView.tsx",
   "SidebarFooter": "src/components/SidebarFooter.tsx",
   "Surface": "src/components/ui/Surface.tsx",
   "StateDot": "src/components/StateDot.tsx",
@@ -451,7 +449,7 @@ export function UiGalleryPage() {
         <section className="ui-gallery-section">
           <h3>Forms</h3>
           <div className="ui-pattern-grid">
-            <PatternCard name="FormActionRow" status="under migration">
+            <PatternCard name="chip-group" status="standard">
               <div className="panel-section">
                 <div className="chip-group">
                   <ActionButton>Apply</ActionButton>
@@ -582,14 +580,6 @@ export function UiGalleryPage() {
                 </div>
               </div>
             </PatternCard>
-            <PatternCard name="MapInlineNotice" status="exception">
-              <div className="ui-gallery-map-notice-stage">
-                <div className="map-inline-notice map-inline-notice-warning" role="status">
-                  <span>Offline mode active. Changes will sync later.</span>
-                  <ActionButton>Dismiss</ActionButton>
-                </div>
-              </div>
-            </PatternCard>
             <PatternCard name="NotificationBell" status="exception">
               <div className="chip-group">
                 <button className="notification-bell" type="button">
@@ -698,18 +688,6 @@ export function UiGalleryPage() {
         <section className="ui-gallery-section">
           <h3>Meta / Map UI</h3>
           <div className="ui-pattern-grid">
-            <PatternCard name="MapControls" status="standard">
-              <div className="map-controls map-controls-unified">
-                <div className="map-controls-group">
-                  <MapControlButton title="Layers">
-                    <Layers aria-hidden="true" size={16} strokeWidth={1.8} />
-                  </MapControlButton>
-                  <MapControlButton title="Refresh">
-                    <RefreshCw aria-hidden="true" size={16} strokeWidth={1.8} />
-                  </MapControlButton>
-                </div>
-              </div>
-            </PatternCard>
             <PatternCard name="SidebarFooter" status="standard">
               <footer className="sidebar-footer">
                 <div className="sidebar-footer-links">

--- a/src/index.css
+++ b/src/index.css
@@ -1073,43 +1073,6 @@ input {
   z-index: 60;
 }
 
-.map-inline-notice {
-  position: absolute;
-  top: calc(18px + 36px + (var(--workspace-panel-gap) * 2));
-  left: 50%;
-  transform: translateX(-50%);
-  width: max-content;
-  max-width: min(calc(100% - 36px), calc(100% - (var(--sidebar-overlay-width) * 2) - 60px));
-  z-index: 55;
-  display: inline-flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  padding: 6px 10px;
-  border-radius: var(--radius-pill);
-  border: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
-  background: color-mix(in srgb, var(--surface-2) 90%, transparent);
-  font-size: 0.84rem;
-  box-shadow: var(--shadow-elev-3);
-}
-
-.workspace-panel.is-map-expanded .map-inline-notice,
-.workspace-panel.is-profile-expanded .map-inline-notice {
-  max-width: calc(100% - 36px);
-}
-
-.map-inline-notice-warning {
-  border-color: color-mix(in srgb, var(--accent) 52%, var(--border));
-}
-
-.map-inline-notice-error {
-  border-color: color-mix(in srgb, var(--text) 34%, var(--border));
-}
-
-.map-inline-notice .btn {
-  white-space: nowrap;
-  padding: 4px 10px;
-}
 
 .app-notification-stack {
   position: absolute;
@@ -3185,10 +3148,6 @@ html.panorama-gesture-lock body {
     right: 12px;
   }
 
-  .map-inline-notice {
-    top: calc(var(--mobile-controls-top) + 42px + (var(--workspace-panel-gap) * 2));
-    max-width: calc(100% - 24px);
-  }
 
   .map-provider-field .locale-select {
     min-width: 100%;
@@ -4681,22 +4640,6 @@ html.panorama-gesture-lock body {
   align-items: center;
 }
 
-.ui-gallery-map-notice-stage {
-  position: relative;
-  min-height: 86px;
-  border-radius: var(--radius-card);
-  border: 1px solid color-mix(in srgb, var(--border) 68%, transparent);
-  background: color-mix(in srgb, var(--surface) 84%, transparent);
-  overflow: hidden;
-}
-
-.ui-gallery-map-notice-stage .map-inline-notice {
-  left: 12px;
-  right: 12px;
-  top: 12px;
-  transform: none;
-  max-width: calc(100% - 24px);
-}
 
 @media (max-width: 980px) {
   .app-notification-stack {


### PR DESCRIPTION
## Summary

- **MapInlineNotice**: `MapView`'s `notice` prop was never passed from `AppShell` — the demo notice already used `NotificationStack`. Removes the prop, its JSX, all CSS rules (including mobile override and gallery stage), the gallery PatternCard, and SOURCE_PATHS entry. Fixes stale comment in AppShell.
- **MapControls**: internal positional container for the map overlay bar — not a useful gallery specimen. Removes PatternCard and SOURCE_PATHS entry (CSS stays, it's live).
- **FormActionRow**: never existed as a real component or CSS class. Replaces the stale `under-migration` PatternCard with an accurate `chip-group` card reflecting what the app actually uses.

## Test plan

- [ ] UI Gallery → Notifications tab: `MapInlineNotice` card is gone
- [ ] UI Gallery → Meta/Map UI tab: `MapControls` card is gone
- [ ] UI Gallery → Forms tab: `chip-group` card present, `FormActionRow` gone
- [ ] App renders normally — anonymous guest demo notice still appears (via NotificationStack)
- [ ] `tsc -b config/tsconfig.json --noEmit` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)