### PR TITLE
Fix map camera follow-up for user location

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -70,6 +70,7 @@ import { SimulationResultsSection } from "./SimulationResultsSection";
 import { ActionButton } from "./ActionButton";
 import { StateDot } from "./StateDot";
 import { useMapControls } from "./map/useMapControls";
+import { animateMapToCenter, fitMapToBounds, resolveMapCameraPadding } from "./map/mapCamera";
 import { PanelToolbar } from "./ui/PanelToolbar";
 
 const UI_SECTION_KEYS = {
@@ -843,15 +844,18 @@ export function MapView({
           };
           setUserLocationFix(nextFix);
           if (isUserLocationFollowingRef.current) {
-            updateMapViewport({
+            setInteractionViewState(null);
+            const didAnimate = animateMapToCenter(mapRef, {
               center: { lat: nextFix.lat, lon: nextFix.lon },
               zoom: USER_LOCATION_ZOOM,
+              padding: resolveMapCameraPadding(fitChromePadding, fitBottomInset),
             });
-            setInteractionViewState({
-              longitude: nextFix.lon,
-              latitude: nextFix.lat,
-              zoom: USER_LOCATION_ZOOM,
-            });
+            if (!didAnimate) {
+              updateMapViewport({
+                center: { lat: nextFix.lat, lon: nextFix.lon },
+                zoom: USER_LOCATION_ZOOM,
+              });
+            }
           }
         },
         (error) => {
@@ -866,7 +870,16 @@ export function MapView({
       publishLocationNotice("Could not get your location.");
       stopUserLocation();
     }
-  }, [publishLocationNotice, stopUserLocation, updateMapViewport]);
+  }, [
+    fitBottomInset,
+    fitChromePadding.bottom,
+    fitChromePadding.left,
+    fitChromePadding.right,
+    fitChromePadding.top,
+    publishLocationNotice,
+    stopUserLocation,
+    updateMapViewport,
+  ]);
 
   const toggleUserLocation = useCallback(() => {
     if (isUserLocationActiveRef.current) {
@@ -2462,11 +2475,8 @@ export function MapView({
     if (!fitControlActive || !fitSitesEpoch || !isMapLoaded || !mapRef.current) return;
     const bounds = computeSiteFitBounds(sites, overlayRadiusKm);
     if (!bounds) return;
-    mapRef.current.fitBounds(bounds, {
-      padding: { ...fitChromePadding, bottom: fitBottomInset },
-      animate: true,
-      linear: false,
-      duration: 900,
+    fitMapToBounds(mapRef, bounds, {
+      padding: resolveMapCameraPadding(fitChromePadding, fitBottomInset),
       maxZoom: 14,
     });
     setInteractionViewState(null);
@@ -3429,28 +3439,28 @@ export function MapView({
 
         {userLocationFix ? (
           <Marker
-            anchor="bottom"
+            anchor="center"
             latitude={userLocationFix.lat}
             longitude={userLocationFix.lon}
-            offset={SITE_PIN_MARKER_OFFSET}
             style={{ zIndex: pendingNewSiteDraft ? 2 : 5 }}
           >
-            <MarkerActionButton
-              ariaLabel={`User location, ${userLocationFix.lat.toFixed(5)}, ${userLocationFix.lon.toFixed(5)}, ${fmtAccuracy(userLocationFix.accuracyM)}`}
-              className="map-site-surface is-selected"
-              pointerTail
-              pointerTone="selection"
-              tone={canPersist && !pendingNewSiteDraft ? "default" : "muted"}
+            <button
+              type="button"
+              aria-label={`User location, ${userLocationFix.lat.toFixed(5)}, ${userLocationFix.lon.toFixed(5)}, ${fmtAccuracy(userLocationFix.accuracyM)}`}
+              className={`user-location-marker ${canPersist && !pendingNewSiteDraft ? "" : "is-muted"}`}
+              title="User location"
               onMouseEnter={() =>
                 setOverlayHoverInfo({
                   text: `User location · ${userLocationFix.lat.toFixed(5)}, ${userLocationFix.lon.toFixed(5)} · ${fmtAccuracy(userLocationFix.accuracyM)}`,
                 })
               }
               onMouseLeave={() => setOverlayHoverInfo(null)}
-              onActivate={beginUserLocationSiteDraft}
-            >
-              <span>User Location</span>
-            </MarkerActionButton>
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                beginUserLocationSiteDraft();
+              }}
+            />
           </Marker>
         ) : null}
 

--- a/src/components/MapView.userLocation.test.tsx
+++ b/src/components/MapView.userLocation.test.tsx
@@ -4,6 +4,7 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mapMock = vi.hoisted(() => ({
+  easeTo: vi.fn(),
   latestProps: null as null | {
     onMove?: (event: { originalEvent?: unknown; viewState: { longitude: number; latitude: number; zoom: number } }) => void;
   },
@@ -28,17 +29,23 @@ vi.hoisted(() => {
   vi.stubGlobal("localStorage", localStorageMock);
 });
 
-vi.mock("react-map-gl/maplibre", () => {
+vi.mock("react-map-gl/maplibre", async () => {
+  const ReactMock = await vi.importActual<typeof import("react")>("react");
   return {
-    default: (
+    default: ReactMock.forwardRef((
       props: {
         children?: React.ReactNode;
         onMove?: (event: { originalEvent?: unknown; viewState: { longitude: number; latitude: number; zoom: number } }) => void;
       },
+      ref: React.ForwardedRef<{ easeTo: typeof mapMock.easeTo; queryRenderedFeatures: () => unknown[] }>,
     ) => {
       mapMock.latestProps = props;
+      ReactMock.useImperativeHandle(ref, () => ({
+        easeTo: mapMock.easeTo,
+        queryRenderedFeatures: () => [],
+      }));
       return <div data-testid="mock-map">{props.children}</div>;
-    },
+    }),
     Layer: () => null,
     Marker: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
     Source: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
@@ -134,9 +141,12 @@ describe("MapView user location flow", () => {
       success(position(60.12345, 11.23456, 18));
     });
 
-    expect(useAppStore.getState().mapViewport).toMatchObject({
-      center: { lat: 60.12345, lon: 11.23456 },
+    expect(mapMock.easeTo).toHaveBeenCalledWith({
+      center: [11.23456, 60.12345],
       zoom: 12,
+      offset: [-25, 0],
+      duration: 900,
+      essential: true,
     });
 
     act(() => {
@@ -147,11 +157,9 @@ describe("MapView user location flow", () => {
       success(position(62, 13, 24, 2));
     });
 
-    expect(useAppStore.getState().mapViewport).toMatchObject({
-      center: { lat: 60.12345, lon: 11.23456 },
-      zoom: 12,
-    });
-    expect(screen.getByRole("button", { name: /User location/i })).toHaveTextContent("User Location");
+    expect(mapMock.easeTo).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("button", { name: /User location/i })).toHaveClass("user-location-marker");
+    expect(screen.getByRole("button", { name: /User location/i })).not.toHaveClass("map-site-surface");
   });
 
   it("reuses the existing temporary site draft path when the marker is clicked", () => {

--- a/src/components/map/mapCamera.test.ts
+++ b/src/components/map/mapCamera.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  MAP_CAMERA_ANIMATION_MS,
+  animateMapToCenter,
+  animateMapToZoom,
+  fitMapToBounds,
+  mapCameraOffsetForPadding,
+  resolveMapCameraPadding,
+} from "./mapCamera";
+
+describe("map camera helpers", () => {
+  it("resolves shared fit and center padding from app chrome measurements", () => {
+    expect(resolveMapCameraPadding({ top: 30, right: 70, bottom: 30, left: 320 }, 280)).toEqual({
+      top: 30,
+      right: 70,
+      bottom: 280,
+      left: 320,
+    });
+  });
+
+  it("moves the target to the center of panel-free map space", () => {
+    expect(mapCameraOffsetForPadding({ top: 30, right: 70, bottom: 30, left: 320 })).toEqual([125, 0]);
+    expect(mapCameraOffsetForPadding({ top: 30, right: 70, bottom: 280, left: 70 })).toEqual([0, -125]);
+  });
+
+  it("animates centered camera moves with the shared offset", () => {
+    const easeTo = vi.fn();
+
+    animateMapToCenter(
+      { current: { easeTo } },
+      {
+        center: { lat: 60.5, lon: 11.5 },
+        zoom: 12,
+        padding: { top: 30, right: 70, bottom: 280, left: 320 },
+      },
+    );
+
+    expect(easeTo).toHaveBeenCalledWith({
+      center: [11.5, 60.5],
+      zoom: 12,
+      offset: [125, -125],
+      duration: MAP_CAMERA_ANIMATION_MS,
+      essential: true,
+    });
+  });
+
+  it("animates zoom-only camera moves with the shared offset", () => {
+    const easeTo = vi.fn();
+
+    animateMapToZoom(
+      { current: { easeTo } },
+      {
+        zoom: 9,
+        padding: { top: 30, right: 70, bottom: 30, left: 320 },
+      },
+    );
+
+    expect(easeTo).toHaveBeenCalledWith({
+      zoom: 9,
+      offset: [125, 0],
+      duration: MAP_CAMERA_ANIMATION_MS,
+      essential: true,
+    });
+  });
+
+  it("fits bounds through the shared animated fit options", () => {
+    const fitBounds = vi.fn();
+    const bounds: [[number, number], [number, number]] = [[10, 59], [12, 61]];
+
+    fitMapToBounds(
+      { current: { fitBounds } },
+      bounds,
+      {
+        padding: { top: 30, right: 70, bottom: 280, left: 320 },
+        maxZoom: 14,
+      },
+    );
+
+    expect(fitBounds).toHaveBeenCalledWith(bounds, {
+      padding: { top: 30, right: 70, bottom: 280, left: 320 },
+      animate: true,
+      linear: false,
+      duration: MAP_CAMERA_ANIMATION_MS,
+      maxZoom: 14,
+    });
+  });
+});

--- a/src/components/map/mapCamera.ts
+++ b/src/components/map/mapCamera.ts
@@ -1,0 +1,117 @@
+import type { RefObject } from "react";
+
+export type MapCameraPadding = {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+};
+
+type MapCameraRef = RefObject<{
+  easeTo?: (options: {
+    center?: [number, number];
+    zoom?: number;
+    offset?: [number, number];
+    duration?: number;
+    essential?: boolean;
+  }) => void;
+  fitBounds?: (
+    bounds: [[number, number], [number, number]],
+    options: {
+      padding: MapCameraPadding;
+      animate: boolean;
+      linear: boolean;
+      duration: number;
+      maxZoom?: number;
+    },
+  ) => void;
+} | null>;
+
+export const MAP_CAMERA_ANIMATION_MS = 900;
+
+export const resolveMapCameraPadding = (
+  fitChromePadding: MapCameraPadding,
+  fitBottomInset: number,
+): MapCameraPadding => ({
+  ...fitChromePadding,
+  bottom: fitBottomInset,
+});
+
+export const mapCameraOffsetForPadding = (padding: MapCameraPadding): [number, number] => [
+  (padding.left - padding.right) / 2,
+  (padding.top - padding.bottom) / 2,
+];
+
+export const animateMapToCenter = (
+  mapRef: MapCameraRef,
+  {
+    center,
+    zoom,
+    padding,
+    duration = MAP_CAMERA_ANIMATION_MS,
+  }: {
+    center: { lat: number; lon: number };
+    zoom: number;
+    padding: MapCameraPadding;
+    duration?: number;
+  },
+): boolean => {
+  const map = mapRef.current;
+  if (!map?.easeTo) return false;
+  map.easeTo({
+    center: [center.lon, center.lat],
+    zoom,
+    offset: mapCameraOffsetForPadding(padding),
+    duration,
+    essential: true,
+  });
+  return true;
+};
+
+export const animateMapToZoom = (
+  mapRef: MapCameraRef,
+  {
+    zoom,
+    padding,
+    duration = MAP_CAMERA_ANIMATION_MS,
+  }: {
+    zoom: number;
+    padding: MapCameraPadding;
+    duration?: number;
+  },
+): boolean => {
+  const map = mapRef.current;
+  if (!map?.easeTo) return false;
+  map.easeTo({
+    zoom,
+    offset: mapCameraOffsetForPadding(padding),
+    duration,
+    essential: true,
+  });
+  return true;
+};
+
+export const fitMapToBounds = (
+  mapRef: MapCameraRef,
+  bounds: [[number, number], [number, number]],
+  {
+    padding,
+    maxZoom,
+    duration = MAP_CAMERA_ANIMATION_MS,
+  }: {
+    padding: MapCameraPadding;
+    maxZoom?: number;
+    duration?: number;
+  },
+): boolean => {
+  const map = mapRef.current;
+  if (!map?.fitBounds) return false;
+  map.fitBounds(bounds, {
+    padding,
+    animate: true,
+    linear: false,
+    duration,
+    maxZoom,
+  });
+  return true;
+};

--- a/src/components/map/useMapControls.ts
+++ b/src/components/map/useMapControls.ts
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import type { RefObject } from "react";
 import type { MapRef } from "react-map-gl/maplibre";
+import { animateMapToZoom, fitMapToBounds, resolveMapCameraPadding, type MapCameraPadding } from "./mapCamera";
 
 type ViewState = {
   zoom: number;
@@ -13,7 +14,7 @@ type UseMapControlsParams = {
   providerMaxZoom: number;
   sites: Array<{ position: { lat: number; lon: number } }>;
   computeSiteFitBounds: (sites: Array<{ position: { lat: number; lon: number } }>) => [[number, number], [number, number]] | null;
-  fitChromePadding: { left: number; right: number; top: number; bottom: number };
+  fitChromePadding: MapCameraPadding;
   clamp: (value: number, min: number, max: number) => number;
   setInteractionViewState: (value: null) => void;
   updateMapViewport: (patch: { zoom?: number }) => void;
@@ -49,7 +50,11 @@ export function useMapControls({
     setFitControlActive(computeNextAutoFitEnabledAfterInteraction());
     const nextZoom = computeNextZoom(activeViewState.zoom, delta, providerMaxZoom, clamp);
     setInteractionViewState(null);
-    updateMapViewport({ zoom: nextZoom });
+    const didAnimate = animateMapToZoom(mapRef, {
+      zoom: nextZoom,
+      padding: resolveMapCameraPadding(fitChromePadding, fitBottomInset),
+    });
+    if (!didAnimate) updateMapViewport({ zoom: nextZoom });
   };
 
   const fitToNodes = () => {
@@ -60,9 +65,8 @@ export function useMapControls({
     const bounds = computeSiteFitBounds(sites);
     if (!bounds) return;
     setInteractionViewState(null);
-    mapRef.current.fitBounds(bounds, {
-      padding: { ...fitChromePadding, bottom: fitBottomInset },
-      animate: true,
+    fitMapToBounds(mapRef, bounds, {
+      padding: resolveMapCameraPadding(fitChromePadding, fitBottomInset),
       maxZoom: 14,
     });
   };

--- a/src/index.css
+++ b/src/index.css
@@ -113,6 +113,12 @@ input {
   font: inherit;
 }
 
+button {
+  appearance: none;
+  -webkit-appearance: none;
+  color: inherit;
+}
+
 .app-shell {
   display: grid;
   --sidebar-overlay-width: clamp(280px, 20vw, 400px);
@@ -1984,6 +1990,51 @@ input {
 .map-site-surface.is-temporary {
   --surface-pill-border: var(--temporary);
   box-shadow: 0 0 0 3px var(--temporary-ring);
+}
+
+.user-location-marker {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--selection);
+  cursor: pointer;
+  isolation: isolate;
+}
+
+.user-location-marker::before {
+  content: "";
+  width: 14px;
+  height: 14px;
+  border-radius: var(--radius-pill);
+  background: currentColor;
+  box-shadow:
+    0 0 0 3px var(--selection-soft),
+    0 0 0 1px var(--surface);
+}
+
+.user-location-marker::after {
+  content: "";
+  position: absolute;
+  width: 4px;
+  height: 4px;
+  border-radius: var(--radius-pill);
+  background: var(--surface);
+}
+
+.user-location-marker:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+.user-location-marker.is-muted {
+  cursor: default;
+  opacity: 0.72;
 }
 
 .profile-map-cursor {


### PR DESCRIPTION
## Summary\n- centralize animated map camera center/zoom/fit helpers with shared panel-aware padding\n- route user-location follow, zoom controls, and fit paths through the shared camera helpers\n- replace the user-location Site-style marker with a themed dot marker\n- reset native button appearance/color to prevent iOS Safari blue icon leakage\n\n## Tests\n- npm test\n- npm run build\n\nCloses follow-up feedback on #250.