### PR TITLE
chore(ui): split ErrorHelperStates — delete terrain-alert, move field-help-error to Forms (#616)

### DIFF
--- a/src/components/UiGalleryPage.tsx
+++ b/src/components/UiGalleryPage.tsx
@@ -50,7 +50,6 @@ const SOURCE_PATHS: Record<string, string> = {
   "NotificationBell": "src/components/NotificationBell.tsx",
   "EmptyState": "src/components/ui/EmptyState.tsx",
   "LoadingState": "src/components/ui/LoadingState.tsx",
-  "ErrorHelperStates": "src/components/ErrorHelperStates.tsx",
   "SidebarFooter": "src/components/SidebarFooter.tsx",
   "Surface": "src/components/ui/Surface.tsx",
   "StateDot": "src/components/StateDot.tsx",
@@ -458,6 +457,13 @@ export function UiGalleryPage() {
                 </div>
               </div>
             </PatternCard>
+            <PatternCard name="field-help-error" status="standard">
+              <label className="field-grid">
+                <span>Simulation Name</span>
+                <input defaultValue="AB" type="text" aria-describedby="gallery-field-error" />
+              </label>
+              <p id="gallery-field-error" className="field-help field-help-error">Name must be at least 3 characters.</p>
+            </PatternCard>
             <PatternCard name="Input" status="standard">
               <label className="field-grid">
                 <span>Simulation Name</span>
@@ -604,12 +610,6 @@ export function UiGalleryPage() {
                 <div className="map-progress-fill map-progress-fill-indeterminate" />
               </div>
               <p className="field-help">Loading terrain and profile data…</p>
-            </PatternCard>
-            <PatternCard name="ErrorHelperStates" status="under migration">
-              <p className="field-help field-help-error">Name must be at least 3 characters.</p>
-              <div className="terrain-alert">
-                <p>Terrain fetch failed for one tile. Retry when network is stable.</p>
-              </div>
             </PatternCard>
           </div>
         </section>

--- a/src/index.css
+++ b/src/index.css
@@ -4364,21 +4364,6 @@ html.panorama-gesture-lock body {
   background: color-mix(in srgb, var(--danger) 16%, transparent);
 }
 
-.terrain-alert {
-  border: 1px solid color-mix(in srgb, var(--warning) 55%, var(--border));
-  background: color-mix(in srgb, var(--warning) 16%, transparent);
-  border-radius: 10px;
-  padding: 10px;
-  display: grid;
-  gap: 8px;
-}
-
-.terrain-alert p {
-  margin: 0;
-  color: var(--text);
-  font-size: 0.79rem;
-}
-
 .whatif-table {
   border: 1px solid var(--border);
   border-radius: var(--radius-btn);


### PR DESCRIPTION
## Summary

- **`terrain-alert`**: dead CSS — nothing in the live app renders it. Removes the two CSS rules and the gallery specimen.
- **`field-help-error`**: active inline validation pattern used across Sidebar, UserAdminPanel, SettingsPanel etc. Moves it to the Forms tab as a proper `standard` PatternCard with a realistic input + error text specimen.
- Removes the bogus `ErrorHelperStates.tsx` SOURCE_PATHS entry (that file doesn't exist).

## Test plan

- [ ] UI Gallery → States tab: `ErrorHelperStates` card is gone
- [ ] UI Gallery → Forms tab: `field-help-error` card present with input and error text
- [ ] `tsc -b config/tsconfig.json --noEmit` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)