### PR TITLE
fix: ignore squash release ancestry drift

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -34,4 +34,4 @@
 
 ## Hotfix follow-up (required when source branch is `hotfix/*`)
 
-- [ ] After merge, open a `chore/sync-main-to-staging` PR to bring `main` back into `staging` and prevent ancestry drift on the next milestone release.
+- [ ] After merge, open a `chore/sync-main-to-staging` PR that applies the main-only hotfix content to `staging`, then let CI redeploy staging.

--- a/.github/workflows/detect-staging-drift.yml
+++ b/.github/workflows/detect-staging-drift.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -27,13 +28,26 @@ jobs:
             git log --oneline origin/staging..origin/main
           fi
 
-      - name: Open drift issue if needed
+      - name: Classify drift source
+        id: drift_policy
         if: steps.drift.outputs.count != '0'
+        env:
+          DRIFT_COUNT: ${{ steps.drift.outputs.count }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_SHA: ${{ github.sha }}
+        run: node scripts/staging-drift-policy.mjs
+
+      - name: Open drift issue if needed
+        if: steps.drift.outputs.count != '0' && steps.drift_policy.outputs.open_issue == 'true'
         uses: actions/github-script@v7
+        env:
+          DRIFT_REASON: ${{ steps.drift_policy.outputs.reason }}
         with:
           script: |
             const count = '${{ steps.drift.outputs.count }}';
             const sha = context.sha.slice(0, 8);
+            const reason = process.env.DRIFT_REASON || 'main push was not classified as a staging promotion';
 
             // Check for an existing open drift issue to avoid duplicates
             const issues = await github.rest.issues.listForRepo({
@@ -54,12 +68,14 @@ jobs:
               body: [
                 `**${count} commit(s)** in \`main\` are not in \`staging\`'s ancestry after push to main at ${sha}.`,
                 '',
-                'This drift will cause conflicts on the next `staging → main` promotion.',
+                `Policy reason: ${reason}`,
+                '',
+                'This push was not classified as a normal squash-merged `staging → main` release promotion.',
                 '',
                 '## Required action',
                 '1. Create a `chore/sync-main-to-staging` branch from `origin/staging`',
-                '2. `git merge origin/main -X ours --no-edit` (prefer staging for any conflicts)',
-                '3. PR the branch into `staging`, merge, redeploy staging',
+                '2. Apply the main-only hotfix/reconcile content to staging in commits that can be squash-merged',
+                '3. PR the branch into `staging`, merge, and let CI redeploy staging',
                 '4. Close this issue',
                 '',
                 '> Auto-opened by the detect-staging-drift workflow.',

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,8 @@
   - If code changes after staging verification, rerun local verification and redeploy staging before production.
   - Normal production promotion PR must be `staging` -> `main`.
   - Hotfix promotion PR may be `hotfix/<slug>` -> `main` only with explicit user approval in-thread.
-- **After any hotfix merges to main**: immediately create a `chore/sync-main-to-staging` branch from `origin/staging`, run `git merge origin/main -X ours --no-edit`, PR into `staging`, merge, and redeploy staging. Do not start new feature work until staging is back in sync. The `detect-staging-drift` workflow will open a GitHub Issue as a reminder if this is missed.
+- Normal squash-merged `staging` -> `main` production releases are not staging drift; the release content already came from `staging`, even though the squash commit is not in staging ancestry.
+- **After any hotfix merges to main**: immediately create a `chore/sync-main-to-staging` branch from `origin/staging`, apply the main-only hotfix/reconcile content in commits that can be squash-merged, PR into `staging`, merge, and let CI redeploy staging. Do not start new feature work until staging is back in sync. The `detect-staging-drift` workflow will open a GitHub Issue as a reminder if this is missed.
 - **Release-reconcile fallback rule**: if production promotion cannot be completed via direct `staging` -> `main` and uses a `hotfix/*` snapshot/reconcile PR instead, the same pass is not complete until `main` is synced back into `staging`, staging is redeployed, and the drift issue is closed.
 - Local run reliability:
   - Restart local server whenever runtime/config/env changes can affect behavior.
@@ -125,7 +126,8 @@
   - Run and report: `git log --oneline origin/staging -5`
   - Run and report: `git log --oneline origin/main -5`
   - Run and report: `git cherry -v origin/staging origin/main`
-  - If drift exists, create a dedicated `chore/reconcile-...` PR before feature work.
+  - If `git cherry` only reports the latest normal squash-merged `staging` -> `main` production release commit, treat it as expected ancestry-only drift and proceed.
+  - If new main-only hotfix/reconcile content appears, create a dedicated `chore/sync-main-to-staging` PR before feature work.
 - Verification gates for deep-link/API-affecting work:
   - `npm run test -- --run src/lib/deepLink.test.ts`
   - `npm run test -- --run functions/api/v1/calculate.test.ts`

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -126,33 +126,12 @@
 - Issue branches must be created from latest `origin/staging`.
 - PRs into `staging` or `main` must be up-to-date with the base branch before merge.
 - Never promote from `issue/*` or `chore/*` directly into `main`.
+- Normal squash-merged `staging` -> `main` production releases are not staging drift. The release content already came from `staging`, even though the squash commit is not in staging ancestry.
 - After any `hotfix/*` merge into `main` (including release-reconcile fallback), immediately:
   1. create `chore/sync-main-to-staging` from `origin/staging`
-  2. `git merge origin/main -X ours --no-edit`
+  2. apply the main-only hotfix/reconcile content in commits that can be squash-merged
   3. PR and merge into `staging`
-  4. `npm run deploy:staging` and verify deployment
-  5. close the drift issue
-
-## Drift prevention rules
-- Issue branches must be created from latest `origin/staging`.
-- PRs into `staging` or `main` must be up-to-date with the base branch before merge.
-- Never promote from `issue/*` or `chore/*` directly into `main`.
-- After any `hotfix/*` merge into `main` (including release-reconcile fallback), immediately:
-  1. create `chore/sync-main-to-staging` from `origin/staging`
-  2. `git merge origin/main -X ours --no-edit`
-  3. PR and merge into `staging`
-  4. `npm run deploy:staging` and verify deployment
-  5. close the drift issue
-
-## Drift prevention rules
-- Issue branches must be created from latest `origin/staging`.
-- PRs into `staging` or `main` must be up-to-date with the base branch before merge.
-- Never promote from `issue/*` or `chore/*` directly into `main`.
-- After any `hotfix/*` merge into `main` (including release-reconcile fallback), immediately:
-  1. create `chore/sync-main-to-staging` from `origin/staging`
-  2. `git merge origin/main -X ours --no-edit`
-  3. PR and merge into `staging`
-  4. `npm run deploy:staging` and verify deployment
+  4. let CI deploy staging and verify deployment
   5. close the drift issue
 
 ## Deploy Targets Reference

--- a/scripts/staging-drift-policy.mjs
+++ b/scripts/staging-drift-policy.mjs
@@ -1,0 +1,84 @@
+const asCount = (value) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : 0;
+};
+
+const normalizePullRequest = (pullRequest) => ({
+  headRefName: pullRequest?.headRefName ?? pullRequest?.head?.ref ?? "",
+  baseRefName: pullRequest?.baseRefName ?? pullRequest?.base?.ref ?? "",
+  mergedAt: pullRequest?.mergedAt ?? pullRequest?.merged_at ?? null,
+  htmlUrl: pullRequest?.url ?? pullRequest?.html_url ?? "",
+});
+
+export const isNormalStagingPromotion = (pullRequest) => {
+  const normalized = normalizePullRequest(pullRequest);
+  return normalized.baseRefName === "main" && normalized.headRefName === "staging" && Boolean(normalized.mergedAt);
+};
+
+export const shouldOpenStagingDriftIssue = ({ driftCount, associatedPullRequests }) => {
+  const count = asCount(driftCount);
+  if (count === 0) {
+    return { openIssue: false, reason: "no ancestry drift detected" };
+  }
+  const pullRequests = Array.isArray(associatedPullRequests) ? associatedPullRequests : [];
+  const stagingPromotion = pullRequests.map(normalizePullRequest).find(isNormalStagingPromotion);
+  if (stagingPromotion) {
+    return {
+      openIssue: false,
+      reason: `normal squash-merged staging->main promotion: ${stagingPromotion.htmlUrl || "associated PR"}`,
+    };
+  }
+  return { openIssue: true, reason: `${count} main commit(s) are not represented by a staging promotion PR` };
+};
+
+const writeGitHubOutput = async (entries) => {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  const lines = Object.entries(entries).map(([key, value]) => `${key}=${value}`);
+  if (!outputPath) {
+    console.log(lines.join("\n"));
+    return;
+  }
+  const { appendFileSync } = await import("node:fs");
+  appendFileSync(outputPath, `${lines.join("\n")}\n`);
+};
+
+const fetchAssociatedPullRequests = async ({ token, repository, sha }) => {
+  const [owner, repo] = repository.split("/");
+  if (!owner || !repo) throw new Error(`Invalid GITHUB_REPOSITORY: ${repository}`);
+  const response = await fetch(`https://api.github.com/repos/${owner}/${repo}/commits/${sha}/pulls`, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`GitHub API returned ${response.status} while reading associated PRs`);
+  }
+  return response.json();
+};
+
+export const runCli = async () => {
+  const driftCount = process.env.DRIFT_COUNT ?? "0";
+  const token = process.env.GITHUB_TOKEN ?? "";
+  const repository = process.env.GITHUB_REPOSITORY ?? "";
+  const sha = process.env.GITHUB_SHA ?? "";
+  if (!token || !repository || !sha) {
+    throw new Error("GITHUB_TOKEN, GITHUB_REPOSITORY, and GITHUB_SHA are required");
+  }
+
+  const associatedPullRequests = await fetchAssociatedPullRequests({ token, repository, sha });
+  const result = shouldOpenStagingDriftIssue({ driftCount, associatedPullRequests });
+  await writeGitHubOutput({
+    open_issue: result.openIssue ? "true" : "false",
+    reason: result.reason,
+  });
+  console.log(`[staging-drift-policy] ${result.openIssue ? "open issue" : "skip issue"}: ${result.reason}`);
+};
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runCli().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/src/lib/stagingDriftPolicy.test.ts
+++ b/src/lib/stagingDriftPolicy.test.ts
@@ -1,0 +1,82 @@
+/// <reference types="node" />
+
+import { describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+
+const scriptPath = resolve(process.cwd(), "scripts/staging-drift-policy.mjs");
+
+const evaluatePolicy = (expression: string) => {
+  const output = execFileSync(
+    process.execPath,
+    [
+      "--input-type=module",
+      "--eval",
+      `import { isNormalStagingPromotion, shouldOpenStagingDriftIssue } from ${JSON.stringify(scriptPath)};
+       const result = ${expression};
+       console.log(JSON.stringify(result));`,
+    ],
+    { encoding: "utf8" },
+  );
+  return JSON.parse(output) as unknown;
+};
+
+describe("staging drift policy", () => {
+  it("does not open a drift issue for a squash-merged staging to main promotion", () => {
+    const result = evaluatePolicy(`shouldOpenStagingDriftIssue({
+      driftCount: 1,
+      associatedPullRequests: [
+        {
+          head: { ref: "staging" },
+          base: { ref: "main" },
+          merged_at: "2026-04-27T12:00:00Z",
+          html_url: "https://github.com/wilhel1812/LinkSim/pull/769",
+        },
+      ],
+    })`) as { openIssue: boolean; reason: string };
+
+    expect(result.openIssue).toBe(false);
+    expect(result.reason).toContain("staging->main");
+  });
+
+  it("opens a drift issue for hotfix or other non-staging main pushes", () => {
+    const result = evaluatePolicy(`shouldOpenStagingDriftIssue({
+      driftCount: 1,
+      associatedPullRequests: [
+        {
+          head: { ref: "hotfix/auth-timeout" },
+          base: { ref: "main" },
+          merged_at: "2026-04-27T12:00:00Z",
+        },
+      ],
+    })`) as { openIssue: boolean };
+
+    expect(result.openIssue).toBe(true);
+  });
+
+  it("does not open a drift issue when there are no main-only commits", () => {
+    const result = evaluatePolicy(`shouldOpenStagingDriftIssue({
+      driftCount: 0,
+      associatedPullRequests: [],
+    })`) as { openIssue: boolean };
+
+    expect(result.openIssue).toBe(false);
+  });
+
+  it("recognizes associated pull request shapes from the GitHub API and GraphQL-style data", () => {
+    expect(
+      evaluatePolicy(`isNormalStagingPromotion({
+        head: { ref: "staging" },
+        base: { ref: "main" },
+        merged_at: "2026-04-27T12:00:00Z",
+      })`),
+    ).toBe(true);
+    expect(
+      evaluatePolicy(`isNormalStagingPromotion({
+        headRefName: "staging",
+        baseRefName: "main",
+        mergedAt: "2026-04-27T12:00:00Z",
+      })`),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Update `detect-staging-drift` so normal squash-merged `staging -> main` production releases do not open drift issues solely because ancestry is not preserved.
- Keep drift issues for hotfix/non-staging main pushes by classifying the push via associated PR metadata.
- Update AGENTS.md, release flow docs, and the PR template to use squash-merge-compatible hotfix sync wording.
- Deduplicate the repeated drift-prevention section in `docs/release-flow.md`.

Fixes #780.

## Drift check
- `git cherry -v origin/staging origin/main` showed only the known 0.18.0 squash-policy release commit tracked by #780.

## Verification
- `npm run test -- --run src/lib/stagingDriftPolicy.test.ts`
- `node --check scripts/staging-drift-policy.mjs`
- `npm test`
- `npm run build`