### PR TITLE
feat: scope deep links by username

### DIFF
--- a/docs/deep-links.md
+++ b/docs/deep-links.md
@@ -6,10 +6,10 @@ LinkSim supports shareable deep links that link directly to a specific simulatio
 
 | Scenario | URL Format | Example |
 |----------|------------|---------|
-| **Simulation only** | `/<simulation>` | `/Blefjell` |
-| **Single site** | `/<simulation>/<site>` | `/Blefjell/Fyrisjøen` |
-| **Multi-site** | `/<simulation>/<site1>+<site2>+<site3>` | `/Blefjell/Fyrisjøen+HOEG-ROUTER` |
-| **Link** | `/<simulation>/<site1>~<site2>` | `/Blefjell/Fyrisjøen~HOEG-ROUTER` |
+| **Simulation only** | `/<username>/<simulation>` | `/Alice/Blefjell` |
+| **Single site** | `/<username>/<simulation>/<site>` | `/Alice/Blefjell/Fyrisjøen` |
+| **Multi-site** | `/<username>/<simulation>/<site1>+<site2>+<site3>` | `/Alice/Blefjell/Fyrisjøen+HOEG-ROUTER` |
+| **Link** | `/<username>/<simulation>/<site1>~<site2>` | `/Alice/Blefjell/Fyrisjøen~HOEG-ROUTER` |
 
 ## Features
 
@@ -19,8 +19,9 @@ LinkSim supports shareable deep links that link directly to a specific simulatio
 - No URL encoding required for special characters
 
 ### Case Handling
-- URLs preserve original case (e.g., `/Blefjell` not `/blefjell`)
+- URLs preserve original case (e.g., `/Alice/Blefjell` not `/alice/blefjell`)
 - Matching is case-insensitive using canonical slug comparison
+- Simulation names are resolved inside the owner username namespace, so different users can use the same Simulation name.
 
 ### Delimiters
 - **Multi-site selection**: `+` between site names
@@ -44,6 +45,8 @@ Old-style deep links using query parameters are still supported:
 ```
 
 When accessed, these links will load the simulation but may not preserve site/link selection (legacy limitation).
+
+The previous path-only format `/<simulation>` is no longer a valid deep link because path links now require an owner username segment.
 
 ## Generating Deep Links
 

--- a/functions/_lib/db.sharedSimulation.test.ts
+++ b/functions/_lib/db.sharedSimulation.test.ts
@@ -133,9 +133,10 @@ class FakeDb {
     }
     if (sql.includes("SELECT id FROM simulations WHERE lower(name) = lower(?)")) {
       const name = String(bound[0] ?? "").trim().toLowerCase();
-      const id = String(bound[1] ?? "");
+      const ownerUserId = String(bound[1] ?? "");
+      const id = String(bound[2] ?? "");
       for (const row of this.simulations.values()) {
-        if (String(row.name ?? "").trim().toLowerCase() === name && row.id !== id) {
+        if (String(row.name ?? "").trim().toLowerCase() === name && row.owner_user_id === ownerUserId && row.id !== id) {
           return { id: row.id };
         }
       }

--- a/functions/_lib/db.ts
+++ b/functions/_lib/db.ts
@@ -803,6 +803,12 @@ export const updateUserProfile = async (
   if (!nextEmail) throw new Error("Email is required and must be valid.");
   if (nextAvatar === null) throw new Error("Profile picture must be a valid http(s) URL.");
 
+  const duplicateUser = await env.DB
+    .prepare("SELECT id FROM users WHERE lower(username) = lower(?) AND id != ? LIMIT 1")
+    .bind(nextName, userId)
+    .first<{ id: string }>();
+  if (duplicateUser?.id) throw new Error("Username is already in use.");
+
   await env.DB.prepare(
     `UPDATE users
      SET username = ?,
@@ -1255,10 +1261,11 @@ const upsertOwnedResource = async (
         `SELECT id
          FROM simulations
          WHERE lower(name) = lower(?)
+           AND owner_user_id = ?
            AND id != ?
          LIMIT 1`,
       )
