### PR TITLE
fix: use Button directly for icon-only controls (UI gallery)

### DIFF
--- a/src/components/AccessSettingsEditor.tsx
+++ b/src/components/AccessSettingsEditor.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useRef, useState } from "react";
 import { Pencil, Trash2 } from "lucide-react";
 import type { CollaboratorDirectoryUser } from "../lib/cloudUser";
+import { Button } from "./ui/Button";
 import { ActionButton } from "./ActionButton";
 import { AvatarBadge } from "./AvatarBadge";
 import { FloatingPopover } from "./ui/FloatingPopover";
@@ -118,7 +119,7 @@ export function AccessSettingsEditor({
               <span className="field-help access-collaborators-empty">No collaborators</span>
             )}
           </div>
-           <ActionButton
+           <Button
              aria-label="Edit collaborators"
              ref={triggerRef}
              disabled={disabled}
@@ -128,7 +129,7 @@ export function AccessSettingsEditor({
              type="button"
            >
              <Pencil size={14} />
-           </ActionButton>
+           </Button>
         </div>
       </div>
       <FloatingPopover

--- a/src/components/map/MapEditorPanel.tsx
+++ b/src/components/map/MapEditorPanel.tsx
@@ -15,6 +15,7 @@ import { useAppStore } from "../../store/appStore";
 import { useMapEditorFormState } from "./useMapEditorFormState";
 import { AccessSettingsEditor } from "../AccessSettingsEditor";
 import { ActionButton } from "../ActionButton";
+import { Button } from "../ui/Button";
 import { Surface } from "../ui/Surface";
 import { InlineCloseIconButton } from "../InlineCloseIconButton";
 import { SiteBeamVisualizer } from "../SiteBeamVisualizer";
@@ -281,7 +282,7 @@ function SiteEditorCard({
               type="text"
               value={form.siteSearchQuery}
             />
-            <ActionButton
+            <Button
               aria-label="Search location"
               disabled={form.siteSearchBusy}
               onClick={() => void form.runSiteSearch()}
@@ -290,7 +291,7 @@ function SiteEditorCard({
               type="button"
             >
               {form.siteSearchBusy ? <Loader2 className="animate-spin" size={14} /> : <Search size={14} />}
-            </ActionButton>
+            </Button>
           </div>
         </label>
         {form.siteSearchStatus ? <p className="field-help">{form.siteSearchStatus}</p> : null}
@@ -317,7 +318,7 @@ function SiteEditorCard({
               type="number"
               value={form.groundDraft}
             />
-            <ActionButton
+            <Button
               aria-label="Fetch elevation"
               disabled={form.isEditorTerrainFetching}
               onClick={() => {
@@ -335,7 +336,7 @@ function SiteEditorCard({
               type="button"
             >
               {form.isEditorTerrainFetching ? <Loader2 className="animate-spin" size={14} /> : <RefreshCw size={14} />}
-            </ActionButton>
+            </Button>
           </div>
         </label>
 


### PR DESCRIPTION
## Summary
- Use `Button` component directly instead of `ActionButton` wrapper
- `ActionButton` not passing `size` prop correctly to `Button`
- Now renders proper `btn-icon` (34×34 transparent) per UI gallery pattern
- Same pattern as `MapControlButton` and UI gallery examples
- Icons: `Pencil` (Edit), `Search` (Map Search), `RefreshCw` (Fetch elevation)
- Loading states use animated `Loader2` spinner

## Relates to
Issue #804