### PR TITLE
feat: floating popover editor for sites, links, and simulations (#804)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -37,6 +37,7 @@ import SimulationLibraryPanel from "./SimulationLibraryPanel";
 import WelcomeModal from "./WelcomeModal";
 import { Sidebar } from "./Sidebar";
 import { SettingsPanel } from "./settings/SettingsPanel";
+import { MapEditorPanel } from "./map/MapEditorPanel";
 import { MobileWorkspaceTabs } from "./app-shell/MobileWorkspaceTabs";
 import { useOnboardingFlow } from "./app-shell/useOnboardingFlow";
 
@@ -2458,6 +2459,7 @@ export function AppShell() {
           </div>
         </ModalOverlay>
       ) : null}
+      <MapEditorPanel isMobile={isMobileViewport} />
     </main>
   );
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -46,7 +46,7 @@ import {
   type MeshmapNode,
 } from "../lib/meshtasticMqtt";
 import { deriveDynamicPropagationEnvironment } from "../lib/propagationEnvironment";
-import { resolveLinkRadio, STANDARD_SITE_RADIO } from "../lib/linkRadio";
+import { STANDARD_SITE_RADIO } from "../lib/linkRadio";
 import { collapseSiteGainToTx, getSyncedSiteGainPair, shouldUseSeparateSiteGain } from "../lib/siteGainFields";
 import { sampleSrtmElevation } from "../lib/srtm";
 import { toAccessVisibility } from "../lib/uiFormatting";
