### PR TITLE
fix: keep workspace visible on auth timeouts

### DIFF
--- a/functions/_lib/auth.test.ts
+++ b/functions/_lib/auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { inspectAuthRequest, verifyAuth } from "./auth";
+import { AuthVerificationTimeoutError, inspectAuthRequest, verifyAuth } from "./auth";
 import type { Env } from "./types";
 
 const makeEnv = (overrides?: Partial<Env>): Env =>
@@ -39,6 +39,31 @@ describe("verifyAuth", () => {
     const auth = await verifyAuth(request, makeEnv());
     expect(auth?.userId).toBe("user@example.com");
     expect(auth?.source).toBe("headers");
+  });
+
+  it("uses header-based auth before jwt verification when both are present", async () => {
+    const request = new Request("https://example.test/api/me", {
+      headers: {
+        "Cf-Access-Authenticated-User-Email": "user@example.com",
+        cookie: "CF_Authorization=not-a-real-jwt",
+      },
+    });
+    const auth = await verifyAuth(request, makeEnv({ ACCESS_AUD: "aud", ACCESS_TEAM_DOMAIN: "team.example" }));
+    expect(auth?.userId).toBe("user@example.com");
+    expect(auth?.source).toBe("headers");
+  });
+
+  it("throws a controlled timeout when jwt verification does not finish in time", async () => {
+    const header = Buffer.from(JSON.stringify({ alg: "RS256", kid: "test-key" })).toString("base64url");
+    const payload = Buffer.from(JSON.stringify({ iss: "https://team.example" })).toString("base64url");
+    const request = new Request("https://example.test/api/me", {
+      headers: {
+        cookie: `CF_Authorization=${header}.${payload}.signature`,
+      },
+    });
+    await expect(
+      verifyAuth(request, makeEnv({ ACCESS_AUD: "aud", ACCESS_TEAM_DOMAIN: "team.example", AUTH_VERIFY_TIMEOUT_MS: "0" })),
+    ).rejects.toBeInstanceOf(AuthVerificationTimeoutError);
   });
 
   it("falls back to insecure dev auth when enabled", async () => {

--- a/functions/_lib/auth.ts
+++ b/functions/_lib/auth.ts
@@ -2,6 +2,14 @@ import { createRemoteJWKSet, jwtVerify } from "jose";
 import type { AuthContext, Env } from "./types";
 
 const jwksCache = new Map<string, ReturnType<typeof createRemoteJWKSet>>();
+const DEFAULT_AUTH_VERIFY_TIMEOUT_MS = 3_000;
+
+export class AuthVerificationTimeoutError extends Error {
+  constructor() {
+    super("Auth verification timed out");
+    this.name = "AuthVerificationTimeoutError";
+  }
+}
 
 const remoteJwksFor = (url: string) => {
   const cached = jwksCache.get(url);
@@ -125,6 +133,29 @@ const emitAuthLog = (env: Env, payload: Record<string, unknown>) => {
   console.info(JSON.stringify({ event: "auth", ...payload }));
 };
 
+const authVerifyTimeoutMs = (env: Env): number => {
+  const parsed = Number(env.AUTH_VERIFY_TIMEOUT_MS ?? "");
+  if (Number.isFinite(parsed) && parsed >= 0) return parsed;
+  return DEFAULT_AUTH_VERIFY_TIMEOUT_MS;
+};
+
+const withAuthVerifyTimeout = async <T>(promise: Promise<T>, timeoutMs: number): Promise<T> => {
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  return await new Promise<T>((resolve, reject) => {
+    timeoutId = setTimeout(() => reject(new AuthVerificationTimeoutError()), timeoutMs);
+    promise.then(
+      (value) => {
+        if (timeoutId) clearTimeout(timeoutId);
+        resolve(value);
+      },
+      (error) => {
+        if (timeoutId) clearTimeout(timeoutId);
+        reject(error);
+      },
+    );
+  });
+};
+
 const verifyCloudflareAccessJwt = async (
   token: string,
   request: Request,
@@ -233,6 +264,12 @@ const allowInsecureDevAuth = (env: Env): AuthContext | null => {
 export const verifyAuth = async (request: Request, env: Env): Promise<AuthContext | null> => {
   const authSignals = inspectAuthRequest(request);
   try {
+    const byHeader = verifyByHeadersOnly(request);
+    if (byHeader) {
+      emitAuthLog(env, { result: "ok", source: byHeader.source, ...authSignals });
+      return byHeader;
+    }
+
     const token =
       request.headers.get("cf-access-jwt-assertion") ??
       request.headers.get("Cf-Access-Jwt-Assertion") ??
@@ -240,7 +277,10 @@ export const verifyAuth = async (request: Request, env: Env): Promise<AuthContex
       "";
 
     if (token.trim()) {
-      const jwtVerified = await verifyCloudflareAccessJwt(token.trim(), request, env);
+      const jwtVerified = await withAuthVerifyTimeout(
+        verifyCloudflareAccessJwt(token.trim(), request, env),
+        authVerifyTimeoutMs(env),
+      );
       if (jwtVerified) {
         emitAuthLog(env, { result: "ok", source: jwtVerified.source, ...authSignals });
         return jwtVerified;
@@ -248,12 +288,11 @@ export const verifyAuth = async (request: Request, env: Env): Promise<AuthContex
       emitAuthLog(env, { result: "fail", reason: "jwt_verify_failed", ...authSignals });
     }
 
-    const byHeader = verifyByHeadersOnly(request);
-    if (byHeader) {
-      emitAuthLog(env, { result: "ok", source: byHeader.source, ...authSignals });
-      return byHeader;
+  } catch (error) {
+    if (error instanceof AuthVerificationTimeoutError) {
+      emitAuthLog(env, { result: "fail", reason: "jwt_verify_timeout", ...authSignals });
+      throw error;
     }
-  } catch {
     emitAuthLog(env, { result: "fail", reason: "auth_exception", ...authSignals });
     // Fail closed to header/dev fallback instead of surfacing auth internals as 500.
   }

--- a/functions/_lib/http.ts
+++ b/functions/_lib/http.ts
@@ -40,6 +40,7 @@ export const handleOptions = (request: Request): Response =>
 export const normalizeApiErrorMessage = (message: string): string => {
   const lower = message.toLowerCase();
   if (lower.includes("session revoked by admin")) return "Session revoked by admin.";
+  if (lower.includes("auth verification timed out")) return "Auth verification timed out.";
   if (lower.includes("access revoked by admin")) return "Account access revoked by admin.";
   if (lower.includes("pending approval")) return "Account pending approval.";
   if (lower.includes("unauthorized")) return "Unauthorized.";
@@ -54,6 +55,7 @@ export const normalizeApiErrorMessage = (message: string): string => {
 export const statusFromErrorMessage = (message: string, fallback = 500): number => {
   const lower = message.toLowerCase();
   if (lower.includes("schema out of date")) return 503;
+  if (lower.includes("auth verification timed out")) return 503;
   if (lower.includes("session revoked by admin")) return 401;
   if (lower.includes("access revoked by admin")) return 403;
   if (lower.includes("unauthorized")) return 401;
@@ -64,14 +66,27 @@ export const statusFromErrorMessage = (message: string, fallback = 500): number 
   return fallback;
 };
 
+const codeFromErrorMessage = (message: string): string | null => {
+  const lower = message.toLowerCase();
+  if (lower.includes("auth verification timed out")) return "auth_timeout";
+  if (lower.includes("schema out of date")) return "schema_unavailable";
+  return null;
+};
+
 export const errorResponse = (request: Request, error: unknown, fallback = 500): Response => {
   const message = error instanceof Error ? error.message : String(error);
+  const code = codeFromErrorMessage(message);
   return withCors(
     request,
     json(
-      {
-        error: normalizeApiErrorMessage(message),
-      },
+      code
+        ? {
+            error: normalizeApiErrorMessage(message),
+            code,
+          }
+        : {
+            error: normalizeApiErrorMessage(message),
+          },
       { status: statusFromErrorMessage(message, fallback) },
     ),
   );

--- a/functions/_lib/types.ts
+++ b/functions/_lib/types.ts
@@ -29,6 +29,7 @@ export type Env = {
   ACCESS_TEAM_DOMAIN?: string;
   ACCESS_AUD?: string;
   AUTH_OBSERVABILITY?: string;
+  AUTH_VERIFY_TIMEOUT_MS?: string;
   ALLOW_INSECURE_DEV_AUTH?: string;
   DEV_AUTH_USER_ID?: string;
   ADMIN_USER_IDS?: string;

--- a/functions/api/me.test.ts
+++ b/functions/api/me.test.ts
@@ -34,6 +34,13 @@ describe("api/me", () => {
     expect(res.headers.get("cache-control")).toBe("no-store");
   });
 
+  it("returns a controlled service unavailable response when auth verification times out", async () => {
+    verifyAuthMock.mockRejectedValue(new Error("Auth verification timed out"));
+    const res = await onRequestGet(mkCtx(new Request("https://example.test/api/me")));
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: "Auth verification timed out.", code: "auth_timeout" });
+  });
+
   it("returns no-store on PATCH", async () => {
     const req = new Request("https://example.test/api/me", {
       method: "PATCH",

--- a/src/components/AppShell.deeplink.test.ts
+++ b/src/components/AppShell.deeplink.test.ts
@@ -76,6 +76,16 @@ const hoisted = vi.hoisted(() => {
 });
 
 vi.mock("../lib/cloudUser", () => ({
+  CloudApiError: class CloudApiError extends Error {
+    status: number | null;
+    code: string;
+
+    constructor(message: string, input?: { status?: number | null; code?: string }) {
+      super(message);
+      this.status = input?.status ?? null;
+      this.code = input?.code ?? "api_error";
+    }
+  },
   fetchCollaboratorDirectory: vi.fn(async () => []),
   fetchDeepLinkStatus: hoisted.fetchDeepLinkStatus,
   fetchMe: hoisted.fetchMe,
@@ -230,6 +240,53 @@ describe("AppShell deeplink cold-load flow", () => {
       window as Window & { linksimNotifications?: { list: () => Array<{ id: string }> } }
     ).linksimNotifications?.list?.() ?? [];
     expect(notifications.some((entry) => entry.id === "shared-simulation-unavailable")).toBe(false);
+
+    root.unmount();
+    host.remove();
+  });
+
+  it("keeps the workspace visible and pins a warning when auth bootstrap times out", async () => {
+    window.history.replaceState(null, "", "/");
+    hoisted.fetchMe.mockRejectedValue(new Error("524 : server timed out"));
+
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    root.render(React.createElement(AppShell));
+
+    await waitForCondition(() => document.body.textContent?.includes("Cloud save is unavailable") === true);
+    expect(document.querySelector(".access-locked-shell")).toBeNull();
+    expect(document.body.textContent).not.toContain("Signed out");
+    expect(document.body.textContent).toContain("Your changes may not be saved");
+    expect(document.querySelector(".app-notification-item-error button")).toBeNull();
+
+    root.unmount();
+    host.remove();
+  });
+
+  it("keeps the workspace visible for revoked accounts", async () => {
+    window.history.replaceState(null, "", "/");
+    hoisted.fetchMe.mockResolvedValue({
+      id: "user-1",
+      username: "Owner",
+      isAdmin: false,
+      isModerator: false,
+      isApproved: false,
+      accountState: "revoked",
+      avatarUrl: "",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      bio: "",
+    });
+
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    root.render(React.createElement(AppShell));
+
+    await waitForCondition(() => document.body.textContent?.includes("Account access is unavailable") === true);
+    expect(document.querySelector(".access-locked-shell")).toBeNull();
+    expect(document.body.textContent).toContain("Your changes may not be saved");
 
     root.unmount();
     host.remove();

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,6 +1,6 @@
 import { type CSSProperties, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { CircleAlert, CircleCheck, CircleUserRound, CircleX, CloudAlert, Copy, Globe, Info, PanelBottomClose, PanelBottomOpen, PanelLeftClose, PanelLeftOpen, PanelRightClose, PanelRightOpen, Share, UserRoundPlus, UserRoundSearch, Users, X } from "lucide-react";
-import { type CollaboratorDirectoryUser, fetchCollaboratorDirectory, fetchDeepLinkStatus, fetchMe, setLocalDevRole } from "../lib/cloudUser";
+import { CircleAlert, CircleCheck, CircleX, Copy, Globe, Info, PanelBottomClose, PanelBottomOpen, PanelLeftClose, PanelLeftOpen, PanelRightClose, PanelRightOpen, Share, UserRoundPlus, UserRoundSearch, Users, X } from "lucide-react";
+import { CloudApiError, type CollaboratorDirectoryUser, fetchCollaboratorDirectory, fetchDeepLinkStatus, fetchMe } from "../lib/cloudUser";
 import { fetchCloudLibrary, fetchPublicSimulationLibrary, pushCloudLibrary } from "../lib/cloudLibrary";
 import { buildDeepLinkPathname, buildDeepLinkUrl, buildSettingsPath, canonicalizeDeepLinkKey, matchSettingsPath, parseDeepLinkFromLocation, slugifyName, type SettingsSectionId } from "../lib/deepLink";
 import { canRunDeepLinkApply } from "../lib/deepLinkApplyGate";
@@ -37,7 +37,6 @@ import OnboardingTutorialModal from "./OnboardingTutorialModal";
 import SimulationLibraryPanel from "./SimulationLibraryPanel";
 import WelcomeModal from "./WelcomeModal";
 import { Sidebar } from "./Sidebar";
-import { UserAdminPanel } from "./UserAdminPanel";
 import { SettingsPanel } from "./settings/SettingsPanel";
 import { MobileWorkspaceTabs } from "./app-shell/MobileWorkspaceTabs";
 import { useOnboardingFlow } from "./app-shell/useOnboardingFlow";
@@ -48,7 +47,9 @@ const LAST_SIMULATION_REF_KEY = "rmw-last-simulation-ref-v1";
 const ONBOARDING_SEEN_KEY_PREFIX = "linksim:onboarding-seen:v1:";
 const LOCAL_FORCE_READONLY_KEY = "linksim:local-force-readonly:v1";
 const ACCESS_CHECK_TIMEOUT_MS = 10_000;
+const ACCESS_FETCH_TIMEOUT_MS = 8_000;
 const ACCESS_CHECKING_NOTICE_ID = "access-checking";
+const AUTH_DEGRADED_NOTICE_ID = "auth-degraded";
 const OFFLINE_SYNC_NOTICE_ID = "offline-sync";
 const BLANK_SIM_NOTICE_ID = "blank-simulation-guidance";
 // Shell vocabulary mapping for cleanup work:
@@ -64,6 +65,7 @@ type AppNotice = {
   message: string;
   tone: "info" | "warning" | "error";
   persistent: boolean;
+  pinned?: boolean;
 };
 
 type NotificationDebugWindow = Window & {
@@ -186,8 +188,6 @@ export function AppShell() {
   const [profileMotionPhase, setProfileMotionPhase] = useState<PanelMotionPhase>("idle");
   const [accessState, setAccessState] = useState<"checking" | "granted" | "readonly" | "pending" | "locked">("checking");
   const [accessDiagnosticMessage, setAccessDiagnosticMessage] = useState<string | null>(null);
-  // Derived early so effects below can reference them without temporal dead zone.
-  const lockedNeedsSignIn = isAuthSignInRequiredMessage(accessDiagnosticMessage);
   const isAnonymousGuestReadonly = accessState === "readonly" && !currentUser;
   const [activeUserId, setActiveUserId] = useState("");
   const [settingsRoute, setSettingsRoute] = useState<{ section: SettingsSectionId | null } | null>(() => {
@@ -248,7 +248,6 @@ export function AppShell() {
   const [mobileBottomOccupied, setMobileBottomOccupied] = useState(0);
   const [measuredSidebarWidth, setMeasuredSidebarWidth] = useState(0);
   const [measuredInspectorWidth, setMeasuredInspectorWidth] = useState(0);
-  const [localDevStatus, setLocalDevStatus] = useState<string | null>(null);
   const [offlineBannerDismissed, setOfflineBannerDismissed] = useState(false);
   const [showLibraryFromRequest, setShowLibraryFromRequest] = useState(false);
   const deepLinkAppliedRef = useRef(false);
@@ -336,7 +335,7 @@ export function AppShell() {
     [dismissNotification, dismissingNotificationIds],
   );
   const clearNotifications = useCallback(() => {
-    const next = clearUiNotifications();
+    const next = clearUiNotifications(uiNotificationsRef.current);
     setUiNotifications(next);
     uiNotificationsRef.current = next;
     setPausedNotificationIds([]);
@@ -344,7 +343,7 @@ export function AppShell() {
   }, []);
   const removeNotificationImmediately = useCallback((id: string) => {
     setUiNotifications((current) => {
-      const next = dismissUiNotification(current, id);
+      const next = dismissUiNotification(current, id, { force: true });
       uiNotificationsRef.current = next;
       return next;
     });
@@ -370,6 +369,7 @@ export function AppShell() {
       message: notice.message,
       tone: notice.tone,
       dismissMode: notice.persistent ? "manual" : "auto",
+      pinned: notice.pinned,
     });
   }, [pushNotification]);
   const publishTransientNotice = useCallback(
@@ -543,11 +543,11 @@ export function AppShell() {
         isInitializing,
       });
       setAccessDiagnosticMessage(
-        "Access check timed out. Reload the page. If this continues, open the console and share the startup error.",
+        "Cloud save is unavailable. Your changes may not be saved. The sign-in check timed out; reload or sign in again when the service recovers.",
       );
       setCurrentUser(null);
       setAuthState("signed_out");
-      setAccessState("locked");
+      setAccessState("readonly");
     }, ACCESS_CHECK_TIMEOUT_MS);
 
     console.info("[AppShell] Starting access check", {
@@ -593,7 +593,7 @@ export function AppShell() {
             return;
           }
         }
-        const profile = await fetchMe();
+        const profile = await fetchMe({ timeoutMs: ACCESS_FETCH_TIMEOUT_MS });
         if (cancelled || timedOut) return;
         window.clearTimeout(timeoutId);
         setAccessDiagnosticMessage(null);
@@ -610,7 +610,10 @@ export function AppShell() {
           // ignore storage errors
         }
         if (profile.accountState === "revoked") {
-          setAccessState("locked");
+          setAccessDiagnosticMessage(
+            "Account access is unavailable. Your changes may not be saved. Sign in again or contact an admin if you need access restored.",
+          );
+          setAccessState("readonly");
           return;
         }
         if (profile.isAdmin || profile.isModerator || profile.isApproved) {
@@ -621,11 +624,17 @@ export function AppShell() {
           setAccessState("readonly");
           return;
         }
-        setAccessState("pending");
+        setAccessDiagnosticMessage(
+          "Account approval is pending. Your changes may not be saved until a moderator or admin approves access.",
+        );
+        setAccessState("readonly");
       } catch (error) {
         if (cancelled || timedOut) return;
         window.clearTimeout(timeoutId);
         const message = getUiErrorMessage(error);
+        const isServerTimeout =
+          error instanceof CloudApiError &&
+          (error.code === "timeout" || error.code === "server_timeout" || error.code === "auth_timeout" || error.status === 524);
         const isOnlineNow = typeof navigator === "undefined" ? true : navigator.onLine;
         const fallbackToReadonly = shouldUseReadonlyFallbackForAuthBootstrap({
           message,
@@ -650,14 +659,20 @@ export function AppShell() {
             fallbackToReadonly,
           });
         }
-        setAccessDiagnosticMessage(`Access check failed: ${message}`);
+        setAccessDiagnosticMessage(
+          isServerTimeout
+            ? "Cloud save is unavailable. Your changes may not be saved. The sign-in service timed out; reload or sign in again when it recovers."
+            : `Cloud save is unavailable. Your changes may not be saved. Sign in again to resume cloud saving. (${message})`,
+        );
         const hadAuthenticatedSession = hadAuthenticatedSessionRef.current;
         if (hadAuthenticatedSession) {
           setCurrentUser(null);
           setAuthState("signed_out");
         }
         if (message.includes("Session revoked by admin")) {
-          window.location.href = "/cdn-cgi/access/logout";
+          setCurrentUser(null);
+          setAuthState("signed_out");
+          setAccessState("readonly");
           return;
         }
         if (deepLinkParse.ok) {
@@ -666,8 +681,8 @@ export function AppShell() {
         }
         if (fallbackToReadonly) {
           if (hadAuthenticatedSession) {
-            setAccessDiagnosticMessage("You are signed out. Sign in to continue.");
-            setAccessState("locked");
+            setAccessDiagnosticMessage("Cloud save is unavailable. Your changes may not be saved. Sign in again to resume cloud saving.");
+            setAccessState("readonly");
           } else {
             setAccessDiagnosticMessage("Sign-in check was blocked by browser auth redirects. Continuing in read-only demo mode.");
             setAccessState("readonly");
@@ -676,14 +691,14 @@ export function AppShell() {
         }
         if (isAuthSignInRequiredMessage(message)) {
           if (hadAuthenticatedSession) {
-            setAccessDiagnosticMessage("You are signed out. Sign in to continue.");
-            setAccessState("locked");
+            setAccessDiagnosticMessage("Cloud save is unavailable. Your changes may not be saved. Sign in again to resume cloud saving.");
+            setAccessState("readonly");
           } else {
             setAccessState("readonly");
           }
           return;
         }
-        setAccessState("locked");
+        setAccessState("readonly");
       }
     })();
     return () => {
@@ -696,9 +711,23 @@ export function AppShell() {
     if (authState !== "signed_out") return;
     if (accessState === "checking") return;
     if (!hadAuthenticatedSessionRef.current) return;
-    setAccessDiagnosticMessage("You are signed out. Sign in to continue.");
-    setAccessState("locked");
+    setAccessDiagnosticMessage("Cloud save is unavailable. Your changes may not be saved. Sign in again to resume cloud saving.");
+    setAccessState("readonly");
   }, [accessState, authState]);
+
+  useEffect(() => {
+    if (!accessDiagnosticMessage) {
+      removeNotificationImmediately(AUTH_DEGRADED_NOTICE_ID);
+      return;
+    }
+    pushNotification({
+      id: AUTH_DEGRADED_NOTICE_ID,
+      message: accessDiagnosticMessage,
+      tone: "error",
+      dismissMode: "manual",
+      pinned: true,
+    });
+  }, [accessDiagnosticMessage, pushNotification, removeNotificationImmediately]);
 
   useEffect(() => {
     if (accessState === "granted") {
@@ -722,59 +751,10 @@ export function AppShell() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isAnonymousGuestReadonly, deepLinkParse.ok]);
 
-  const signOutOrReadonly = useCallback(() => {
-    setCurrentUser(null);
-    setAuthState("signed_out");
-    hadAuthenticatedSessionRef.current = true;
-    if (isLocalRuntime) {
-      try {
-        localStorage.setItem(LOCAL_FORCE_READONLY_KEY, "1");
-      } catch {
-        // ignore storage errors
-      }
-      window.location.reload();
-      return;
-    }
-    if (deepLinkParse.ok) {
-      window.location.reload();
-      return;
-    }
-    window.location.href = "/cdn-cgi/access/logout";
-  }, [deepLinkParse.ok, isLocalRuntime, setAuthState, setCurrentUser]);
-
-  const signIn = useCallback(() => {
-    const returnTo = `${window.location.pathname}${window.location.search}${window.location.hash}`;
-    window.location.href = `/api/auth-start?returnTo=${encodeURIComponent(returnTo || "/")}`;
-  }, []);
-
-  const switchLocalRole = useCallback(
-    async (role: "admin" | "moderator" | "user" | "pending") => {
-      try {
-        setLocalDevStatus(`Switching local role to ${role}...`);
-        await setLocalDevRole(role);
-        try {
-          localStorage.removeItem(LOCAL_FORCE_READONLY_KEY);
-        } catch {
-          // ignore storage errors
-        }
-        window.location.reload();
-      } catch (error) {
-        const message = getUiErrorMessage(error);
-        setLocalDevStatus(`Local role switch failed: ${message}`);
-        publishAppNotice({
-          id: "local-role-switch-failed",
-          message: `Local role switch failed: ${message}`,
-          tone: "error",
-          persistent: true,
-        });
-      }
-    },
-    [publishAppNotice],
-  );
-
   useEffect(() => {
     const timers: number[] = [];
     for (const notification of uiNotifications) {
+      if (notification.pinned) continue;
       if (notification.dismissMode !== "auto") continue;
       if (pausedNotificationIds.includes(notification.id)) continue;
       timers.push(window.setTimeout(() => requestDismissNotification(notification.id, "auto"), notification.durationMs));
@@ -1817,109 +1797,6 @@ export function AppShell() {
     [mobileBottomPanelMode, setMobileBottomPanelVisibility],
   );
 
-  if (accessState === "pending") {
-    return (
-      <main className="app-shell access-locked-shell">
-        <section className="panel-section access-locked-panel">
-          <UserAdminPanel onOpenSettings={() => openSettings("profile")} />
-          <h2>Closed Beta: Access Pending Approval</h2>
-          <p className="field-help">
-            You can sign in and edit your profile, but simulation tools stay locked until a moderator or admin approves your access.
-          </p>
-          <p className="field-help">LinkSim is currently invite/approval-only while we run a closed beta.</p>
-          <p className="field-help">To continue:</p>
-          <ul className="field-help access-pending-list">
-            <li>Open User Settings.</li>
-            <li>Add your name and valid email address.</li>
-            <li>Optionally add an access request note to explain why you need access.</li>
-            <li>Wait for moderator/admin approval. You will keep profile access while pending.</li>
-          </ul>
-          {isLocalRuntime ? (
-            <div className="chip-group">
-              <ActionButton onClick={() => void switchLocalRole("admin")} type="button">
-                Use Admin (Local)
-              </ActionButton>
-              <ActionButton onClick={() => void switchLocalRole("moderator")} type="button">
-                Use Moderator (Local)
-              </ActionButton>
-              <ActionButton onClick={() => void switchLocalRole("user")} type="button">
-                Use User (Local)
-              </ActionButton>
-              <ActionButton onClick={() => void switchLocalRole("pending")} type="button">
-                Use Pending (Local)
-              </ActionButton>
-            </div>
-          ) : null}
-           {localDevStatus ? <p className="field-help">{localDevStatus}</p> : null}
-        </section>
-        <WelcomeModal onClose={closeWelcome} onCreateNewSimulation={createNewFromWelcome} onOpenLibrary={openLibraryFromWelcome} onOpenOnboarding={openWelcomeFromWelcome} open={showWelcomeModal} />
-        <OnboardingTutorialModal onClose={() => setShowOnboardingTutorial(false)} onOpenLibrary={() => setShowSimulationLibraryRequest(true)} onOpenSiteLibrary={() => setShowSiteLibraryRequest(true)} open={showOnboardingTutorial} />
-      </main>
-    );
-  }
-
-  if (accessState === "locked") {
-    const shouldPromptSignIn = lockedNeedsSignIn || authState === "signed_out";
-    return (
-      <main className="app-shell access-locked-shell">
-        <section className="panel-section access-locked-panel">
-          {shouldPromptSignIn ? (
-            <div className="access-locked-alert-icon sync-error" aria-hidden="true">
-              <CloudAlert strokeWidth={1.8} />
-            </div>
-          ) : null}
-          <h2>{shouldPromptSignIn ? "Signed out" : "Access unavailable"}</h2>
-          {accessDiagnosticMessage ? <p className="field-help">{accessDiagnosticMessage}</p> : null}
-          {shouldPromptSignIn ? (
-            <p className="field-help">Sign in again to continue where you left off.</p>
-          ) : (
-            <>
-              <p className="field-help">
-                Your account session is valid, but this account is not available in LinkSim right now.
-              </p>
-              <p className="field-help">
-                If your user was removed by an admin, ask for re-approval. Then sign out and sign in again.
-              </p>
-            </>
-          )}
-          <div className="chip-group">
-          {shouldPromptSignIn ? (
-              <>
-                <ActionButton onClick={signIn} type="button">
-                  <CircleUserRound aria-hidden="true" strokeWidth={1.8} />
-                  <span>Sign In</span>
-                </ActionButton>
-              </>
-            ) : (
-              <ActionButton onClick={signOutOrReadonly} type="button">
-                Sign Out
-              </ActionButton>
-            )}
-            {isLocalRuntime ? (
-              <>
-                <ActionButton onClick={() => void switchLocalRole("admin")} type="button">
-                  Use Admin (Local)
-                </ActionButton>
-                <ActionButton onClick={() => void switchLocalRole("moderator")} type="button">
-                  Use Moderator (Local)
-                </ActionButton>
-                <ActionButton onClick={() => void switchLocalRole("user")} type="button">
-                  Use User (Local)
-                </ActionButton>
-                <ActionButton onClick={() => void switchLocalRole("pending")} type="button">
-                  Use Pending (Local)
-                </ActionButton>
-              </>
-            ) : null}
-          </div>
-          {localDevStatus ? <p className="field-help">{localDevStatus}</p> : null}
-        </section>
-        <WelcomeModal onClose={closeWelcome} onCreateNewSimulation={createNewFromWelcome} onOpenLibrary={openLibraryFromWelcome} onOpenOnboarding={openWelcomeFromWelcome} open={showWelcomeModal} />
-        <OnboardingTutorialModal onClose={() => setShowOnboardingTutorial(false)} onOpenLibrary={() => setShowSimulationLibraryRequest(true)} onOpenSiteLibrary={() => setShowSiteLibraryRequest(true)} open={showOnboardingTutorial} />
-      </main>
-    );
-  }
-
   return (
     <main
       ref={appShellRef}
@@ -2233,24 +2110,26 @@ export function AppShell() {
                 <div className="app-notification-copy">
                   <span>{notification.message}</span>
                 </div>
-                <button
-                  aria-label="Dismiss notification"
-                  className="app-notification-dismiss"
-                  onClick={() => {
-                    if (notification.id === OFFLINE_SYNC_NOTICE_ID) {
-                      setOfflineBannerDismissed(true);
-                    }
-                    requestDismissNotification(notification.id, "manual");
-                  }}
-                  title="Dismiss"
-                  type="button"
-                >
-                  <X aria-hidden="true" size={14} strokeWidth={2} />
-                </button>
+                {notification.pinned ? null : (
+                  <button
+                    aria-label="Dismiss notification"
+                    className="app-notification-dismiss"
+                    onClick={() => {
+                      if (notification.id === OFFLINE_SYNC_NOTICE_ID) {
+                        setOfflineBannerDismissed(true);
+                      }
+                      requestDismissNotification(notification.id, "manual");
+                    }}
+                    title="Dismiss"
+                    type="button"
+                  >
+                    <X aria-hidden="true" size={14} strokeWidth={2} />
+                  </button>
+                )}
               </div>
             ))}
           </div>
-          {uiNotifications.length >= DISMISS_ALL_THRESHOLD ? (
+          {uiNotifications.filter((notification) => !notification.pinned).length >= DISMISS_ALL_THRESHOLD ? (
             <div className="app-notification-stack-controls">
               <ActionButton onClick={clearNotifications} type="button">
                 Dismiss all

--- a/src/lib/cloudUser.ts
+++ b/src/lib/cloudUser.ts
@@ -124,28 +124,83 @@ export type CollaboratorDirectoryUser = {
 export type DeepLinkStatus = "ok" | "forbidden" | "missing";
 export type DeepLinkStatusResult = { status: DeepLinkStatus; simulationId?: string; authenticated?: boolean };
 
-const apiCall = async <T>(path: string, init?: RequestInit): Promise<T> => {
+export class CloudApiError extends Error {
+  status: number | null;
+  code: string;
+
+  constructor(message: string, input?: { status?: number | null; code?: string }) {
+    super(message);
+    this.name = "CloudApiError";
+    this.status = input?.status ?? null;
+    this.code = input?.code ?? "api_error";
+  }
+}
+
+type ApiCallInit = RequestInit & {
+  timeoutMs?: number;
+};
+
+const isAbortError = (error: unknown): boolean =>
+  error instanceof DOMException
+    ? error.name === "AbortError" || error.name === "TimeoutError"
+    : error instanceof Error &&
+      (error.name === "AbortError" || error.name === "TimeoutError" || error.message === "Request timed out");
+
+const apiCall = async <T>(path: string, init?: ApiCallInit): Promise<T> => {
   const headers = new Headers(init?.headers ?? {});
   const hasBody = init?.body !== undefined && init.body !== null;
   if (hasBody && !headers.has("content-type")) {
     headers.set("content-type", "application/json");
   }
-  const response = await fetch(path, {
-    ...init,
-    headers,
-  });
+  const { timeoutMs, signal, ...requestInit } = init ?? {};
+  const timeoutController = timeoutMs !== undefined ? new AbortController() : null;
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  const abortFromParent = () => timeoutController?.abort(signal?.reason);
+  if (timeoutController && signal) {
+    if (signal.aborted) {
+      timeoutController.abort(signal.reason);
+    } else {
+      signal.addEventListener("abort", abortFromParent, { once: true });
+    }
+  }
+  if (timeoutController && timeoutMs !== undefined) {
+    timeoutId = setTimeout(() => timeoutController.abort(new Error("Request timed out")), Math.max(0, timeoutMs));
+  }
+  let response: Response;
+  try {
+    response = await fetch(path, {
+      ...requestInit,
+      headers,
+      signal: timeoutController?.signal ?? signal,
+    });
+  } catch (error) {
+    if (isAbortError(error)) {
+      throw new CloudApiError("Request timed out", { code: "timeout" });
+    }
+    throw error;
+  } finally {
+    if (timeoutId !== null) clearTimeout(timeoutId);
+    if (timeoutController && signal) signal.removeEventListener("abort", abortFromParent);
+  }
   if (!response.ok) {
     const raw = await response.text();
     let message = raw;
+    let code = response.status === 524 ? "server_timeout" : "api_error";
     try {
-      const parsed = JSON.parse(raw) as { error?: unknown };
+      const parsed = JSON.parse(raw) as { error?: unknown; code?: unknown };
       if (typeof parsed.error === "string" && parsed.error.trim()) {
         message = parsed.error.trim();
+      }
+      if (typeof parsed.code === "string" && parsed.code.trim()) {
+        code = parsed.code.trim();
       }
     } catch {
       // Keep raw fallback.
     }
-    throw new Error(`${response.status} ${response.statusText}: ${message}`);
+    throw new CloudApiError(`${response.status} ${response.statusText}: ${message}`, {
+      status: response.status,
+      code,
+    });
   }
   return (await response.json()) as T;
 };
@@ -157,12 +212,12 @@ export const clearMeCache = (): void => {
   meCache = null;
 };
 
-export const fetchMe = async (): Promise<CloudUser> => {
+export const fetchMe = async (input?: { timeoutMs?: number }): Promise<CloudUser> => {
   const now = Date.now();
   if (meCache && now < meCache.expiresAt) {
     return meCache.user;
   }
-  const data = await apiCall<{ user: CloudUser }>("/api/me", { method: "GET" });
+  const data = await apiCall<{ user: CloudUser }>("/api/me", { method: "GET", timeoutMs: input?.timeoutMs });
   meCache = { user: data.user, expiresAt: now + ME_CACHE_TTL_MS };
   return data.user;
 };

--- a/src/lib/uiNotifications.test.ts
+++ b/src/lib/uiNotifications.test.ts
@@ -23,7 +23,12 @@ describe("createUiNotification", () => {
       dismissMode: "auto",
       durationMs: 5000,
       createdAt: 100,
+      pinned: false,
     });
+  });
+
+  it("forces manual dismiss mode for pinned notifications", () => {
+    expect(createUiNotification({ id: "auth", message: "Auth warning", pinned: true }).dismissMode).toBe("manual");
   });
 });
 
@@ -52,10 +57,21 @@ describe("dismissUiNotification", () => {
     expect(next).toHaveLength(1);
     expect(next[0].id).toBe("beta");
   });
+
+  it("keeps pinned notifications unless forced", () => {
+    const seeded = [createUiNotification({ id: "auth", message: "Auth warning", pinned: true }, 100)];
+    expect(dismissUiNotification(seeded, "auth").map((item) => item.id)).toEqual(["auth"]);
+    expect(dismissUiNotification(seeded, "auth", { force: true })).toEqual([]);
+  });
 });
 
 describe("clearUiNotifications", () => {
-  it("returns an empty list", () => {
-    expect(clearUiNotifications()).toEqual([]);
+  it("preserves pinned notifications unless forced", () => {
+    const seeded = [
+      createUiNotification({ id: "auth", message: "Auth warning", pinned: true }, 100),
+      createUiNotification({ id: "saved", message: "Saved" }, 200),
+    ];
+    expect(clearUiNotifications(seeded).map((item) => item.id)).toEqual(["auth"]);
+    expect(clearUiNotifications(seeded, { force: true })).toEqual([]);
   });
 });

--- a/src/lib/uiNotifications.ts
+++ b/src/lib/uiNotifications.ts
@@ -8,6 +8,7 @@ export type UiNotification = {
   dismissMode: UiNotificationDismissMode;
   durationMs: number;
   createdAt: number;
+  pinned: boolean;
 };
 
 export type UiNotificationInput = {
@@ -16,6 +17,7 @@ export type UiNotificationInput = {
   tone?: UiNotificationTone;
   dismissMode?: UiNotificationDismissMode;
   durationMs?: number;
+  pinned?: boolean;
 };
 
 const DEFAULT_DURATION_MS = 5_000;
@@ -24,9 +26,10 @@ export const createUiNotification = (input: UiNotificationInput, now = Date.now(
   id: input.id,
   message: input.message,
   tone: input.tone ?? "info",
-  dismissMode: input.dismissMode ?? "auto",
+  dismissMode: input.pinned ? "manual" : input.dismissMode ?? "auto",
   durationMs: Math.max(0, input.durationMs ?? DEFAULT_DURATION_MS),
   createdAt: now,
+  pinned: input.pinned === true,
 });
 
 export const upsertUiNotification = (
@@ -40,7 +43,13 @@ export const upsertUiNotification = (
   return notifications.map((item, itemIndex) => (itemIndex === index ? next : item));
 };
 
-export const dismissUiNotification = (notifications: UiNotification[], id: string): UiNotification[] =>
-  notifications.filter((item) => item.id !== id);
+export const dismissUiNotification = (
+  notifications: UiNotification[],
+  id: string,
+  options?: { force?: boolean },
+): UiNotification[] => notifications.filter((item) => item.id !== id || (item.pinned && options?.force !== true));
 
-export const clearUiNotifications = (): UiNotification[] => [];
+export const clearUiNotifications = (
+  notifications: UiNotification[] = [],
+  options?: { force?: boolean },
+): UiNotification[] => (options?.force === true ? [] : notifications.filter((item) => item.pinned));


### PR DESCRIPTION
## Summary
- keep AppShell in the workspace for auth/API timeout, signed-out, pending, forbidden, and revoked degraded states
- add pinned app notifications so auth/save risk warnings cannot be dismissed while degraded
- make /api/me auth verification prefer Cloudflare Access headers and fail fast with typed 503 auth_timeout responses

## Verification
- npm test
- npm run build

Closes #776