### PR TITLE
fix: retry auth recovery automatically

### DIFF
--- a/src/components/AppShell.deeplink.test.ts
+++ b/src/components/AppShell.deeplink.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createRoot } from "react-dom/client";
+import { act, render } from "@testing-library/react";
 
 const hoisted = vi.hoisted(() => {
   const fetchMe = vi.fn();
@@ -70,6 +70,7 @@ const hoisted = vi.hoisted(() => {
     fetchCloudLibrary,
     fetchPublicSimulationLibrary,
     loadSimulationPreset,
+    runtimeEnvironment: "production",
     state,
     useAppStore,
   };
@@ -110,6 +111,10 @@ vi.mock("../lib/deepLinkApplyGate", () => ({
 
 vi.mock("../hooks/useThemeVariant", () => ({
   useThemeVariant: () => ({ theme: "light", colorTheme: "green", variant: { cssVars: {} } }),
+}));
+
+vi.mock("../lib/environment", () => ({
+  getCurrentRuntimeEnvironment: () => hoisted.runtimeEnvironment,
 }));
 
 vi.mock("../store/appStore", () => ({
@@ -154,9 +159,61 @@ const waitForCondition = async (check: () => boolean, timeoutMs = 2500): Promise
   }
 };
 
+const installLocalStorageMock = (): void => {
+  const values = new Map<string, string>();
+  const localStorageMock = {
+    get length() {
+      return values.size;
+    },
+    clear: vi.fn(() => values.clear()),
+    getItem: vi.fn((key: string) => values.get(key) ?? null),
+    key: vi.fn((index: number) => Array.from(values.keys())[index] ?? null),
+    removeItem: vi.fn((key: string) => {
+      values.delete(key);
+    }),
+    setItem: vi.fn((key: string, value: string) => {
+      values.set(key, String(value));
+    }),
+  };
+  vi.stubGlobal("localStorage", localStorageMock);
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: localStorageMock,
+  });
+};
+
+const flushMicrotasks = async (): Promise<void> => {
+  await act(async () => {
+    await Promise.resolve();
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+};
+
+const renderAppShell = async (): Promise<ReturnType<typeof render>> => {
+  const view = render(React.createElement(AppShell));
+  await flushMicrotasks();
+  return view;
+};
+
+const unmountAppShell = (view: ReturnType<typeof render>): void => {
+  view.unmount();
+};
+
+const advanceTimers = async (ms: number): Promise<void> => {
+  await act(async () => {
+    vi.advanceTimersByTime(ms);
+    await Promise.resolve();
+  });
+  await flushMicrotasks();
+};
+
 describe("AppShell deeplink cold-load flow", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    hoisted.runtimeEnvironment = "production";
+    installLocalStorageMock();
     vi.stubGlobal("React", React);
     Object.assign(hoisted.state, {
       simulationPresets: [],
@@ -228,10 +285,7 @@ describe("AppShell deeplink cold-load flow", () => {
   });
 
   it("loads the resolved simulation id and does not emit unavailable", async () => {
-    const host = document.createElement("div");
-    document.body.appendChild(host);
-    const root = createRoot(host);
-    root.render(React.createElement(AppShell));
+    const view = await renderAppShell();
 
     await waitForCondition(() => hoisted.loadSimulationPreset.mock.calls.length > 0);
     expect(hoisted.loadSimulationPreset).toHaveBeenCalledWith("sim-mmtk88wx-2didtk");
@@ -241,18 +295,187 @@ describe("AppShell deeplink cold-load flow", () => {
     ).linksimNotifications?.list?.() ?? [];
     expect(notifications.some((entry) => entry.id === "shared-simulation-unavailable")).toBe(false);
 
-    root.unmount();
-    host.remove();
+    unmountAppShell(view);
+  });
+
+  it("recovers automatically when a quick auth retry succeeds", async () => {
+    vi.useFakeTimers();
+    window.history.replaceState(null, "", "/");
+    hoisted.fetchMe
+      .mockRejectedValueOnce(new Error("524 : server timed out"))
+      .mockResolvedValueOnce({
+        id: "user-1",
+        username: "Owner",
+        isAdmin: false,
+        isModerator: false,
+        isApproved: true,
+        accountState: "approved",
+        avatarUrl: "",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        bio: "",
+      });
+
+    const view = await renderAppShell();
+
+    try {
+      expect(hoisted.fetchMe).toHaveBeenCalledTimes(1);
+      expect(document.body.textContent).toContain("Cloud save is unavailable");
+
+      await advanceTimers(2_000);
+
+      expect(hoisted.fetchMe).toHaveBeenCalledTimes(2);
+      expect(document.body.textContent).not.toContain("Cloud save is unavailable");
+    } finally {
+      unmountAppShell(view);
+      vi.useRealTimers();
+    }
+  });
+
+  it("uses quick retries before falling back to the steady retry interval", async () => {
+    vi.useFakeTimers();
+    window.history.replaceState(null, "", "/");
+    hoisted.fetchMe.mockRejectedValue(new Error("524 : server timed out"));
+
+    const view = await renderAppShell();
+
+    try {
+      expect(hoisted.fetchMe).toHaveBeenCalledTimes(1);
+
+      await advanceTimers(1_999);
+      expect(hoisted.fetchMe).toHaveBeenCalledTimes(1);
+
+      await advanceTimers(1);
+      expect(hoisted.fetchMe).toHaveBeenCalledTimes(2);
+
+      await advanceTimers(5_000);
+      expect(hoisted.fetchMe).toHaveBeenCalledTimes(3);
+
+      await advanceTimers(10_000);
+      expect(hoisted.fetchMe).toHaveBeenCalledTimes(4);
+
+      await advanceTimers(59_999);
+      expect(hoisted.fetchMe).toHaveBeenCalledTimes(4);
+
+      await advanceTimers(1);
+      expect(hoisted.fetchMe).toHaveBeenCalledTimes(5);
+    } finally {
+      unmountAppShell(view);
+      vi.useRealTimers();
+    }
+  });
+
+  it("retries immediately when the browser comes online", async () => {
+    vi.useFakeTimers();
+    window.history.replaceState(null, "", "/");
+    hoisted.fetchMe
+      .mockRejectedValueOnce(new Error("524 : server timed out"))
+      .mockResolvedValueOnce({
+        id: "user-1",
+        username: "Owner",
+        isAdmin: false,
+        isModerator: false,
+        isApproved: true,
+        accountState: "approved",
+        avatarUrl: "",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        bio: "",
+      });
+
+    const view = await renderAppShell();
+
+    try {
+      expect(hoisted.fetchMe).toHaveBeenCalledTimes(1);
+      window.dispatchEvent(new Event("online"));
+      await flushMicrotasks();
+
+      expect(hoisted.fetchMe).toHaveBeenCalledTimes(2);
+      expect(document.body.textContent).not.toContain("Cloud save is unavailable");
+    } finally {
+      unmountAppShell(view);
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops auth recovery retries after success", async () => {
+    vi.useFakeTimers();
+    window.history.replaceState(null, "", "/");
+    hoisted.fetchMe
+      .mockRejectedValueOnce(new Error("524 : server timed out"))
+      .mockResolvedValueOnce({
+        id: "user-1",
+        username: "Owner",
+        isAdmin: false,
+        isModerator: false,
+        isApproved: true,
+        accountState: "approved",
+        avatarUrl: "",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        bio: "",
+      });
+
+    const view = await renderAppShell();
+
+    try {
+      await advanceTimers(2_000);
+      expect(hoisted.fetchMe).toHaveBeenCalledTimes(2);
+
+      await advanceTimers(60_000);
+      expect(hoisted.fetchMe).toHaveBeenCalledTimes(2);
+    } finally {
+      unmountAppShell(view);
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not start auth recovery for local forced read-only mode", async () => {
+    vi.useFakeTimers();
+    window.history.replaceState(null, "", "/");
+    hoisted.runtimeEnvironment = "local";
+    localStorage.setItem("linksim:local-force-readonly:v1", "1");
+
+    const view = await renderAppShell();
+
+    try {
+      expect(hoisted.fetchMe).not.toHaveBeenCalled();
+      await advanceTimers(120_000);
+      expect(hoisted.fetchMe).not.toHaveBeenCalled();
+    } finally {
+      unmountAppShell(view);
+      localStorage.removeItem("linksim:local-force-readonly:v1");
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not start auth recovery for unauthenticated deep-link guests", async () => {
+    vi.useFakeTimers();
+    hoisted.fetchDeepLinkStatus.mockResolvedValue({
+      status: "ok",
+      simulationId: "sim-mmtk88wx-2didtk",
+      authenticated: false,
+    });
+
+    const view = await renderAppShell();
+
+    try {
+      expect(hoisted.fetchDeepLinkStatus).toHaveBeenCalledTimes(1);
+      expect(hoisted.fetchMe).not.toHaveBeenCalled();
+
+      await advanceTimers(120_000);
+      expect(hoisted.fetchMe).not.toHaveBeenCalled();
+    } finally {
+      unmountAppShell(view);
+      vi.useRealTimers();
+    }
   });
 
   it("keeps the workspace visible and pins a warning when auth bootstrap times out", async () => {
     window.history.replaceState(null, "", "/");
     hoisted.fetchMe.mockRejectedValue(new Error("524 : server timed out"));
 
-    const host = document.createElement("div");
-    document.body.appendChild(host);
-    const root = createRoot(host);
-    root.render(React.createElement(AppShell));
+    const view = await renderAppShell();
 
     await waitForCondition(() => document.body.textContent?.includes("Cloud save is unavailable") === true);
     expect(document.querySelector(".access-locked-shell")).toBeNull();
@@ -260,8 +483,7 @@ describe("AppShell deeplink cold-load flow", () => {
     expect(document.body.textContent).toContain("Your changes may not be saved");
     expect(document.querySelector(".app-notification-item-error button")).toBeNull();
 
-    root.unmount();
-    host.remove();
+    unmountAppShell(view);
   });
 
   it("keeps the workspace visible for revoked accounts", async () => {
@@ -279,16 +501,12 @@ describe("AppShell deeplink cold-load flow", () => {
       bio: "",
     });
 
-    const host = document.createElement("div");
-    document.body.appendChild(host);
-    const root = createRoot(host);
-    root.render(React.createElement(AppShell));
+    const view = await renderAppShell();
 
     await waitForCondition(() => document.body.textContent?.includes("Account access is unavailable") === true);
     expect(document.querySelector(".access-locked-shell")).toBeNull();
     expect(document.body.textContent).toContain("Your changes may not be saved");
 
-    root.unmount();
-    host.remove();
+    unmountAppShell(view);
   });
 });

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,13 +1,12 @@
 import { type CSSProperties, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CircleAlert, CircleCheck, CircleX, Copy, Globe, Info, PanelBottomClose, PanelBottomOpen, PanelLeftClose, PanelLeftOpen, PanelRightClose, PanelRightOpen, Share, UserRoundPlus, UserRoundSearch, Users, X } from "lucide-react";
-import { CloudApiError, type CollaboratorDirectoryUser, fetchCollaboratorDirectory, fetchDeepLinkStatus, fetchMe } from "../lib/cloudUser";
+import { CloudApiError, type CloudUser, type CollaboratorDirectoryUser, fetchCollaboratorDirectory, fetchDeepLinkStatus, fetchMe } from "../lib/cloudUser";
 import { fetchCloudLibrary, fetchPublicSimulationLibrary, pushCloudLibrary } from "../lib/cloudLibrary";
 import { buildDeepLinkPathname, buildDeepLinkUrl, buildSettingsPath, canonicalizeDeepLinkKey, matchSettingsPath, parseDeepLinkFromLocation, slugifyName, type SettingsSectionId } from "../lib/deepLink";
 import { canRunDeepLinkApply } from "../lib/deepLinkApplyGate";
 import {
   formatPrivateSiteReferenceBlockMessage,
   type DeepLinkApplyOutcome,
-  isAuthSignInRequiredMessage,
   shouldRewritePathAfterDeepLinkApply,
   shouldUseReadonlyFallbackForAuthBootstrap,
 } from "../lib/appShellGuards";
@@ -48,6 +47,8 @@ const ONBOARDING_SEEN_KEY_PREFIX = "linksim:onboarding-seen:v1:";
 const LOCAL_FORCE_READONLY_KEY = "linksim:local-force-readonly:v1";
 const ACCESS_CHECK_TIMEOUT_MS = 10_000;
 const ACCESS_FETCH_TIMEOUT_MS = 8_000;
+const AUTH_RECOVERY_QUICK_RETRY_DELAYS_MS = [2_000, 5_000, 10_000] as const;
+const AUTH_RECOVERY_STEADY_RETRY_MS = 60_000;
 const ACCESS_CHECKING_NOTICE_ID = "access-checking";
 const AUTH_DEGRADED_NOTICE_ID = "auth-degraded";
 const OFFLINE_SYNC_NOTICE_ID = "offline-sync";
@@ -267,6 +268,15 @@ export function AppShell() {
   const mapExpandedProfileWasHiddenRef = useRef(false);
   const mapExpandToggleTimerRef = useRef<number | null>(null);
   const hadAuthenticatedSessionRef = useRef(false);
+  const authCheckInFlightRef = useRef(false);
+  const authRecoveryActiveRef = useRef(false);
+  const authRecoveryDisabledRef = useRef(false);
+  const authRetryQuickAttemptRef = useRef(0);
+  const authRetryTimerRef = useRef<number | null>(null);
+  const authCheckGenerationRef = useRef(0);
+  const runAccessCheckRef = useRef<(reason: "initial" | "retry" | "online") => void>(() => {});
+  const setShowWelcomeModalRef = useRef<(show: boolean) => void>(() => {});
+  const isInitializingRef = useRef(isInitializing);
   const {
     showWelcomeModal,
     setShowWelcomeModal,
@@ -282,6 +292,14 @@ export function AppShell() {
     setShowSimulationLibraryRequest,
     setShowNewSimulationRequest,
   });
+
+  useEffect(() => {
+    setShowWelcomeModalRef.current = setShowWelcomeModal;
+  }, [setShowWelcomeModal]);
+
+  useEffect(() => {
+    isInitializingRef.current = isInitializing;
+  }, [isInitializing]);
 
   const { theme, colorTheme, variant } = useThemeVariant();
   const basemapStyleId = useAppStore((state) => state.basemapStyleId);
@@ -509,6 +527,9 @@ export function AppShell() {
     const onOnline = () => {
       setIsOnline(true);
       void performCloudSyncPush();
+      if (authRecoveryActiveRef.current) {
+        runAccessCheckRef.current("online");
+      }
     };
     const onOffline = () => {
       setIsOnline(false);
@@ -528,63 +549,157 @@ export function AppShell() {
     }
   }, [isOnline]);
 
-  useEffect(() => {
-    let cancelled = false;
-    let timedOut = false;
-    setAuthState("checking");
-    const timeoutId = window.setTimeout(() => {
-      if (cancelled) return;
-      timedOut = true;
-      console.error("[AppShell] Access check timed out", {
-        timeoutMs: ACCESS_CHECK_TIMEOUT_MS,
-        isLocalRuntime,
-        deepLinkMode: deepLinkParse.ok,
-        online: typeof navigator === "undefined" ? true : navigator.onLine,
-        isInitializing,
+  const clearAuthRetryTimer = useCallback(() => {
+    if (authRetryTimerRef.current !== null) {
+      window.clearTimeout(authRetryTimerRef.current);
+      authRetryTimerRef.current = null;
+    }
+  }, []);
+
+  const scheduleAuthRecoveryRetry = useCallback(
+    (source: "timeout" | "failure") => {
+      if (authRecoveryDisabledRef.current) return;
+      const online = typeof navigator === "undefined" ? true : navigator.onLine;
+      if (!online) return;
+      if (authRetryTimerRef.current !== null) return;
+
+      const quickAttempt = authRetryQuickAttemptRef.current;
+      const delayMs =
+        quickAttempt < AUTH_RECOVERY_QUICK_RETRY_DELAYS_MS.length
+          ? AUTH_RECOVERY_QUICK_RETRY_DELAYS_MS[quickAttempt]
+          : AUTH_RECOVERY_STEADY_RETRY_MS;
+      if (quickAttempt < AUTH_RECOVERY_QUICK_RETRY_DELAYS_MS.length) {
+        authRetryQuickAttemptRef.current = quickAttempt + 1;
+      }
+
+      console.info("[AppShell] Scheduling auth recovery retry", {
+        source,
+        delayMs,
+        quickAttempt: Math.min(quickAttempt + 1, AUTH_RECOVERY_QUICK_RETRY_DELAYS_MS.length),
       });
-      setAccessDiagnosticMessage(
-        "Cloud save is unavailable. Your changes may not be saved. The sign-in check timed out; reload or sign in again when the service recovers.",
-      );
+      authRetryTimerRef.current = window.setTimeout(() => {
+        authRetryTimerRef.current = null;
+        runAccessCheckRef.current("retry");
+      }, delayMs);
+    },
+    [],
+  );
+
+  const setAuthDegraded = useCallback(
+    (message: string, source: "timeout" | "failure") => {
+      authRecoveryActiveRef.current = true;
+      setAccessDiagnosticMessage(message);
       setCurrentUser(null);
       setAuthState("signed_out");
       setAccessState("readonly");
-    }, ACCESS_CHECK_TIMEOUT_MS);
+      scheduleAuthRecoveryRetry(source);
+    },
+    [scheduleAuthRecoveryRetry, setAuthState, setCurrentUser],
+  );
 
-    console.info("[AppShell] Starting access check", {
-      isLocalRuntime,
-      deepLinkMode: deepLinkParse.ok,
-      online: typeof navigator === "undefined" ? true : navigator.onLine,
-      isInitializing,
-    });
-
-    void (async () => {
-      try {
-        if (cancelled || timedOut) return;
-        const localForceReadonly =
-          isLocalRuntime &&
-          (() => {
-            try {
-              return localStorage.getItem(LOCAL_FORCE_READONLY_KEY) === "1";
-            } catch {
-              return false;
-            }
-          })();
-        if (localForceReadonly) {
-          if (cancelled || timedOut) return;
-          window.clearTimeout(timeoutId);
-          setAccessDiagnosticMessage(null);
-          setCurrentUser(null);
-          setAuthState("signed_out");
-          setAccessState("readonly");
-          return;
+  const applyRecoveredProfile = useCallback(
+    (profile: CloudUser, reason: "initial" | "retry" | "online") => {
+      clearAuthRetryTimer();
+      authRecoveryActiveRef.current = false;
+      authRecoveryDisabledRef.current = false;
+      authRetryQuickAttemptRef.current = 0;
+      setAccessDiagnosticMessage(null);
+      setCurrentUser(profile);
+      setAuthState("signed_in");
+      hadAuthenticatedSessionRef.current = true;
+      setActiveUserId(profile.id);
+      if (reason === "initial") {
+        try {
+          const seen = localStorage.getItem(`${ONBOARDING_SEEN_KEY_PREFIX}${profile.id}`);
+          if (!seen && !deepLinkParse.ok) {
+            setShowWelcomeModalRef.current(true);
+          }
+        } catch {
+          // ignore storage errors
         }
-        if (deepLinkParse.ok && !isLocalRuntime) {
-          const deepLinkStatus = await fetchDeepLinkStatus({
-            simulationId: deepLinkParse.payload.simulationId,
-            simulationSlug: deepLinkParse.payload.simulationSlug,
-          });
-          if (!deepLinkStatus.authenticated) {
-            if (cancelled || timedOut) return;
+      }
+      if (profile.accountState === "revoked") {
+        setAccessDiagnosticMessage(
+          "Account access is unavailable. Your changes may not be saved. Sign in again or contact an admin if you need access restored.",
+        );
+        setAccessState("readonly");
+        return;
+      }
+      if (profile.isAdmin || profile.isModerator || profile.isApproved) {
+        console.info("[AppShell] Access check recovered", { reason, userId: profile.id });
+        setAccessState("granted");
+        return;
+      }
+      if (deepLinkParse.ok) {
+        setAccessState("readonly");
+        return;
+      }
+      setAccessDiagnosticMessage(
+        "Account approval is pending. Your changes may not be saved until a moderator or admin approves access.",
+      );
+      setAccessState("readonly");
+    },
+    [clearAuthRetryTimer, deepLinkParse.ok, setAuthState, setCurrentUser],
+  );
+
+  const runAccessCheck = useCallback(
+    (reason: "initial" | "retry" | "online" = "initial") => {
+      if (authCheckInFlightRef.current) {
+        console.info("[AppShell] Access check skipped; another check is in flight", { reason });
+        return;
+      }
+      const runId = authCheckGenerationRef.current + 1;
+      authCheckGenerationRef.current = runId;
+      authCheckInFlightRef.current = true;
+      clearAuthRetryTimer();
+      if (reason === "initial") {
+        setAuthState("checking");
+      }
+
+      console.info("[AppShell] Starting access check", {
+        reason,
+        isLocalRuntime,
+        deepLinkMode: deepLinkParse.ok,
+        online: typeof navigator === "undefined" ? true : navigator.onLine,
+        isInitializing: isInitializingRef.current,
+      });
+
+      let timedOut = false;
+      const timeoutId = window.setTimeout(() => {
+        if (authCheckGenerationRef.current !== runId) return;
+        timedOut = true;
+        authCheckInFlightRef.current = false;
+        console.error("[AppShell] Access check timed out", {
+          reason,
+          timeoutMs: ACCESS_CHECK_TIMEOUT_MS,
+          isLocalRuntime,
+          deepLinkMode: deepLinkParse.ok,
+          online: typeof navigator === "undefined" ? true : navigator.onLine,
+          isInitializing: isInitializingRef.current,
+        });
+        setAuthDegraded(
+          "Cloud save is unavailable. Your changes may not be saved. The sign-in check timed out; LinkSim is retrying automatically.",
+          "timeout",
+        );
+      }, ACCESS_CHECK_TIMEOUT_MS);
+
+      void (async () => {
+        try {
+          const isCurrentRun = () => authCheckGenerationRef.current === runId && !timedOut;
+          const localForceReadonly =
+            isLocalRuntime &&
+            (() => {
+              try {
+                return localStorage.getItem(LOCAL_FORCE_READONLY_KEY) === "1";
+              } catch {
+                return false;
+              }
+            })();
+          if (localForceReadonly) {
+            if (!isCurrentRun()) return;
+            authRecoveryActiveRef.current = false;
+            authRecoveryDisabledRef.current = true;
+            authRetryQuickAttemptRef.current = 0;
             window.clearTimeout(timeoutId);
             setAccessDiagnosticMessage(null);
             setCurrentUser(null);
@@ -592,128 +707,129 @@ export function AppShell() {
             setAccessState("readonly");
             return;
           }
-        }
-        const profile = await fetchMe({ timeoutMs: ACCESS_FETCH_TIMEOUT_MS });
-        if (cancelled || timedOut) return;
-        window.clearTimeout(timeoutId);
-        setAccessDiagnosticMessage(null);
-        setCurrentUser(profile);
-        setAuthState("signed_in");
-        hadAuthenticatedSessionRef.current = true;
-        setActiveUserId(profile.id);
-        try {
-          const seen = localStorage.getItem(`${ONBOARDING_SEEN_KEY_PREFIX}${profile.id}`);
-          if (!seen && !deepLinkParse.ok) {
-            setShowWelcomeModal(true);
+          if (deepLinkParse.ok && !isLocalRuntime) {
+            const deepLinkStatus = await fetchDeepLinkStatus({
+              simulationId: deepLinkParse.payload.simulationId,
+              simulationSlug: deepLinkParse.payload.simulationSlug,
+            });
+            if (!deepLinkStatus.authenticated) {
+              if (!isCurrentRun()) return;
+              authRecoveryActiveRef.current = false;
+              authRecoveryDisabledRef.current = true;
+              authRetryQuickAttemptRef.current = 0;
+              window.clearTimeout(timeoutId);
+              setAccessDiagnosticMessage(null);
+              setCurrentUser(null);
+              setAuthState("signed_out");
+              setAccessState("readonly");
+              return;
+            }
           }
-        } catch {
-          // ignore storage errors
-        }
-        if (profile.accountState === "revoked") {
-          setAccessDiagnosticMessage(
-            "Account access is unavailable. Your changes may not be saved. Sign in again or contact an admin if you need access restored.",
-          );
-          setAccessState("readonly");
-          return;
-        }
-        if (profile.isAdmin || profile.isModerator || profile.isApproved) {
-          setAccessState("granted");
-          return;
-        }
-        if (deepLinkParse.ok) {
-          setAccessState("readonly");
-          return;
-        }
-        setAccessDiagnosticMessage(
-          "Account approval is pending. Your changes may not be saved until a moderator or admin approves access.",
-        );
-        setAccessState("readonly");
-      } catch (error) {
-        if (cancelled || timedOut) return;
-        window.clearTimeout(timeoutId);
-        const message = getUiErrorMessage(error);
-        const isServerTimeout =
-          error instanceof CloudApiError &&
-          (error.code === "timeout" || error.code === "server_timeout" || error.code === "auth_timeout" || error.status === 524);
-        const isOnlineNow = typeof navigator === "undefined" ? true : navigator.onLine;
-        const fallbackToReadonly = shouldUseReadonlyFallbackForAuthBootstrap({
-          message,
-          deepLinkMode: deepLinkParse.ok,
-          isLocalRuntime,
-          isOnline: isOnlineNow,
-          userAgent: typeof navigator === "undefined" ? "" : navigator.userAgent,
-        });
-        if (deepLinkParse.ok) {
-          console.info("[AppShell] Guest deep-link bootstrap using read-only fallback", {
+          const profile = await fetchMe({ timeoutMs: ACCESS_FETCH_TIMEOUT_MS });
+          if (!isCurrentRun()) return;
+          window.clearTimeout(timeoutId);
+          applyRecoveredProfile(profile, reason);
+        } catch (error) {
+          if (authCheckGenerationRef.current !== runId || timedOut) return;
+          window.clearTimeout(timeoutId);
+          const message = getUiErrorMessage(error);
+          const isServerTimeout =
+            error instanceof CloudApiError &&
+            (error.code === "timeout" || error.code === "server_timeout" || error.code === "auth_timeout" || error.status === 524);
+          const isOnlineNow = typeof navigator === "undefined" ? true : navigator.onLine;
+          const fallbackToReadonly = shouldUseReadonlyFallbackForAuthBootstrap({
             message,
-            isLocalRuntime,
             deepLinkMode: deepLinkParse.ok,
-            online: isOnlineNow,
-          });
-        } else {
-          console.error("[AppShell] Access check failed", {
-            message,
             isLocalRuntime,
-            deepLinkMode: deepLinkParse.ok,
-            online: isOnlineNow,
-            fallbackToReadonly,
+            isOnline: isOnlineNow,
+            userAgent: typeof navigator === "undefined" ? "" : navigator.userAgent,
           });
-        }
-        setAccessDiagnosticMessage(
-          isServerTimeout
-            ? "Cloud save is unavailable. Your changes may not be saved. The sign-in service timed out; reload or sign in again when it recovers."
-            : `Cloud save is unavailable. Your changes may not be saved. Sign in again to resume cloud saving. (${message})`,
-        );
-        const hadAuthenticatedSession = hadAuthenticatedSessionRef.current;
-        if (hadAuthenticatedSession) {
-          setCurrentUser(null);
-          setAuthState("signed_out");
-        }
-        if (message.includes("Session revoked by admin")) {
-          setCurrentUser(null);
-          setAuthState("signed_out");
-          setAccessState("readonly");
-          return;
-        }
-        if (deepLinkParse.ok) {
-          setAccessState("readonly");
-          return;
-        }
-        if (fallbackToReadonly) {
-          if (hadAuthenticatedSession) {
-            setAccessDiagnosticMessage("Cloud save is unavailable. Your changes may not be saved. Sign in again to resume cloud saving.");
-            setAccessState("readonly");
+          if (deepLinkParse.ok) {
+            console.info("[AppShell] Guest deep-link bootstrap using read-only fallback", {
+              reason,
+              message,
+              isLocalRuntime,
+              deepLinkMode: deepLinkParse.ok,
+              online: isOnlineNow,
+            });
           } else {
+            console.error("[AppShell] Access check failed", {
+              reason,
+              message,
+              isLocalRuntime,
+              deepLinkMode: deepLinkParse.ok,
+              online: isOnlineNow,
+              fallbackToReadonly,
+            });
+          }
+          if (message.includes("Session revoked by admin")) {
+            setAuthDegraded(
+              "Cloud save is unavailable. Your changes may not be saved. Sign in again to resume cloud saving; LinkSim is retrying automatically.",
+              "failure",
+            );
+            return;
+          }
+          if (deepLinkParse.ok) {
+            authRecoveryActiveRef.current = false;
+            authRecoveryDisabledRef.current = true;
+            authRetryQuickAttemptRef.current = 0;
+            setAccessState("readonly");
+            return;
+          }
+          if (fallbackToReadonly && !hadAuthenticatedSessionRef.current) {
+            authRecoveryActiveRef.current = false;
+            authRecoveryDisabledRef.current = true;
+            authRetryQuickAttemptRef.current = 0;
             setAccessDiagnosticMessage("Sign-in check was blocked by browser auth redirects. Continuing in read-only demo mode.");
             setAccessState("readonly");
+            return;
           }
-          return;
-        }
-        if (isAuthSignInRequiredMessage(message)) {
-          if (hadAuthenticatedSession) {
-            setAccessDiagnosticMessage("Cloud save is unavailable. Your changes may not be saved. Sign in again to resume cloud saving.");
-            setAccessState("readonly");
-          } else {
-            setAccessState("readonly");
+          setAuthDegraded(
+            isServerTimeout
+              ? "Cloud save is unavailable. Your changes may not be saved. The sign-in service timed out; LinkSim is retrying automatically."
+              : `Cloud save is unavailable. Your changes may not be saved. LinkSim is retrying sign-in automatically. (${message})`,
+            "failure",
+          );
+        } finally {
+          if (authCheckGenerationRef.current === runId && !timedOut) {
+            authCheckInFlightRef.current = false;
           }
-          return;
         }
-        setAccessState("readonly");
-      }
-    })();
+      })();
+    },
+    [
+      applyRecoveredProfile,
+      clearAuthRetryTimer,
+      deepLinkParse,
+      isLocalRuntime,
+      setAuthDegraded,
+      setAuthState,
+      setCurrentUser,
+    ],
+  );
+
+  useEffect(() => {
+    runAccessCheckRef.current = runAccessCheck;
+  }, [runAccessCheck]);
+
+  useEffect(() => {
+    runAccessCheck("initial");
     return () => {
-      cancelled = true;
-      window.clearTimeout(timeoutId);
+      authCheckGenerationRef.current += 1;
+      authCheckInFlightRef.current = false;
+      clearAuthRetryTimer();
     };
-  }, [deepLinkParse, isLocalRuntime, isInitializing, setAuthState, setCurrentUser]);
+  }, [clearAuthRetryTimer, runAccessCheck]);
 
   useEffect(() => {
     if (authState !== "signed_out") return;
     if (accessState === "checking") return;
     if (!hadAuthenticatedSessionRef.current) return;
-    setAccessDiagnosticMessage("Cloud save is unavailable. Your changes may not be saved. Sign in again to resume cloud saving.");
-    setAccessState("readonly");
-  }, [accessState, authState]);
+    setAuthDegraded(
+      "Cloud save is unavailable. Your changes may not be saved. LinkSim is retrying sign-in automatically.",
+      "failure",
+    );
+  }, [accessState, authState, setAuthDegraded]);
 
   useEffect(() => {
     if (!accessDiagnosticMessage) {


### PR DESCRIPTION
## Summary
- refactor AppShell access bootstrap into a reusable access check used by initial load, retries, and browser online recovery
- add 2s/5s/10s quick retries, then 60s background retries while auth/cloud save is degraded and the browser is online
- keep local forced read-only and unauthenticated deep-link guest flows out of the retry loop
- clear the pinned auth warning and restore granted access after successful recovery

Refs #776

## Verification
- git diff --check
- npm test
- npm run build