### PR TITLE
fix: redirect to CF Access login when user-initiated sign-in fails (#776)

### DIFF
--- a/functions/api/auth-start.ts
+++ b/functions/api/auth-start.ts
@@ -17,7 +17,7 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
   const url = new URL(request.url);
   const returnTo = sanitizeReturnTo(url.searchParams.get("returnTo"), url.origin);
   const redirectUrl = `${url.origin}${returnTo}`;
-  const teamDomain = env.ACCESS_TEAM_DOMAIN;
+  const teamDomain = env?.ACCESS_TEAM_DOMAIN;
   if (teamDomain) {
     return Response.redirect(
       `https://${teamDomain}/cdn-cgi/access/login?redirect_url=${encodeURIComponent(redirectUrl)}`,

--- a/functions/api/auth-start.ts
+++ b/functions/api/auth-start.ts
@@ -1,3 +1,5 @@
+import type { Env } from "../_lib/types";
+
 const sanitizeReturnTo = (raw: string | null, origin: string): string => {
   if (typeof raw !== "string") return "/";
   const trimmed = raw.trim();
@@ -11,8 +13,16 @@ const sanitizeReturnTo = (raw: string | null, origin: string): string => {
   }
 };
 
-export const onRequestGet = async ({ request }: { request: Request }) => {
+export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
   const url = new URL(request.url);
   const returnTo = sanitizeReturnTo(url.searchParams.get("returnTo"), url.origin);
-  return Response.redirect(`${url.origin}${returnTo}`, 302);
+  const redirectUrl = `${url.origin}${returnTo}`;
+  const teamDomain = env.ACCESS_TEAM_DOMAIN;
+  if (teamDomain) {
+    return Response.redirect(
+      `https://${teamDomain}/cdn-cgi/access/login?redirect_url=${encodeURIComponent(redirectUrl)}`,
+      302,
+    );
+  }
+  return Response.redirect(redirectUrl, 302);
 };

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -274,6 +274,7 @@ export function AppShell() {
   const authRetryQuickAttemptRef = useRef(0);
   const authRetryTimerRef = useRef<number | null>(null);
   const authCheckGenerationRef = useRef(0);
+  const userInitiatedSignInRef = useRef(false);
   const runAccessCheckRef = useRef<(reason: "initial" | "retry" | "online") => void>(() => {});
   const setShowWelcomeModalRef = useRef<(show: boolean) => void>(() => {});
   const isInitializingRef = useRef(isInitializing);
@@ -556,6 +557,12 @@ export function AppShell() {
     }
   }, []);
 
+  const handleUserSignInRequested = useCallback(() => {
+    userInitiatedSignInRef.current = true;
+    clearAuthRetryTimer();
+    runAccessCheckRef.current("retry");
+  }, [clearAuthRetryTimer]);
+
   const scheduleAuthRecoveryRetry = useCallback(
     (source: "timeout" | "failure") => {
       if (authRecoveryDisabledRef.current) return;
@@ -603,6 +610,7 @@ export function AppShell() {
       authRecoveryActiveRef.current = false;
       authRecoveryDisabledRef.current = false;
       authRetryQuickAttemptRef.current = 0;
+      userInitiatedSignInRef.current = false;
       setAccessDiagnosticMessage(null);
       setCurrentUser(profile);
       setAuthState("signed_in");
@@ -677,6 +685,12 @@ export function AppShell() {
           online: typeof navigator === "undefined" ? true : navigator.onLine,
           isInitializing: isInitializingRef.current,
         });
+        if (userInitiatedSignInRef.current) {
+          userInitiatedSignInRef.current = false;
+          const returnTo = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+          window.location.href = `/api/auth-start?returnTo=${encodeURIComponent(returnTo || "/")}`;
+          return;
+        }
         setAuthDegraded(
           "Cloud save is unavailable. Your changes may not be saved. The sign-in check timed out; LinkSim is retrying automatically.",
           "timeout",
@@ -782,6 +796,12 @@ export function AppShell() {
             authRetryQuickAttemptRef.current = 0;
             setAccessDiagnosticMessage("Sign-in check was blocked by browser auth redirects. Continuing in read-only demo mode.");
             setAccessState("readonly");
+            return;
+          }
+          if (userInitiatedSignInRef.current) {
+            userInitiatedSignInRef.current = false;
+            const returnTo = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+            window.location.href = `/api/auth-start?returnTo=${encodeURIComponent(returnTo || "/")}`;
             return;
           }
           setAuthDegraded(
@@ -1975,6 +1995,7 @@ export function AppShell() {
             hideLibraryBrowsing={isReadOnlyShell}
             onOpenHelp={openOnboardingTutorial}
             onOpenSettings={() => openSettings("profile")}
+            onSignInRequested={handleUserSignInRequested}
             readOnly={!canPersistWorkspace}
             panelToggleControl={
               isMobileViewport ? (
@@ -2191,7 +2212,8 @@ export function AppShell() {
                 authBootstrapPending={accessState === "checking"}
                 hideLibraryBrowsing={isReadOnlyShell}
                 onOpenHelp={openOnboardingTutorial}
-            onOpenSettings={() => openSettings("profile")}
+                onOpenSettings={() => openSettings("profile")}
+                onSignInRequested={handleUserSignInRequested}
                 readOnly={!canPersistWorkspace}
                 panelToggleControl={panelSizeControls("Navigator")}
               />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -243,6 +243,7 @@ const formatMqttSourceMeta = (value: unknown): string[] => {
 type SidebarProps = {
   onOpenHelp?: () => void;
   onOpenSettings?: () => void;
+  onSignInRequested?: () => void;
   hideLibraryBrowsing?: boolean;
   readOnly?: boolean;
   authBootstrapPending?: boolean;
@@ -255,6 +256,7 @@ type SidebarProps = {
 export function Sidebar({
   onOpenHelp,
   onOpenSettings,
+  onSignInRequested,
   hideLibraryBrowsing = false,
   readOnly = false,
   authBootstrapPending = false,
@@ -1896,7 +1898,7 @@ export function Sidebar({
 
   return (
     <aside className={`sidebar-panel ${panelClassName ?? ""}`.trim()}>
-      <UserAdminPanel authBootstrapPending={authBootstrapPending} extraActions={panelToggleControl} onOpenHelp={onOpenHelp} onOpenSettings={onOpenSettings} />
+      <UserAdminPanel authBootstrapPending={authBootstrapPending} extraActions={panelToggleControl} onOpenHelp={onOpenHelp} onOpenSettings={onOpenSettings} onSignInRequested={onSignInRequested} />
       <header>
         <div className="sidebar-title-row">
           <h1>{t(locale, "appTitle")}</h1>

--- a/src/components/UserAdminPanel.tsx
+++ b/src/components/UserAdminPanel.tsx
@@ -137,6 +137,11 @@ type UserAdminPanelProps = {
    * AppShell to navigate to `/settings/profile`.
    */
   onOpenSettings?: () => void;
+  /**
+   * When provided, clicking "Sign in" triggers a silent auth check first;
+   * only if that fails does it redirect to the CF Access login page.
+   */
+  onSignInRequested?: () => void;
 };
 
 export function UserAdminPanel({
@@ -145,6 +150,7 @@ export function UserAdminPanel({
   extraActions,
   renderMode = "chip",
   onOpenSettings,
+  onSignInRequested,
 }: UserAdminPanelProps) {
   const runtimeEnvironment = getCurrentRuntimeEnvironment();
   const isLocalRuntime = runtimeEnvironment === "local";
@@ -704,9 +710,13 @@ export function UserAdminPanel({
   }, [isLocalRuntime, setAuthState, setCurrentUser]);
 
   const handleSignUp = useCallback(() => {
+    if (onSignInRequested) {
+      onSignInRequested();
+      return;
+    }
     const returnTo = `${window.location.pathname}${window.location.search}${window.location.hash}`;
     window.location.href = `/api/auth-start?returnTo=${encodeURIComponent(returnTo || "/")}`;
-  }, []);
+  }, [onSignInRequested]);
 
   const [syncModalOpen, setSyncModalOpen] = useState(false);
 


### PR DESCRIPTION
## Summary
- `auth-start` was bouncing the user straight back to the app instead of redirecting to Cloudflare Access login — `CF_Authorization` was never set, causing an infinite 401 retry loop
- Sign-in button now triggers a silent access check first; only if that fails does it navigate to `/api/auth-start` (which now goes to the actual CF Access login page)
- Background retry loop is unchanged — it keeps retrying silently without ever navigating away

## Test plan
- [ ] Open staging signed out — confirm sign-in button is visible
- [ ] Click "Sign in" — app tries a silent check, then redirects to `skarvassbu.cloudflareaccess.com` login
- [ ] Complete login — redirected back, `/api/me` returns 200, access granted
- [ ] Simulate a network blip — background retries fire silently, no unwanted redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)