### PR TITLE
Add user location map flow

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -2094,6 +2094,7 @@ export function AppShell() {
           onToggleMapExpanded={toggleMapExpanded}
           fitBottomInset={mapFitBottomInset}
           fitChromePadding={mapFitChromePadding}
+          onPublishNotice={publishAppNotice}
         />
         {isMobileViewport ? (
           <MobileWorkspaceTabs

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent, type ReactNode } from "react";
-import { Egg, Fullscreen, Maximize2, Minimize2, Rabbit, RefreshCw, SquareStack, ZoomIn, ZoomOut } from "lucide-react";
+import { Egg, Fullscreen, Locate, LocateFixed, Maximize2, Minimize2, Rabbit, RefreshCw, SquareStack, ZoomIn, ZoomOut } from "lucide-react";
 import { CompactDetails, CompactDetailsSummary } from "./ui/CompactDetails";
 import { MapControlButton } from "./ui/MapControlButton";
 import { Surface } from "./ui/Surface";
@@ -181,6 +181,16 @@ const terrainRasterPaint = {
   "raster-saturation": -0.06,
 };
 
+const userLocationAccuracyLayer = (color: string): LayerProps => ({
+  id: "user-location-accuracy-layer",
+  type: "fill",
+  paint: {
+    "fill-color": color,
+    "fill-opacity": 0.16,
+    "fill-outline-color": color,
+  },
+});
+
 const supportsWebgl = (): boolean => {
   try {
     const canvas = document.createElement("canvas");
@@ -197,6 +207,8 @@ const supportsWebgl = (): boolean => {
 const clamp = (value: number, min: number, max: number): number =>
   Math.max(min, Math.min(max, value));
 const fmtDbm = (value: number): string => `${value.toFixed(1)} dBm`;
+const fmtAccuracy = (value: number | null): string =>
+  typeof value === "number" && Number.isFinite(value) ? `accuracy ${Math.round(value)} m` : "accuracy unavailable";
 
 const guessSiteNameForPosition = async (lat: number, lon: number): Promise<string> => {
   const fallback = `Site ${lat.toFixed(5)}, ${lon.toFixed(5)}`;
@@ -501,6 +513,7 @@ type MapViewProps = {
   fitBottomInset?: number;
   /** Pixel insets reserved for map-internal chrome when fitting bounds. */
   fitChromePadding?: { top: number; right: number; bottom: number; left: number };
+  onPublishNotice?: (notice: { id: string; message: string; tone: "info" | "warning" | "error"; persistent: boolean }) => void;
 };
 
 type MarkerActionButtonProps = {
@@ -553,6 +566,12 @@ type PendingNewSiteDraft = {
   lon: number;
 };
 
+type UserLocationFix = {
+  lat: number;
+  lon: number;
+  accuracyM: number | null;
+};
+
 type PendingSiteMove = {
   siteId: string;
   originalPosition: { lat: number; lon: number };
@@ -578,6 +597,53 @@ const DEFAULT_MAP_VIEWPORT = {
 };
 
 const SITE_PIN_MARKER_OFFSET: [number, number] = [0, -11];
+const USER_LOCATION_ZOOM = 12;
+const USER_LOCATION_WATCH_OPTIONS: PositionOptions = {
+  enableHighAccuracy: true,
+  maximumAge: 0,
+  timeout: 15_000,
+};
+const USER_LOCATION_NOTICE_ID = "user-location";
+
+const userLocationErrorMessage = (error: GeolocationPositionError): string => {
+  if (error.code === error.PERMISSION_DENIED) return "Location permission was denied.";
+  if (error.code === error.POSITION_UNAVAILABLE) return "Your location is currently unavailable.";
+  if (error.code === error.TIMEOUT) return "Location request timed out.";
+  return "Could not get your location.";
+};
+
+const buildUserLocationAccuracyGeoJson = (fix: UserLocationFix | null) => {
+  const accuracyM = fix?.accuracyM;
+  if (!fix || typeof accuracyM !== "number" || !Number.isFinite(accuracyM) || accuracyM <= 0) {
+    return {
+      type: "FeatureCollection" as const,
+      features: [],
+    };
+  }
+  const pointCount = 64;
+  const latRadius = accuracyM / 111_320;
+  const lonRadius = latRadius / Math.max(0.1, Math.cos((fix.lat * Math.PI) / 180));
+  const coordinates = Array.from({ length: pointCount + 1 }, (_, index) => {
+    const angle = (index / pointCount) * Math.PI * 2;
+    return [
+      fix.lon + Math.cos(angle) * lonRadius,
+      fix.lat + Math.sin(angle) * latRadius,
+    ];
+  });
+  return {
+    type: "FeatureCollection" as const,
+    features: [
+      {
+        type: "Feature" as const,
+        properties: {},
+        geometry: {
+          type: "Polygon" as const,
+          coordinates: [coordinates],
+        },
+      },
+    ],
+  };
+};
 
 export function MapView({
   isMapExpanded,
@@ -591,6 +657,7 @@ export function MapView({
   inspectorActions,
   fitBottomInset = 30,
   fitChromePadding = FIT_CHROME_PADDING,
+  onPublishNotice,
 }: MapViewProps) {
   const sites = useAppStore((state) => state.sites);
   const siteLibrary = useAppStore((state) => state.siteLibrary);
@@ -714,18 +781,100 @@ export function MapView({
   } | null>(null);
   const [useFallbackMapStyle, setUseFallbackMapStyle] = useState(false);
   const [mapProviderWarning, setMapProviderWarning] = useState<string | null>(null);
+  const [isUserLocationActive, setIsUserLocationActive] = useState(false);
+  const [userLocationFix, setUserLocationFix] = useState<UserLocationFix | null>(null);
   const [interactionViewState, setInteractionViewState] = useState<{
     longitude: number;
     latitude: number;
     zoom: number;
   } | null>(null);
   const mapRef = useRef<MapRef | null>(null);
+  const userLocationWatchIdRef = useRef<number | null>(null);
+  const isUserLocationActiveRef = useRef(false);
+  const isUserLocationFollowingRef = useRef(false);
   const panoramaLensBaseViewRef = useRef<{
     center: { lat: number; lon: number };
     zoom: number;
     bearing: number;
     pitch: number;
   } | null>(null);
+
+  const stopUserLocation = useCallback(() => {
+    if (userLocationWatchIdRef.current !== null && navigator.geolocation) {
+      navigator.geolocation.clearWatch(userLocationWatchIdRef.current);
+    }
+    userLocationWatchIdRef.current = null;
+    isUserLocationActiveRef.current = false;
+    isUserLocationFollowingRef.current = false;
+    setIsUserLocationActive(false);
+    setUserLocationFix(null);
+  }, []);
+
+  useEffect(() => () => stopUserLocation(), [stopUserLocation]);
+
+  const publishLocationNotice = useCallback(
+    (message: string, tone: "info" | "warning" | "error" = "error") => {
+      onPublishNotice?.({
+        id: USER_LOCATION_NOTICE_ID,
+        message,
+        tone,
+        persistent: false,
+      });
+    },
+    [onPublishNotice],
+  );
+
+  const startUserLocation = useCallback(() => {
+    if (!navigator.geolocation) {
+      publishLocationNotice("Your browser does not support location services.");
+      return;
+    }
+    isUserLocationActiveRef.current = true;
+    isUserLocationFollowingRef.current = true;
+    setIsUserLocationActive(true);
+    setUserLocationFix(null);
+    try {
+      userLocationWatchIdRef.current = navigator.geolocation.watchPosition(
+        (position) => {
+          const nextFix: UserLocationFix = {
+            lat: position.coords.latitude,
+            lon: position.coords.longitude,
+            accuracyM: Number.isFinite(position.coords.accuracy) ? position.coords.accuracy : null,
+          };
+          setUserLocationFix(nextFix);
+          if (isUserLocationFollowingRef.current) {
+            updateMapViewport({
+              center: { lat: nextFix.lat, lon: nextFix.lon },
+              zoom: USER_LOCATION_ZOOM,
+            });
+            setInteractionViewState({
+              longitude: nextFix.lon,
+              latitude: nextFix.lat,
+              zoom: USER_LOCATION_ZOOM,
+            });
+          }
+        },
+        (error) => {
+          console.error("[user-location] geolocation watch failed", error);
+          publishLocationNotice(userLocationErrorMessage(error));
+          stopUserLocation();
+        },
+        USER_LOCATION_WATCH_OPTIONS,
+      );
+    } catch (error) {
+      console.error("[user-location] geolocation watch failed", error);
+      publishLocationNotice("Could not get your location.");
+      stopUserLocation();
+    }
+  }, [publishLocationNotice, stopUserLocation, updateMapViewport]);
+
+  const toggleUserLocation = useCallback(() => {
+    if (isUserLocationActiveRef.current) {
+      stopUserLocation();
+      return;
+    }
+    startUserLocation();
+  }, [startUserLocation, stopUserLocation]);
 
   useEffect(() => {
     const handleViewportChange = () => {
@@ -2114,6 +2263,11 @@ export function MapView({
     setSiteDraftStatus(null);
   };
 
+  const beginUserLocationSiteDraft = () => {
+    if (!canPersist || !userLocationFix || pendingNewSiteDraft) return;
+    beginPendingNewSiteDraft(userLocationFix.lat, userLocationFix.lon);
+  };
+
   const onMapClick = (event: MapLayerMouseEvent) => {
     const rawTarget = event.originalEvent?.target;
     if (rawTarget instanceof Element && rawTarget.closest(".map-site-surface")) return;
@@ -2264,6 +2418,11 @@ export function MapView({
   const themedOverlay = resolvedBasemap.isThemed
     ? { color: variant.cssVars["--terrain"], opacity: theme === "dark" ? 0.1 : 0.08 }
     : null;
+  const userLocationAccuracyGeoJson = useMemo(
+    () => buildUserLocationAccuracyGeoJson(userLocationFix),
+    [userLocationFix],
+  );
+  const userLocationSelectionColor = variant.cssVars["--selection"] ?? selectedLinkColor;
   // Track the selected category in local state; initialize from the current style's category.
   const [selectedCategory, setSelectedCategory] = useState<BasemapCategory>(
     () => getCategoryForStyleId(basemapStyleId),
@@ -2411,6 +2570,14 @@ export function MapView({
           </MapControlButton>
           <MapControlButton aria-label="Zoom in" onClick={() => zoomBy(1)} title="Zoom in">
             <ZoomIn aria-hidden="true" strokeWidth={1.8} />
+          </MapControlButton>
+          <MapControlButton
+            aria-label="Use my location"
+            isSelected={isUserLocationActive}
+            onClick={toggleUserLocation}
+            title="Use my location"
+          >
+            {isUserLocationActive ? <LocateFixed aria-hidden="true" strokeWidth={1.8} /> : <Locate aria-hidden="true" strokeWidth={1.8} />}
           </MapControlButton>
           <MapControlButton
             aria-label="Fit map to sites"
@@ -3059,6 +3226,9 @@ export function MapView({
         onMove={(event) => {
           if (event.originalEvent) {
             clearFitControlActive();
+            if (isUserLocationActiveRef.current && isUserLocationFollowingRef.current) {
+              isUserLocationFollowingRef.current = false;
+            }
           }
           setInteractionViewState({
             longitude: event.viewState.longitude,
@@ -3111,6 +3281,12 @@ export function MapView({
             url={coverageOverlay.url}
           >
             <Layer {...coverageRasterLayer} />
+          </Source>
+        ) : null}
+
+        {userLocationFix ? (
+          <Source data={userLocationAccuracyGeoJson} id="user-location-accuracy" type="geojson">
+            <Layer {...userLocationAccuracyLayer(userLocationSelectionColor)} />
           </Source>
         ) : null}
 
@@ -3248,6 +3424,33 @@ export function MapView({
             <Surface variant="pill" className="map-site-surface is-temporary" pointerTail pointerTone="temporary">
               <span>New Site</span>
             </Surface>
+          </Marker>
+        ) : null}
+
+        {userLocationFix ? (
+          <Marker
+            anchor="bottom"
+            latitude={userLocationFix.lat}
+            longitude={userLocationFix.lon}
+            offset={SITE_PIN_MARKER_OFFSET}
+            style={{ zIndex: pendingNewSiteDraft ? 2 : 5 }}
+          >
+            <MarkerActionButton
+              ariaLabel={`User location, ${userLocationFix.lat.toFixed(5)}, ${userLocationFix.lon.toFixed(5)}, ${fmtAccuracy(userLocationFix.accuracyM)}`}
+              className="map-site-surface is-selected"
+              pointerTail
+              pointerTone="selection"
+              tone={canPersist && !pendingNewSiteDraft ? "default" : "muted"}
+              onMouseEnter={() =>
+                setOverlayHoverInfo({
+                  text: `User location · ${userLocationFix.lat.toFixed(5)}, ${userLocationFix.lon.toFixed(5)} · ${fmtAccuracy(userLocationFix.accuracyM)}`,
+                })
+              }
+              onMouseLeave={() => setOverlayHoverInfo(null)}
+              onActivate={beginUserLocationSiteDraft}
+            >
+              <span>User Location</span>
+            </MarkerActionButton>
           </Marker>
         ) : null}
 

--- a/src/components/MapView.userLocation.test.tsx
+++ b/src/components/MapView.userLocation.test.tsx
@@ -1,0 +1,230 @@
+// @vitest-environment jsdom
+import React from "react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mapMock = vi.hoisted(() => ({
+  latestProps: null as null | {
+    onMove?: (event: { originalEvent?: unknown; viewState: { longitude: number; latitude: number; zoom: number } }) => void;
+  },
+}));
+
+vi.hoisted(() => {
+  const data = new Map<string, string>();
+  const localStorageMock = {
+    getItem: (key: string) => data.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      data.set(key, String(value));
+    },
+    removeItem: (key: string) => {
+      data.delete(key);
+    },
+    clear: () => data.clear(),
+    key: (index: number) => Array.from(data.keys())[index] ?? null,
+    get length() {
+      return data.size;
+    },
+  };
+  vi.stubGlobal("localStorage", localStorageMock);
+});
+
+vi.mock("react-map-gl/maplibre", () => {
+  return {
+    default: (
+      props: {
+        children?: React.ReactNode;
+        onMove?: (event: { originalEvent?: unknown; viewState: { longitude: number; latitude: number; zoom: number } }) => void;
+      },
+    ) => {
+      mapMock.latestProps = props;
+      return <div data-testid="mock-map">{props.children}</div>;
+    },
+    Layer: () => null,
+    Marker: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    Source: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+const watchPosition = vi.fn();
+const clearWatch = vi.fn();
+
+const installGeolocation = () => {
+  Object.defineProperty(globalThis.navigator, "geolocation", {
+    configurable: true,
+    value: {
+      watchPosition,
+      clearWatch,
+    },
+  });
+};
+
+const position = (latitude: number, longitude: number, accuracy: number, timestamp = 1): GeolocationPosition => ({
+  coords: {
+    latitude,
+    longitude,
+    accuracy,
+    altitude: null,
+    altitudeAccuracy: null,
+    heading: null,
+    speed: null,
+    toJSON: () => ({ latitude, longitude, accuracy }),
+  },
+  timestamp,
+  toJSON: () => ({ coords: { latitude, longitude, accuracy }, timestamp }),
+});
+
+import { useAppStore } from "../store/appStore";
+import { MapView } from "./MapView";
+
+const renderMapView = (props: Partial<React.ComponentProps<typeof MapView>> = {}) =>
+  render(
+    <MapView
+      canPersist
+      isMapExpanded={false}
+      onToggleMapExpanded={() => undefined}
+      showInspector={false}
+      {...props}
+    />,
+  );
+
+describe("MapView user location flow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mapMock.latestProps = null;
+    installGeolocation();
+    watchPosition.mockReturnValue(42);
+    Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
+      configurable: true,
+      value: vi.fn(() => ({})),
+    });
+    useAppStore.setState({
+      sites: [],
+      links: [],
+      selectedSiteId: "",
+      selectedSiteIds: [],
+      selectedLinkId: "",
+      mapViewport: { center: { lat: 59.9, lon: 10.75 }, zoom: 8 },
+    });
+  });
+
+  it("starts and stops live geolocation from the map control", () => {
+    renderMapView();
+
+    fireEvent.click(screen.getByRole("button", { name: "Use my location" }));
+
+    expect(watchPosition).toHaveBeenCalledWith(expect.any(Function), expect.any(Function), {
+      enableHighAccuracy: true,
+      maximumAge: 0,
+      timeout: 15_000,
+    });
+    expect(screen.getByRole("button", { name: "Use my location" })).toHaveClass("is-selected");
+
+    fireEvent.click(screen.getByRole("button", { name: "Use my location" }));
+
+    expect(clearWatch).toHaveBeenCalledWith(42);
+    expect(screen.queryByRole("button", { name: /User location/i })).not.toBeInTheDocument();
+  });
+
+  it("centers on the first location update and stops following after user pan", () => {
+    renderMapView();
+    fireEvent.click(screen.getByRole("button", { name: "Use my location" }));
+    const success = watchPosition.mock.calls[0]?.[0] as PositionCallback;
+
+    act(() => {
+      success(position(60.12345, 11.23456, 18));
+    });
+
+    expect(useAppStore.getState().mapViewport).toMatchObject({
+      center: { lat: 60.12345, lon: 11.23456 },
+      zoom: 12,
+    });
+
+    act(() => {
+      mapMock.latestProps?.onMove?.({
+        originalEvent: {},
+        viewState: { latitude: 61, longitude: 12, zoom: 10 },
+      });
+      success(position(62, 13, 24, 2));
+    });
+
+    expect(useAppStore.getState().mapViewport).toMatchObject({
+      center: { lat: 60.12345, lon: 11.23456 },
+      zoom: 12,
+    });
+    expect(screen.getByRole("button", { name: /User location/i })).toHaveTextContent("User Location");
+  });
+
+  it("reuses the existing temporary site draft path when the marker is clicked", () => {
+    renderMapView();
+    fireEvent.click(screen.getByRole("button", { name: "Use my location" }));
+    const success = watchPosition.mock.calls[0]?.[0] as PositionCallback;
+
+    act(() => {
+      success(position(60.5, 11.5, 12));
+    });
+
+    expect(screen.queryByText("New Site")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /User location/i }));
+
+    expect(screen.getByText("New Site")).toBeInTheDocument();
+  });
+
+  it("does not create a temporary site from the marker in read-only mode", () => {
+    renderMapView({ canPersist: false, readOnly: true });
+    fireEvent.click(screen.getByRole("button", { name: "Use my location" }));
+    const success = watchPosition.mock.calls[0]?.[0] as PositionCallback;
+
+    act(() => {
+      success(position(60.5, 11.5, 12));
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /User location/i }));
+
+    expect(screen.queryByText("New Site")).not.toBeInTheDocument();
+  });
+
+  it("publishes plain location failure notifications", () => {
+    const onPublishNotice = vi.fn();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    Object.defineProperty(globalThis.navigator, "geolocation", {
+      configurable: true,
+      value: undefined,
+    });
+    renderMapView({ onPublishNotice });
+
+    fireEvent.click(screen.getByRole("button", { name: "Use my location" }));
+
+    expect(onPublishNotice).toHaveBeenCalledWith({
+      id: "user-location",
+      message: "Your browser does not support location services.",
+      tone: "error",
+      persistent: false,
+    });
+
+    installGeolocation();
+    watchPosition.mockImplementationOnce((_success, error) => {
+      error({
+        code: 1,
+        message: "User denied Geolocation",
+        PERMISSION_DENIED: 1,
+        POSITION_UNAVAILABLE: 2,
+        TIMEOUT: 3,
+      } as GeolocationPositionError);
+      return 7;
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Use my location" }));
+
+    expect(onPublishNotice).toHaveBeenLastCalledWith({
+      id: "user-location",
+      message: "Location permission was denied.",
+      tone: "error",
+      persistent: false,
+    });
+    expect(consoleError).toHaveBeenCalledWith(
+      "[user-location] geolocation watch failed",
+      expect.objectContaining({ code: 1 }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add a live `Use my location` map control with active selected state and icon swap.
- Show a live user-position marker and accuracy circle while geolocation is active.
- Reuse the existing temporary Site draft flow when clicking the user marker in editable mode.

## Verification
- `npm test` passed (427 tests).
- `npm run build` passed.

## Issue
Refs #250