### PR TITLE
fix: honor no-milestone issue close exception

### DIFF
--- a/.github/workflows/require-milestone-on-close.yml
+++ b/.github/workflows/require-milestone-on-close.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   enforce-milestone:
-    if: github.event.issue.state_reason == 'completed' && github.event.issue.milestone == null && !contains(toJson(github.event.issue.labels), '\"name\":\"no-milestone-close-ok\"')
+    if: github.event.issue.state_reason == 'completed' && github.event.issue.milestone == null && !contains(github.event.issue.labels.*.name, 'no-milestone-close-ok')
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/functions/_lib/requireMilestoneOnCloseWorkflow.test.ts
+++ b/functions/_lib/requireMilestoneOnCloseWorkflow.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+describe("require milestone on close workflow", () => {
+  it("honors the no-milestone-close-ok exception label by name", () => {
+    const workflow = readFileSync(
+      resolve(process.cwd(), ".github/workflows/require-milestone-on-close.yml"),
+      "utf8",
+    );
+
+    expect(workflow).toContain(
+      "contains(github.event.issue.labels.*.name, 'no-milestone-close-ok')",
+    );
+    expect(workflow).not.toContain("toJson(github.event.issue.labels)");
+  });
+});


### PR DESCRIPTION
## Summary
- Replace brittle JSON string matching in the issue-close milestone guard with a direct label-name check.
- Add a regression test for the no-milestone-close-ok exception.

## Verification
- npm run test -- --run functions/_lib/requireMilestoneOnCloseWorkflow.test.ts
- npm test
- npm run build

Related: #704