### PR TITLE
fix: revert auth-start to simple redirect (#776)

### DIFF
--- a/functions/api/auth-start.ts
+++ b/functions/api/auth-start.ts
@@ -1,5 +1,3 @@
-import type { Env } from "../_lib/types";
-
 const sanitizeReturnTo = (raw: string | null, origin: string): string => {
   if (typeof raw !== "string") return "/";
   const trimmed = raw.trim();
@@ -13,16 +11,8 @@ const sanitizeReturnTo = (raw: string | null, origin: string): string => {
   }
 };
 
-export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
+export const onRequestGet = async ({ request }: { request: Request }) => {
   const url = new URL(request.url);
   const returnTo = sanitizeReturnTo(url.searchParams.get("returnTo"), url.origin);
-  const redirectUrl = `${url.origin}${returnTo}`;
-  const teamDomain = env?.ACCESS_TEAM_DOMAIN;
-  if (teamDomain) {
-    return Response.redirect(
-      `https://${teamDomain}/cdn-cgi/access/login?redirect_url=${encodeURIComponent(redirectUrl)}`,
-      302,
-    );
-  }
-  return Response.redirect(redirectUrl, 302);
+  return Response.redirect(`${url.origin}${returnTo}`, 302);
 };


### PR DESCRIPTION
## Summary
- Reverts the `auth-start.ts` change from #783
- The original simple redirect was correct: CF Access protects `staging.linksim.link/api/*` at the edge, so any unauthenticated request to `/api/auth-start` triggers the CF Access login flow automatically
- The manual login URL construction introduced a 404 and left a bad `CF_Authorization` cookie causing 503 JWKS timeouts
- AppShell/Sidebar/UserAdminPanel changes from #783 are kept (silent check before redirect is still correct behaviour)

## Test plan
- [ ] Clear `CF_Authorization` cookie in DevTools
- [ ] Click "Sign in" — should redirect through CF Access login (not 404)
- [ ] After login — `/api/me` returns 200, access granted

🤖 Generated with [Claude Code](https://claude.com/claude-code)