### PR TITLE
fix: use ActionButton size=icon per UI gallery

### DIFF
--- a/src/components/AccessSettingsEditor.test.tsx
+++ b/src/components/AccessSettingsEditor.test.tsx
@@ -59,8 +59,7 @@ describe("AccessSettingsEditor", () => {
     );
 
     const editCollaborators = screen.getByRole("button", { name: "Edit collaborators" });
-    expect(editCollaborators).toHaveClass("field-inline-btn");
-    expect(editCollaborators).not.toHaveClass("btn");
+    expect(editCollaborators).toHaveClass("btn-icon");
     expect(editCollaborators).not.toHaveClass("inline-action");
     expect(editCollaborators).not.toHaveClass("action-button");
 

--- a/src/components/AccessSettingsEditor.tsx
+++ b/src/components/AccessSettingsEditor.tsx
@@ -118,17 +118,17 @@ export function AccessSettingsEditor({
               <span className="field-help access-collaborators-empty">No collaborators</span>
             )}
           </div>
-           <button
+           <ActionButton
              aria-label="Edit collaborators"
-             className="field-inline-btn"
              ref={triggerRef}
              disabled={disabled}
              onClick={() => setPopoverOpen((open) => !open)}
+             size="icon"
              title="Edit collaborators"
              type="button"
            >
              <Pencil size={14} />
-           </button>
+           </ActionButton>
         </div>
       </div>
       <FloatingPopover

--- a/src/components/map/MapEditorPanel.tsx
+++ b/src/components/map/MapEditorPanel.tsx
@@ -281,16 +281,16 @@ function SiteEditorCard({
               type="text"
               value={form.siteSearchQuery}
             />
-            <button
+            <ActionButton
               aria-label="Search location"
-              className="field-inline-btn"
               disabled={form.siteSearchBusy}
               onClick={() => void form.runSiteSearch()}
+              size="icon"
               title="Search location"
               type="button"
             >
               {form.siteSearchBusy ? <Loader2 className="animate-spin" size={14} /> : <Search size={14} />}
-            </button>
+            </ActionButton>
           </div>
         </label>
         {form.siteSearchStatus ? <p className="field-help">{form.siteSearchStatus}</p> : null}
@@ -317,9 +317,8 @@ function SiteEditorCard({
               type="number"
               value={form.groundDraft}
             />
-            <button
+            <ActionButton
               aria-label="Fetch elevation"
-              className="field-inline-btn"
               disabled={form.isEditorTerrainFetching}
               onClick={() => {
                 const elevation = form.fetchGroundElevation();
@@ -331,11 +330,12 @@ function SiteEditorCard({
                 }
                 form.setGroundDraft(elevation);
               }}
+              size="icon"
               title="Fetch elevation"
               type="button"
             >
               {form.isEditorTerrainFetching ? <Loader2 className="animate-spin" size={14} /> : <RefreshCw size={14} />}
-            </button>
+            </ActionButton>
           </div>
         </label>
 


### PR DESCRIPTION
## Summary
- Use `ActionButton` with `size="icon"` which renders `btn-icon` per UI gallery
- Reverts plain `<button>` approach that looked like Win 3.1 style
- `btn-icon`: 34×34 transparent icon-only button (no pill shape, no border-radius)
- Icons: Pencil (Edit), Search (Map Search), RefreshCw (Fetch elevation)
- Loading states use animated `Loader2` spinner
- Update test to expect `btn-icon` class

## Relates to
Issue #804