### PR TITLE
fix: increase JWKS verify timeout from 3s to 8s (#776)

### DIFF
--- a/functions/_lib/auth.ts
+++ b/functions/_lib/auth.ts
@@ -2,7 +2,7 @@ import { createRemoteJWKSet, jwtVerify } from "jose";
 import type { AuthContext, Env } from "./types";
 
 const jwksCache = new Map<string, ReturnType<typeof createRemoteJWKSet>>();
-const DEFAULT_AUTH_VERIFY_TIMEOUT_MS = 3_000;
+const DEFAULT_AUTH_VERIFY_TIMEOUT_MS = 8_000;
 
 export class AuthVerificationTimeoutError extends Error {
   constructor() {


### PR DESCRIPTION
## Summary
- The 3s `DEFAULT_AUTH_VERIFY_TIMEOUT_MS` introduced in #779 is too tight for JWKS fetches on cold starts, causing every `/api/me` call to return 503 "Auth verification timed out"
- Increasing to 8s matches the client-side `ACCESS_FETCH_TIMEOUT_MS` — the server will never time out before the client does

## Root cause
`617a2443` introduced the timeout as a guard against hanging auth checks, but 3s turns out to be shorter than JWKS cold-start fetch time in the Pages function runtime.

## Test plan
- [ ] Load staging — `/api/me` should return 200 instead of 503
- [ ] Sign in should work without being stuck in the retry loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)