### PR TITLE
Compact map editor metadata footer

### DIFF
--- a/src/components/map/MapEditorPanel.test.tsx
+++ b/src/components/map/MapEditorPanel.test.tsx
@@ -136,19 +136,78 @@ describe("MapEditorPanel", () => {
     });
   });
 
-  it("shows compact site metadata and opens the existing change log flow", async () => {
+  it("shows compact site metadata footer and opens the existing change log flow", async () => {
     render(<MapEditorPanel isMobile={false} />);
 
     await waitFor(() => expect(screen.getByText("Owner")).toBeInTheDocument());
-    expect(screen.getByText("Owner User")).toBeInTheDocument();
+    expect(screen.queryByText("Owner User")).not.toBeInTheDocument();
     expect(screen.getByText("Last edited")).toBeInTheDocument();
-    expect(screen.getByText("Editor User")).toBeInTheDocument();
+    expect(screen.queryByText("Editor User")).not.toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole("button", { name: "Change log" }));
+    await userEvent.click(screen.getByRole("button", { name: "Open change log" }));
 
     expect(fetchResourceChanges).toHaveBeenCalledWith("site", "site-lib-1");
     expect(await screen.findByText("Change Log · Alpha Site")).toBeInTheDocument();
     expect(screen.getByText("Moved site")).toBeInTheDocument();
+  });
+
+  it("shows compact simulation metadata footer and opens the simulation change log flow", async () => {
+    useAppStore.setState({
+      simulationPresets: [
+        {
+          id: "sim-1",
+          name: "Mesh Plan",
+          description: "Shared plan",
+          visibility: "shared",
+          sharedWith: [],
+          ownerUserId: "owner-1",
+          effectiveRole: "owner",
+          createdByUserId: "owner-1",
+          createdByName: "Owner User",
+          createdByAvatarUrl: "",
+          lastEditedByUserId: "editor-1",
+          lastEditedByName: "Editor User",
+          lastEditedByAvatarUrl: "",
+          updatedAt: "2026-01-02T00:00:00.000Z",
+          snapshot: {
+            sites: [],
+            links: [],
+            systems: [],
+            networks: [],
+            selectedSiteId: "",
+            selectedLinkId: "",
+            selectedNetworkId: "",
+            selectedCoverageResolution: "24",
+            propagationModel: "ITM",
+            selectedFrequencyPresetId: "custom",
+            rxSensitivityTargetDbm: -120,
+            environmentLossDb: 0,
+            propagationEnvironment: useAppStore.getState().propagationEnvironment,
+            autoPropagationEnvironment: true,
+            terrainDataset: "copernicus30",
+          },
+        },
+      ],
+      mapEditor: {
+        kind: "simulation",
+        resourceId: "sim-1",
+        isNew: false,
+        label: "Mesh Plan",
+        anchorRect,
+      },
+    });
+
+    render(<MapEditorPanel isMobile={false} />);
+
+    await waitFor(() => expect(screen.getByText("Owner")).toBeInTheDocument());
+    expect(screen.queryByText("Owner User")).not.toBeInTheDocument();
+    expect(screen.getByText("Last edited")).toBeInTheDocument();
+    expect(screen.queryByText("Editor User")).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Open change log" }));
+
+    expect(fetchResourceChanges).toHaveBeenCalledWith("simulation", "sim-1");
+    expect(await screen.findByText("Change Log · Mesh Plan")).toBeInTheDocument();
   });
 
   it("keeps the editor open when new site creation fails", async () => {

--- a/src/components/map/MapEditorPanel.tsx
+++ b/src/components/map/MapEditorPanel.tsx
@@ -1,5 +1,6 @@
 import { createPortal } from "react-dom";
 import { useEffect, useRef, useState } from "react";
+import { History } from "lucide-react";
 import { FREQUENCY_PRESETS, frequencyPresetGroups } from "../../lib/frequencyPlans";
 import {
   fetchResourceChanges,
@@ -58,12 +59,88 @@ function computePosition(
   return { left, top };
 }
 
+type ResourceKindWithChanges = "site" | "simulation";
+
+type ResourceMetadata = {
+  kind: ResourceKindWithChanges;
+  resourceId: string;
+  label: string;
+  owner: {
+    id: string;
+    name: string;
+    avatarUrl?: string | null;
+  };
+  lastEditedBy: {
+    id: string;
+    name: string;
+    avatarUrl?: string | null;
+  };
+};
+
 const UserBadge = ({ name, avatarUrl }: { name: string; avatarUrl?: string | null }) => (
   <span className="user-list-row">
     <AvatarBadge avatarUrl={avatarUrl} imageClassName="profile-avatar" name={name} />
     <span>{name}</span>
   </span>
 );
+
+function EditorMetadataStrip({
+  metadata,
+  onOpenChangeLog,
+  onOpenUserProfile,
+}: {
+  metadata: ResourceMetadata;
+  onOpenChangeLog: (kind: ResourceKindWithChanges, resourceId: string, label: string) => void;
+  onOpenUserProfile: (userId: string) => void;
+}) {
+  return (
+    <div className="editor-meta-footer" aria-label="Resource metadata">
+      <span className="editor-meta-item">
+        <span className="editor-meta-label">Owner</span>
+        <ActionButton
+          aria-label={`Open owner profile: ${metadata.owner.name}`}
+          className="editor-meta-avatar-button"
+          onClick={() => onOpenUserProfile(metadata.owner.id)}
+          size="icon"
+          title={`Owner: ${metadata.owner.name}`}
+          type="button"
+        >
+          <AvatarBadge
+            avatarUrl={metadata.owner.avatarUrl}
+            imageClassName="editor-meta-avatar"
+            name={metadata.owner.name}
+          />
+        </ActionButton>
+      </span>
+      <span className="editor-meta-item">
+        <span className="editor-meta-label">Last edited</span>
+        <ActionButton
+          aria-label={`Open last editor profile: ${metadata.lastEditedBy.name}`}
+          className="editor-meta-avatar-button"
+          onClick={() => onOpenUserProfile(metadata.lastEditedBy.id)}
+          size="icon"
+          title={`Last edited by: ${metadata.lastEditedBy.name}`}
+          type="button"
+        >
+          <AvatarBadge
+            avatarUrl={metadata.lastEditedBy.avatarUrl}
+            imageClassName="editor-meta-avatar"
+            name={metadata.lastEditedBy.name}
+          />
+        </ActionButton>
+      </span>
+      <ActionButton
+        aria-label="Open change log"
+        onClick={() => onOpenChangeLog(metadata.kind, metadata.resourceId, metadata.label)}
+        size="icon"
+        title="Change log"
+        type="button"
+      >
+        <History aria-hidden="true" size={17} strokeWidth={1.8} />
+      </ActionButton>
+    </div>
+  );
+}
 
 const formatChangeSummary = (action: string, note: string | null): string => {
   if (note && note.trim()) return note;
@@ -116,7 +193,7 @@ function SiteEditorCard({
   isNew: boolean;
   form: ReturnType<typeof useMapEditorFormState>;
   onClose: () => void;
-  onOpenChangeLog: (kind: "site", resourceId: string, label: string) => void;
+  onOpenChangeLog: (kind: ResourceKindWithChanges, resourceId: string, label: string) => void;
   onOpenUserProfile: (userId: string) => void;
 }) {
   const mapEditor = useAppStore((state) => state.mapEditor);
@@ -131,40 +208,6 @@ function SiteEditorCard({
       {!form.canWrite && !isNew && (
         <p className="field-help warning-text">Read-only: you can view this site but cannot edit it.</p>
       )}
-
-      {!isNew && form.siteMetadata ? (
-        <div className="site-editor-meta-row">
-          <button
-            className="site-editor-meta-chip"
-            onClick={() => onOpenUserProfile(form.siteMetadata?.owner.id ?? "")}
-            type="button"
-          >
-            <span className="site-editor-meta-label">Owner</span>
-            <UserBadge avatarUrl={form.siteMetadata.owner.avatarUrl} name={form.siteMetadata.owner.name} />
-          </button>
-          <button
-            className="site-editor-meta-chip"
-            onClick={() => onOpenUserProfile(form.siteMetadata?.lastEditedBy.id ?? "")}
-            type="button"
-          >
-            <span className="site-editor-meta-label">Last edited</span>
-            <UserBadge
-              avatarUrl={form.siteMetadata.lastEditedBy.avatarUrl}
-              name={form.siteMetadata.lastEditedBy.name}
-            />
-          </button>
-          <ActionButton
-            onClick={() =>
-              form.siteMetadata
-                ? onOpenChangeLog("site", form.siteMetadata.resourceId, form.siteMetadata.label)
-                : undefined
-            }
-            type="button"
-          >
-            Change log
-          </ActionButton>
-        </div>
-      ) : null}
 
       <fieldset className="resource-edit-fieldset" disabled={!form.canWrite && !isNew}>
         <label className="field-grid">
@@ -386,6 +429,14 @@ function SiteEditorCard({
           Cancel
         </ActionButton>
       </div>
+
+      {!isNew && form.siteMetadata ? (
+        <EditorMetadataStrip
+          metadata={form.siteMetadata}
+          onOpenChangeLog={onOpenChangeLog}
+          onOpenUserProfile={onOpenUserProfile}
+        />
+      ) : null}
     </>
   );
 }
@@ -527,10 +578,14 @@ function SimulationEditorCard({
   isNew,
   form,
   onClose,
+  onOpenChangeLog,
+  onOpenUserProfile,
 }: {
   isNew: boolean;
   form: ReturnType<typeof useMapEditorFormState>;
   onClose: () => void;
+  onOpenChangeLog: (kind: ResourceKindWithChanges, resourceId: string, label: string) => void;
+  onOpenUserProfile: (userId: string) => void;
 }) {
   const mapEditor = useAppStore((state) => state.mapEditor);
 
@@ -643,6 +698,14 @@ function SimulationEditorCard({
           </ActionButton>
         </div>
       ) : null}
+
+      {!isNew && form.simulationMetadata ? (
+        <EditorMetadataStrip
+          metadata={form.simulationMetadata}
+          onOpenChangeLog={onOpenChangeLog}
+          onOpenUserProfile={onOpenUserProfile}
+        />
+      ) : null}
     </>
   );
 }
@@ -664,7 +727,7 @@ export function MapEditorPanel({ isMobile }: MapEditorPanelProps) {
   const [profilePopupBusy, setProfilePopupBusy] = useState(false);
   const [profilePopupStatus, setProfilePopupStatus] = useState("");
   const [changeLogPopup, setChangeLogPopup] = useState<{
-    kind: "site";
+    kind: ResourceKindWithChanges;
     resourceId: string;
     label: string;
     changes: ResourceChange[];
@@ -686,7 +749,7 @@ export function MapEditorPanel({ isMobile }: MapEditorPanelProps) {
     }
   };
 
-  const openChangeLogPopup = async (kind: "site", resourceId: string, label: string) => {
+  const openChangeLogPopup = async (kind: ResourceKindWithChanges, resourceId: string, label: string) => {
     setChangeLogPopup({ kind, resourceId, label, changes: [], busy: true, status: "" });
     try {
       const changes = await fetchResourceChanges(kind, resourceId);
@@ -703,7 +766,7 @@ export function MapEditorPanel({ isMobile }: MapEditorPanelProps) {
     }
   };
 
-  const revertChangeAsCopy = async (kind: "site", resourceId: string, changeId: number) => {
+  const revertChangeAsCopy = async (kind: ResourceKindWithChanges, resourceId: string, changeId: number) => {
     try {
       await revertResourceChangeCopy(kind, resourceId, changeId);
       const refreshed = await fetchResourceChanges(kind, resourceId);
@@ -782,7 +845,15 @@ export function MapEditorPanel({ isMobile }: MapEditorPanelProps) {
       return <LinkEditorCard form={form} isNew={mapEditor.isNew} onClose={closeMapEditor} />;
     }
     if (mapEditor.kind === "simulation") {
-      return <SimulationEditorCard form={form} isNew={mapEditor.isNew} onClose={closeMapEditor} />;
+      return (
+        <SimulationEditorCard
+          form={form}
+          isNew={mapEditor.isNew}
+          onClose={closeMapEditor}
+          onOpenChangeLog={openChangeLogPopup}
+          onOpenUserProfile={(userId) => void openUserProfilePopup(userId)}
+        />
+      );
     }
     return null;
   })();
@@ -854,7 +925,7 @@ function MapEditorAuxiliaryModals({
   profilePopupUser,
 }: {
   changeLogPopup: {
-    kind: "site";
+    kind: ResourceKindWithChanges;
     resourceId: string;
     label: string;
     changes: ResourceChange[];
@@ -863,7 +934,7 @@ function MapEditorAuxiliaryModals({
   } | null;
   onCloseChangeLog: () => void;
   onOpenUserProfile: (userId: string) => void;
-  onRevertChange: (kind: "site", resourceId: string, changeId: number) => void;
+  onRevertChange: (kind: ResourceKindWithChanges, resourceId: string, changeId: number) => void;
   canRevert: boolean;
   onCloseProfile: () => void;
   profilePopupBusy: boolean;

--- a/src/components/map/useMapEditorFormState.ts
+++ b/src/components/map/useMapEditorFormState.ts
@@ -296,13 +296,17 @@ export function useMapEditorFormState() {
     mapEditor?.kind === "site" && mapEditor.resourceId
       ? siteLibrary.find((entry) => entry.id === mapEditor.resourceId) ?? null
       : null;
+  const currentSimulationPreset =
+    mapEditor?.kind === "simulation" && mapEditor.resourceId
+      ? simulationPresets.find((preset) => preset.id === mapEditor.resourceId) ?? null
+      : null;
   const ownerUserId = (() => {
     if (!mapEditor) return "";
     if (mapEditor.kind === "site" && mapEditor.resourceId) {
       return currentSiteEntry?.ownerUserId ?? "";
     }
     if (mapEditor.kind === "simulation" && mapEditor.resourceId) {
-      return (simulationPresets.find((p) => p.id === mapEditor.resourceId) as any)?.ownerUserId ?? "";
+      return currentSimulationPreset?.ownerUserId ?? "";
     }
     return currentUser_id;
   })();
@@ -355,6 +359,7 @@ export function useMapEditorFormState() {
   const siteMetadata =
     mapEditor?.kind === "site" && currentSiteEntry
       ? {
+          kind: "site" as const,
           resourceId: currentSiteEntry.id,
           label: currentSiteEntry.name,
           owner: resolveUserSummary(
@@ -366,6 +371,24 @@ export function useMapEditorFormState() {
             currentSiteEntry.lastEditedByUserId,
             currentSiteEntry.lastEditedByName,
             currentSiteEntry.lastEditedByAvatarUrl,
+          ),
+        }
+      : null;
+  const simulationMetadata =
+    mapEditor?.kind === "simulation" && currentSimulationPreset
+      ? {
+          kind: "simulation" as const,
+          resourceId: currentSimulationPreset.id,
+          label: currentSimulationPreset.name,
+          owner: resolveUserSummary(
+            currentSimulationPreset.ownerUserId,
+            currentSimulationPreset.createdByName,
+            currentSimulationPreset.createdByAvatarUrl,
+          ),
+          lastEditedBy: resolveUserSummary(
+            currentSimulationPreset.lastEditedByUserId,
+            currentSimulationPreset.lastEditedByName,
+            currentSimulationPreset.lastEditedByAvatarUrl,
           ),
         }
       : null;
@@ -738,6 +761,7 @@ export function useMapEditorFormState() {
     ownerUserId,
     currentUserIsOwner,
     siteMetadata,
+    simulationMetadata,
     canWrite,
     currentUser,
     // site

--- a/src/index.css
+++ b/src/index.css
@@ -5239,45 +5239,46 @@ html.panorama-gesture-lock body {
   gap: 10px;
 }
 
-.site-editor-meta-row {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto;
-  gap: 6px;
+.editor-meta-footer {
+  border-top: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
+  display: flex;
   align-items: center;
-}
-
-.site-editor-meta-chip {
+  justify-content: flex-end;
+  gap: 10px;
   min-width: 0;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-btn);
-  background: color-mix(in srgb, var(--surface-2) 72%, transparent);
-  color: var(--text);
-  display: grid;
-  gap: 2px;
-  justify-items: start;
-  padding: 5px 7px;
-  cursor: pointer;
+  padding-top: 8px;
 }
 
-.site-editor-meta-chip .user-list-row {
+.editor-meta-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   min-width: 0;
-  max-width: 100%;
 }
 
-.site-editor-meta-chip .user-list-row span:last-child {
-  overflow: hidden;
-  text-overflow: ellipsis;
+.editor-meta-label {
+  color: var(--muted);
+  font-size: 0.68rem;
+  line-height: 1;
   white-space: nowrap;
 }
 
-.site-editor-meta-label {
-  color: var(--muted);
-  font-size: 0.66rem;
-  line-height: 1;
+.editor-meta-avatar-button.btn-icon {
+  width: 24px;
+  min-width: 24px;
+  height: 24px;
 }
 
-@media (max-width: 520px) {
-  .site-editor-meta-row {
-    grid-template-columns: minmax(0, 1fr) auto;
-  }
+.editor-meta-avatar {
+  width: 22px;
+  height: 22px;
+  border-radius: var(--radius-pill);
+  border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
+  background: color-mix(in srgb, var(--surface-2) 90%, transparent);
+  color: var(--text);
+  font-size: 0.62rem;
+  font-weight: 700;
+  display: grid;
+  place-items: center;
+  object-fit: cover;
 }


### PR DESCRIPTION
## Summary
- move site owner / last edited / changelog controls to a compact footer strip
- show user avatars without visible names and use icon-only changelog action
- add the same metadata footer and changelog flow to simulation edit mode

## Verification
- npm test
- npm run build

Follow-up for #804.