### PR TITLE
fix: block read-only site edits

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -606,6 +606,8 @@ const USER_LOCATION_WATCH_OPTIONS: PositionOptions = {
 };
 const USER_LOCATION_NOTICE_ID = "user-location";
 const READ_ONLY_SIMULATION_SITE_HELP = "Read-only: you need edit permission to add sites to this simulation.";
+const READ_ONLY_SIMULATION_SITE_EDIT_HELP =
+  "Read-only: you need edit permission to move or edit sites in this simulation.";
 
 const userLocationErrorMessage = (error: GeolocationPositionError): string => {
   if (error.code === error.PERMISSION_DENIED) return "Location permission was denied.";
@@ -2158,6 +2160,10 @@ export function MapView({
 
   const savePendingSiteMove = () => {
     if (!pendingMoveCount) return;
+    if (!canPersist) {
+      setSiteDraftStatus(READ_ONLY_SIMULATION_SITE_EDIT_HELP);
+      return;
+    }
     for (const move of pendingMoveEntries) {
       updateSite(move.siteId, {
         position: move.currentPosition,
@@ -2194,6 +2200,10 @@ export function MapView({
   };
 
   const onSiteDrag = (siteId: string, event: MarkerDragEvent) => {
+    if (!canPersist) {
+      setSiteDraftStatus(READ_ONLY_SIMULATION_SITE_EDIT_HELP);
+      return;
+    }
     if (pendingNewSiteDraft) {
       setSiteDraftStatus("Dismiss or save the new map site before moving existing sites.");
       return;
@@ -2231,6 +2241,10 @@ export function MapView({
 
   const onSiteDragEnd = (siteId: string, event: MarkerDragEvent) => {
     setIsDraggingSite(false);
+    if (!canPersist) {
+      setSiteDraftStatus(READ_ONLY_SIMULATION_SITE_EDIT_HELP);
+      return;
+    }
     const site = sites.find((candidate) => candidate.id === siteId);
     if (!site) return;
     const nextPosition = {
@@ -2565,6 +2579,7 @@ export function MapView({
     );
   }
   if (selectedDiscoveryLibraryEntry && !canPersist) inspectorLines.push(READ_ONLY_SIMULATION_SITE_HELP);
+  if (selectedSite && !canPersist) inspectorLines.push(READ_ONLY_SIMULATION_SITE_EDIT_HELP);
   if (showDiscoveryMqtt && !mqttLoadStatus) {
     inspectorLines.push(
       mqttTooDenseInView
@@ -3333,7 +3348,7 @@ export function MapView({
           return (
             <Marker
               anchor="bottom"
-              draggable
+              draggable={canPersist}
               key={site.id}
               latitude={markerPosition.lat}
               longitude={markerPosition.lon}

--- a/src/components/MapView.userLocation.test.tsx
+++ b/src/components/MapView.userLocation.test.tsx
@@ -248,6 +248,32 @@ describe("MapView user location flow", () => {
     expect(screen.getByText("Read-only: you need edit permission to add sites to this simulation.")).toBeInTheDocument();
   });
 
+  it("explains why selected simulation sites cannot be edited in read-only mode", () => {
+    useAppStore.setState({
+      sites: [
+        {
+          id: "site-alpha",
+          name: "Site Alpha",
+          position: { lat: 60.5, lon: 11.5 },
+          groundElevationM: 120,
+          antennaHeightM: 2,
+          txPowerDbm: 20,
+          txGainDbi: 2,
+          rxGainDbi: 2,
+          cableLossDb: 1,
+        },
+      ],
+      selectedSiteId: "site-alpha",
+      selectedSiteIds: ["site-alpha"],
+      mapOverlayMode: "none",
+    });
+    renderMapView({ canPersist: false, readOnly: true, showInspector: true });
+
+    expect(
+      screen.getByText("Read-only: you need edit permission to move or edit sites in this simulation."),
+    ).toBeInTheDocument();
+  });
+
   it("publishes plain location failure notifications", () => {
     const onPublishNotice = vi.fn();
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);

--- a/src/components/Sidebar.readOnly.test.tsx
+++ b/src/components/Sidebar.readOnly.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.hoisted(() => {
+  const data = new Map<string, string>();
+  const localStorageMock = {
+    getItem: (key: string) => data.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      data.set(key, String(value));
+    },
+    removeItem: (key: string) => {
+      data.delete(key);
+    },
+    clear: () => data.clear(),
+    key: (index: number) => Array.from(data.keys())[index] ?? null,
+    get length() {
+      return data.size;
+    },
+  };
+  vi.stubGlobal("localStorage", localStorageMock);
+});
+
+vi.mock("react-map-gl/maplibre", () => {
+  return {
+    default: ({ children }: { children?: React.ReactNode }) => <div data-testid="mock-map">{children}</div>,
+    Layer: () => null,
+    Marker: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    Source: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+vi.mock("./UserAdminPanel", () => ({
+  UserAdminPanel: () => null,
+}));
+
+import { useAppStore } from "../store/appStore";
+import { Sidebar } from "./Sidebar";
+
+describe("Sidebar read-only simulation site actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAppStore.setState({
+      sites: [
+        {
+          id: "site-alpha",
+          name: "Site Alpha",
+          position: { lat: 60.5, lon: 11.5 },
+          groundElevationM: 120,
+          antennaHeightM: 2,
+          txPowerDbm: 20,
+          txGainDbi: 2,
+          rxGainDbi: 2,
+          cableLossDb: 1,
+        },
+      ],
+      links: [],
+      selectedSiteId: "site-alpha",
+      selectedSiteIds: ["site-alpha"],
+      selectedLinkId: "",
+      siteLibrary: [],
+    });
+  });
+
+  it("does not expose selected-site editing when the simulation is read-only", () => {
+    render(<Sidebar readOnly />);
+
+    const sitesSection = screen.getByText("Sites").closest("section");
+    expect(sitesSection).not.toBeNull();
+    expect(within(sitesSection as HTMLElement).queryByRole("button", { name: "Edit" })).not.toBeInTheDocument();
+    expect(
+      within(sitesSection as HTMLElement).getByText(
+        "Read-only: you need edit permission to add or edit sites in this simulation.",
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -93,7 +93,8 @@ const parseNumber = (value: string): number => {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : 0;
 };
-const READ_ONLY_SIMULATION_SITE_HELP = "Read-only: you need edit permission to add sites to this simulation.";
+const READ_ONLY_SIMULATION_SITE_HELP =
+  "Read-only: you need edit permission to add or edit sites in this simulation.";
 
 const UserBadge = ({ name, avatarUrl }: { name: string; avatarUrl?: string | null }) => (
   <span className="user-list-row">
@@ -1981,9 +1982,11 @@ export function Sidebar({
                   Insert newest
                 </ActionButton>
               ) : null}
-              <ActionButton onClick={openLibraryForSelectedSite} type="button">
-                Edit
-              </ActionButton>
+              {!readOnly ? (
+                <ActionButton onClick={openLibraryForSelectedSite} type="button">
+                  Edit
+                </ActionButton>
+              ) : null}
             </>
           ) : null}
           {!readOnly ? (


### PR DESCRIPTION
## Summary
- Disable map marker dragging for simulation sites when the active Simulation is read-only.
- Show existing inspector/help text explaining that read-only users need edit permission to move or edit sites.
- Hide the selected-site Edit action in the Sites panel while keeping library browsing available.

Follow-up for #774 staging feedback.

## Drift check
- `git cherry -v origin/staging origin/main` showed only the known 0.18.0 squash-policy drift tracked by #780.

## Verification
- `npm run test -- --run src/components/MapView.userLocation.test.tsx`
- `npm run test -- --run src/components/Sidebar.readOnly.test.tsx`
- `npm test`
- `npm run build`