### PR TITLE
fix: polish collaborator and location controls

### DIFF
--- a/src/components/AccessSettingsEditor.test.tsx
+++ b/src/components/AccessSettingsEditor.test.tsx
@@ -58,7 +58,12 @@ describe("AccessSettingsEditor", () => {
       />,
     );
 
-    await userEvent.click(screen.getByRole("button", { name: "Edit collaborators" }));
+    const editCollaborators = screen.getByRole("button", { name: "Edit collaborators" });
+    expect(editCollaborators).toHaveClass("btn");
+    expect(editCollaborators).not.toHaveClass("inline-action");
+    expect(editCollaborators).not.toHaveClass("action-button");
+
+    await userEvent.click(editCollaborators);
     const popover = await screen.findByRole("dialog", { name: "Edit collaborators" });
     const surface = popover.closest(".ui-surface-pill");
     expect(surface).toHaveClass("ui-surface-pill");

--- a/src/components/AccessSettingsEditor.tsx
+++ b/src/components/AccessSettingsEditor.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useRef, useState } from "react";
 import { Trash2 } from "lucide-react";
 import type { CollaboratorDirectoryUser } from "../lib/cloudUser";
+import { ActionButton } from "./ActionButton";
 import { AvatarBadge } from "./AvatarBadge";
 import { FloatingPopover } from "./ui/FloatingPopover";
 
@@ -115,16 +116,15 @@ export function AccessSettingsEditor({
               <span className="field-help access-collaborators-empty">No collaborators</span>
             )}
           </div>
-          <button
+          <ActionButton
             aria-label="Edit collaborators"
-            className="inline-action action-button"
             ref={triggerRef}
             disabled={disabled}
             onClick={() => setPopoverOpen((open) => !open)}
             type="button"
           >
             Edit
-          </button>
+          </ActionButton>
         </div>
       </div>
       <FloatingPopover

--- a/src/components/ActionButton.tsx
+++ b/src/components/ActionButton.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from "react";
 import type { ButtonHTMLAttributes, ReactNode } from "react";
 import { Button } from "./ui/Button";
 
@@ -6,6 +7,8 @@ type ActionButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   variant?: "default" | "danger";
 };
 
-export function ActionButton({ variant = "default", ...props }: ActionButtonProps) {
-  return <Button variant={variant} {...props} />;
-}
+export const ActionButton = forwardRef<HTMLButtonElement, ActionButtonProps>(({ variant = "default", ...props }, ref) => (
+  <Button ref={ref} variant={variant} {...props} />
+));
+
+ActionButton.displayName = "ActionButton";

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -793,6 +793,7 @@ export function MapView({
   const userLocationWatchIdRef = useRef<number | null>(null);
   const isUserLocationActiveRef = useRef(false);
   const isUserLocationFollowingRef = useRef(false);
+  const clearFitControlActiveRef = useRef<() => void>(() => undefined);
   const panoramaLensBaseViewRef = useRef<{
     center: { lat: number; lon: number };
     zoom: number;
@@ -832,6 +833,7 @@ export function MapView({
     }
     isUserLocationActiveRef.current = true;
     isUserLocationFollowingRef.current = true;
+    clearFitControlActiveRef.current();
     setIsUserLocationActive(true);
     setUserLocationFix(null);
     try {
@@ -2471,6 +2473,13 @@ export function MapView({
     setInteractionViewState,
     updateMapViewport,
   });
+  clearFitControlActiveRef.current = clearFitControlActive;
+  const handleFitToNodes = () => {
+    if (isUserLocationActiveRef.current && isUserLocationFollowingRef.current) {
+      isUserLocationFollowingRef.current = false;
+    }
+    fitToNodes();
+  };
   useEffect(() => {
     if (!fitControlActive || !fitSitesEpoch || !isMapLoaded || !mapRef.current) return;
     const bounds = computeSiteFitBounds(sites, overlayRadiusKm);
@@ -2592,7 +2601,7 @@ export function MapView({
           <MapControlButton
             aria-label="Fit map to sites"
             isSelected={fitControlActive}
-            onClick={fitToNodes}
+            onClick={handleFitToNodes}
             title="Fit"
           >
             <Fullscreen aria-hidden="true" strokeWidth={1.8} />

--- a/src/components/MapView.userLocation.test.tsx
+++ b/src/components/MapView.userLocation.test.tsx
@@ -162,6 +162,31 @@ describe("MapView user location flow", () => {
     expect(screen.getByRole("button", { name: /User location/i })).not.toHaveClass("map-site-surface");
   });
 
+  it("turns off fit when location starts and keeps tracking without following after manual fit", () => {
+    renderMapView();
+    const fitControl = screen.getByRole("button", { name: "Fit map to sites" });
+    expect(fitControl).toHaveClass("is-selected");
+
+    fireEvent.click(screen.getByRole("button", { name: "Use my location" }));
+    expect(fitControl).not.toHaveClass("is-selected");
+    const success = watchPosition.mock.calls[0]?.[0] as PositionCallback;
+
+    act(() => {
+      success(position(60.12345, 11.23456, 18));
+    });
+    expect(mapMock.easeTo).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(fitControl);
+    expect(fitControl).toHaveClass("is-selected");
+
+    act(() => {
+      success(position(62, 13, 24, 2));
+    });
+
+    expect(mapMock.easeTo).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("button", { name: /User location/i })).toHaveClass("user-location-marker");
+  });
+
   it("reuses the existing temporary site draft path when the marker is clicked", () => {
     renderMapView();
     fireEvent.click(screen.getByRole("button", { name: "Use my location" }));


### PR DESCRIPTION
## Summary
- Fixes #771 by disabling Fit when user location starts, and by releasing location-follow when Fit is manually enabled while keeping location tracking active.
- Fixes #773 by moving the Edit collaborators trigger onto the documented ActionButton/Button system instead of the legacy `inline-action action-button` classes.
- Adds ref forwarding to `ActionButton` so popover triggers can use the shared primitive safely.

## Verification
- `npm run test -- --run src/components/AccessSettingsEditor.test.tsx`
- `npm run test -- --run src/components/MapView.userLocation.test.tsx`
- `npm run test -- --run src/components/map/useMapControls.test.ts`
- `npm test`
- `npm run build`

## Notes
- Batched #771 and #773 per current-thread approval to reduce staging deploy churn.
- Pre-coding drift check reported only the known 0.18.0 squash-policy drift tracked by #780.