-      .bind(name, id)
+      .bind(name, ownerId, id)
       .first<{ id: string }>();
     if (duplicate?.id) {
       return { ok: false, reason: "simulation_name_taken" };
@@ -1963,9 +1970,60 @@ export const resolveSimulationIdBySlug = async (
   return null;
 };
 
+export const resolveUserIdByUsernameSegment = async (env: Env, username: string): Promise<string | null> => {
+  await ensureSchema(env);
+  const slug = slugifyName(username);
+  const canonicalKey = canonicalizeSimulationLookupKey(username);
+  if (!slug && !canonicalKey) return null;
+  const rows = await env.DB.prepare("SELECT id, username FROM users LIMIT 8000").all<{ id: string; username: string }>();
+  for (const row of rows.results) {
+    const name = row.username ?? "";
+    if (slug && slugifyName(name) === slug) return row.id;
+    if (canonicalKey && canonicalizeSimulationLookupKey(name) === canonicalKey) return row.id;
+  }
+  return null;
+};
+
+export const resolveSimulationIdByOwnerSlug = async (
+  env: Env,
+  username: string,
+  simulationSlug: string,
+): Promise<string | null> => {
+  await ensureSchema(env);
+  const ownerId = await resolveUserIdByUsernameSegment(env, username);
+  if (!ownerId) return null;
+  const slug = slugifyName(simulationSlug);
+  const canonicalKey = canonicalizeSimulationLookupKey(simulationSlug);
+  if (!slug && !canonicalKey) return null;
+  const rows = await env.DB
+    .prepare("SELECT id, name, payload_json FROM simulations WHERE owner_user_id = ? LIMIT 8000")
+    .bind(ownerId)
+    .all<{ id: string; name: string; payload_json: string }>();
+  for (const row of rows.results) {
+    const nameSlug = slugifyName(row.name);
+    if (slug && nameSlug === slug) return row.id;
+    if (canonicalKey && canonicalizeSimulationLookupKey(row.name) === canonicalKey) return row.id;
+    try {
+      const payload = JSON.parse(row.payload_json) as { slug?: unknown; slugAliases?: unknown };
+      const payloadSlugRaw = typeof payload.slug === "string" ? payload.slug : "";
+      const payloadSlug = slugifyName(payloadSlugRaw);
+      if (slug && payloadSlug && payloadSlug === slug) return row.id;
+      if (canonicalKey && payloadSlugRaw && canonicalizeSimulationLookupKey(payloadSlugRaw) === canonicalKey) return row.id;
+      const aliases = Array.isArray(payload.slugAliases)
+        ? payload.slugAliases.filter((alias): alias is string => typeof alias === "string" && alias.trim().length > 0)
+        : [];
+      if (slug && aliases.some((alias) => slugifyName(alias) === slug)) return row.id;
+      if (canonicalKey && aliases.some((alias) => canonicalizeSimulationLookupKey(alias) === canonicalKey)) return row.id;
+    } catch {
+      // ignore invalid payload rows
+    }
+  }
+  return null;
+};
+
 export const fetchPublicSimulationBundle = async (
   env: Env,
-  options: { simulationId?: string; simulationSlug?: string; actorId?: string | null },
+  options: { simulationId?: string; username?: string; simulationSlug?: string; actorId?: string | null },
 ): Promise<
   | { status: "missing" | "forbidden" }
   | {
@@ -1978,7 +2036,9 @@ export const fetchPublicSimulationBundle = async (
   await ensureSchema(env);
   const resolvedId =
     (options.simulationId && options.simulationId.trim()) ||
-    (options.simulationSlug ? await resolveSimulationIdBySlug(env, options.simulationSlug) : null);
+    (options.username && options.simulationSlug
+      ? await resolveSimulationIdByOwnerSlug(env, options.username, options.simulationSlug)
+      : null);
   if (!resolvedId) return { status: "missing" };
 
   const simulationRow = await env.DB

--- a/functions/api/deep-link-status.test.ts
+++ b/functions/api/deep-link-status.test.ts
@@ -5,13 +5,13 @@ const {
   ensureUserMock,
   fetchUserProfileMock,
   resolveSimulationAccessForUserMock,
-  resolveSimulationIdBySlugMock,
+  resolveSimulationIdByOwnerSlugMock,
 } = vi.hoisted(() => ({
   verifyAuthMock: vi.fn(),
   ensureUserMock: vi.fn(),
   fetchUserProfileMock: vi.fn(),
   resolveSimulationAccessForUserMock: vi.fn(),
-  resolveSimulationIdBySlugMock: vi.fn(),
+  resolveSimulationIdByOwnerSlugMock: vi.fn(),
 }));
 
 vi.mock("../_lib/auth", () => ({ verifyAuth: verifyAuthMock }));
@@ -19,7 +19,7 @@ vi.mock("../_lib/db", () => ({
   ensureUser: ensureUserMock,
   fetchUserProfile: fetchUserProfileMock,
   resolveSimulationAccessForUser: resolveSimulationAccessForUserMock,
-  resolveSimulationIdBySlug: resolveSimulationIdBySlugMock,
+  resolveSimulationIdByOwnerSlug: resolveSimulationIdByOwnerSlugMock,
 }));
 
 import { onRequestGet } from "./deep-link-status";
@@ -33,7 +33,7 @@ beforeEach(() => {
   ensureUserMock.mockResolvedValue(undefined);
   fetchUserProfileMock.mockResolvedValue({ id: "u1", isAdmin: false, isModerator: false, accountState: "approved" });
   resolveSimulationAccessForUserMock.mockResolvedValue("ok");
-  resolveSimulationIdBySlugMock.mockResolvedValue(null);
+  resolveSimulationIdByOwnerSlugMock.mockResolvedValue(null);
 });
 
 describe("api/deep-link-status", () => {
@@ -56,10 +56,11 @@ describe("api/deep-link-status", () => {
     await expect(res.json()).resolves.toEqual({ status: "forbidden", simulationId: "sim-2", authenticated: true });
   });
 
-  it("resolves slug to simulation id", async () => {
-    resolveSimulationIdBySlugMock.mockResolvedValueOnce("sim-abc");
-    const res = await onRequestGet(mkCtx(new Request("https://example.test/api/deep-link-status?slug=my-sim")));
+  it("resolves username-scoped slug to simulation id", async () => {
+    resolveSimulationIdByOwnerSlugMock.mockResolvedValueOnce("sim-abc");
+    const res = await onRequestGet(mkCtx(new Request("https://example.test/api/deep-link-status?username=Owner&slug=my-sim")));
     expect(res.status).toBe(200);
+    expect(resolveSimulationIdByOwnerSlugMock).toHaveBeenCalledWith(expect.anything(), "Owner", "my-sim");
     await expect(res.json()).resolves.toEqual({ status: "ok", simulationId: "sim-abc", authenticated: true });
   });
 });

--- a/functions/api/deep-link-status.ts
+++ b/functions/api/deep-link-status.ts
@@ -1,5 +1,5 @@
 import { verifyAuth } from "../_lib/auth";
-import { ensureUser, fetchUserProfile, resolveSimulationAccessForUser, resolveSimulationIdBySlug } from "../_lib/db";
+import { ensureUser, fetchUserProfile, resolveSimulationAccessForUser, resolveSimulationIdByOwnerSlug } from "../_lib/db";
 import { errorResponse, handleOptions, json, withCors } from "../_lib/http";
 import type { Env } from "../_lib/types";
 
@@ -24,10 +24,11 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
     }
 
     const url = new URL(request.url);
+    const username = (url.searchParams.get("username") ?? "").trim();
     const simulationSlug = (url.searchParams.get("slug") ?? "").trim();
     let simulationId = (url.searchParams.get("sim") ?? "").trim();
-    if (!simulationId && simulationSlug) {
-      simulationId = (await resolveSimulationIdBySlug(env, simulationSlug)) ?? "";
+    if (!simulationId && username && simulationSlug) {
+      simulationId = (await resolveSimulationIdByOwnerSlug(env, username, simulationSlug)) ?? "";
     }
     if (!simulationId) {
       return withCors(request, json({ status: "missing", authenticated }));

--- a/functions/api/public-simulation.test.ts
+++ b/functions/api/public-simulation.test.ts
@@ -60,6 +60,14 @@ describe("api/public-simulation", () => {
     );
   });
 
+  it("passes username-scoped slug lookup parameters", async () => {
+    await onRequestGet(mkCtx(new Request("https://example.test/api/public-simulation?username=Owner&slug=my-sim")));
+    expect(fetchPublicSimulationBundleMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ username: "Owner", simulationSlug: "my-sim" }),
+    );
+  });
+
   it("returns 403 when bundle status is forbidden", async () => {
     fetchPublicSimulationBundleMock.mockResolvedValue({ status: "forbidden" });
     const res = await onRequestGet(mkCtx(new Request("https://example.test/api/public-simulation?sim=sim-1")));

--- a/functions/api/public-simulation.ts
+++ b/functions/api/public-simulation.ts
@@ -11,9 +11,10 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
   try {
     const url = new URL(request.url);
     const simulationId = (url.searchParams.get("sim") ?? "").trim();
+    const username = (url.searchParams.get("username") ?? "").trim();
     const simulationSlug = (url.searchParams.get("slug") ?? "").trim();
-    if (!simulationId && !simulationSlug) {
-      return withCors(request, json({ error: "Missing simulation id or slug" }, { status: 400, headers: NO_STORE_HEADERS }));
+    if (!simulationId && (!username || !simulationSlug)) {
+      return withCors(request, json({ error: "Missing simulation id or username-scoped slug" }, { status: 400, headers: NO_STORE_HEADERS }));
     }
 
     const auth = await verifyAuth(request, env).catch(() => null);
@@ -21,6 +22,7 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
 
     const bundle = await fetchPublicSimulationBundle(env, {
       simulationId: simulationId || undefined,
+      username: username || undefined,
       simulationSlug: simulationSlug || undefined,
       actorId,
     });

--- a/src/components/AppShell.deeplink.test.ts
+++ b/src/components/AppShell.deeplink.test.ts
@@ -18,6 +18,8 @@ const hoisted = vi.hoisted(() => {
         ? payload.simulationPresets.map((preset) => ({
             id: preset.id,
             name: preset.name,
+            ownerUserId: (preset as { ownerUserId?: string }).ownerUserId,
+            createdByName: (preset as { createdByName?: string }).createdByName,
             visibility: "shared",
             snapshot: { sites: Array.isArray(preset.snapshot?.sites) ? preset.snapshot.sites : [] },
           }))
@@ -251,6 +253,8 @@ describe("AppShell deeplink cold-load flow", () => {
         {
           id: "sim-mmtk88wx-2didtk",
           name: "Høgevarde hyttefelt",
+          ownerUserId: "user-1",
+          createdByName: "Owner",
           visibility: "shared",
           snapshot: { sites: [] },
         },
@@ -281,7 +285,7 @@ describe("AppShell deeplink cold-load flow", () => {
     vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => window.setTimeout(() => cb(0), 0));
     vi.stubGlobal("cancelAnimationFrame", (id: number) => window.clearTimeout(id));
 
-    window.history.replaceState(null, "", "/H%C3%B8gevarde-hyttefelt/Fyrisj%C3%B8vegen");
+    window.history.replaceState(null, "", "/Owner/H%C3%B8gevarde-hyttefelt/Fyrisj%C3%B8vegen");
   });
 
   it("builds direct auth-start navigation for explicit sign-in clicks", () => {

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -433,6 +433,12 @@ export function AppShell() {
 
   const currentShareLink = useMemo(() => {
     if (!activeSimulation) return "";
+    const ownerUserId = (activeSimulation as { ownerUserId?: string }).ownerUserId ?? "";
+    const ownerUsername =
+      ownerUserId && currentUser?.id === ownerUserId
+        ? currentUser.username
+        : shareDirectory.find((user) => user.id === ownerUserId)?.username ||
+          ((activeSimulation as { createdByName?: string }).createdByName ?? currentUser?.username ?? "");
     const simulationSlug = activeSimulation.name;
     const selectedSites = selectedSiteIds
       .map((id) => sites.find((site) => site.id === id))
@@ -460,6 +466,7 @@ export function AppShell() {
     return buildDeepLinkUrl(
       {
         version: 2,
+        username: ownerUsername,
         simulationId: activeSimulation.id,
         simulationSlug,
         ...(selectedLinkSlugs ? { selectedLinkSlugs } : {}),
@@ -468,7 +475,7 @@ export function AppShell() {
       window.location.origin,
       "/",
     );
-  }, [activeSimulation, selectedLink, selectedSiteIds, sites]);
+  }, [activeSimulation, currentUser, selectedLink, selectedSiteIds, shareDirectory, sites]);
 
   useEffect(() => {
     if (
@@ -495,7 +502,13 @@ export function AppShell() {
         return;
       }
     } else if (activeSimulation) {
-      targetPath = buildDeepLinkPathname(activeSimulation.name, {
+      const ownerUserId = (activeSimulation as { ownerUserId?: string }).ownerUserId ?? "";
+      const ownerUsername =
+        ownerUserId && currentUser?.id === ownerUserId
+          ? currentUser.username
+          : shareDirectory.find((user) => user.id === ownerUserId)?.username ||
+            ((activeSimulation as { createdByName?: string }).createdByName ?? currentUser?.username ?? "");
+      targetPath = buildDeepLinkPathname(ownerUsername, activeSimulation.name, {
         selectedSiteSlugs: selectedSiteIds
           .map((id) => sites.find((site) => site.id === id)?.name)
           .filter((name): name is string => Boolean(name)),
@@ -505,7 +518,7 @@ export function AppShell() {
     if (currentPath !== targetPath) {
       window.history.replaceState(null, "", targetPath);
     }
-  }, [currentShareLink, activeSimulation, selectedSiteIds, sites, deepLinkParse.ok]);
+  }, [currentShareLink, activeSimulation, currentUser, selectedSiteIds, shareDirectory, sites, deepLinkParse.ok]);
 
   useEffect(() => {
     const root = document.documentElement;
@@ -719,10 +732,11 @@ export function AppShell() {
             return;
           }
           if (deepLinkParse.ok && !isLocalRuntime) {
-            const deepLinkStatus = await fetchDeepLinkStatus({
-              simulationId: deepLinkParse.payload.simulationId,
-              simulationSlug: deepLinkParse.payload.simulationSlug,
-            });
+          const deepLinkStatus = await fetchDeepLinkStatus({
+            simulationId: deepLinkParse.payload.simulationId,
+            username: deepLinkParse.payload.username,
+            simulationSlug: deepLinkParse.payload.simulationSlug,
+          });
             if (!deepLinkStatus.authenticated) {
               if (!isCurrentRun()) return;
               authRecoveryActiveRef.current = false;
@@ -1173,6 +1187,14 @@ export function AppShell() {
           .getState()
           .simulationPresets.find((preset) => {
             const presetSlugRaw = typeof (preset as { slug?: unknown }).slug === "string" ? String((preset as { slug?: unknown }).slug) : "";
+            const targetUsername = payload.username ? canonicalizeDeepLinkKey(payload.username) : "";
+            const ownerUserId = typeof (preset as { ownerUserId?: unknown }).ownerUserId === "string" ? String((preset as { ownerUserId?: unknown }).ownerUserId) : "";
+            const createdByName = typeof (preset as { createdByName?: unknown }).createdByName === "string" ? String((preset as { createdByName?: unknown }).createdByName) : "";
+            if (targetUsername) {
+              const ownerMatchesCurrent = ownerUserId && currentUser?.id === ownerUserId && canonicalizeDeepLinkKey(currentUser.username) === targetUsername;
+              const ownerMatchesCreatedBy = createdByName && canonicalizeDeepLinkKey(createdByName) === targetUsername;
+              if (!ownerMatchesCurrent && !ownerMatchesCreatedBy) return false;
+            }
             const presetSlugValue = presetSlugRaw.trim() ? presetSlugRaw : preset.name;
             const presetPretty = slugifyName(presetSlugValue);
             const presetCanonical = canonicalizeDeepLinkKey(presetSlugValue);
@@ -1221,10 +1243,11 @@ export function AppShell() {
 
       if (!exists && accessState === "readonly") {
         try {
-          const publicBundle = await fetchPublicSimulationLibrary({
-            simulationId: resolvedSimulationId || undefined,
-            simulationSlug: payload.simulationSlug,
-          });
+            const publicBundle = await fetchPublicSimulationLibrary({
+              simulationId: resolvedSimulationId || undefined,
+              username: payload.username,
+              simulationSlug: payload.simulationSlug,
+            });
           importLibraryData(
             {
               siteLibrary: publicBundle.siteLibrary as Parameters<typeof importLibraryData>[0]["siteLibrary"],
@@ -1250,6 +1273,7 @@ export function AppShell() {
         try {
           const status = await fetchDeepLinkStatus({
             simulationId: resolvedSimulationId || undefined,
+            username: payload.username,
             simulationSlug: payload.simulationSlug,
           });
           if (status.status === "forbidden") {
@@ -1391,6 +1415,7 @@ export function AppShell() {
     })();
   }, [
     accessState,
+    currentUser,
     deepLinkParse,
     importLibraryData,
     isInitializing,

--- a/src/lib/cloudLibrary.ts
+++ b/src/lib/cloudLibrary.ts
@@ -48,10 +48,12 @@ export const fetchCloudLibrary = async (opts?: { since?: string }): Promise<Clou
 
 export const fetchPublicSimulationLibrary = async (params: {
   simulationId?: string;
+  username?: string;
   simulationSlug?: string;
 }): Promise<CloudLibraryPayload & { simulationId?: string }> => {
   const query = new URLSearchParams();
   if (params.simulationId?.trim()) query.set("sim", params.simulationId.trim());
+  if (params.username?.trim()) query.set("username", params.username.trim());
   if (params.simulationSlug?.trim()) query.set("slug", params.simulationSlug.trim());
   const data = await apiCall<{ siteLibrary?: unknown[]; simulationPresets?: unknown[]; simulationId?: unknown }>(
     `/api/public-simulation?${query.toString()}`,

--- a/src/lib/cloudUser.ts
+++ b/src/lib/cloudUser.ts
@@ -406,10 +406,12 @@ export const uploadAvatar = async (originalDataUrl: string, thumbDataUrl: string
 
 export const fetchDeepLinkStatus = async (input: {
   simulationId?: string;
+  username?: string;
   simulationSlug?: string;
 }): Promise<DeepLinkStatusResult> => {
   const params = new URLSearchParams();
   if (input.simulationId?.trim()) params.set("sim", input.simulationId.trim());
+  if (input.username?.trim()) params.set("username", input.username.trim());
   if (input.simulationSlug?.trim()) params.set("slug", input.simulationSlug.trim());
   const data = await apiCall<{ status?: unknown; simulationId?: unknown; authenticated?: unknown }>(
     `/api/deep-link-status?${params.toString()}`,

--- a/src/lib/deepLink.test.ts
+++ b/src/lib/deepLink.test.ts
@@ -39,13 +39,14 @@ describe("deepLink", () => {
     expect(parsed).toEqual({ ok: false, reason: "missing_sim" });
   });
 
-  it("parses v2 path with just simulation (no query params)", () => {
+  it("parses v2 path with username and just simulation (no query params)", () => {
     const parsed = parseDeepLinkFromLocation({
-      pathname: "/Høgevarde",
+      pathname: "/Owner/Høgevarde",
       search: "",
     });
     expect(parsed.ok).toBe(true);
     if (!parsed.ok) return;
+    expect(parsed.payload.username).toBe("Owner");
     expect(parsed.payload.simulationSlug).toBe("Høgevarde");
     expect(parsed.payload.selectedSiteSlugs).toBeUndefined();
     expect(parsed.payload.selectedLinkSlugs).toBeUndefined();
@@ -53,18 +54,19 @@ describe("deepLink", () => {
 
   it("parses v2 path with single site", () => {
     const parsed = parseDeepLinkFromLocation({
-      pathname: "/Høgevarde/Fyrisjøen",
+      pathname: "/Owner/Høgevarde/Fyrisjøen",
       search: "",
     });
     expect(parsed.ok).toBe(true);
     if (!parsed.ok) return;
+    expect(parsed.payload.username).toBe("Owner");
     expect(parsed.payload.simulationSlug).toBe("Høgevarde");
     expect(parsed.payload.selectedSiteSlugs).toEqual(["Fyrisjøen"]);
   });
 
   it("parses v2 path with multiple sites (multi-site selection)", () => {
     const parsed = parseDeepLinkFromLocation({
-      pathname: "/Høgevarde/Fyrisjøen+HOEG-ROUTER",
+      pathname: "/Owner/Høgevarde/Fyrisjøen+HOEG-ROUTER",
       search: "",
     });
     expect(parsed.ok).toBe(true);
@@ -75,7 +77,7 @@ describe("deepLink", () => {
 
   it("parses v2 path with link (two sites in ~)", () => {
     const parsed = parseDeepLinkFromLocation({
-      pathname: "/Høgevarde/Fyrisjøen~HOEG-ROUTER",
+      pathname: "/Owner/Høgevarde/Fyrisjøen~HOEG-ROUTER",
       search: "",
     });
     expect(parsed.ok).toBe(true);
@@ -86,7 +88,7 @@ describe("deepLink", () => {
 
   it("parses legacy <> link delimiter", () => {
     const parsed = parseDeepLinkFromLocation({
-      pathname: "/Høgevarde/Fyrisjøen<>HOEG-ROUTER",
+      pathname: "/Owner/Høgevarde/Fyrisjøen<>HOEG-ROUTER",
       search: "",
     });
     expect(parsed.ok).toBe(true);
@@ -96,7 +98,7 @@ describe("deepLink", () => {
 
   it("parses encoded unicode path with encoded <> delimiter", () => {
     const parsed = parseDeepLinkFromLocation({
-      pathname: "/%F0%9F%92%A9/%F0%9F%8F%9D%EF%B8%8F%3C%3E%F0%9F%8C%8B",
+      pathname: "/Owner/%F0%9F%92%A9/%F0%9F%8F%9D%EF%B8%8F%3C%3E%F0%9F%8C%8B",
       search: "",
     });
     expect(parsed.ok).toBe(true);
@@ -109,53 +111,57 @@ describe("deepLink", () => {
     const url = buildDeepLinkUrl(
       {
         version: 2,
+        username: "Owner",
         simulationId: "sim-999",
         simulationSlug: "Høgevarde",
       },
       "https://linksim.pages.dev",
     );
-    expect(url).toBe("https://linksim.pages.dev/Høgevarde");
+    expect(url).toBe("https://linksim.pages.dev/Owner/Høgevarde");
   });
 
   it("builds v2 URL with multiple selected sites", () => {
     const url = buildDeepLinkUrl(
       {
         version: 2,
+        username: "Owner",
         simulationId: "sim-999",
         simulationSlug: "Høgevarde",
         selectedSiteSlugs: ["Fyrisjøen", "HOEG-ROUTER", "Fagerlinattan"],
       },
       "https://linksim.pages.dev",
     );
-    expect(url).toBe("https://linksim.pages.dev/Høgevarde/Fyrisjøen+HOEG-ROUTER+Fagerlinattan");
+    expect(url).toBe("https://linksim.pages.dev/Owner/Høgevarde/Fyrisjøen+HOEG-ROUTER+Fagerlinattan");
   });
 
   it("builds v2 URL with link selection", () => {
     const url = buildDeepLinkUrl(
       {
         version: 2,
+        username: "Owner",
         simulationId: "sim-999",
         simulationSlug: "Høgevarde",
         selectedLinkSlugs: ["Fyrisjøen", "HOEG-ROUTER"],
       },
       "https://linksim.pages.dev",
     );
-    expect(url).toBe("https://linksim.pages.dev/Høgevarde/Fyrisjøen~HOEG-ROUTER");
+    expect(url).toBe("https://linksim.pages.dev/Owner/Høgevarde/Fyrisjøen~HOEG-ROUTER");
   });
 
   it("builds and parses korean simulation/site paths", () => {
     const url = buildDeepLinkUrl(
       {
         version: 2,
+        username: "사용자",
         simulationId: "sim-kor",
         simulationSlug: "한국조선",
         selectedSiteSlugs: ["남산-서울-타워", "평양텔레비죤탑"],
       },
       "https://linksim.pages.dev",
     );
-    expect(url).toBe("https://linksim.pages.dev/한국조선/남산-서울-타워+평양텔레비죤탑");
+    expect(url).toBe("https://linksim.pages.dev/사용자/한국조선/남산-서울-타워+평양텔레비죤탑");
 
-    const parsed = parseDeepLinkFromLocation({ pathname: "/한국조선/남산-서울-타워+평양텔레비죤탑", search: "" });
+    const parsed = parseDeepLinkFromLocation({ pathname: "/사용자/한국조선/남산-서울-타워+평양텔레비죤탑", search: "" });
     expect(parsed.ok).toBe(true);
     if (!parsed.ok) return;
     expect(parsed.payload.simulationSlug).toBe("한국조선");
@@ -191,79 +197,79 @@ describe("deepLink", () => {
   });
 
   it("builds pathname for simulation only", () => {
-    const pathname = buildDeepLinkPathname("Høgevarde");
-    expect(pathname).toBe("/Høgevarde");
+    const pathname = buildDeepLinkPathname("Owner", "Høgevarde");
+    expect(pathname).toBe("/Owner/Høgevarde");
   });
 
   it("builds pathname with selected site slugs", () => {
-    const pathname = buildDeepLinkPathname("Høgevarde", {
+    const pathname = buildDeepLinkPathname("Owner", "Høgevarde", {
       selectedSiteSlugs: ["Fyrisjøen", "HOEG-ROUTER"],
     });
-    expect(pathname).toBe("/Høgevarde/Fyrisjøen+HOEG-ROUTER");
+    expect(pathname).toBe("/Owner/Høgevarde/Fyrisjøen+HOEG-ROUTER");
   });
 
   it("builds pathname with selected link slugs", () => {
-    const pathname = buildDeepLinkPathname("Høgevarde", {
+    const pathname = buildDeepLinkPathname("Owner", "Høgevarde", {
       selectedLinkSlugs: ["Fyrisjøen", "HOEG-ROUTER"],
     });
-    expect(pathname).toBe("/Høgevarde/Fyrisjøen~HOEG-ROUTER");
+    expect(pathname).toBe("/Owner/Høgevarde/Fyrisjøen~HOEG-ROUTER");
   });
 
   it("builds pathname ignoring link slugs when fewer or more than 2", () => {
-    const pathnameOne = buildDeepLinkPathname("Høgevarde", {
+    const pathnameOne = buildDeepLinkPathname("Owner", "Høgevarde", {
       selectedLinkSlugs: ["Fyrisjøen"],
     });
-    expect(pathnameOne).toBe("/Høgevarde");
+    expect(pathnameOne).toBe("/Owner/Høgevarde");
 
-    const pathnameThree = buildDeepLinkPathname("Høgevarde", {
+    const pathnameThree = buildDeepLinkPathname("Owner", "Høgevarde", {
       selectedLinkSlugs: ["A", "B", "C"],
     });
-    expect(pathnameThree).toBe("/Høgevarde");
+    expect(pathnameThree).toBe("/Owner/Høgevarde");
   });
 
   it("prefers link slugs over site slugs when both present with 2 links", () => {
-    const pathname = buildDeepLinkPathname("Høgevarde", {
+    const pathname = buildDeepLinkPathname("Owner", "Høgevarde", {
       selectedLinkSlugs: ["Fyrisjøen", "HOEG-ROUTER"],
       selectedSiteSlugs: ["Fyrisjøen", "HOEG-ROUTER", "Extra"],
     });
-    expect(pathname).toBe("/Høgevarde/Fyrisjøen~HOEG-ROUTER");
+    expect(pathname).toBe("/Owner/Høgevarde/Fyrisjøen~HOEG-ROUTER");
   });
 
   it("falls back to site slugs when link slugs not exactly 2", () => {
-    const pathname = buildDeepLinkPathname("Høgevarde", {
+    const pathname = buildDeepLinkPathname("Owner", "Høgevarde", {
       selectedLinkSlugs: ["Fyrisjøen"],
       selectedSiteSlugs: ["Fyrisjøen", "HOEG-ROUTER"],
     });
-    expect(pathname).toBe("/Høgevarde/Fyrisjøen+HOEG-ROUTER");
+    expect(pathname).toBe("/Owner/Høgevarde/Fyrisjøen+HOEG-ROUTER");
   });
 
   it("returns / for empty simulation slug", () => {
-    const pathname = buildDeepLinkPathname("");
+    const pathname = buildDeepLinkPathname("Owner", "");
     expect(pathname).toBe("/");
 
-    const pathnameNull = buildDeepLinkPathname(undefined as unknown as string);
+    const pathnameNull = buildDeepLinkPathname("", "Høgevarde");
     expect(pathnameNull).toBe("/");
   });
 
   it("strips delimiter characters from slugs", () => {
-    const pathname = buildDeepLinkPathname("Test+Sim", {
+    const pathname = buildDeepLinkPathname("Owner+Name", "Test+Sim", {
       selectedSiteSlugs: ["Site~One", "Site+Two"],
     });
-    expect(pathname).toBe("/TestSim/SiteOne+SiteTwo");
+    expect(pathname).toBe("/OwnerName/TestSim/SiteOne+SiteTwo");
   });
 
   it("builds pathname with single site", () => {
-    const pathname = buildDeepLinkPathname("Høgevarde", {
+    const pathname = buildDeepLinkPathname("Owner", "Høgevarde", {
       selectedSiteSlugs: ["Fyrisjøen"],
     });
-    expect(pathname).toBe("/Høgevarde/Fyrisjøen");
+    expect(pathname).toBe("/Owner/Høgevarde/Fyrisjøen");
   });
 
   it("builds pathname for unicode simulation and sites", () => {
-    const pathname = buildDeepLinkPathname("한국조선", {
+    const pathname = buildDeepLinkPathname("사용자", "한국조선", {
       selectedSiteSlugs: ["남산-서울-타워", "평양텔레비죤탑"],
     });
-    expect(pathname).toBe("/한국조선/남산-서울-타워+평양텔레비죤탑");
+    expect(pathname).toBe("/사용자/한국조선/남산-서울-타워+평양텔레비죤탑");
   });
 
   it("treats /settings as a reserved path head (no simulation parsed)", () => {

--- a/src/lib/deepLink.ts
+++ b/src/lib/deepLink.ts
@@ -5,6 +5,7 @@ const LEGACY_LINK_DELIMITER = "<>";
 
 export type DeepLinkPayloadV2 = {
   version: 2;
+  username?: string;
   simulationId?: string;
   simulationSlug?: string;
   selectedSiteSlugs?: string[];
@@ -88,8 +89,6 @@ const normalizeSlugSegment = (value: string): string =>
 const isV2Path = (pathname: string): boolean => {
   const segments = (pathname ?? "/").split("/").filter(Boolean);
   if (segments.length >= 2) return true;
-  if (segments[0]?.includes("+") || segments[0]?.includes("<>")) return true;
-  if (segments[0]) return true;
   return false;
 };
 
@@ -123,21 +122,23 @@ const parseV2Path = (pathname: string) => {
     .map((s) => safeDecodeURIComponent(s))
     .filter(Boolean);
 
-  if (!segments.length) return { simulationSlug: undefined, selection: undefined };
+  if (segments.length < 2) return { username: undefined, simulationSlug: undefined, selection: undefined };
 
-  const simulationSlugRaw = segments[0];
-  if (isReservedPathHead(simulationSlugRaw)) {
-    return { simulationSlug: undefined, selection: undefined };
+  const usernameRaw = segments[0];
+  if (isReservedPathHead(usernameRaw)) {
+    return { username: undefined, simulationSlug: undefined, selection: undefined };
+  }
+  const username = normalizeSlugSegment(usernameRaw);
+  if (!username) return { username: undefined, simulationSlug: undefined, selection: undefined };
+
+  const simulationSlug = normalizeSlugSegment(segments[1] ?? "");
+  if (!simulationSlug) return { username: undefined, simulationSlug: undefined, selection: undefined };
+
+  if (segments.length === 2) {
+    return { username, simulationSlug, selection: undefined };
   }
 
-  const simulationSlug = normalizeSlugSegment(simulationSlugRaw);
-  if (!simulationSlug) return { simulationSlug: undefined, selection: undefined };
-
-  if (segments.length === 1) {
-    return { simulationSlug, selection: undefined };
-  }
-
-  const selectionPart = segments.slice(1).join("/");
+  const selectionPart = segments.slice(2).join("/");
 
   const linkDelimiter = selectionPart.includes(PRIMARY_LINK_DELIMITER)
     ? PRIMARY_LINK_DELIMITER
@@ -149,16 +150,17 @@ const parseV2Path = (pathname: string) => {
     const [fromSlug, toSlug] = selectionPart.split(linkDelimiter).map(normalizeSlugSegment);
     return {
       simulationSlug,
+      username,
       selection: { type: "link", fromSlug: fromSlug ?? "", toSlug: toSlug ?? "" },
     };
   }
 
   const siteSlugs = selectionPart.split("+").map(normalizeSlugSegment).filter(Boolean);
   if (siteSlugs.length >= 1) {
-    return { simulationSlug, selection: { type: "sites", siteSlugs } };
+    return { username, simulationSlug, selection: { type: "sites", siteSlugs } };
   }
 
-  return { simulationSlug, selection: undefined };
+  return { username, simulationSlug, selection: undefined };
 };
 
 export const parseDeepLinkFromLocation = (locationLike: DeepLinkLocationLike): DeepLinkParseResult => {
@@ -207,9 +209,10 @@ export const parseDeepLinkFromLocation = (locationLike: DeepLinkLocationLike): D
     };
   }
 
-  const { simulationSlug: pathSimulationSlug, selection } = parseV2Path(locationLike.pathname ?? "/");
+  const { username: pathUsername, simulationSlug: pathSimulationSlug, selection } = parseV2Path(locationLike.pathname ?? "/");
 
   const simulationId = trimToUndefined(params.get("sim"));
+  const username = trimToUndefined(params.get("username")) ?? pathUsername;
   const simulationSlug = trimToUndefined(params.get("sim_slug")) ?? pathSimulationSlug;
 
   if (!simulationId && !simulationSlug) {
@@ -225,6 +228,7 @@ export const parseDeepLinkFromLocation = (locationLike: DeepLinkLocationLike): D
       payload: {
         version: 2,
         simulationId,
+        username,
         simulationSlug,
         selectedLinkSlugs: linkSlugs,
       },
@@ -237,6 +241,7 @@ export const parseDeepLinkFromLocation = (locationLike: DeepLinkLocationLike): D
       payload: {
         version: 2,
         simulationId,
+        username,
         simulationSlug,
         selectedSiteSlugs: selection.siteSlugs,
       },
@@ -248,6 +253,7 @@ export const parseDeepLinkFromLocation = (locationLike: DeepLinkLocationLike): D
     payload: {
       version: 2,
       simulationId,
+      username,
       simulationSlug,
     },
   };
@@ -264,13 +270,15 @@ const cleanSlug = (s: string): string =>
     .replace(/^-+|-+$/g, "");
 
 export const buildDeepLinkPathname = (
+  username: string,
   simulationSlug: string,
   options?: { selectedLinkSlugs?: string[]; selectedSiteSlugs?: string[] },
 ): string => {
+  const pathUsername = slugifyName(username ?? "");
   const pathSlug = slugifyName(simulationSlug ?? "");
-  if (!pathSlug) return "/";
+  if (!pathUsername || !pathSlug) return "/";
 
-  let path = `/${pathSlug}`;
+  let path = `/${cleanSlug(pathUsername)}/${pathSlug}`;
 
   if (options?.selectedLinkSlugs && options.selectedLinkSlugs.length === 2) {
     const [from, to] = options.selectedLinkSlugs;
@@ -288,16 +296,19 @@ export const buildDeepLinkUrl = (
   pathname = "/",
 ): string => {
   const simulationSlug = payload.simulationSlug ?? "";
+  const username = payload.username ?? "";
+  const pathUsername = slugifyName(username);
   const pathSlug = slugifyName(simulationSlug);
 
-  if (!pathSlug) {
+  if (!pathUsername || !pathSlug) {
     const url = new URL(pathname, origin);
     if (payload.simulationId) url.searchParams.set("sim", payload.simulationId);
+    if (payload.username) url.searchParams.set("username", payload.username);
     if (payload.simulationSlug) url.searchParams.set("sim_slug", payload.simulationSlug);
     return url.toString();
   }
 
-  let pathPart = `/${cleanSlug(pathSlug)}`;
+  let pathPart = `/${cleanSlug(pathUsername)}/${cleanSlug(pathSlug)}`;
 
   if (payload.selectedLinkSlugs && payload.selectedLinkSlugs.length === 2) {
     const [from, to] = payload.selectedLinkSlugs;


### PR DESCRIPTION
## Summary
- Change path deep links to `/<username>/<simulation>/<selection>` and update docs/tests.
- Resolve deep-link API slug lookups inside the owner username namespace.
- Allow duplicate Simulation names across owners while rejecting duplicates for the same owner, and reject case-insensitive duplicate usernames on profile updates.

## Verification
- `git diff --check`
- Local `npm test` / `npm run build` not run: no JS package manager is available in this shell (`npm`, `pnpm`, `yarn`, `bun` are not on PATH). CI is the verification gate for this PR.

Closes #813 after staging verification and sign-off.