### PR TITLE
fix: plain icon buttons without button shape

### DIFF
--- a/src/components/AccessSettingsEditor.test.tsx
+++ b/src/components/AccessSettingsEditor.test.tsx
@@ -59,7 +59,8 @@ describe("AccessSettingsEditor", () => {
     );
 
     const editCollaborators = screen.getByRole("button", { name: "Edit collaborators" });
-    expect(editCollaborators).toHaveClass("btn");
+    expect(editCollaborators).toHaveClass("field-inline-btn");
+    expect(editCollaborators).not.toHaveClass("btn");
     expect(editCollaborators).not.toHaveClass("inline-action");
     expect(editCollaborators).not.toHaveClass("action-button");
 

--- a/src/components/AccessSettingsEditor.tsx
+++ b/src/components/AccessSettingsEditor.tsx
@@ -118,16 +118,17 @@ export function AccessSettingsEditor({
               <span className="field-help access-collaborators-empty">No collaborators</span>
             )}
           </div>
-          <ActionButton
-            aria-label="Edit collaborators"
-            ref={triggerRef}
-            disabled={disabled}
-            onClick={() => setPopoverOpen((open) => !open)}
-            title="Edit collaborators"
-            type="button"
-          >
-            <Pencil size={14} />
-          </ActionButton>
+           <button
+             aria-label="Edit collaborators"
+             className="field-inline-btn"
+             ref={triggerRef}
+             disabled={disabled}
+             onClick={() => setPopoverOpen((open) => !open)}
+             title="Edit collaborators"
+             type="button"
+           >
+             <Pencil size={14} />
+           </button>
         </div>
       </div>
       <FloatingPopover

--- a/src/components/map/MapEditorPanel.tsx
+++ b/src/components/map/MapEditorPanel.tsx
@@ -281,7 +281,7 @@ function SiteEditorCard({
               type="text"
               value={form.siteSearchQuery}
             />
-            <ActionButton
+            <button
               aria-label="Search location"
               className="field-inline-btn"
               disabled={form.siteSearchBusy}
@@ -290,7 +290,7 @@ function SiteEditorCard({
               type="button"
             >
               {form.siteSearchBusy ? <Loader2 className="animate-spin" size={14} /> : <Search size={14} />}
-            </ActionButton>
+            </button>
           </div>
         </label>
         {form.siteSearchStatus ? <p className="field-help">{form.siteSearchStatus}</p> : null}
@@ -317,7 +317,7 @@ function SiteEditorCard({
               type="number"
               value={form.groundDraft}
             />
-            <ActionButton
+            <button
               aria-label="Fetch elevation"
               className="field-inline-btn"
               disabled={form.isEditorTerrainFetching}
@@ -335,7 +335,7 @@ function SiteEditorCard({
               type="button"
             >
               {form.isEditorTerrainFetching ? <Loader2 className="animate-spin" size={14} /> : <RefreshCw size={14} />}
-            </ActionButton>
+            </button>
           </div>
         </label>
 


### PR DESCRIPTION
## Summary
- Replace `ActionButton` with plain `<button>` + `field-inline-btn` class for edit/search/fetch
- `field-inline-btn`: no border, no border-radius, transparent background (no button shape)
- Icons (Pencil, Search, RefreshCw) render without pill/button shape per UI gallery pattern
- Update test to expect `field-inline-btn` class instead of `btn`

## Relates to
Issue #804