### PR TITLE
fix: explain read-only simulation site actions

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -605,6 +605,7 @@ const USER_LOCATION_WATCH_OPTIONS: PositionOptions = {
   timeout: 15_000,
 };
 const USER_LOCATION_NOTICE_ID = "user-location";
+const READ_ONLY_SIMULATION_SITE_HELP = "Read-only: you need edit permission to add sites to this simulation.";
 
 const userLocationErrorMessage = (error: GeolocationPositionError): string => {
   if (error.code === error.PERMISSION_DENIED) return "Location permission was denied.";
@@ -2346,7 +2347,7 @@ export function MapView({
 
   const addDiscoveryLibrarySiteToSimulation = (entryId: string) => {
     if (!canPersist) {
-      setSiteDraftStatus("Read-only mode: cannot add library sites to this simulation.");
+      setSiteDraftStatus(READ_ONLY_SIMULATION_SITE_HELP);
       return;
     }
     if (sites.some((site) => site.libraryEntryId === entryId)) {
@@ -2558,9 +2559,12 @@ export function MapView({
   if (mapProviderWarning) inspectorLines.push(mapProviderWarning);
   if (showDiscoverySites) {
     inspectorLines.push(
-      `Shared/Public Library Sites visible: ${sharedOrPublicLibrarySites.length}. Click a marker to inspect, then choose Add to Simulation.`,
+      canPersist
+        ? `Shared/Public Library Sites visible: ${sharedOrPublicLibrarySites.length}. Click a marker to inspect, then choose Add to Simulation.`
+        : `Shared/Public Library Sites visible: ${sharedOrPublicLibrarySites.length}. Click a marker to inspect it.`,
     );
   }
+  if (selectedDiscoveryLibraryEntry && !canPersist) inspectorLines.push(READ_ONLY_SIMULATION_SITE_HELP);
   if (showDiscoveryMqtt && !mqttLoadStatus) {
     inspectorLines.push(
       mqttTooDenseInView

--- a/src/components/MapView.userLocation.test.tsx
+++ b/src/components/MapView.userLocation.test.tsx
@@ -217,6 +217,37 @@ describe("MapView user location flow", () => {
     expect(screen.queryByText("New Site")).not.toBeInTheDocument();
   });
 
+  it("explains why library sites cannot be added in read-only mode", () => {
+    useAppStore.setState({
+      siteLibrary: [
+        {
+          id: "lib-alpha",
+          name: "Library Alpha",
+          visibility: "shared",
+          sharedWith: [],
+          ownerUserId: "owner-1",
+          effectiveRole: "viewer",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          position: { lat: 60.5, lon: 11.5 },
+          groundElevationM: 120,
+          antennaHeightM: 2,
+          txPowerDbm: 20,
+          txGainDbi: 2,
+          rxGainDbi: 2,
+          cableLossDb: 1,
+        },
+      ],
+    });
+    renderMapView({ canPersist: false, readOnly: true, showInspector: true });
+
+    fireEvent.click(screen.getByText("Map"));
+    fireEvent.change(screen.getByLabelText("Visible Sites"), { target: { value: "library" } });
+    fireEvent.click(screen.getByRole("button", { name: "Library Alpha" }));
+
+    expect(screen.queryByRole("button", { name: "Add to Simulation" })).not.toBeInTheDocument();
+    expect(screen.getByText("Read-only: you need edit permission to add sites to this simulation.")).toBeInTheDocument();
+  });
+
   it("publishes plain location failure notifications", () => {
     const onPublishNotice = vi.fn();
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -93,6 +93,7 @@ const parseNumber = (value: string): number => {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : 0;
 };
+const READ_ONLY_SIMULATION_SITE_HELP = "Read-only: you need edit permission to add sites to this simulation.";
 
 const UserBadge = ({ name, avatarUrl }: { name: string; avatarUrl?: string | null }) => (
   <span className="user-list-row">
@@ -1975,7 +1976,7 @@ export function Sidebar({
               <ActionButton onClick={() => setShowSiteLibraryManager(true)} type="button">
                 Library
               </ActionButton>
-              {newestSiteLibraryEntryId ? (
+              {newestSiteLibraryEntryId && !readOnly ? (
                 <ActionButton onClick={() => insertSiteFromLibrary(newestSiteLibraryEntryId)} type="button">
                   Insert newest
                 </ActionButton>
@@ -2003,6 +2004,7 @@ export function Sidebar({
             </ActionButton>
           ) : null}
         </div>
+        {!hideLibraryBrowsing && readOnly ? <p className="field-help">{READ_ONLY_SIMULATION_SITE_HELP}</p> : null}
       </section>
 
       <section className="panel-section section-path">
@@ -3919,9 +3921,13 @@ export function Sidebar({
                     );
                   })()}
                   <div className="library-row-actions">
-                    <ActionButton onClick={() => insertSiteFromLibrary(entry.id)} type="button">
-                      Add to simulation
-                    </ActionButton>
+                    {readOnly ? (
+                      <span className="field-help">{READ_ONLY_SIMULATION_SITE_HELP}</span>
+                    ) : (
+                      <ActionButton onClick={() => insertSiteFromLibrary(entry.id)} type="button">
+                        Add to simulation
+                      </ActionButton>
+                    )}
                     <ActionButton
                       onClick={() =>
                         openResourceDetailsPopup({


### PR DESCRIPTION
## Summary
- Explain why read-only collaborators cannot add library sites to shared simulations.
- Hide add actions for read-only users while preserving marker inspection and library browsing.
- Keep the feedback on existing field-help/status surfaces; no new styling or interaction pattern.

Fixes #774.

## Drift check
- `git cherry -v origin/staging origin/main` showed only the known 0.18.0 squash-policy drift tracked by #780.

## Verification
- `npm run test -- --run src/components/MapView.userLocation.test.tsx`
- `npm test`
- `npm run build`