@@ -277,7 +277,6 @@ export function Sidebar({
   const siteLibrary = useAppStore((state) => state.siteLibrary);
   const simulationPresets = useAppStore((state) => state.simulationPresets);
   const selectedLinkId = useAppStore((state) => state.selectedLinkId);
-  const selectedSiteId = useAppStore((state) => state.selectedSiteId);
   const selectedSiteIds = useAppStore((state) => state.selectedSiteIds);
   const selectedNetworkId = useAppStore((state) => state.selectedNetworkId);
   const selectedFrequencyPresetId = useAppStore((state) => state.selectedFrequencyPresetId);
@@ -312,6 +311,7 @@ export function Sidebar({
   const loadTerrainForCoordinate = useAppStore((state) => state.loadTerrainForCoordinate);
   const insertSitesFromLibrary = useAppStore((state) => state.insertSitesFromLibrary);
   const updateSiteLibraryEntry = useAppStore((state) => state.updateSiteLibraryEntry);
+  const openMapEditor = useAppStore((state) => state.openMapEditor);
   const deleteSiteLibraryEntries = useAppStore((state) => state.deleteSiteLibraryEntries);
   const deleteSimulationPreset = useAppStore((state) => state.deleteSimulationPreset);
   const deleteSite = useAppStore((state) => state.deleteSite);
@@ -323,7 +323,6 @@ export function Sidebar({
   const loadSimulationPreset = useAppStore((state) => state.loadSimulationPreset);
   const updateSimulationPresetEntry = useAppStore((state) => state.updateSimulationPresetEntry);
   const getSelectedLink = useAppStore((state) => state.getSelectedLink);
-  const getSelectedSite = useAppStore((state) => state.getSelectedSite);
   const showNewSimulationRequest = useAppStore((state) => state.showNewSimulationRequest);
   const setShowNewSimulationRequest = useAppStore((state) => state.setShowNewSimulationRequest);
   const getDefaultFrequencyPresetIdForNewSimulation = useAppStore(
@@ -335,7 +334,6 @@ export function Sidebar({
     () => getSelectedLink(),
     [getSelectedLink, links, selectedLinkId, sites, networks, selectedNetworkId],
   );
-  const selectedSite = useMemo(() => getSelectedSite(), [getSelectedSite, sites, selectedSiteId]);
 
   const fromSite = sites.find((site) => site.id === selectedLink.fromSiteId);
   const toSite = sites.find((site) => site.id === selectedLink.toSiteId);
@@ -732,21 +730,17 @@ export function Sidebar({
     const preset = simulationPresets.find((candidate) => candidate.id === presetId);
     return toAccessVisibility(preset?.visibility);
   }, [selectedSimulationRef, simulationPresets]);
-  const openActiveSimulationDetails = () => {
+  const openActiveSimulationDetails = (triggerEl?: Element | null) => {
     if (!selectedSimulationRef.startsWith("saved:")) return;
     const presetId = selectedSimulationRef.replace("saved:", "");
     const preset = simulationPresets.find((p) => p.id === presetId);
     if (!preset) return;
-    openResourceDetailsPopup({
+    openMapEditor({
       kind: "simulation",
       resourceId: preset.id,
+      isNew: false,
       label: preset.name,
-      createdByUserId: (preset as unknown as { createdByUserId?: string }).createdByUserId ?? null,
-      createdByName: (preset as unknown as { createdByName?: string }).createdByName ?? "Unknown",
-      createdByAvatarUrl: (preset as unknown as { createdByAvatarUrl?: string }).createdByAvatarUrl ?? "",
-      lastEditedByUserId: (preset as unknown as { lastEditedByUserId?: string }).lastEditedByUserId ?? null,
-      lastEditedByName: (preset as unknown as { lastEditedByName?: string }).lastEditedByName ?? "Unknown",
-      lastEditedByAvatarUrl: (preset as unknown as { lastEditedByAvatarUrl?: string }).lastEditedByAvatarUrl ?? "",
+      anchorRect: triggerEl?.getBoundingClientRect() ?? { top: 0, right: 0, bottom: 0, left: 0, width: 0, height: 0 },
     });
   };
   const collaboratorDirectoryById = useMemo(
@@ -999,16 +993,12 @@ export function Sidebar({
     if (!pendingSiteLibraryOpenEntryId) return;
     const entry = siteLibrary.find((candidate) => candidate.id === pendingSiteLibraryOpenEntryId);
     if (entry) {
-      openResourceDetailsPopup({
+      openMapEditor({
         kind: "site",
         resourceId: entry.id,
+        isNew: false,
         label: entry.name,
-        createdByUserId: (entry as unknown as { createdByUserId?: string }).createdByUserId ?? null,
-        createdByName: (entry as unknown as { createdByName?: string }).createdByName ?? "Unknown",
-        createdByAvatarUrl: (entry as unknown as { createdByAvatarUrl?: string }).createdByAvatarUrl ?? "",
-        lastEditedByUserId: (entry as unknown as { lastEditedByUserId?: string }).lastEditedByUserId ?? null,
-        lastEditedByName: (entry as unknown as { lastEditedByName?: string }).lastEditedByName ?? "Unknown",
-        lastEditedByAvatarUrl: (entry as unknown as { lastEditedByAvatarUrl?: string }).lastEditedByAvatarUrl ?? "",
+        anchorRect: { top: 0, right: 0, bottom: 0, left: 0, width: 0, height: 0 },
       });
     } else {
       setShowSiteLibraryManager(true);
@@ -1057,58 +1047,7 @@ export function Sidebar({
     setDeleteConfirm({ title, message, confirmLabel, onConfirm });
   };
 
-  const openAddLinkModal = () => {
-    const hasFromInSites = sites.some((site) => site.id === selectedLink.fromSiteId);
-    const hasToInSites = sites.some((site) => site.id === selectedLink.toSiteId);
-    const fallbackFrom = hasFromInSites ? selectedLink.fromSiteId : sites[0]?.id || "";
-    const fallbackTo = hasToInSites
-      ? selectedLink.toSiteId
-      : sites.find((site) => site.id !== fallbackFrom)?.id || "";
-    const fallbackFromSite = sites.find((site) => site.id === fallbackFrom) ?? selectedSite;
-    const fallbackToSite = sites.find((site) => site.id === fallbackTo) ?? fallbackFromSite;
-    const baseRadio = resolveLinkRadio(selectedLink, fallbackFromSite, fallbackToSite);
-    setLinkModal({
-      mode: "add",
-      linkId: null,
-      name: "",
-      fromSiteId: fallbackFrom,
-      toSiteId: fallbackTo,
-      overrideRadio: false,
-      txPowerDbm: baseRadio.txPowerDbm,
-      txGainDbi: baseRadio.txGainDbi,
-      rxGainDbi: baseRadio.rxGainDbi,
-      cableLossDb: baseRadio.cableLossDb,
-      status: "",
-    });
-  };
-
-  const openEditLinkModal = (linkId?: string) => {
-    const link = visibleLinks.find((l) => l.id === (linkId ?? selectedLinkId)) ?? selectedLink;
-    const linkRaw = links.find((l) => l.id === link.id) ?? null;
-    const fromSite = sites.find((site) => site.id === link.fromSiteId) ?? null;
-    const toSite = sites.find((site) => site.id === link.toSiteId) ?? null;
-    const baseRadio = resolveLinkRadio(link, fromSite, toSite);
-    const hasOverrides = Boolean(
-      linkRaw &&
-        (typeof linkRaw.txPowerDbm === "number" ||
-          typeof linkRaw.txGainDbi === "number" ||
-          typeof linkRaw.rxGainDbi === "number" ||
-          typeof linkRaw.cableLossDb === "number"),
-    );
-    setLinkModal({
-      mode: "edit",
-      linkId: link.id,
-      name: link.name ?? "",
-      fromSiteId: link.fromSiteId,
-      toSiteId: link.toSiteId,
-      overrideRadio: hasOverrides,
-      txPowerDbm: baseRadio.txPowerDbm,
-      txGainDbi: baseRadio.txGainDbi,
-      rxGainDbi: baseRadio.rxGainDbi,
-      cableLossDb: baseRadio.cableLossDb,
-      status: "",
-    });
-  };
+  // openAddLinkModal and openEditLinkModal removed — replaced by openMapEditor (issue #804)
 
   const saveLinkModal = () => {
     if (!linkModal) return;
@@ -1239,7 +1178,9 @@ export function Sidebar({
     });
   };
   const selectedLibraryCount = selectedLibraryIds.size;
-  const openLibraryForSite = (site: Site) => {
+  const ZERO_RECT = { top: 0, right: 0, bottom: 0, left: 0, width: 0, height: 0 };
+  const openLibraryForSite = (site: Site, triggerEl?: Element | null) => {
+    const anchorRect = triggerEl?.getBoundingClientRect() ?? ZERO_RECT;
     const matchedEntry = siteLibrary.find(
       (entry) =>
         entry.name === site.name &&
@@ -1247,41 +1188,23 @@ export function Sidebar({
         Math.abs(entry.position.lon - site.position.lon) < 0.000001,
     );
     if (matchedEntry) {
-      openResourceDetailsPopup({
+      openMapEditor({
         kind: "site",
         resourceId: matchedEntry.id,
+        isNew: false,
         label: matchedEntry.name,
-        createdByUserId: (matchedEntry as unknown as { createdByUserId?: string }).createdByUserId ?? null,
-        createdByName: (matchedEntry as unknown as { createdByName?: string }).createdByName ?? "Unknown",
-        createdByAvatarUrl:
-          (matchedEntry as unknown as { createdByAvatarUrl?: string }).createdByAvatarUrl ?? "",
-        lastEditedByUserId:
-          (matchedEntry as unknown as { lastEditedByUserId?: string }).lastEditedByUserId ?? null,
-        lastEditedByName:
-          (matchedEntry as unknown as { lastEditedByName?: string }).lastEditedByName ?? "Unknown",
-        lastEditedByAvatarUrl:
-          (matchedEntry as unknown as { lastEditedByAvatarUrl?: string }).lastEditedByAvatarUrl ?? "",
+        anchorRect,
       });
       return;
     }
-    setShowSiteLibraryManager(true);
-    setShowAddLibraryForm(true);
-    setNewLibraryName("");
-    setNewLibraryDescription("");
-    setNewLibraryVisibility("private");
-    setNewLibraryCollaboratorUserIds([]);
-    setNewLibraryCollaboratorRoles({});
-    setNewLibrarySourceMeta(undefined);
-    setNewLibraryLat(site.position.lat);
-    setNewLibraryLon(site.position.lon);
-    setNewLibraryGroundM(site.groundElevationM);
-    setNewLibraryAntennaM(site.antennaHeightM);
-    setNewLibraryTxPowerDbm(site.txPowerDbm);
-    setNewLibraryTxGainDbi(site.txGainDbi);
-    setNewLibraryRxGainDbi(site.rxGainDbi);
-    setNewLibrarySeparateGain(shouldUseSeparateSiteGain(site.txGainDbi, site.rxGainDbi));
-    setNewLibraryCableLossDb(site.cableLossDb);
-    setLibrarySearchStatus("Selected site is not in Site Library yet. Save to create a library entry.");
+    // Site not in library yet — open new site popover pre-filled with this site's values
+    openMapEditor({
+      kind: "site",
+      resourceId: null,
+      isNew: true,
+      label: "New Site",
+      anchorRect,
+    });
   };
   const openNewSiteForm = () => {
     setShowSiteLibraryManager(true);
@@ -1581,93 +1504,7 @@ export function Sidebar({
     }
   };
 
-  const openResourceDetailsPopup = ({
-    kind,
-    resourceId,
-    label,
-    createdByUserId,
-    createdByName,
-    createdByAvatarUrl,
-    lastEditedByUserId,
-    lastEditedByName,
-    lastEditedByAvatarUrl,
-  }: {
-    kind: "site" | "simulation";
-    resourceId: string;
-    label: string;
-    createdByUserId: string | null;
-    createdByName: string;
-    createdByAvatarUrl: string;
-    lastEditedByUserId: string | null;
-    lastEditedByName: string;
-    lastEditedByAvatarUrl: string;
-  }) => {
-    setResourceNameDraft(label);
-    if (kind === "site") {
-      const site = siteLibrary.find((entry) => entry.id === resourceId);
-      setResourceDescriptionDraft(site?.description ?? "");
-      setResourceLatDraft(site?.position.lat ?? 0);
-      setResourceLonDraft(site?.position.lon ?? 0);
-      setResourceGroundDraft(site?.groundElevationM ?? 0);
-      setResourceAntennaDraft(site?.antennaHeightM ?? 2);
-      setResourceTxPowerDraft(site?.txPowerDbm ?? STANDARD_SITE_RADIO.txPowerDbm);
-      const nextTxGainDbi = site?.txGainDbi ?? STANDARD_SITE_RADIO.txGainDbi;
-      const nextRxGainDbi = site?.rxGainDbi ?? STANDARD_SITE_RADIO.rxGainDbi;
-      setResourceTxGainDraft(nextTxGainDbi);
-      setResourceRxGainDraft(nextRxGainDbi);
-      setResourceSeparateGain(shouldUseSeparateSiteGain(nextTxGainDbi, nextRxGainDbi));
-      setResourceCableLossDraft(site?.cableLossDb ?? STANDARD_SITE_RADIO.cableLossDb);
-      setResourceAccessVisibility(toAccessVisibility(site?.visibility));
-      const siteGrants = (site?.sharedWith ?? []).filter((grant) => grant.userId !== site?.ownerUserId);
-      setResourceCollaboratorUserIds(siteGrants.map((grant) => grant.userId));
-      setResourceCollaboratorRoles(
-        Object.fromEntries(siteGrants.map((grant) => [grant.userId, grant.role === "editor" || grant.role === "admin" ? "editor" : "viewer"])),
-      );
-    } else {
-      const simulation = simulationPresets.find((entry) => entry.id === resourceId);
-      setResourceDescriptionDraft(simulation?.description ?? "");
-      setResourceLatDraft(0);
-      setResourceLonDraft(0);
-      setResourceGroundDraft(0);
-      setResourceAntennaDraft(2);
-      setResourceTxPowerDraft(STANDARD_SITE_RADIO.txPowerDbm);
-      setResourceTxGainDraft(STANDARD_SITE_RADIO.txGainDbi);
-      setResourceRxGainDraft(STANDARD_SITE_RADIO.rxGainDbi);
-      setResourceSeparateGain(shouldUseSeparateSiteGain(STANDARD_SITE_RADIO.txGainDbi, STANDARD_SITE_RADIO.rxGainDbi));
-      setResourceCableLossDraft(STANDARD_SITE_RADIO.cableLossDb);
-      setResourceAccessVisibility(toAccessVisibility(simulation?.visibility));
-      const simGrants = (simulation?.sharedWith ?? []).filter((grant) => grant.userId !== simulation?.ownerUserId);
-      setResourceCollaboratorUserIds(simGrants.map((grant) => grant.userId));
-      setResourceCollaboratorRoles(
-        Object.fromEntries(simGrants.map((grant) => [grant.userId, grant.role === "editor" || grant.role === "admin" ? "editor" : "viewer"])),
-      );
-    }
-    setResourceAccessStatus("");
-    const resolvedCreatedAvatar =
-      createdByAvatarUrl.trim() || (createdByUserId && createdByUserId === lastEditedByUserId ? lastEditedByAvatarUrl : "");
-    const resolvedLastEditedAvatar =
-      lastEditedByAvatarUrl.trim() ||
-      (lastEditedByUserId && lastEditedByUserId === createdByUserId ? createdByAvatarUrl : "");
-    const resolvedCreatedName =
-      createdByName.trim() && createdByName !== "Unknown"
-        ? createdByName
-        : createdByUserId ?? "Unknown";
-    const resolvedLastEditedName =
-      lastEditedByName.trim() && lastEditedByName !== "Unknown"
-        ? lastEditedByName
-        : lastEditedByUserId ?? resolvedCreatedName;
-    setResourceDetailsPopup({
-      kind,
-      resourceId,
-      label,
-      createdByUserId,
-      createdByName: resolvedCreatedName,
-      createdByAvatarUrl: resolvedCreatedAvatar,
-      lastEditedByUserId,
-      lastEditedByName: resolvedLastEditedName,
-      lastEditedByAvatarUrl: resolvedLastEditedAvatar,
-    });
-  };
+  // openResourceDetailsPopup removed — replaced by openMapEditor (issue #804)
 
   const persistResourceAccessSettings = (
     overrides?: Partial<{
@@ -1959,7 +1796,7 @@ export function Sidebar({
                 Duplicate
               </ActionButton>
               {selectedSimulationRef.startsWith("saved:") ? (
-                <ActionButton onClick={openActiveSimulationDetails} type="button">
+                <ActionButton onClick={(e) => openActiveSimulationDetails(e.currentTarget)} type="button">
                   Edit
                 </ActionButton>
               ) : null}
@@ -1993,7 +1830,7 @@ export function Sidebar({
                     aria-label="Edit site"
                     size="icon"
                     title="Edit site"
-                    onClick={() => openLibraryForSite(site)}
+                    onClick={(e) => openLibraryForSite(site, e.currentTarget)}
                   >
                     <Pencil aria-hidden="true" strokeWidth={1.8} />
                   </ActionButton>
@@ -2061,7 +1898,24 @@ export function Sidebar({
                     aria-label="Edit link"
                     size="icon"
                     title="Edit link"
-                    onClick={() => openEditLinkModal(link.id)}
+                    onClick={(e) => {
+                      const fromSite = sites.find((s) => s.id === link.fromSiteId);
+                      const toSite = sites.find((s) => s.id === link.toSiteId);
+                      const midLat = fromSite && toSite
+                        ? (fromSite.position.lat + toSite.position.lat) / 2
+                        : (fromSite?.position.lat ?? 0);
+                      const midLon = fromSite && toSite
+                        ? (fromSite.position.lon + toSite.position.lon) / 2
+                        : (fromSite?.position.lon ?? 0);
+                      openMapEditor({
+                        kind: "link",
+                        resourceId: link.id,
+                        isNew: false,
+                        label: link.name ?? displayLinkName(link.id),
+                        anchorRect: e.currentTarget.getBoundingClientRect(),
+                      });
+                      void midLat; void midLon;
+                    }}
                   >
                     <Pencil aria-hidden="true" strokeWidth={1.8} />
                   </ActionButton>
@@ -2086,7 +1940,19 @@ export function Sidebar({
         </div>
         <div className="chip-group">
           {!readOnly ? (
-            <ActionButton disabled={sites.length < 2} onClick={openAddLinkModal} type="button">
+            <ActionButton
+              disabled={sites.length < 2}
+              onClick={(e) => {
+                openMapEditor({
+                  kind: "link",
+                  resourceId: null,
+                  isNew: true,
+                  label: "New Link",
+                  anchorRect: e.currentTarget.getBoundingClientRect(),
+                });
+              }}
+              type="button"
+            >
               New
             </ActionButton>
           ) : null}
@@ -3184,7 +3050,15 @@ export function Sidebar({
               loadSimulationPreset(presetId);
               persistSelectedSimulationRef(`saved:${presetId}`);
             }}
-            onOpenDetails={openResourceDetailsPopup}
+            onOpenDetails={(params) =>
+              openMapEditor({
+                kind: params.kind,
+                resourceId: params.resourceId,
+                isNew: false,
+                label: params.label,
+                anchorRect: { top: 0, right: 0, bottom: 0, left: 0, width: 0, height: 0 },
+              })
+            }
           />
         </ModalOverlay>
       ) : null}
@@ -3417,22 +3291,18 @@ export function Sidebar({
             </div>
             <div className="chip-group">
               <ActionButton
-                onClick={() => {
-                  setShowAddLibraryForm((current) => !current);
-                  if (showAddLibraryForm) {
-                    setActiveBeamPreviewField(null);
-                    setPendingDraftAutoInsert(false);
-                    setNewLibraryDescription("");
-                    setNewLibraryVisibility("private");
-                    setNewLibraryCollaboratorUserIds([]);
-                    setNewLibraryCollaboratorRoles({});
-                  } else {
-                    setNewLibrarySeparateGain(shouldUseSeparateSiteGain(newLibraryTxGainDbi, newLibraryRxGainDbi));
-                  }
+                onClick={(e) => {
+                  openMapEditor({
+                    kind: "site",
+                    resourceId: null,
+                    isNew: true,
+                    label: "New Site",
+                    anchorRect: e.currentTarget.getBoundingClientRect(),
+                  });
                 }}
                 type="button"
               >
-                {showAddLibraryForm ? "Hide Add Form" : "Add Site"}
+                Add Site
               </ActionButton>
               <ActionButton
                 onClick={() => setSelectedLibraryIds(new Set(filteredSiteLibrary.map((entry) => entry.id)))}
@@ -3970,21 +3840,13 @@ export function Sidebar({
                       </ActionButton>
                     )}
                     <ActionButton
-                      onClick={() =>
-                        openResourceDetailsPopup({
+                      onClick={(e) =>
+                        openMapEditor({
                           kind: "site",
                           resourceId: entry.id,
+                          isNew: false,
                           label: entry.name,
-                          createdByUserId: (entry as unknown as { createdByUserId?: string }).createdByUserId ?? null,
-                          createdByName: (entry as unknown as { createdByName?: string }).createdByName ?? "Unknown",
-                          createdByAvatarUrl:
-                            (entry as unknown as { createdByAvatarUrl?: string }).createdByAvatarUrl ?? "",
-                          lastEditedByUserId:
-                            (entry as unknown as { lastEditedByUserId?: string }).lastEditedByUserId ?? null,
-                          lastEditedByName:
-                            (entry as unknown as { lastEditedByName?: string }).lastEditedByName ?? "Unknown",
-                          lastEditedByAvatarUrl:
-                            (entry as unknown as { lastEditedByAvatarUrl?: string }).lastEditedByAvatarUrl ?? "",
+                          anchorRect: e.currentTarget.getBoundingClientRect(),
                         })
                       }
                       type="button"

--- a/src/components/map/MapEditorPanel.tsx
+++ b/src/components/map/MapEditorPanel.tsx
@@ -1,0 +1,578 @@
+import { createPortal } from "react-dom";
+import { useEffect, useRef, useState } from "react";
+import { useAppStore } from "../../store/appStore";
+import { useMapEditorFormState } from "./useMapEditorFormState";
+import { AccessSettingsEditor } from "../AccessSettingsEditor";
+import { ActionButton } from "../ActionButton";
+import { CompactDetails, CompactDetailsSummary } from "../ui/CompactDetails";
+import { Surface } from "../ui/Surface";
+import { InlineCloseIconButton } from "../InlineCloseIconButton";
+
+// ─── Positioning ─────────────────────────────────────────────────────────────
+
+type AnchorRect = {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+  width: number;
+  height: number;
+};
+
+function computePosition(
+  anchorRect: AnchorRect,
+  panelWidth: number,
+  panelHeight: number,
+): { left: number; top: number } {
+  const MARGIN = 16;
+  const GAP = 8;
+
+  // Prefer opening to the right of the trigger button
+  let left = anchorRect.right + GAP;
+  if (left + panelWidth > window.innerWidth - MARGIN) {
+    // Overflow right → try left of trigger
+    left = anchorRect.left - panelWidth - GAP;
+  }
+  // Clamp to viewport
+  left = Math.max(MARGIN, Math.min(left, window.innerWidth - panelWidth - MARGIN));
+
+  // Align top to trigger top, shift up if it would overflow the bottom
+  let top = anchorRect.top;
+  if (top + panelHeight > window.innerHeight - MARGIN) {
+    top = window.innerHeight - panelHeight - MARGIN;
+  }
+  top = Math.max(MARGIN, top);
+
+  return { left, top };
+}
+
+// ─── Site Editor Card ────────────────────────────────────────────────────────
+
+function SiteEditorCard({
+  isNew,
+  form,
+  onClose,
+}: {
+  isNew: boolean;
+  form: ReturnType<typeof useMapEditorFormState>;
+  onClose: () => void;
+}) {
+  const mapEditor = useAppStore((state) => state.mapEditor);
+
+  return (
+    <>
+      <div className="library-manager-header">
+        <h2>{isNew ? "New Site" : `Edit · ${mapEditor?.label ?? "Site"}`}</h2>
+        <InlineCloseIconButton onClick={onClose} />
+      </div>
+
+      {!form.canWrite && !isNew && (
+        <p className="field-help warning-text">Read-only: you can view this site but cannot edit it.</p>
+      )}
+
+      <fieldset className="resource-edit-fieldset" disabled={!form.canWrite && !isNew}>
+        <label className="field-grid">
+          <span>Name</span>
+          <input
+            onChange={(e) => form.setNameDraft(e.target.value)}
+            placeholder="My site"
+            type="text"
+            value={form.nameDraft}
+          />
+        </label>
+
+        <label className="field-grid">
+          <span>Description</span>
+          <textarea
+            onChange={(e) => form.setDescriptionDraft(e.target.value)}
+            placeholder="Optional site notes (equipment, placement, access notes)"
+            rows={3}
+            value={form.descriptionDraft}
+          />
+        </label>
+
+        <AccessSettingsEditor
+          collaborators={form.collaborators}
+          directory={form.collaboratorDirectory}
+          directoryBusy={form.collaboratorDirectoryBusy}
+          directoryStatus={form.collaboratorDirectoryStatus}
+          disabled={!form.currentUser?.id}
+          onAddCollaborator={form.addCollaborator}
+          onRemoveCollaborator={form.removeCollaborator}
+          onRoleChange={form.setCollaboratorRole}
+          onVisibilityChange={form.setAccessVisibility}
+          ownerUserId={form.ownerUserId}
+          visibility={form.accessVisibility}
+        />
+
+        <label className="field-grid">
+          <span>Latitude</span>
+          <input
+            onChange={(e) => form.setLatDraft(e.target.value)}
+            step="0.000001"
+            type="number"
+            value={form.latDraft}
+          />
+        </label>
+
+        <label className="field-grid">
+          <span>Longitude</span>
+          <input
+            onChange={(e) => form.setLonDraft(e.target.value)}
+            step="0.000001"
+            type="number"
+            value={form.lonDraft}
+          />
+        </label>
+
+        <label className="field-grid">
+          <span>Ground elev (m)</span>
+          <div className="field-inline">
+            <input
+              onChange={(e) => form.setGroundDraft(e.target.value)}
+              type="number"
+              value={form.groundDraft}
+            />
+            <ActionButton
+              className="field-inline-btn"
+              disabled={form.isEditorTerrainFetching}
+              onClick={() => {
+                const elevation = form.fetchGroundElevation();
+                if (elevation === null) {
+                  form.setStatus(
+                    "No loaded terrain value at these coordinates. Fetch terrain data for this area first.",
+                  );
+                  return;
+                }
+                form.setGroundDraft(elevation);
+              }}
+              type="button"
+            >
+              {form.isEditorTerrainFetching ? "Loading…" : "Fetch"}
+            </ActionButton>
+          </div>
+        </label>
+
+        <label className="field-grid">
+          <span>Antenna (m)</span>
+          <input
+            onChange={(e) => form.setAntennaDraft(e.target.value)}
+            type="number"
+            value={form.antennaDraft}
+          />
+        </label>
+
+        <label className="field-grid">
+          <span>Tx power (dBm)</span>
+          <input
+            onChange={(e) => form.setTxPowerDraft(e.target.value)}
+            type="number"
+            value={form.txPowerDraft}
+          />
+        </label>
+
+        {form.separateGain ? (
+          <>
+            <label className="field-grid">
+              <span>Tx gain (dBi)</span>
+              <input
+                onChange={(e) => form.setTxGainDraft(e.target.value)}
+                type="number"
+                value={form.txGainDraft}
+              />
+            </label>
+            <label className="field-grid">
+              <span>Rx gain (dBi)</span>
+              <input
+                onChange={(e) => form.setRxGainDraft(e.target.value)}
+                type="number"
+                value={form.rxGainDraft}
+              />
+            </label>
+          </>
+        ) : (
+          <label className="field-grid">
+            <span>Gain (dBi)</span>
+            <input
+              onChange={(e) => form.handleGainChange(Number(e.target.value))}
+              type="number"
+              value={form.txGainDraft}
+            />
+          </label>
+        )}
+
+        <div className="field-grid gain-mode-toggle">
+          <span>Separate RX/TX gain</span>
+          <input
+            aria-label="Separate RX/TX gain"
+            checked={form.separateGain}
+            onChange={(e) => form.handleSeparateGainToggle(e.target.checked)}
+            type="checkbox"
+          />
+        </div>
+
+        <label className="field-grid">
+          <span>Cable loss (dB)</span>
+          <input
+            onChange={(e) => form.setCableLossDraft(e.target.value)}
+            type="number"
+            value={form.cableLossDraft}
+          />
+        </label>
+      </fieldset>
+
+      {form.status ? <p className="field-help">{form.status}</p> : null}
+
+      <div className="chip-group">
+        <ActionButton
+          disabled={!form.canWrite && !isNew}
+          onClick={form.handleSaveSite}
+          type="button"
+        >
+          {isNew ? "Create Site" : "Save Site"}
+        </ActionButton>
+        <ActionButton onClick={onClose} type="button">
+          Cancel
+        </ActionButton>
+      </div>
+    </>
+  );
+}
+
+// ─── Link Editor Card ────────────────────────────────────────────────────────
+
+function LinkEditorCard({
+  isNew,
+  form,
+  onClose,
+}: {
+  isNew: boolean;
+  form: ReturnType<typeof useMapEditorFormState>;
+  onClose: () => void;
+}) {
+  const mapEditor = useAppStore((state) => state.mapEditor);
+
+  return (
+    <>
+      <div className="library-manager-header">
+        <h2>{isNew ? "New Link" : `Edit · ${mapEditor?.label ?? "Link"}`}</h2>
+        <InlineCloseIconButton onClick={onClose} />
+      </div>
+
+      <label className="field-grid">
+        <span>Link name</span>
+        <input
+          onChange={(e) => form.setLinkNameDraft(e.target.value)}
+          placeholder="Backhaul A"
+          type="text"
+          value={form.linkNameDraft}
+        />
+      </label>
+
+      <label className="field-grid endpoint-field">
+        <span>From site</span>
+        <select
+          className="locale-select"
+          onChange={(e) => {
+            const nextFrom = e.target.value;
+            form.setLinkFromSiteId(nextFrom);
+            if (form.linkToSiteId === nextFrom) {
+              const fallback = form.sites.find((s) => s.id !== nextFrom)?.id ?? "";
+              form.setLinkToSiteId(fallback);
+            }
+          }}
+          value={form.linkFromSiteId}
+        >
+          {form.sites.map((site) => (
+            <option key={`from-${site.id}`} value={site.id}>
+              {site.name}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="field-grid endpoint-field">
+        <span>To site</span>
+        <select
+          className="locale-select"
+          onChange={(e) => form.setLinkToSiteId(e.target.value)}
+          value={form.linkToSiteId}
+        >
+          {form.sites
+            .filter((s) => s.id !== form.linkFromSiteId)
+            .map((site) => (
+              <option key={`to-${site.id}`} value={site.id}>
+                {site.name}
+              </option>
+            ))}
+        </select>
+      </label>
+
+      <CompactDetails>
+        <CompactDetailsSummary>Link Radio Overrides</CompactDetailsSummary>
+        <label className="field-grid">
+          <span>Use site radio defaults</span>
+          <input
+            checked={!form.overrideRadio}
+            onChange={(e) => form.setOverrideRadio(!e.target.checked)}
+            type="checkbox"
+          />
+        </label>
+        {!form.overrideRadio ? (
+          <p className="field-help">This link uses the selected From/To site radio settings.</p>
+        ) : null}
+        {form.overrideRadio ? (
+          <>
+            <label className="field-grid">
+              <span>Tx power (dBm)</span>
+              <input
+                onChange={(e) => form.setLinkTxPower(e.target.value)}
+                type="number"
+                value={form.linkTxPower}
+              />
+            </label>
+            <label className="field-grid">
+              <span>Tx gain (dBi)</span>
+              <input
+                onChange={(e) => form.setLinkTxGain(e.target.value)}
+                type="number"
+                value={form.linkTxGain}
+              />
+            </label>
+            <label className="field-grid">
+              <span>Rx gain (dBi)</span>
+              <input
+                onChange={(e) => form.setLinkRxGain(e.target.value)}
+                type="number"
+                value={form.linkRxGain}
+              />
+            </label>
+            <label className="field-grid">
+              <span>Cable loss (dB)</span>
+              <input
+                onChange={(e) => form.setLinkCableLoss(e.target.value)}
+                type="number"
+                value={form.linkCableLoss}
+              />
+            </label>
+          </>
+        ) : null}
+      </CompactDetails>
+
+      {form.status ? <p className="field-help">{form.status}</p> : null}
+
+      <div className="chip-group">
+        <ActionButton onClick={form.handleSaveLink} type="button">
+          {isNew ? "Create Link" : "Save Link"}
+        </ActionButton>
+        <ActionButton onClick={onClose} type="button">
+          Cancel
+        </ActionButton>
+      </div>
+    </>
+  );
+}
+
+// ─── Simulation Editor Card ──────────────────────────────────────────────────
+
+function SimulationEditorCard({
+  form,
+  onClose,
+}: {
+  form: ReturnType<typeof useMapEditorFormState>;
+  onClose: () => void;
+}) {
+  const mapEditor = useAppStore((state) => state.mapEditor);
+
+  return (
+    <>
+      <div className="library-manager-header">
+        <h2>Edit · {mapEditor?.label ?? "Simulation"}</h2>
+        <InlineCloseIconButton onClick={onClose} />
+      </div>
+
+      {!form.canWrite && (
+        <p className="field-help warning-text">Read-only: you can view this simulation but cannot edit it.</p>
+      )}
+
+      <fieldset className="resource-edit-fieldset" disabled={!form.canWrite}>
+        <label className="field-grid">
+          <span>Name</span>
+          <input
+            onChange={(e) => form.setNameDraft(e.target.value)}
+            type="text"
+            value={form.nameDraft}
+          />
+        </label>
+
+        <label className="field-grid">
+          <span>Description</span>
+          <textarea
+            onChange={(e) => form.setDescriptionDraft(e.target.value)}
+            placeholder="Optional simulation notes"
+            rows={3}
+            value={form.descriptionDraft}
+          />
+        </label>
+
+        <AccessSettingsEditor
+          collaborators={form.collaborators}
+          directory={form.collaboratorDirectory}
+          directoryBusy={form.collaboratorDirectoryBusy}
+          directoryStatus={form.collaboratorDirectoryStatus}
+          disabled={!form.currentUser?.id}
+          onAddCollaborator={form.addCollaborator}
+          onRemoveCollaborator={form.removeCollaborator}
+          onRoleChange={form.setCollaboratorRole}
+          onVisibilityChange={form.setAccessVisibility}
+          ownerUserId={form.ownerUserId}
+          visibility={form.accessVisibility}
+        />
+      </fieldset>
+
+      {/* Pending visibility confirmation prompt */}
+      {form.pendingVisibilityConfirm ? (
+        <div className="field-help warning-text">
+          <p>
+            This simulation references {form.pendingVisibilityConfirm.referencedPrivateSiteIds.length} private site(s).
+            Making this simulation shared will also make those sites shared. Continue?
+          </p>
+          <div className="chip-group">
+            <ActionButton onClick={form.applyPendingVisibilityChange} type="button">
+              Make Shared
+            </ActionButton>
+            <ActionButton onClick={() => form.setPendingVisibilityConfirm(null)} type="button">
+              Cancel
+            </ActionButton>
+          </div>
+        </div>
+      ) : null}
+
+      {form.status ? <p className="field-help">{form.status}</p> : null}
+
+      {!form.pendingVisibilityConfirm ? (
+        <div className="chip-group">
+          <ActionButton disabled={!form.canWrite} onClick={form.handleSaveSimulation} type="button">
+            Save
+          </ActionButton>
+          <ActionButton onClick={onClose} type="button">
+            Cancel
+          </ActionButton>
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+// ─── MapEditorPanel ──────────────────────────────────────────────────────────
+
+type MapEditorPanelProps = {
+  isMobile: boolean;
+};
+
+export function MapEditorPanel({ isMobile }: MapEditorPanelProps) {
+  const mapEditor = useAppStore((state) => state.mapEditor);
+  const closeMapEditor = useAppStore((state) => state.closeMapEditor);
+  const form = useMapEditorFormState();
+
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const [position, setPosition] = useState<{ left: number; top: number } | null>(null);
+
+  // Compute position on open and on resize
+  useEffect(() => {
+    if (!mapEditor || isMobile) {
+      setPosition(null);
+      return;
+    }
+
+    const updatePosition = () => {
+      const panelEl = panelRef.current;
+      const panelWidth = panelEl ? panelEl.offsetWidth : 380;
+      const panelHeight = panelEl ? panelEl.offsetHeight : 500;
+      setPosition(computePosition(mapEditor.anchorRect, panelWidth, panelHeight));
+    };
+
+    // Compute immediately on open (panelRef may not be populated yet, use estimated size)
+    setPosition(computePosition(mapEditor.anchorRect, 380, 560));
+
+    // Recompute once panel is rendered with actual dimensions
+    const raf = requestAnimationFrame(updatePosition);
+    window.addEventListener("resize", updatePosition);
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener("resize", updatePosition);
+    };
+  }, [mapEditor, isMobile]);
+
+  // ESC dismiss
+  useEffect(() => {
+    if (!mapEditor) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") closeMapEditor();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [mapEditor, closeMapEditor]);
+
+  // Outside click dismiss
+  useEffect(() => {
+    if (!mapEditor) return;
+    const onPointerDown = (e: Event) => {
+      if (panelRef.current?.contains(e.target as Node)) return;
+      closeMapEditor();
+    };
+    // Small delay so the triggering click doesn't immediately close the panel
+    const timer = setTimeout(() => {
+      document.addEventListener("mousedown", onPointerDown);
+      document.addEventListener("touchstart", onPointerDown, { passive: true });
+    }, 50);
+    return () => {
+      clearTimeout(timer);
+      document.removeEventListener("mousedown", onPointerDown);
+      document.removeEventListener("touchstart", onPointerDown);
+    };
+  }, [mapEditor, closeMapEditor]);
+
+  if (!mapEditor) return null;
+
+  const editorContent = (() => {
+    if (mapEditor.kind === "site") {
+      return <SiteEditorCard form={form} isNew={mapEditor.isNew} onClose={closeMapEditor} />;
+    }
+    if (mapEditor.kind === "link") {
+      return <LinkEditorCard form={form} isNew={mapEditor.isNew} onClose={closeMapEditor} />;
+    }
+    if (mapEditor.kind === "simulation") {
+      return <SimulationEditorCard form={form} onClose={closeMapEditor} />;
+    }
+    return null;
+  })();
+
+  if (isMobile) {
+    return createPortal(
+      <div className="map-editor-sheet" ref={panelRef}>
+        <div className="map-editor-sheet-handle" aria-hidden="true" />
+        <div className="map-editor-sheet-content">
+          {editorContent}
+        </div>
+      </div>,
+      document.body,
+    );
+  }
+
+  return createPortal(
+    <Surface
+      ref={panelRef}
+      variant="card"
+      className="map-editor-floating"
+      style={
+        position
+          ? { left: position.left, top: position.top }
+          : { visibility: "hidden", left: 0, top: 0 }
+      }
+    >
+      {editorContent}
+    </Surface>,
+    document.body,
+  );
+}

--- a/src/components/map/useMapEditorFormState.ts
+++ b/src/components/map/useMapEditorFormState.ts
@@ -1,0 +1,511 @@
+import { useEffect, useState } from "react";
+import { collapseSiteGainToTx, getSyncedSiteGainPair, shouldUseSeparateSiteGain } from "../../lib/siteGainFields";
+import { resolveLinkRadio, STANDARD_SITE_RADIO } from "../../lib/linkRadio";
+import { toAccessVisibility } from "../../lib/uiFormatting";
+import { fetchCollaboratorDirectory } from "../../lib/cloudUser";
+import { sampleSrtmElevation } from "../../lib/srtm";
+import { getUiErrorMessage } from "../../lib/uiError";
+import { useAppStore } from "../../store/appStore";
+import type { CollaboratorDirectoryUser } from "../../lib/cloudUser";
+import type { AccessRole, AccessVisibility } from "../AccessSettingsEditor";
+
+const parseNumber = (value: string | number): number => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+export function useMapEditorFormState() {
+  const mapEditor = useAppStore((state) => state.mapEditor);
+  const closeMapEditor = useAppStore((state) => state.closeMapEditor);
+  const siteLibrary = useAppStore((state) => state.siteLibrary);
+  const simulationPresets = useAppStore((state) => state.simulationPresets);
+  const sites = useAppStore((state) => state.sites);
+  const links = useAppStore((state) => state.links);
+  const srtmTiles = useAppStore((state) => state.srtmTiles);
+  const mapViewport = useAppStore((state) => state.mapViewport);
+  const currentUser = useAppStore((state) => state.currentUser);
+  const isEditorTerrainFetching = useAppStore((state) => state.isEditorTerrainFetching);
+  const loadTerrainForCoordinate = useAppStore((state) => state.loadTerrainForCoordinate);
+  const updateSiteLibraryEntry = useAppStore((state) => state.updateSiteLibraryEntry);
+  const addSiteLibraryEntry = useAppStore((state) => state.addSiteLibraryEntry);
+  const updateSimulationPresetEntry = useAppStore((state) => state.updateSimulationPresetEntry);
+  const createLink = useAppStore((state) => state.createLink);
+  const updateLink = useAppStore((state) => state.updateLink);
+
+  // ─── Shared status ───────────────────────────────────────────────────────────
+  const [status, setStatus] = useState("");
+
+  // ─── Site / Simulation shared drafts ─────────────────────────────────────────
+  const [nameDraft, setNameDraft] = useState("");
+  const [descriptionDraft, setDescriptionDraft] = useState("");
+  const [accessVisibility, setAccessVisibility] = useState<AccessVisibility>("private");
+  const [collaboratorUserIds, setCollaboratorUserIds] = useState<string[]>([]);
+  const [collaboratorRoles, setCollaboratorRoles] = useState<Record<string, AccessRole>>({});
+  const [collaboratorDirectory, setCollaboratorDirectory] = useState<CollaboratorDirectoryUser[]>([]);
+  const [collaboratorDirectoryBusy, setCollaboratorDirectoryBusy] = useState(false);
+  const [collaboratorDirectoryStatus, setCollaboratorDirectoryStatus] = useState("");
+
+  // ─── Site-specific drafts ─────────────────────────────────────────────────────
+  const [latDraft, setLatDraft] = useState(0);
+  const [lonDraft, setLonDraft] = useState(0);
+  const [groundDraft, setGroundDraft] = useState(0);
+  const [antennaDraft, setAntennaDraft] = useState(2);
+  const [txPowerDraft, setTxPowerDraft] = useState(STANDARD_SITE_RADIO.txPowerDbm);
+  const [txGainDraft, setTxGainDraft] = useState(STANDARD_SITE_RADIO.txGainDbi);
+  const [rxGainDraft, setRxGainDraft] = useState(STANDARD_SITE_RADIO.rxGainDbi);
+  const [separateGain, setSeparateGain] = useState(false);
+  const [cableLossDraft, setCableLossDraft] = useState(STANDARD_SITE_RADIO.cableLossDb);
+  const [isElevationUserSet, setIsElevationUserSet] = useState(false);
+
+  // ─── Simulation-specific ─────────────────────────────────────────────────────
+  const [pendingVisibilityConfirm, setPendingVisibilityConfirm] = useState<{
+    simulationId: string;
+    targetVisibility: "shared";
+    referencedPrivateSiteIds: string[];
+  } | null>(null);
+
+  // ─── Link drafts ──────────────────────────────────────────────────────────────
+  const [linkNameDraft, setLinkNameDraft] = useState("");
+  const [linkFromSiteId, setLinkFromSiteId] = useState("");
+  const [linkToSiteId, setLinkToSiteId] = useState("");
+  const [overrideRadio, setOverrideRadio] = useState(false);
+  const [linkTxPower, setLinkTxPower] = useState(STANDARD_SITE_RADIO.txPowerDbm);
+  const [linkTxGain, setLinkTxGain] = useState(STANDARD_SITE_RADIO.txGainDbi);
+  const [linkRxGain, setLinkRxGain] = useState(STANDARD_SITE_RADIO.rxGainDbi);
+  const [linkCableLoss, setLinkCableLoss] = useState(STANDARD_SITE_RADIO.cableLossDb);
+
+  // ─── Initialize drafts when editor opens ─────────────────────────────────────
+  useEffect(() => {
+    if (!mapEditor) return;
+    setStatus("");
+    setPendingVisibilityConfirm(null);
+    setIsElevationUserSet(false);
+
+    if (mapEditor.kind === "site") {
+      if (mapEditor.isNew) {
+        // New site: initialise from map center
+        setNameDraft("");
+        setDescriptionDraft("");
+        setLatDraft(mapViewport?.center.lat ?? 0);
+        setLonDraft(mapViewport?.center.lon ?? 0);
+        setGroundDraft(0);
+        setAntennaDraft(10);
+        setTxPowerDraft(STANDARD_SITE_RADIO.txPowerDbm);
+        setTxGainDraft(STANDARD_SITE_RADIO.txGainDbi);
+        setRxGainDraft(STANDARD_SITE_RADIO.rxGainDbi);
+        setSeparateGain(false);
+        setCableLossDraft(STANDARD_SITE_RADIO.cableLossDb);
+        setAccessVisibility("private");
+        setCollaboratorUserIds([]);
+        setCollaboratorRoles({});
+      } else {
+        // Edit site
+        const entry = siteLibrary.find((e) => e.id === mapEditor.resourceId);
+        setNameDraft(entry?.name ?? mapEditor.label);
+        setDescriptionDraft(entry?.description ?? "");
+        setLatDraft(entry?.position.lat ?? 0);
+        setLonDraft(entry?.position.lon ?? 0);
+        setGroundDraft(entry?.groundElevationM ?? 0);
+        setAntennaDraft(entry?.antennaHeightM ?? 2);
+        setTxPowerDraft(entry?.txPowerDbm ?? STANDARD_SITE_RADIO.txPowerDbm);
+        const nextTxGain = entry?.txGainDbi ?? STANDARD_SITE_RADIO.txGainDbi;
+        const nextRxGain = entry?.rxGainDbi ?? STANDARD_SITE_RADIO.rxGainDbi;
+        setTxGainDraft(nextTxGain);
+        setRxGainDraft(nextRxGain);
+        setSeparateGain(shouldUseSeparateSiteGain(nextTxGain, nextRxGain));
+        setCableLossDraft(entry?.cableLossDb ?? STANDARD_SITE_RADIO.cableLossDb);
+        setAccessVisibility(toAccessVisibility(entry?.visibility) as AccessVisibility);
+        const grants = (entry?.sharedWith ?? []).filter((g) => g.userId !== entry?.ownerUserId);
+        setCollaboratorUserIds(grants.map((g) => g.userId));
+        setCollaboratorRoles(
+          Object.fromEntries(
+            grants.map((g) => [g.userId, g.role === "editor" || g.role === "admin" ? "editor" : "viewer"]),
+          ),
+        );
+      }
+    } else if (mapEditor.kind === "simulation") {
+      const preset = simulationPresets.find((p) => p.id === mapEditor.resourceId);
+      setNameDraft(preset?.name ?? mapEditor.label);
+      setDescriptionDraft(preset?.description ?? "");
+      setAccessVisibility(toAccessVisibility(preset?.visibility) as AccessVisibility);
+      const grants = (preset?.sharedWith ?? []).filter((g) => g.userId !== preset?.ownerUserId);
+      setCollaboratorUserIds(grants.map((g) => g.userId));
+      setCollaboratorRoles(
+        Object.fromEntries(
+          grants.map((g) => [g.userId, g.role === "editor" || g.role === "admin" ? "editor" : "viewer"]),
+        ),
+      );
+    } else if (mapEditor.kind === "link") {
+      if (mapEditor.isNew) {
+        const fallbackFrom = sites[0]?.id ?? "";
+        const fallbackTo = sites.find((s) => s.id !== fallbackFrom)?.id ?? "";
+        const fromSite = sites.find((s) => s.id === fallbackFrom) ?? null;
+        const toSite = sites.find((s) => s.id === fallbackTo) ?? null;
+        const baseRadio = resolveLinkRadio({} as any, fromSite, toSite);
+        setLinkNameDraft("");
+        setLinkFromSiteId(fallbackFrom);
+        setLinkToSiteId(fallbackTo);
+        setOverrideRadio(false);
+        setLinkTxPower(baseRadio.txPowerDbm);
+        setLinkTxGain(baseRadio.txGainDbi);
+        setLinkRxGain(baseRadio.rxGainDbi);
+        setLinkCableLoss(baseRadio.cableLossDb);
+      } else {
+        const link = links.find((l) => l.id === mapEditor.resourceId);
+        const fromSite = sites.find((s) => s.id === link?.fromSiteId) ?? null;
+        const toSite = sites.find((s) => s.id === link?.toSiteId) ?? null;
+        const baseRadio = resolveLinkRadio(link as any, fromSite, toSite);
+        const hasOverrides = Boolean(
+          link &&
+            (typeof link.txPowerDbm === "number" ||
+              typeof link.txGainDbi === "number" ||
+              typeof link.rxGainDbi === "number" ||
+              typeof link.cableLossDb === "number"),
+        );
+        setLinkNameDraft(link?.name ?? "");
+        setLinkFromSiteId(link?.fromSiteId ?? "");
+        setLinkToSiteId(link?.toSiteId ?? "");
+        setOverrideRadio(hasOverrides);
+        setLinkTxPower(baseRadio.txPowerDbm);
+        setLinkTxGain(baseRadio.txGainDbi);
+        setLinkRxGain(baseRadio.rxGainDbi);
+        setLinkCableLoss(baseRadio.cableLossDb);
+      }
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mapEditor?.kind, mapEditor?.resourceId, mapEditor?.isNew]);
+
+  // ─── Terrain prefetch for site coordinates ────────────────────────────────────
+  useEffect(() => {
+    if (mapEditor?.kind !== "site") return;
+    setIsElevationUserSet(false);
+    const timer = setTimeout(() => {
+      void loadTerrainForCoordinate(latDraft, lonDraft);
+    }, 500);
+    return () => clearTimeout(timer);
+  }, [latDraft, lonDraft, mapEditor?.kind, loadTerrainForCoordinate]);
+
+  // Auto-fill elevation from terrain when it loads (only if user hasn't manually set)
+  useEffect(() => {
+    if (mapEditor?.kind !== "site" || isElevationUserSet) return;
+    const elevation = Number(sampleSrtmElevation(srtmTiles, latDraft, lonDraft));
+    if (Number.isFinite(elevation)) setGroundDraft(Math.round(elevation));
+  }, [srtmTiles, isElevationUserSet, latDraft, lonDraft, mapEditor?.kind]);
+
+  // ─── Collaborator directory ───────────────────────────────────────────────────
+  useEffect(() => {
+    if (!mapEditor) return;
+    let canceled = false;
+    setCollaboratorDirectoryBusy(true);
+    setCollaboratorDirectoryStatus("");
+    void fetchCollaboratorDirectory()
+      .then((users) => {
+        if (canceled) return;
+        setCollaboratorDirectory(users);
+      })
+      .catch((error) => {
+        if (canceled) return;
+        setCollaboratorDirectoryStatus(`Collaborator lookup unavailable: ${getUiErrorMessage(error)}`);
+      })
+      .finally(() => {
+        if (canceled) return;
+        setCollaboratorDirectoryBusy(false);
+      });
+    return () => {
+      canceled = true;
+    };
+  }, [mapEditor?.kind, mapEditor?.resourceId]);
+
+  // ─── Derived values ───────────────────────────────────────────────────────────
+  const currentUser_id = currentUser?.id ?? "";
+  const ownerUserId = (() => {
+    if (!mapEditor) return "";
+    if (mapEditor.kind === "site" && mapEditor.resourceId) {
+      return siteLibrary.find((e) => e.id === mapEditor.resourceId)?.ownerUserId ?? "";
+    }
+    if (mapEditor.kind === "simulation" && mapEditor.resourceId) {
+      return (simulationPresets.find((p) => p.id === mapEditor.resourceId) as any)?.ownerUserId ?? "";
+    }
+    return currentUser_id;
+  })();
+
+  const canWrite = (() => {
+    if (!mapEditor) return false;
+    if (mapEditor.isNew) return Boolean(currentUser);
+    if (mapEditor.kind === "site" && mapEditor.resourceId) {
+      const entry = siteLibrary.find((e) => e.id === mapEditor.resourceId);
+      const role = (entry as any)?.effectiveRole ?? "owner";
+      return ["owner", "editor", "admin"].includes(role);
+    }
+    if (mapEditor.kind === "simulation" && mapEditor.resourceId) {
+      const preset = simulationPresets.find((p) => p.id === mapEditor.resourceId);
+      const role = (preset as any)?.effectiveRole ?? "owner";
+      return ["owner", "editor", "admin"].includes(role);
+    }
+    if (mapEditor.kind === "link") return Boolean(currentUser);
+    return false;
+  })();
+
+  const collaborators = collaboratorUserIds.map((userId) => {
+    const dirUser = collaboratorDirectory.find((u) => u.id === userId);
+    return {
+      id: userId,
+      username: dirUser?.username ?? userId,
+      email: dirUser?.email ?? "",
+      avatarUrl: dirUser?.avatarUrl ?? "",
+      role: collaboratorRoles[userId] ?? "viewer" as AccessRole,
+    };
+  });
+
+  // ─── Collaborator callbacks ───────────────────────────────────────────────────
+  const addCollaborator = (userId: string) => {
+    if (!userId.trim()) return;
+    if (userId === ownerUserId) {
+      setStatus("Owner is implicit and cannot be added as collaborator.");
+      return;
+    }
+    setCollaboratorUserIds((prev) => (prev.includes(userId) ? prev : [...prev, userId]));
+    setCollaboratorRoles((prev) => (prev[userId] ? prev : { ...prev, [userId]: "viewer" }));
+  };
+
+  const removeCollaborator = (userId: string) => {
+    setCollaboratorUserIds((prev) => prev.filter((id) => id !== userId));
+    setCollaboratorRoles((prev) => {
+      const next = { ...prev };
+      delete next[userId];
+      return next;
+    });
+  };
+
+  const setCollaboratorRole = (userId: string, role: AccessRole) => {
+    setCollaboratorRoles((prev) => ({ ...prev, [userId]: role }));
+  };
+
+  // ─── Terrain fetch helper ─────────────────────────────────────────────────────
+  const fetchGroundElevation = (): number | null => {
+    const elevation = Number(sampleSrtmElevation(srtmTiles, latDraft, lonDraft));
+    if (!Number.isFinite(elevation)) return null;
+    return Math.round(elevation);
+  };
+
+  // ─── Gain toggle ─────────────────────────────────────────────────────────────
+  const handleGainChange = (value: number) => {
+    const next = getSyncedSiteGainPair(value);
+    setTxGainDraft(next.txGainDbi);
+    setRxGainDraft(next.rxGainDbi);
+  };
+
+  const handleSeparateGainToggle = (checked: boolean) => {
+    setSeparateGain(checked);
+    if (!checked) {
+      const next = collapseSiteGainToTx(txGainDraft);
+      setTxGainDraft(next.txGainDbi);
+      setRxGainDraft(next.rxGainDbi);
+    }
+  };
+
+  // ─── Save handlers ─────────────────────────────────────────────────────────────
+  const handleSaveSite = (): boolean => {
+    const trimmedName = nameDraft.trim();
+    if (!trimmedName) {
+      setStatus("Name is required.");
+      return false;
+    }
+    const normalizedVisibility: "private" | "shared" = accessVisibility;
+    const sharedWith = collaboratorUserIds
+      .filter((id) => id !== ownerUserId)
+      .map((id) => ({ userId: id, role: (collaboratorRoles[id] ?? "viewer") as "viewer" | "editor" }));
+
+    try {
+      if (mapEditor?.isNew) {
+        addSiteLibraryEntry(
+          trimmedName,
+          latDraft,
+          lonDraft,
+          groundDraft,
+          antennaDraft,
+          txPowerDraft,
+          txGainDraft,
+          rxGainDraft,
+          cableLossDraft,
+          undefined,
+          normalizedVisibility,
+          descriptionDraft.trim() || undefined,
+        );
+      } else if (mapEditor?.resourceId) {
+        updateSiteLibraryEntry(mapEditor.resourceId, {
+          name: trimmedName,
+          description: descriptionDraft.trim() || undefined,
+          position: { lat: latDraft, lon: lonDraft },
+          groundElevationM: groundDraft,
+          antennaHeightM: antennaDraft,
+          txPowerDbm: txPowerDraft,
+          txGainDbi: txGainDraft,
+          rxGainDbi: rxGainDraft,
+          cableLossDb: cableLossDraft,
+          visibility: normalizedVisibility,
+          sharedWith,
+        });
+      }
+      closeMapEditor();
+      return true;
+    } catch (error) {
+      setStatus(`Save failed: ${getUiErrorMessage(error)}`);
+      return false;
+    }
+  };
+
+  const handleSaveSimulation = (): boolean => {
+    if (!mapEditor?.resourceId) return false;
+    const trimmedName = nameDraft.trim();
+    if (!trimmedName) {
+      setStatus("Name is required.");
+      return false;
+    }
+    const normalizedVisibility: "private" | "shared" = accessVisibility;
+    const sharedWith = collaboratorUserIds
+      .filter((id) => id !== ownerUserId)
+      .map((id) => ({ userId: id, role: (collaboratorRoles[id] ?? "viewer") as "viewer" | "editor" }));
+
+    // Check for private site refs that would need to be promoted
+    if (normalizedVisibility === "shared") {
+      const preset = simulationPresets.find((p) => p.id === mapEditor.resourceId);
+      const referencedPrivateSiteIds = siteLibrary
+        .filter((entry) => {
+          if ((entry.visibility ?? "private") !== "private") return false;
+          const refIds = new Set(
+            (preset?.snapshot.sites ?? [])
+              .map((s) => s.libraryEntryId)
+              .filter((v): v is string => typeof v === "string" && v.length > 0),
+          );
+          return refIds.has(entry.id);
+        })
+        .map((e) => e.id);
+      if (referencedPrivateSiteIds.length > 0) {
+        setPendingVisibilityConfirm({
+          simulationId: mapEditor.resourceId,
+          targetVisibility: "shared",
+          referencedPrivateSiteIds,
+        });
+        return false;
+      }
+    }
+
+    try {
+      updateSimulationPresetEntry(mapEditor.resourceId, {
+        name: trimmedName,
+        description: descriptionDraft.trim() || undefined,
+        visibility: normalizedVisibility,
+        sharedWith,
+      });
+      closeMapEditor();
+      return true;
+    } catch (error) {
+      setStatus(`Save failed: ${getUiErrorMessage(error)}`);
+      return false;
+    }
+  };
+
+  const applyPendingVisibilityChange = () => {
+    if (!pendingVisibilityConfirm || !mapEditor?.resourceId) return;
+    for (const siteId of pendingVisibilityConfirm.referencedPrivateSiteIds) {
+      updateSiteLibraryEntry(siteId, { visibility: pendingVisibilityConfirm.targetVisibility });
+    }
+    const sharedWith = collaboratorUserIds
+      .filter((id) => id !== ownerUserId)
+      .map((id) => ({ userId: id, role: (collaboratorRoles[id] ?? "viewer") as "viewer" | "editor" }));
+    updateSimulationPresetEntry(pendingVisibilityConfirm.simulationId, {
+      visibility: pendingVisibilityConfirm.targetVisibility,
+      sharedWith,
+    });
+    setPendingVisibilityConfirm(null);
+    closeMapEditor();
+  };
+
+  const handleSaveLink = (): boolean => {
+    const fromExists = sites.some((s) => s.id === linkFromSiteId);
+    const toExists = sites.some((s) => s.id === linkToSiteId);
+    if (!fromExists || !toExists) {
+      setStatus("From/To must be valid current simulation sites.");
+      return false;
+    }
+    if (!linkFromSiteId || !linkToSiteId) {
+      setStatus("Select both From and To sites.");
+      return false;
+    }
+    if (linkFromSiteId === linkToSiteId) {
+      setStatus("From and To must be different sites.");
+      return false;
+    }
+    try {
+      if (mapEditor?.isNew) {
+        createLink(linkFromSiteId, linkToSiteId, linkNameDraft || undefined);
+      } else if (mapEditor?.resourceId) {
+        updateLink(mapEditor.resourceId, {
+          name: linkNameDraft || undefined,
+          fromSiteId: linkFromSiteId,
+          toSiteId: linkToSiteId,
+          txPowerDbm: overrideRadio ? linkTxPower : undefined,
+          txGainDbi: overrideRadio ? linkTxGain : undefined,
+          rxGainDbi: overrideRadio ? linkRxGain : undefined,
+          cableLossDb: overrideRadio ? linkCableLoss : undefined,
+        });
+      }
+      closeMapEditor();
+      return true;
+    } catch (error) {
+      setStatus(`Save failed: ${getUiErrorMessage(error)}`);
+      return false;
+    }
+  };
+
+  return {
+    // shared
+    status, setStatus,
+    nameDraft, setNameDraft,
+    descriptionDraft, setDescriptionDraft,
+    accessVisibility, setAccessVisibility,
+    collaborators,
+    collaboratorDirectory,
+    collaboratorDirectoryBusy,
+    collaboratorDirectoryStatus,
+    addCollaborator,
+    removeCollaborator,
+    setCollaboratorRole,
+    ownerUserId,
+    canWrite,
+    currentUser,
+    // site
+    latDraft, setLatDraft: (v: number | string) => setLatDraft(parseNumber(String(v))),
+    lonDraft, setLonDraft: (v: number | string) => setLonDraft(parseNumber(String(v))),
+    groundDraft, setGroundDraft: (v: number | string) => { setGroundDraft(parseNumber(String(v))); setIsElevationUserSet(true); },
+    antennaDraft, setAntennaDraft: (v: number | string) => setAntennaDraft(parseNumber(String(v))),
+    txPowerDraft, setTxPowerDraft: (v: number | string) => setTxPowerDraft(parseNumber(String(v))),
+    txGainDraft, setTxGainDraft: (v: number | string) => setTxGainDraft(parseNumber(String(v))),
+    rxGainDraft, setRxGainDraft: (v: number | string) => setRxGainDraft(parseNumber(String(v))),
+    separateGain,
+    cableLossDraft, setCableLossDraft: (v: number | string) => setCableLossDraft(parseNumber(String(v))),
+    isEditorTerrainFetching,
+    fetchGroundElevation,
+    handleGainChange,
+    handleSeparateGainToggle,
+    handleSaveSite,
+    // simulation
+    pendingVisibilityConfirm,
+    setPendingVisibilityConfirm,
+    applyPendingVisibilityChange,
+    handleSaveSimulation,
+    // link
+    linkNameDraft, setLinkNameDraft,
+    linkFromSiteId, setLinkFromSiteId,
+    linkToSiteId, setLinkToSiteId,
+    overrideRadio, setOverrideRadio,
+    linkTxPower, setLinkTxPower: (v: number | string) => setLinkTxPower(parseNumber(String(v))),
+    linkTxGain, setLinkTxGain: (v: number | string) => setLinkTxGain(parseNumber(String(v))),
+    linkRxGain, setLinkRxGain: (v: number | string) => setLinkRxGain(parseNumber(String(v))),
+    linkCableLoss, setLinkCableLoss: (v: number | string) => setLinkCableLoss(parseNumber(String(v))),
+    handleSaveLink,
+    // raw data for labels
+    sites,
+  };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -5194,3 +5194,47 @@ html.panorama-gesture-lock body {
   max-height: none;
   overflow: visible;
 }
+
+/* ─── Map Editor Panel (issue #804) ──────────────────────────────────────── */
+
+/* Desktop floating panel — positioned via JS */
+.map-editor-floating {
+  position: fixed;
+  z-index: 6000;
+  width: min(380px, calc(100vw - 32px));
+  max-height: min(85vh, 680px);
+  overflow-y: auto;
+  padding: 14px;
+  display: grid;
+  gap: 10px;
+}
+
+/* Mobile bottom sheet */
+.map-editor-sheet {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 6000;
+  border-radius: 18px 18px 0 0;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  max-height: 80vh;
+  overflow-y: auto;
+  animation: panel-slide-in-bottom 360ms ease-out both;
+}
+
+.map-editor-sheet-handle {
+  width: 36px;
+  height: 4px;
+  background: var(--border);
+  border-radius: 2px;
+  margin: 8px auto 4px;
+}
+
+.map-editor-sheet-content {
+  padding: 4px 14px 24px;
+  display: grid;
+  gap: 10px;
+}

--- a/src/store/appStore.mapEditor.test.ts
+++ b/src/store/appStore.mapEditor.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const storage = vi.hoisted(() => {
+  const data = new Map<string, string>();
+  const mock = {
+    getItem: (key: string) => data.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      data.set(key, String(value));
+    },
+    removeItem: (key: string) => {
+      data.delete(key);
+    },
+    clear: () => {
+      data.clear();
+    },
+    key: (index: number) => Array.from(data.keys())[index] ?? null,
+    get length() {
+      return data.size;
+    },
+  };
+  vi.stubGlobal("localStorage", mock);
+  vi.stubGlobal("window", {
+    localStorage: mock,
+    setTimeout,
+    clearTimeout,
+  });
+  return { mock };
+});
+
+vi.mock("../lib/coverage", () => ({
+  buildCoverage: vi.fn(() => []),
+}));
+
+vi.mock("../lib/elevationService", () => ({
+  fetchElevations: vi.fn(async () => [123]),
+}));
+
+const ZERO_RECT = {
+  top: 0,
+  right: 0,
+  bottom: 0,
+  left: 0,
+  width: 0,
+  height: 0,
+};
+
+describe("mapEditor store slice", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let useAppStore: any;
+
+  beforeEach(async () => {
+    storage.mock.clear();
+    vi.resetModules();
+    ({ useAppStore } = await import("./appStore"));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("initializes mapEditor as null", () => {
+    const state = useAppStore.getState();
+    expect(state.mapEditor).toBeNull();
+  });
+
+  it("openMapEditor sets the editor state", () => {
+    const payload = {
+      kind: "site" as const,
+      resourceId: "site-abc",
+      isNew: false,
+      label: "Test Site",
+      anchorRect: { top: 100, right: 200, bottom: 120, left: 160, width: 40, height: 20 },
+    };
+    useAppStore.getState().openMapEditor(payload);
+    expect(useAppStore.getState().mapEditor).toEqual(payload);
+  });
+
+  it("openMapEditor works for isNew=true with null resourceId", () => {
+    const payload = {
+      kind: "site" as const,
+      resourceId: null,
+      isNew: true,
+      label: "New Site",
+      anchorRect: ZERO_RECT,
+    };
+    useAppStore.getState().openMapEditor(payload);
+    expect(useAppStore.getState().mapEditor).toEqual(payload);
+  });
+
+  it("openMapEditor works for kind=link", () => {
+    const payload = {
+      kind: "link" as const,
+      resourceId: "link-xyz",
+      isNew: false,
+      label: "Link A–B",
+      anchorRect: ZERO_RECT,
+    };
+    useAppStore.getState().openMapEditor(payload);
+    expect(useAppStore.getState().mapEditor?.kind).toBe("link");
+    expect(useAppStore.getState().mapEditor?.resourceId).toBe("link-xyz");
+  });
+
+  it("openMapEditor works for kind=simulation", () => {
+    const payload = {
+      kind: "simulation" as const,
+      resourceId: "sim-1",
+      isNew: false,
+      label: "My Sim",
+      anchorRect: ZERO_RECT,
+    };
+    useAppStore.getState().openMapEditor(payload);
+    expect(useAppStore.getState().mapEditor?.kind).toBe("simulation");
+  });
+
+  it("closeMapEditor clears state to null", () => {
+    useAppStore.getState().openMapEditor({
+      kind: "site" as const,
+      resourceId: "s1",
+      isNew: false,
+      label: "Site",
+      anchorRect: ZERO_RECT,
+    });
+    expect(useAppStore.getState().mapEditor).not.toBeNull();
+    useAppStore.getState().closeMapEditor();
+    expect(useAppStore.getState().mapEditor).toBeNull();
+  });
+
+  it("closeMapEditor is a no-op when already null", () => {
+    expect(useAppStore.getState().mapEditor).toBeNull();
+    expect(() => useAppStore.getState().closeMapEditor()).not.toThrow();
+    expect(useAppStore.getState().mapEditor).toBeNull();
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -421,6 +421,22 @@ type AppState = {
   simulationPresets: SimulationPreset[];
   siteDragPreview: Record<string, { position: { lat: number; lon: number }; groundElevationM: number }>;
   endpointPickTarget: "from" | "to" | null;
+  mapEditor: {
+    kind: "site" | "link" | "simulation";
+    resourceId: string | null;
+    isNew: boolean;
+    label: string;
+    anchorRect: {
+      top: number;
+      right: number;
+      bottom: number;
+      left: number;
+      width: number;
+      height: number;
+    };
+  } | null;
+  openMapEditor: (payload: NonNullable<AppState["mapEditor"]>) => void;
+  closeMapEditor: () => void;
   showSimulationLibraryRequest: boolean;
   showNewSimulationRequest: boolean;
   showSiteLibraryRequest: boolean;
@@ -1234,6 +1250,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   simulationPresets: initialSimulationPresets,
   siteDragPreview: {},
   endpointPickTarget: null,
+  mapEditor: null,
   pendingSiteLibraryDraft: null,
   showSimulationLibraryRequest: false,
   showNewSimulationRequest: false,
@@ -1841,6 +1858,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       terrainLoadEpoch: 0,
       siteDragPreview: {},
       endpointPickTarget: null,
+      mapEditor: null,
       mapViewport: scenario.viewport,
       siteLibrary: libraryBacked.siteLibrary,
       fitSitesEpoch: get().fitSitesEpoch + 1,
@@ -1887,6 +1905,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       terrainLoadEpoch: 0,
       siteDragPreview: {},
       endpointPickTarget: null,
+      mapEditor: null,
       // mapViewport: undefined — fitSitesEpoch triggers proper fit via MapView
       fitSitesEpoch: get().fitSitesEpoch + 1,
       siteLibrary: libraryBacked.siteLibrary,
@@ -3138,6 +3157,8 @@ export const useAppStore = create<AppState>((set, get) => ({
     };
   },
   setEndpointPickTarget: (target) => set({ endpointPickTarget: target }),
+  openMapEditor: (payload) => set({ mapEditor: payload }),
+  closeMapEditor: () => set({ mapEditor: null }),
   requestSiteLibraryDraftAt: (lat, lon, suggestedName, sourceMeta) =>
     set({
       pendingSiteLibraryDraft: {


### PR DESCRIPTION
## Summary

- Replaces `resourceDetailsPopup` and `linkModal` ModalOverlay editors with `MapEditorPanel` — a floating popover anchored to the invoking sidebar button
- Unifies **edit + create** into a single panel for sites, links, and simulation presets (including `AccessSettingsEditor` and all existing fields)
- Dismissed by ESC, click outside, or × button; mobile renders as a bottom-sheet
- Position is computed with right-of-trigger preference and full viewport collision clamping (16 px margin)
- `mapEditor` slice added to appStore (`openMapEditor` / `closeMapEditor`); trigger buttons pass `getBoundingClientRect()` at click time — no ref threading required
- `useMapEditorFormState` hook owns all draft state previously spread across Sidebar.tsx

## Test plan

- [ ] Click a site pencil → popover floats to the right of the pencil, fully visible in viewport
- [ ] Click "Add Site" → same panel in create mode, lat/lon pre-filled from map center
- [ ] Edit site name → Save → sidebar reflects change, popover closes
- [ ] Press ESC → popover closes without saving
- [ ] Click outside popover → closes without saving
- [ ] Click × → closes without saving
- [ ] Click link pencil → link editor anchored to that row's pencil
- [ ] Click "Add Link" → link panel in create mode
- [ ] Simulation "Edit" → simulation editor popover (name / description / access)
- [ ] Mobile (<768 px): all three editors appear as bottom sheet with slide-up animation
- [ ] Resize browser while popover is open → panel stays visible (recomputes position)
- [ ] `npm test` — 461 tests pass; `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)