### PR TITLE
fix: increase JWKS verify timeout to 30s (#776)

### DIFF
--- a/functions/_lib/auth.ts
+++ b/functions/_lib/auth.ts
@@ -2,7 +2,7 @@ import { createRemoteJWKSet, jwtVerify } from "jose";
 import type { AuthContext, Env } from "./types";
 
 const jwksCache = new Map<string, ReturnType<typeof createRemoteJWKSet>>();
-const DEFAULT_AUTH_VERIFY_TIMEOUT_MS = 8_000;
+const DEFAULT_AUTH_VERIFY_TIMEOUT_MS = 30_000;
 
 export class AuthVerificationTimeoutError extends Error {
   constructor() {


### PR DESCRIPTION
## Summary
- Increases `DEFAULT_AUTH_VERIFY_TIMEOUT_MS` from 8s to 30s
- Staging workers cold-start on every request (low traffic), causing the JWKS fetch to take longer than 8s
- Prod is unaffected (warmer workers, faster JWKS response)
- The timeout was introduced in #779 at 3s, bumped to 8s in #785; 30s gives cold-start workers enough headroom without reverting the timeout entirely

## Test plan
- [ ] Confirm `/api/me` on staging returns 200 instead of 503
- [ ] Confirm sign-in flow completes on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)