### PR TITLE
fix: refine map editor map interactions

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -687,6 +687,9 @@ export function MapView({
   const clearSiteDragPreview = useAppStore((state) => state.clearSiteDragPreview);
   const setEndpointPickTarget = useAppStore((state) => state.setEndpointPickTarget);
   const openMapEditor = useAppStore((state) => state.openMapEditor);
+  const mapEditor = useAppStore((state) => state.mapEditor);
+  const mapEditorSiteDraft = useAppStore((state) => state.mapEditorSiteDraft);
+  const setMapEditorSiteDraft = useAppStore((state) => state.setMapEditorSiteDraft);
   const requestOpenSiteLibraryEntry = useAppStore((state) => state.requestOpenSiteLibraryEntry);
   const coverageSamples = useCoverageStore((state) => state.coverageSamples);
   const srtmTiles = useAppStore((state) => state.srtmTiles);
@@ -2302,6 +2305,16 @@ export function MapView({
     setSiteDraftStatus(null);
   };
 
+  const setEditorSiteDraftFromMap = (lat: number, lon: number) => {
+    const terrainElevation = sampleSrtmElevation(srtmTiles, lat, lon);
+    const groundElevationM = Number.isFinite(terrainElevation) ? Math.round(terrainElevation as number) : null;
+    setMapEditorSiteDraft({ lat, lon, groundElevationM });
+  };
+
+  const onEditorSiteDraftDragEnd = (event: MarkerDragEvent) => {
+    setEditorSiteDraftFromMap(event.lngLat.lat, event.lngLat.lng);
+  };
+
   const beginPendingNewSiteDraft = (lat: number, lon: number) => {
     if (endpointPickTarget) return;
     if (pendingMoveCount > 0) {
@@ -2321,6 +2334,12 @@ export function MapView({
     const rawTarget = event.originalEvent?.target;
     if (rawTarget instanceof Element && rawTarget.closest(".map-site-surface")) return;
     if (endpointPickTarget) return;
+    if (mapEditor?.kind === "site" && mapEditor.isNew) {
+      setEditorSiteDraftFromMap(event.lngLat.lat, event.lngLat.lng);
+      setArmAddSiteOnNextEmptyMapClick(false);
+      setSelectedDiscoveryLibraryEntryId(null);
+      return;
+    }
     const interactiveFeature = event.features?.find((feature) => feature.layer.id === "link-lines");
     let id = interactiveFeature?.properties ? String(interactiveFeature.properties.id ?? "") : "";
     if (!id && mapRef.current) {
@@ -3533,6 +3552,22 @@ export function MapView({
           >
             <Surface variant="pill" className="map-site-surface is-temporary" pointerTail pointerTone="temporary">
               <span>New Site</span>
+            </Surface>
+          </Marker>
+        ) : null}
+
+        {mapEditor?.kind === "site" && mapEditorSiteDraft ? (
+          <Marker
+            anchor="bottom"
+            draggable={canPersist}
+            latitude={mapEditorSiteDraft.lat}
+            longitude={mapEditorSiteDraft.lon}
+            offset={SITE_PIN_MARKER_OFFSET}
+            style={{ zIndex: 4 }}
+            onDragEnd={onEditorSiteDraftDragEnd}
+          >
+            <Surface variant="pill" className="map-site-surface is-selected" pointerTail pointerTone="selection">
+              <span>{mapEditor.isNew ? "New Site" : mapEditor.label}</span>
             </Surface>
           </Marker>
         ) : null}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1212,6 +1212,7 @@ export function Sidebar({
       isNew: true,
       label: "New Site",
       anchorRect: triggerEl?.getBoundingClientRect() ?? { top: 96, right: 320, bottom: 96, left: 320, width: 0, height: 0 },
+      siteSeed: { awaitMapClick: true },
     });
   };
   const addLibraryEntryNow = () => {
@@ -1965,7 +1966,6 @@ export function Sidebar({
                 onChange={(event) =>
                   setLinkModal((current) => (current ? { ...current, name: event.target.value, status: "" } : current))
                 }
-                placeholder="Backhaul A"
                 type="text"
                 value={linkModal.name}
               />
@@ -2012,15 +2012,15 @@ export function Sidebar({
                   ))}
               </select>
             </label>
-            <CompactDetails>
-              <CompactDetailsSummary>Link Radio Overrides</CompactDetailsSummary>
+            <div className="beam-visualizer-field-group">
               <label className="field-grid">
-                <span>Use site radio defaults</span>
+                <span>Override site radio settings</span>
                 <input
-                  checked={!linkModal.overrideRadio}
+                  aria-label="Override site radio settings"
+                  checked={linkModal.overrideRadio}
                   onChange={(event) =>
                     setLinkModal((current) =>
-                      current ? { ...current, overrideRadio: !event.target.checked, status: "" } : current,
+                      current ? { ...current, overrideRadio: event.target.checked, status: "" } : current,
                     )
                   }
                   type="checkbox"
@@ -2083,7 +2083,7 @@ export function Sidebar({
               </label>
                 </>
               ) : null}
-            </CompactDetails>
+            </div>
             <div className="chip-group">
               <ActionButton onClick={saveLinkModal} type="button">
                 {linkModal.mode === "add" ? "Create Link" : "Save Link"}
@@ -3043,16 +3043,18 @@ export function Sidebar({
               loadSimulationPreset(presetId);
               persistSelectedSimulationRef(`saved:${presetId}`);
             }}
-            onOpenDetails={(params) =>
+            onOpenDetails={(params) => {
+              setShowSimulationLibraryManager(false);
               openMapEditor({
                 kind: params.kind,
                 resourceId: params.resourceId,
                 isNew: false,
                 label: params.label,
                 anchorRect: params.anchorRect,
-              })
-            }
-            onCreateSimulation={(triggerEl) =>
+              });
+            }}
+            onCreateSimulation={(triggerEl) => {
+              setShowSimulationLibraryManager(false);
               openMapEditor({
                 kind: "simulation",
                 resourceId: null,
@@ -3063,8 +3065,8 @@ export function Sidebar({
                   frequencyPresetId: getDefaultFrequencyPresetIdForNewSimulation(),
                   autoPropagationEnvironment,
                 },
-              })
-            }
+              });
+            }}
           />
         </ModalOverlay>
       ) : null}
@@ -3296,6 +3298,22 @@ export function Sidebar({
               </ActionButton>
             </div>
             <div className="chip-group">
+              <ActionButton
+                onClick={(event) => {
+                  setShowSiteLibraryManager(false);
+                  openMapEditor({
+                    kind: "site",
+                    resourceId: null,
+                    isNew: true,
+                    label: "New Site",
+                    anchorRect: event.currentTarget.getBoundingClientRect(),
+                    siteSeed: { awaitMapClick: true },
+                  });
+                }}
+                type="button"
+              >
+                New
+              </ActionButton>
               <ActionButton
                 onClick={() => setSelectedLibraryIds(new Set(filteredSiteLibrary.map((entry) => entry.id)))}
                 type="button"
@@ -3832,15 +3850,16 @@ export function Sidebar({
                       </ActionButton>
                     )}
                     <ActionButton
-                      onClick={(e) =>
+                      onClick={(e) => {
+                        setShowSiteLibraryManager(false);
                         openMapEditor({
                           kind: "site",
                           resourceId: entry.id,
                           isNew: false,
                           label: entry.name,
                           anchorRect: e.currentTarget.getBoundingClientRect(),
-                        })
-                      }
+                        });
+                      }}
                       type="button"
                     >
                       Open

--- a/src/components/map/MapEditorPanel.tsx
+++ b/src/components/map/MapEditorPanel.tsx
@@ -5,7 +5,6 @@ import { useAppStore } from "../../store/appStore";
 import { useMapEditorFormState } from "./useMapEditorFormState";
 import { AccessSettingsEditor } from "../AccessSettingsEditor";
 import { ActionButton } from "../ActionButton";
-import { CompactDetails, CompactDetailsSummary } from "../ui/CompactDetails";
 import { Surface } from "../ui/Surface";
 import { InlineCloseIconButton } from "../InlineCloseIconButton";
 import { SiteBeamVisualizer } from "../SiteBeamVisualizer";
@@ -127,10 +126,9 @@ function SiteEditorCard({
           />
         </label>
 
-        <CompactDetails>
-          <CompactDetailsSummary>Map Search</CompactDetailsSummary>
-          <label className="field-grid">
-            <span>Search</span>
+        <label className="field-grid">
+          <span>Map search</span>
+          <div className="field-inline">
             <input
               onChange={(e) => form.setSiteSearchQuery(e.target.value)}
               onKeyDown={(e) => {
@@ -143,28 +141,31 @@ function SiteEditorCard({
               type="text"
               value={form.siteSearchQuery}
             />
-          </label>
-          <div className="chip-group">
-            <ActionButton disabled={form.siteSearchBusy} onClick={() => void form.runSiteSearch()} type="button">
+            <ActionButton
+              className="field-inline-btn"
+              disabled={form.siteSearchBusy}
+              onClick={() => void form.runSiteSearch()}
+              type="button"
+            >
               {form.siteSearchBusy ? "Searching..." : "Search"}
             </ActionButton>
           </div>
-          {form.siteSearchStatus ? <p className="field-help">{form.siteSearchStatus}</p> : null}
-          {form.siteSearchResults.length ? (
-            <div className="site-quick-list">
-              {form.siteSearchResults.map((result) => (
-                <ActionButton
-                  disabled={form.siteSearchPickBusyId !== null}
-                  key={result.id}
-                  onClick={() => void form.selectSiteSearchResult(result)}
-                  type="button"
-                >
-                  {form.siteSearchPickBusyId === result.id ? "Loading..." : `Use: ${result.label}`}
-                </ActionButton>
-              ))}
-            </div>
-          ) : null}
-        </CompactDetails>
+        </label>
+        {form.siteSearchStatus ? <p className="field-help">{form.siteSearchStatus}</p> : null}
+        {form.siteSearchResults.length ? (
+          <div className="site-quick-list">
+            {form.siteSearchResults.map((result) => (
+              <ActionButton
+                disabled={form.siteSearchPickBusyId !== null}
+                key={result.id}
+                onClick={() => void form.selectSiteSearchResult(result)}
+                type="button"
+              >
+                {form.siteSearchPickBusyId === result.id ? "Loading..." : `Use: ${result.label}`}
+              </ActionButton>
+            ))}
+          </div>
+        ) : null}
 
         <label className="field-grid">
           <span>Ground elev (m)</span>
@@ -316,7 +317,6 @@ function LinkEditorCard({
         <span>Link name</span>
         <input
           onChange={(e) => form.setLinkNameDraft(e.target.value)}
-          placeholder="Backhaul A"
           type="text"
           value={form.linkNameDraft}
         />
@@ -361,13 +361,12 @@ function LinkEditorCard({
         </select>
       </label>
 
-      <CompactDetails>
-        <CompactDetailsSummary>Link Radio Overrides</CompactDetailsSummary>
         <label className="field-grid">
-          <span>Use site radio defaults</span>
+          <span>Override site radio settings</span>
           <input
-            checked={!form.overrideRadio}
-            onChange={(e) => form.setOverrideRadio(!e.target.checked)}
+            aria-label="Override site radio settings"
+            checked={form.overrideRadio}
+            onChange={(e) => form.setOverrideRadio(e.target.checked)}
             type="checkbox"
           />
         </label>
@@ -410,7 +409,6 @@ function LinkEditorCard({
             </label>
           </>
         ) : null}
-      </CompactDetails>
 
       {form.status ? <p className="field-help">{form.status}</p> : null}
 
@@ -484,8 +482,7 @@ function SimulationEditorCard({
           visibility={form.accessVisibility}
         />
         {isNew ? (
-          <CompactDetails open>
-            <CompactDetailsSummary>Simulation Defaults</CompactDetailsSummary>
+          <>
             <label className="field-grid">
               <span>Frequency Plan</span>
               <select
@@ -515,7 +512,7 @@ function SimulationEditorCard({
                 <option value="manual">Manual override</option>
               </select>
             </label>
-          </CompactDetails>
+          </>
         ) : null}
       </fieldset>
 

--- a/src/components/map/useMapEditorFormState.ts
+++ b/src/components/map/useMapEditorFormState.ts
@@ -18,7 +18,9 @@ const parseNumber = (value: string | number): number => {
 
 export function useMapEditorFormState() {
   const mapEditor = useAppStore((state) => state.mapEditor);
+  const mapEditorSiteDraft = useAppStore((state) => state.mapEditorSiteDraft);
   const closeMapEditor = useAppStore((state) => state.closeMapEditor);
+  const setMapEditorSiteDraft = useAppStore((state) => state.setMapEditorSiteDraft);
   const siteLibrary = useAppStore((state) => state.siteLibrary);
   const simulationPresets = useAppStore((state) => state.simulationPresets);
   const sites = useAppStore((state) => state.sites);
@@ -91,6 +93,12 @@ export function useMapEditorFormState() {
   const [linkRxGain, setLinkRxGain] = useState(STANDARD_SITE_RADIO.rxGainDbi);
   const [linkCableLoss, setLinkCableLoss] = useState(STANDARD_SITE_RADIO.cableLossDb);
 
+  const getLinkDefaultName = (fromId: string, toId: string): string => {
+    const from = sites.find((site) => site.id === fromId);
+    const to = sites.find((site) => site.id === toId);
+    return from && to ? `${from.name} -> ${to.name}` : "";
+  };
+
   // ─── Initialize drafts when editor opens ─────────────────────────────────────
   useEffect(() => {
     if (!mapEditor) return;
@@ -101,11 +109,13 @@ export function useMapEditorFormState() {
     if (mapEditor.kind === "site") {
       if (mapEditor.isNew) {
         const seed = mapEditor.siteSeed;
-        // New site: initialise from map center
+        const seededLat = seed?.lat ?? mapViewport?.center.lat ?? 0;
+        const seededLon = seed?.lon ?? mapViewport?.center.lon ?? 0;
+        const shouldPlacePin = typeof seed?.lat === "number" && typeof seed?.lon === "number" && !seed.awaitMapClick;
         setNameDraft(seed?.name ?? "");
         setDescriptionDraft("");
-        setLatDraft(seed?.lat ?? mapViewport?.center.lat ?? 0);
-        setLonDraft(seed?.lon ?? mapViewport?.center.lon ?? 0);
+        setLatDraft(seededLat);
+        setLonDraft(seededLon);
         setGroundDraft(0);
         setAntennaDraft(10);
         setTxPowerDraft(STANDARD_SITE_RADIO.txPowerDbm);
@@ -120,15 +130,19 @@ export function useMapEditorFormState() {
         setInsertSiteAfterSave(Boolean(seed?.insertIntoSimulation));
         setSiteSearchQuery("");
         setSiteSearchResults([]);
-        setSiteSearchStatus("");
+        setSiteSearchStatus(shouldPlacePin ? "" : "Click the map to choose this site's coordinates.");
+        setMapEditorSiteDraft(shouldPlacePin ? { lat: seededLat, lon: seededLon, groundElevationM: null } : null);
       } else {
         // Edit site
         const entry = siteLibrary.find((e) => e.id === mapEditor.resourceId);
+        const entryLat = entry?.position.lat ?? 0;
+        const entryLon = entry?.position.lon ?? 0;
+        const entryGround = entry?.groundElevationM ?? 0;
         setNameDraft(entry?.name ?? mapEditor.label);
         setDescriptionDraft(entry?.description ?? "");
-        setLatDraft(entry?.position.lat ?? 0);
-        setLonDraft(entry?.position.lon ?? 0);
-        setGroundDraft(entry?.groundElevationM ?? 0);
+        setLatDraft(entryLat);
+        setLonDraft(entryLon);
+        setGroundDraft(entryGround);
         setAntennaDraft(entry?.antennaHeightM ?? 2);
         setTxPowerDraft(entry?.txPowerDbm ?? STANDARD_SITE_RADIO.txPowerDbm);
         const nextTxGain = entry?.txGainDbi ?? STANDARD_SITE_RADIO.txGainDbi;
@@ -150,6 +164,7 @@ export function useMapEditorFormState() {
         setSiteSearchQuery("");
         setSiteSearchResults([]);
         setSiteSearchStatus("");
+        setMapEditorSiteDraft({ lat: entryLat, lon: entryLon, groundElevationM: entryGround });
       }
     } else if (mapEditor.kind === "simulation") {
       if (mapEditor.isNew) {
@@ -184,9 +199,9 @@ export function useMapEditorFormState() {
         const fromSite = sites.find((s) => s.id === fallbackFrom) ?? null;
         const toSite = sites.find((s) => s.id === fallbackTo) ?? null;
         const baseRadio = resolveLinkRadio({} as any, fromSite, toSite);
-        setLinkNameDraft("");
         setLinkFromSiteId(fallbackFrom);
         setLinkToSiteId(fallbackTo);
+        setLinkNameDraft(getLinkDefaultName(fallbackFrom, fallbackTo));
         setOverrideRadio(false);
         setLinkTxPower(baseRadio.txPowerDbm);
         setLinkTxGain(baseRadio.txGainDbi);
@@ -204,9 +219,9 @@ export function useMapEditorFormState() {
               typeof link.rxGainDbi === "number" ||
               typeof link.cableLossDb === "number"),
         );
-        setLinkNameDraft(link?.name ?? "");
         setLinkFromSiteId(link?.fromSiteId ?? "");
         setLinkToSiteId(link?.toSiteId ?? "");
+        setLinkNameDraft(link?.name ?? getLinkDefaultName(link?.fromSiteId ?? "", link?.toSiteId ?? ""));
         setOverrideRadio(hasOverrides);
         setLinkTxPower(baseRadio.txPowerDbm);
         setLinkTxGain(baseRadio.txGainDbi);
@@ -216,6 +231,17 @@ export function useMapEditorFormState() {
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mapEditor?.kind, mapEditor?.resourceId, mapEditor?.isNew]);
+
+  useEffect(() => {
+    if (mapEditor?.kind !== "site" || !mapEditorSiteDraft) return;
+    setLatDraft((current) => (current === mapEditorSiteDraft.lat ? current : mapEditorSiteDraft.lat));
+    setLonDraft((current) => (current === mapEditorSiteDraft.lon ? current : mapEditorSiteDraft.lon));
+    if (typeof mapEditorSiteDraft.groundElevationM === "number") {
+      const nextGround = mapEditorSiteDraft.groundElevationM;
+      setGroundDraft((current) => (current === nextGround ? current : nextGround));
+    }
+    if (mapEditor.isNew) setSiteSearchStatus("");
+  }, [mapEditor?.kind, mapEditor?.isNew, mapEditorSiteDraft]);
 
   // ─── Terrain prefetch for site coordinates ────────────────────────────────────
   useEffect(() => {
@@ -231,7 +257,13 @@ export function useMapEditorFormState() {
   useEffect(() => {
     if (mapEditor?.kind !== "site" || isElevationUserSet) return;
     const elevation = Number(sampleSrtmElevation(srtmTiles, latDraft, lonDraft));
-    if (Number.isFinite(elevation)) setGroundDraft(Math.round(elevation));
+    if (Number.isFinite(elevation)) {
+      const roundedElevation = Math.round(elevation);
+      setGroundDraft(roundedElevation);
+      if (mapEditorSiteDraft) {
+        setMapEditorSiteDraft({ lat: latDraft, lon: lonDraft, groundElevationM: roundedElevation });
+      }
+    }
   }, [srtmTiles, isElevationUserSet, latDraft, lonDraft, mapEditor?.kind]);
 
   // ─── Collaborator directory ───────────────────────────────────────────────────
@@ -359,12 +391,16 @@ export function useMapEditorFormState() {
       center: { lat: result.lat, lon: result.lon },
       zoom: 12,
     });
+    setMapEditorSiteDraft({ lat: result.lat, lon: result.lon, groundElevationM: null });
     try {
       const [elevation] = await fetchElevations([{ lat: result.lat, lon: result.lon }]);
       if (Number.isFinite(elevation)) {
-        setGroundDraft(Math.round(elevation));
-        setSiteSearchStatus(`Selected: ${result.label} (elevation ${Math.round(elevation)} m)`);
+        const roundedElevation = Math.round(elevation);
+        setGroundDraft(roundedElevation);
+        setMapEditorSiteDraft({ lat: result.lat, lon: result.lon, groundElevationM: roundedElevation });
+        setSiteSearchStatus(`Selected: ${result.label} (elevation ${roundedElevation} m)`);
       } else {
+        setMapEditorSiteDraft({ lat: result.lat, lon: result.lon, groundElevationM: null });
         setSiteSearchStatus(`Selected: ${result.label} (elevation unavailable)`);
       }
     } catch (error) {
@@ -397,18 +433,25 @@ export function useMapEditorFormState() {
       setStatus("Name is required.");
       return false;
     }
+    if (mapEditor?.kind === "site" && !mapEditorSiteDraft) {
+      setStatus("Click the map or use search to choose coordinates before saving.");
+      return false;
+    }
     const normalizedVisibility: "private" | "shared" = accessVisibility;
     const sharedWith = collaboratorUserIds
       .filter((id) => id !== ownerUserId)
       .map((id) => ({ userId: id, role: (collaboratorRoles[id] ?? "viewer") as "viewer" | "editor" }));
 
     try {
+      const saveLat = mapEditorSiteDraft?.lat ?? latDraft;
+      const saveLon = mapEditorSiteDraft?.lon ?? lonDraft;
+      const saveGround = mapEditorSiteDraft?.groundElevationM ?? groundDraft;
       if (mapEditor?.isNew) {
         const createdId = addSiteLibraryEntry(
           trimmedName,
-          latDraft,
-          lonDraft,
-          groundDraft,
+          saveLat,
+          saveLon,
+          saveGround,
           antennaDraft,
           txPowerDraft,
           txGainDraft,
@@ -428,8 +471,8 @@ export function useMapEditorFormState() {
         updateSiteLibraryEntry(mapEditor.resourceId, {
           name: trimmedName,
           description: descriptionDraft.trim() || undefined,
-          position: { lat: latDraft, lon: lonDraft },
-          groundElevationM: groundDraft,
+          position: { lat: saveLat, lon: saveLon },
+          groundElevationM: saveGround,
           antennaHeightM: antennaDraft,
           txPowerDbm: txPowerDraft,
           txGainDbi: txGainDraft,
@@ -587,6 +630,30 @@ export function useMapEditorFormState() {
     }
   };
 
+  const setSitePositionDraft = (nextLat: number | string, nextLon: number | string, nextGround = groundDraft) => {
+    const lat = parseNumber(String(nextLat));
+    const lon = parseNumber(String(nextLon));
+    setLatDraft(lat);
+    setLonDraft(lon);
+    setMapEditorSiteDraft({ lat, lon, groundElevationM: nextGround });
+  };
+
+  const setLinkFromSiteIdWithName = (nextFrom: string) => {
+    const fallbackTo = linkToSiteId === nextFrom ? sites.find((site) => site.id !== nextFrom)?.id ?? "" : linkToSiteId;
+    setLinkFromSiteId(nextFrom);
+    setLinkToSiteId(fallbackTo);
+    if (mapEditor?.isNew) {
+      setLinkNameDraft(getLinkDefaultName(nextFrom, fallbackTo));
+    }
+  };
+
+  const setLinkToSiteIdWithName = (nextTo: string) => {
+    setLinkToSiteId(nextTo);
+    if (mapEditor?.isNew) {
+      setLinkNameDraft(getLinkDefaultName(linkFromSiteId, nextTo));
+    }
+  };
+
   return {
     // shared
     status, setStatus,
@@ -604,9 +671,16 @@ export function useMapEditorFormState() {
     canWrite,
     currentUser,
     // site
-    latDraft, setLatDraft: (v: number | string) => setLatDraft(parseNumber(String(v))),
-    lonDraft, setLonDraft: (v: number | string) => setLonDraft(parseNumber(String(v))),
-    groundDraft, setGroundDraft: (v: number | string) => { setGroundDraft(parseNumber(String(v))); setIsElevationUserSet(true); },
+    latDraft, setLatDraft: (v: number | string) => setSitePositionDraft(v, lonDraft),
+    lonDraft, setLonDraft: (v: number | string) => setSitePositionDraft(latDraft, v),
+    groundDraft, setGroundDraft: (v: number | string) => {
+      const nextGround = parseNumber(String(v));
+      setGroundDraft(nextGround);
+      if (mapEditorSiteDraft) {
+        setMapEditorSiteDraft({ ...mapEditorSiteDraft, groundElevationM: nextGround });
+      }
+      setIsElevationUserSet(true);
+    },
     antennaDraft, setAntennaDraft: (v: number | string) => setAntennaDraft(parseNumber(String(v))),
     txPowerDraft, setTxPowerDraft: (v: number | string) => setTxPowerDraft(parseNumber(String(v))),
     txGainDraft, setTxGainDraft: (v: number | string) => setTxGainDraft(parseNumber(String(v))),
@@ -629,8 +703,8 @@ export function useMapEditorFormState() {
     handleSaveSimulation,
     // link
     linkNameDraft, setLinkNameDraft,
-    linkFromSiteId, setLinkFromSiteId,
-    linkToSiteId, setLinkToSiteId,
+    linkFromSiteId, setLinkFromSiteId: setLinkFromSiteIdWithName,
+    linkToSiteId, setLinkToSiteId: setLinkToSiteIdWithName,
     overrideRadio, setOverrideRadio,
     linkTxPower, setLinkTxPower: (v: number | string) => setLinkTxPower(parseNumber(String(v))),
     linkTxGain, setLinkTxGain: (v: number | string) => setLinkTxGain(parseNumber(String(v))),

--- a/src/index.css
+++ b/src/index.css
@@ -5220,7 +5220,7 @@ html.panorama-gesture-lock body {
   background: var(--surface);
   border: 1px solid var(--border);
   box-shadow: var(--shadow);
-  max-height: 80vh;
+  max-height: 50vh;
   overflow-y: auto;
   animation: panel-slide-in-bottom 360ms ease-out both;
 }

--- a/src/store/appStore.mapEditor.test.ts
+++ b/src/store/appStore.mapEditor.test.ts
@@ -159,9 +159,16 @@ describe("mapEditor store slice", () => {
       label: "Site",
       anchorRect: ZERO_RECT,
     });
+    useAppStore.getState().setMapEditorSiteDraft({ lat: 1, lon: 2, groundElevationM: 3 });
     expect(useAppStore.getState().mapEditor).not.toBeNull();
     useAppStore.getState().closeMapEditor();
     expect(useAppStore.getState().mapEditor).toBeNull();
+    expect(useAppStore.getState().mapEditorSiteDraft).toBeNull();
+  });
+
+  it("setMapEditorSiteDraft stores active site editor position", () => {
+    useAppStore.getState().setMapEditorSiteDraft({ lat: 60.1, lon: 10.2, groundElevationM: 123 });
+    expect(useAppStore.getState().mapEditorSiteDraft).toEqual({ lat: 60.1, lon: 10.2, groundElevationM: 123 });
   });
 
   it("closeMapEditor is a no-op when already null", () => {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -440,14 +440,17 @@ type AppState = {
       name?: string;
       sourceMeta?: SiteLibraryEntry["sourceMeta"];
       insertIntoSimulation?: boolean;
+      awaitMapClick?: boolean;
     };
     simulationSeed?: {
       frequencyPresetId?: string;
       autoPropagationEnvironment?: boolean;
     };
   } | null;
+  mapEditorSiteDraft: { lat: number; lon: number; groundElevationM: number | null } | null;
   openMapEditor: (payload: NonNullable<AppState["mapEditor"]>) => void;
   closeMapEditor: () => void;
+  setMapEditorSiteDraft: (draft: AppState["mapEditorSiteDraft"]) => void;
   showSimulationLibraryRequest: boolean;
   showNewSimulationRequest: boolean;
   showSiteLibraryRequest: boolean;
@@ -1263,6 +1266,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   siteDragPreview: {},
   endpointPickTarget: null,
   mapEditor: null,
+  mapEditorSiteDraft: null,
   pendingSiteLibraryDraft: null,
   showSimulationLibraryRequest: false,
   showNewSimulationRequest: false,
@@ -1871,6 +1875,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       siteDragPreview: {},
       endpointPickTarget: null,
       mapEditor: null,
+      mapEditorSiteDraft: null,
       mapViewport: scenario.viewport,
       siteLibrary: libraryBacked.siteLibrary,
       fitSitesEpoch: get().fitSitesEpoch + 1,
@@ -1918,6 +1923,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       siteDragPreview: {},
       endpointPickTarget: null,
       mapEditor: null,
+      mapEditorSiteDraft: null,
       // mapViewport: undefined — fitSitesEpoch triggers proper fit via MapView
       fitSitesEpoch: get().fitSitesEpoch + 1,
       siteLibrary: libraryBacked.siteLibrary,
@@ -3169,8 +3175,9 @@ export const useAppStore = create<AppState>((set, get) => ({
     };
   },
   setEndpointPickTarget: (target) => set({ endpointPickTarget: target }),
-  openMapEditor: (payload) => set({ mapEditor: payload }),
-  closeMapEditor: () => set({ mapEditor: null }),
+  openMapEditor: (payload) => set({ mapEditor: payload, mapEditorSiteDraft: null }),
+  closeMapEditor: () => set({ mapEditor: null, mapEditorSiteDraft: null }),
+  setMapEditorSiteDraft: (draft) => set({ mapEditorSiteDraft: draft }),
   requestSiteLibraryDraftAt: (lat, lon, suggestedName, sourceMeta) =>
     set({
       pendingSiteLibraryDraft: {


### PR DESCRIPTION
## Summary
- connect the shared site editor to the main map for new/edit coordinate picking, marker dragging, coordinate edits, and map search results
- keep map search, simulation defaults, and link radio overrides visible without expandable wrappers
- restore a Site Library New action that opens the shared editor, update link default naming from selected endpoints, flip the radio override toggle wording, and cap the mobile editor sheet at 50vh

## Verification
- npm run build
- npm test

Closes follow-up scope for #804.
