### PR TITLE
Add mobile full-screen support for Settings panel

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -2452,7 +2452,7 @@ export function AppShell() {
         </ModalOverlay>
       ) : null}
       {settingsRoute ? (
-        <ModalOverlay aria-label="Settings" onClose={closeSettings} tier="raised">
+        <ModalOverlay aria-label="Settings" onClose={closeSettings} tier="raised" className="settings-overlay">
           <div className="library-manager-card settings-panel-wrapper">
             <SettingsPanel initialSection={settingsRoute.section} onClose={closeSettings} />
           </div>

--- a/src/components/ModalOverlay.tsx
+++ b/src/components/ModalOverlay.tsx
@@ -6,13 +6,14 @@ type ModalOverlayProps = {
   children: ReactNode;
   onClose?: () => void;
   tier?: "base" | "raised";
+  className?: string;
 };
 
 let openModalCount = 0;
 const openModalStack: string[] = [];
 let modalLayerSeed = 0;
 
-export function ModalOverlay({ children, onClose, tier = "base", ...rest }: ModalOverlayProps) {
+export function ModalOverlay({ children, onClose, tier = "base", className, ...rest }: ModalOverlayProps) {
   const modalId = useId();
   const onCloseRef = useRef(onClose);
   onCloseRef.current = onClose;
@@ -54,7 +55,7 @@ export function ModalOverlay({ children, onClose, tier = "base", ...rest }: Moda
   return createPortal(
     <div
       aria-modal="true"
-      className="library-manager-overlay"
+      className={["library-manager-overlay", className].filter(Boolean).join(" ")}
       onMouseDown={(event) => {
         if (!onCloseRef.current) return;
         if (event.target !== event.currentTarget) return;

--- a/src/index.css
+++ b/src/index.css
@@ -4819,6 +4819,26 @@ html.panorama-gesture-lock body {
   .settings-panel-content {
     padding: 16px 16px 36px;
   }
+  .settings-panel-wrapper {
+    width: 100%;
+    height: 100%;
+    max-height: none;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+    padding: 0;
+  }
+  .settings-overlay {
+    padding: 0;
+  }
+  .settings-overlay .library-manager-card {
+    width: 100%;
+    height: 100%;
+    max-height: none;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+  }
 }
 
 /* Settings nav */


### PR DESCRIPTION
## Summary
- On mobile (<=980px), Settings panel now renders full-screen
- Removes border, shadow, rounded corners, and overlay padding on mobile
- Added className prop to ModalOverlay to support per-modal styling

## Related Issue
Updates #798

## Verification
- [x] `npm test` passes (454 tests)
- [x] `npm run build` succeeds
- [ ] Settings panel appears full-screen on mobile/responsive viewport