### PR TITLE
Overhaul RX target and simulation defaults

### DIFF
--- a/functions/_lib/db.sharedSimulation.test.ts
+++ b/functions/_lib/db.sharedSimulation.test.ts
@@ -16,6 +16,7 @@ const TABLE_COLUMNS: Record<string, string[]> = {
     "avatar_url",
     "email_public",
     "default_frequency_preset_id",
+    "simulation_defaults_preference_json",
     "avatar_object_key",
     "avatar_thumb_key",
     "avatar_hash",

--- a/functions/_lib/db.ts
+++ b/functions/_lib/db.ts
@@ -1,5 +1,6 @@
 import type { CloudResourceRecord, DbVisibility, Env, Grant, ResourceRole, UserRole, Visibility } from "./types";
 import { findPresetById } from "../../src/lib/frequencyPlans";
+import { normalizeSimulationDefaults, type UserSimulationDefaultsPreference } from "../../src/lib/simulationDefaults";
 
 const VISIBILITIES: Visibility[] = ["private", "public", "shared"];
 const DB_VISIBILITIES: DbVisibility[] = ["private", "public_read", "public_write"];
@@ -172,6 +173,23 @@ const sanitizeDefaultFrequencyPresetId = (value: unknown): string | null | undef
   return trimmed;
 };
 
+const sanitizeSimulationDefaultsPreference = (value: unknown): string | null | undefined => {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  if (typeof value !== "object" || Array.isArray(value)) throw new Error("Simulation defaults preference must be an object or null.");
+  const raw = value as Partial<UserSimulationDefaultsPreference>;
+  const mode = raw.mode === "custom" ? "custom" : "preset";
+  const presetId = typeof raw.presetId === "string" && findPresetById(raw.presetId) ? raw.presetId : "oslo-local-869618";
+  const normalized: UserSimulationDefaultsPreference = {
+    mode,
+    presetId,
+    overridePresetDefaults: Boolean(raw.overridePresetDefaults),
+    ...(raw.overrides ? { overrides: normalizeSimulationDefaults(raw.overrides) } : {}),
+    ...(raw.custom ? { custom: normalizeSimulationDefaults(raw.custom) } : {}),
+  };
+  return JSON.stringify(normalized);
+};
+
 const deriveDefaultEmail = (userId: string, tokenPayload?: Record<string, unknown>): string => {
   const fromEmail = sanitizeEmail(tokenPayload?.email);
   if (fromEmail) return fromEmail;
@@ -219,6 +237,7 @@ const REQUIRED_COLUMNS: Record<string, string[]> = {
     "avatar_url",
     "email_public",
     "default_frequency_preset_id",
+    "simulation_defaults_preference_json",
     "avatar_object_key",
     "avatar_thumb_key",
     "avatar_hash",
@@ -314,6 +333,7 @@ const ensureSchema = async (env: Env): Promise<void> => {
             avatar_url TEXT,
             email_public INTEGER NOT NULL DEFAULT 1,
             default_frequency_preset_id TEXT,
+            simulation_defaults_preference_json TEXT,
             avatar_object_key TEXT,
             avatar_thumb_key TEXT,
             avatar_hash TEXT,
@@ -428,6 +448,9 @@ const ensureSchema = async (env: Env): Promise<void> => {
       if (!userColumns.has("default_frequency_preset_id")) {
         await env.DB.prepare("ALTER TABLE users ADD COLUMN default_frequency_preset_id TEXT").run();
       }
+      if (!userColumns.has("simulation_defaults_preference_json")) {
+        await env.DB.prepare("ALTER TABLE users ADD COLUMN simulation_defaults_preference_json TEXT").run();
+      }
       if (!userColumns.has("username_set_at")) {
         await env.DB.prepare("ALTER TABLE users ADD COLUMN username_set_at TEXT").run();
         await env.DB
@@ -483,6 +506,7 @@ type UserRow = {
   avatar_url: string | null;
   email_public: number;
   default_frequency_preset_id: string | null;
+  simulation_defaults_preference_json: string | null;
   avatar_object_key: string | null;
   avatar_thumb_key: string | null;
   avatar_hash: string | null;
@@ -537,6 +561,14 @@ const toUserProfile = (row: UserRow) => ({
   avatarUrl: row.avatar_url ?? "",
   emailPublic: row.email_public === 1,
   defaultFrequencyPresetId: row.default_frequency_preset_id,
+  simulationDefaultsPreference: (() => {
+    if (!row.simulation_defaults_preference_json) return null;
+    try {
+      return JSON.parse(row.simulation_defaults_preference_json) as UserSimulationDefaultsPreference;
+    } catch {
+      return null;
+    }
+  })(),
   avatarObjectKey: row.avatar_object_key ?? "",
   avatarThumbKey: row.avatar_thumb_key ?? "",
   avatarHash: row.avatar_hash ?? "",
@@ -569,7 +601,7 @@ const readUserRow = async (env: Env, userId: string): Promise<UserRow | null> =>
   await ensureSchema(env);
   return env.DB
     .prepare(
-      "SELECT id, username, email, username_set_at, bio, access_request_note, idp_email, idp_email_verified, avatar_url, email_public, default_frequency_preset_id, avatar_object_key, avatar_thumb_key, avatar_hash, avatar_bytes, avatar_content_type, is_admin, is_moderator, is_approved, approved_at, approved_by_user_id, created_at, updated_at FROM users WHERE id = ?",
+      "SELECT id, username, email, username_set_at, bio, access_request_note, idp_email, idp_email_verified, avatar_url, email_public, default_frequency_preset_id, simulation_defaults_preference_json, avatar_object_key, avatar_thumb_key, avatar_hash, avatar_bytes, avatar_content_type, is_admin, is_moderator, is_approved, approved_at, approved_by_user_id, created_at, updated_at FROM users WHERE id = ?",
     )
     .bind(userId)
     .first<UserRow>();
@@ -585,7 +617,7 @@ const reconcileUserIdentityByIdpEmail = async (
 
   const rows = await env.DB
     .prepare(
-      `SELECT id, username, email, username_set_at, bio, access_request_note, idp_email, idp_email_verified, avatar_url, email_public, default_frequency_preset_id, avatar_object_key, avatar_thumb_key, avatar_hash, avatar_bytes, avatar_content_type, is_admin, is_moderator, is_approved, approved_at, approved_by_user_id, created_at, updated_at,
+      `SELECT id, username, email, username_set_at, bio, access_request_note, idp_email, idp_email_verified, avatar_url, email_public, default_frequency_preset_id, simulation_defaults_preference_json, avatar_object_key, avatar_thumb_key, avatar_hash, avatar_bytes, avatar_content_type, is_admin, is_moderator, is_approved, approved_at, approved_by_user_id, created_at, updated_at,
               CASE
                 WHEN lower(idp_email) = lower(?) AND idp_email_verified = 1 THEN 'verified_idp_email'
                 WHEN lower(email) = lower(?) THEN 'legacy_email'
@@ -788,6 +820,7 @@ export const updateUserProfile = async (
     avatarUrl?: unknown;
     emailPublic?: unknown;
     defaultFrequencyPresetId?: unknown;
+    simulationDefaultsPreference?: unknown;
   },
 ) => {
   const existing = await readUserRow(env, userId);
@@ -807,6 +840,10 @@ export const updateUserProfile = async (
     patch.defaultFrequencyPresetId === undefined
       ? (existing.default_frequency_preset_id ?? null)
       : sanitizeDefaultFrequencyPresetId(patch.defaultFrequencyPresetId);
+  const nextSimulationDefaultsPreference =
+    patch.simulationDefaultsPreference === undefined
+      ? (existing.simulation_defaults_preference_json ?? null)
+      : sanitizeSimulationDefaultsPreference(patch.simulationDefaultsPreference);
   const shouldClearAvatarMetadata =
     patch.avatarUrl !== undefined && (nextAvatar ?? "") !== (existing.avatar_url ?? "");
 
@@ -828,9 +865,10 @@ export const updateUserProfile = async (
          bio = ?,
          access_request_note = ?,
          avatar_url = ?,
-         email_public = ?,
-         default_frequency_preset_id = ?,
-         avatar_object_key = ?,
+          email_public = ?,
+          default_frequency_preset_id = ?,
+          simulation_defaults_preference_json = ?,
+          avatar_object_key = ?,
          avatar_thumb_key = ?,
          avatar_hash = ?,
          avatar_bytes = ?,
@@ -848,6 +886,7 @@ export const updateUserProfile = async (
       nextAvatar ?? "",
       nextEmailPublic ? 1 : 0,
       nextDefaultFrequencyPresetId ?? null,
+      nextSimulationDefaultsPreference ?? null,
       shouldClearAvatarMetadata ? null : existing.avatar_object_key,
       shouldClearAvatarMetadata ? null : existing.avatar_thumb_key,
       shouldClearAvatarMetadata ? null : existing.avatar_hash,
@@ -924,7 +963,7 @@ export const listUsers = async (env: Env) => {
   await ensureSchema(env);
   const rows = await env.DB
     .prepare(
-      "SELECT id, username, email, username_set_at, bio, access_request_note, idp_email, idp_email_verified, avatar_url, email_public, default_frequency_preset_id, avatar_object_key, avatar_thumb_key, avatar_hash, avatar_bytes, avatar_content_type, is_admin, is_moderator, is_approved, approved_at, approved_by_user_id, created_at, updated_at FROM users ORDER BY created_at DESC LIMIT 2000",
+      "SELECT id, username, email, username_set_at, bio, access_request_note, idp_email, idp_email_verified, avatar_url, email_public, default_frequency_preset_id, simulation_defaults_preference_json, avatar_object_key, avatar_thumb_key, avatar_hash, avatar_bytes, avatar_content_type, is_admin, is_moderator, is_approved, approved_at, approved_by_user_id, created_at, updated_at FROM users ORDER BY created_at DESC LIMIT 2000",
     )
     .all<UserRow>();
   return rows.results.map(toUserProfile);

--- a/functions/api/me.ts
+++ b/functions/api/me.ts
@@ -47,6 +47,7 @@ export const onRequestPatch: PagesFunction<Env> = async ({ request, env }) => {
       avatarUrl?: unknown;
       emailPublic?: unknown;
       defaultFrequencyPresetId?: unknown;
+      simulationDefaultsPreference?: unknown;
     };
     const user = await updateUserProfile(env, auth.userId, body);
     return withCors(request, json({ user }, { headers: NO_STORE_HEADERS }));

--- a/functions/api/users/[id].ts
+++ b/functions/api/users/[id].ts
@@ -89,6 +89,7 @@ export const onRequestPatch: PagesFunction<Env> = async ({ request, env, params 
       avatarUrl?: unknown;
       emailPublic?: unknown;
       defaultFrequencyPresetId?: unknown;
+      simulationDefaultsPreference?: unknown;
       role?: unknown;
       isApproved?: unknown;
     };
@@ -106,7 +107,8 @@ export const onRequestPatch: PagesFunction<Env> = async ({ request, env, params 
       body.bio !== undefined ||
       body.accessRequestNote !== undefined ||
       body.avatarUrl !== undefined ||
-      body.defaultFrequencyPresetId !== undefined
+      body.defaultFrequencyPresetId !== undefined ||
+      body.simulationDefaultsPreference !== undefined
     ) {
       if (!me.isAdmin && targetId !== auth.userId) {
         return withCors(request, json({ error: "Only admins can edit another user's profile fields." }, { status: 403 }));
@@ -119,6 +121,7 @@ export const onRequestPatch: PagesFunction<Env> = async ({ request, env, params 
         avatarUrl: body.avatarUrl,
         emailPublic: body.emailPublic,
         defaultFrequencyPresetId: body.defaultFrequencyPresetId,
+        simulationDefaultsPreference: body.simulationDefaultsPreference,
       });
     }
     if (body.role !== undefined) {

--- a/src/components/SimulationResultsSection.tsx
+++ b/src/components/SimulationResultsSection.tsx
@@ -76,7 +76,6 @@ export function SimulationResultsSection() {
   const temporaryDirectionReversed = useAppStore((state) => state.temporaryDirectionReversed);
   const locale = useAppStore((state) => state.locale);
   const networks = useAppStore((state) => state.networks);
-  const setRxSensitivityTargetDbm = useAppStore((state) => state.setRxSensitivityTargetDbm);
   const setEnvironmentLossDb = useAppStore((state) => state.setEnvironmentLossDb);
   const terrainDataset = useAppStore((state) => state.terrainDataset);
   const terrainFetchStatus = useAppStore((state) => state.terrainFetchStatus);
@@ -328,15 +327,8 @@ export function SimulationResultsSection() {
         )}
         {metric("Worst Fresnel gap", `${analysis.worstFresnelClearanceM.toFixed(2)} m`)}
         {metric("Worst Fresnel point", `${analysis.worstFresnelDistanceKm.toFixed(2)} km`)}
+        {metric("RX target", `${rxSensitivityTargetDbm.toFixed(1)} dBm`)}
       </div>
-      <label className="field-grid">
-        <span>RX target (dBm)</span>
-        <input
-          onChange={(event) => setRxSensitivityTargetDbm(parseNumber(event.target.value))}
-          type="number"
-          value={rxSensitivityTargetDbm}
-        />
-      </label>
       <label className="field-grid">
         <span>Env loss (dB)</span>
         <input
@@ -347,14 +339,10 @@ export function SimulationResultsSection() {
         />
       </label>
       {isLoraEstimateRelevant ? (
-        <div className="section-heading">
-          <ActionButton
-            onClick={() => setRxSensitivityTargetDbm(Math.round(loraSensitivitySuggestionDbm))}
-          >
-            Set RX Target To LoRa Estimate ({loraSensitivitySuggestionDbm.toFixed(1)} dBm)
-          </ActionButton>
-          <InfoTip text="Sets RX target to a LoRa sensitivity estimate from current BW and SF (noise floor + NF + SF SNR limit). This is a helper target, not a measured receiver spec." />
-        </div>
+        <p className="field-help">
+          LoRa sensitivity estimate for this channel: {loraSensitivitySuggestionDbm.toFixed(1)} dBm. Change RX target
+          in simulation settings or account preferences.
+        </p>
       ) : (
         <p className="field-help">
           LoRa RX estimate helper is hidden for reference presets. Switch to a Meshtastic/Local frequency plan to

--- a/src/components/map/MapEditorPanel.tsx
+++ b/src/components/map/MapEditorPanel.tsx
@@ -671,6 +671,53 @@ function SimulationEditorCard({
             </label>
           </>
         ) : null}
+        <label className="field-grid">
+          <span>Override inherited simulation defaults</span>
+          <input
+            aria-label="Override inherited simulation defaults"
+            checked={form.simulationDefaultsOverrideEnabled}
+            onChange={(e) => form.setSimulationDefaultsOverrideEnabled(e.target.checked)}
+            type="checkbox"
+          />
+        </label>
+        {!form.simulationDefaultsOverrideEnabled ? (
+          <p className="field-help">This Simulation inherits the owner's account defaults for channel, RX target, and environment.</p>
+        ) : (
+          <>
+            <label className="field-grid">
+              <span>Frequency (MHz)</span>
+              <input type="number" value={form.simulationDefaultsDraft.frequencyMHz} onChange={(e) => form.setSimulationDefaultsDraft({ frequencyMHz: Number(e.target.value) })} />
+            </label>
+            <label className="field-grid">
+              <span>Bandwidth (kHz)</span>
+              <input type="number" value={form.simulationDefaultsDraft.bandwidthKhz} onChange={(e) => form.setSimulationDefaultsDraft({ bandwidthKhz: Number(e.target.value) })} />
+            </label>
+            <label className="field-grid">
+              <span>Spread factor</span>
+              <input type="number" value={form.simulationDefaultsDraft.spreadFactor} onChange={(e) => form.setSimulationDefaultsDraft({ spreadFactor: Number(e.target.value) })} />
+            </label>
+            <label className="field-grid">
+              <span>Coding rate</span>
+              <input type="number" value={form.simulationDefaultsDraft.codingRate} onChange={(e) => form.setSimulationDefaultsDraft({ codingRate: Number(e.target.value) })} />
+            </label>
+            <label className="field-grid">
+              <span>Region code</span>
+              <input type="text" value={form.simulationDefaultsDraft.regionCode ?? ""} onChange={(e) => form.setSimulationDefaultsDraft({ regionCode: e.target.value || undefined })} />
+            </label>
+            <label className="field-grid">
+              <span>RX target (dBm)</span>
+              <input type="number" value={form.simulationDefaultsDraft.rxSensitivityTargetDbm} onChange={(e) => form.setSimulationDefaultsDraft({ rxSensitivityTargetDbm: Number(e.target.value) })} />
+            </label>
+            <label className="field-grid">
+              <span>Env loss (dB)</span>
+              <input min={0} type="number" value={form.simulationDefaultsDraft.environmentLossDb} onChange={(e) => form.setSimulationDefaultsDraft({ environmentLossDb: Number(e.target.value) })} />
+            </label>
+            <label className="field-grid">
+              <span>Auto environment defaults</span>
+              <input aria-label="Auto environment defaults" checked={form.simulationDefaultsDraft.autoPropagationEnvironment} onChange={(e) => form.setSimulationDefaultsDraft({ autoPropagationEnvironment: e.target.checked })} type="checkbox" />
+            </label>
+          </>
+        )}
       </fieldset>
 
       {/* Pending visibility confirmation prompt */}

--- a/src/components/map/useMapEditorFormState.ts
+++ b/src/components/map/useMapEditorFormState.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { collapseSiteGainToTx, getSyncedSiteGainPair, shouldUseSeparateSiteGain } from "../../lib/siteGainFields";
 import { resolveLinkRadio, STANDARD_SITE_RADIO } from "../../lib/linkRadio";
 import { toAccessVisibility } from "../../lib/uiFormatting";
+import { normalizeSimulationDefaults, resolveUserSimulationDefaults, type SimulationDefaults } from "../../lib/simulationDefaults";
 import { fetchCollaboratorDirectory } from "../../lib/cloudUser";
 import { fetchElevations } from "../../lib/elevationService";
 import { searchLocations, type GeocodeResult } from "../../lib/geocode";
@@ -82,6 +83,10 @@ export function useMapEditorFormState() {
   } | null>(null);
   const [simulationFrequencyPresetId, setSimulationFrequencyPresetId] = useState("");
   const [simulationAutoPropagationEnvironment, setSimulationAutoPropagationEnvironment] = useState(true);
+  const [simulationDefaultsOverrideEnabled, setSimulationDefaultsOverrideEnabled] = useState(false);
+  const [simulationDefaultsDraft, setSimulationDefaultsDraft] = useState<SimulationDefaults>(() =>
+    normalizeSimulationDefaults(null),
+  );
 
   // ─── Link drafts ──────────────────────────────────────────────────────────────
   const [linkNameDraft, setLinkNameDraft] = useState("");
@@ -177,6 +182,9 @@ export function useMapEditorFormState() {
         setSimulationAutoPropagationEnvironment(
           mapEditor.simulationSeed?.autoPropagationEnvironment ?? autoPropagationEnvironment,
         );
+        const inherited = resolveUserSimulationDefaults(currentUser?.simulationDefaultsPreference, currentUser?.defaultFrequencyPresetId);
+        setSimulationDefaultsOverrideEnabled(false);
+        setSimulationDefaultsDraft(inherited);
       } else {
         const preset = simulationPresets.find((p) => p.id === mapEditor.resourceId);
         setNameDraft(preset?.name ?? mapEditor.label);
@@ -184,6 +192,12 @@ export function useMapEditorFormState() {
         setAccessVisibility(toAccessVisibility(preset?.visibility) as AccessVisibility);
         setSimulationFrequencyPresetId(preset?.snapshot.selectedFrequencyPresetId ?? selectedFrequencyPresetId);
         setSimulationAutoPropagationEnvironment(preset?.snapshot.autoPropagationEnvironment ?? autoPropagationEnvironment);
+        setSimulationDefaultsOverrideEnabled(Boolean(preset?.snapshot.simulationDefaultsOverrideEnabled));
+        setSimulationDefaultsDraft(
+          preset?.snapshot.simulationDefaultsOverride
+            ? normalizeSimulationDefaults(preset.snapshot.simulationDefaultsOverride)
+            : resolveUserSimulationDefaults(currentUser?.simulationDefaultsPreference, currentUser?.defaultFrequencyPresetId),
+        );
         const grants = (preset?.sharedWith ?? []).filter((g) => g.userId !== preset?.ownerUserId);
         setCollaboratorUserIds(grants.map((g) => g.userId));
         setCollaboratorRoles(
@@ -659,6 +673,8 @@ export function useMapEditorFormState() {
         description: descriptionDraft.trim() || undefined,
         visibility: normalizedVisibility,
         sharedWith,
+        simulationDefaultsOverrideEnabled,
+        simulationDefaultsOverride: simulationDefaultsOverrideEnabled ? simulationDefaultsDraft : null,
       });
       closeMapEditor();
       return true;
@@ -794,6 +810,11 @@ export function useMapEditorFormState() {
     setSimulationFrequencyPresetId,
     simulationAutoPropagationEnvironment,
     setSimulationAutoPropagationEnvironment,
+    simulationDefaultsOverrideEnabled,
+    setSimulationDefaultsOverrideEnabled,
+    simulationDefaultsDraft,
+    setSimulationDefaultsDraft: (patch: Partial<SimulationDefaults>) =>
+      setSimulationDefaultsDraft((current) => normalizeSimulationDefaults({ ...current, ...patch }, current)),
     handleSaveSimulation,
     // link
     linkNameDraft, setLinkNameDraft,

--- a/src/components/settings/sections/PreferencesSection.tsx
+++ b/src/components/settings/sections/PreferencesSection.tsx
@@ -1,6 +1,12 @@
 import { useCallback, useState } from "react";
 import { updateMyProfile, type CloudUser } from "../../../lib/cloudUser";
 import { FREQUENCY_PRESETS, frequencyPresetGroups } from "../../../lib/frequencyPlans";
+import {
+  resolveUserSimulationDefaults,
+  simulationDefaultsFromPreset,
+  type SimulationDefaults,
+  type UserSimulationDefaultsPreference,
+} from "../../../lib/simulationDefaults";
 import { getUiErrorMessage } from "../../../lib/uiError";
 import { useAppStore } from "../../../store/appStore";
 import { useThemeVariant } from "../../../hooks/useThemeVariant";
@@ -31,11 +37,21 @@ export function PreferencesSection({ me, onMeUpdated }: PreferencesSectionProps)
 
   const [presetState, setPresetState] = useState<SelectFieldState>(IDLE_SELECT);
 
-  const savePreset = useCallback(
-    async (value: string | null) => {
+  const preference: UserSimulationDefaultsPreference = me?.simulationDefaultsPreference ?? {
+    mode: "preset",
+    presetId: me?.defaultFrequencyPresetId ?? "oslo-local-869618",
+    overridePresetDefaults: false,
+  };
+  const activeDefaults = resolveUserSimulationDefaults(preference, me?.defaultFrequencyPresetId);
+
+  const saveSimulationDefaultsPreference = useCallback(
+    async (nextPreference: UserSimulationDefaultsPreference) => {
       setPresetState({ state: "saving", error: null });
       try {
-        const updated = await updateMyProfile({ defaultFrequencyPresetId: value });
+        const updated = await updateMyProfile({
+          defaultFrequencyPresetId: nextPreference.presetId,
+          simulationDefaultsPreference: nextPreference,
+        });
         onMeUpdated(updated);
         setCurrentUser(updated);
         setAuthState("signed_in");
@@ -49,6 +65,16 @@ export function PreferencesSection({ me, onMeUpdated }: PreferencesSectionProps)
     },
     [onMeUpdated, setAuthState, setCurrentUser],
   );
+
+  const patchPreferenceDefaults = (patch: Partial<SimulationDefaults>) => {
+    const base = preference.mode === "custom" ? activeDefaults : simulationDefaultsFromPreset(preference.presetId);
+    const nextDefaults = { ...base, ...activeDefaults, ...patch };
+    void saveSimulationDefaultsPreference({
+      ...preference,
+      overridePresetDefaults: preference.mode === "custom" ? preference.overridePresetDefaults : true,
+      ...(preference.mode === "custom" ? { custom: nextDefaults } : { overrides: nextDefaults }),
+    });
+  };
 
   return (
     <section className="settings-section" aria-labelledby="settings-preferences-heading">
@@ -105,8 +131,8 @@ export function PreferencesSection({ me, onMeUpdated }: PreferencesSectionProps)
         <div className="autosave-field">
           <label className="autosave-field-label" htmlFor="pref-default-preset">
             <span>
-              Default preset for new simulations{" "}
-              <InfoTip text="This cloud setting applies when you create a new simulation. Existing simulations keep their own saved channel settings." />
+              Default simulation settings{" "}
+              <InfoTip text="This cloud setting controls simulations that inherit your account defaults. Use override/custom to edit channel, RX target, and environment defaults." />
             </span>
             <AutoSaveIndicator
               state={presetState.state}
@@ -117,13 +143,22 @@ export function PreferencesSection({ me, onMeUpdated }: PreferencesSectionProps)
           <select
             id="pref-default-preset"
             className="locale-select"
-            value={me?.defaultFrequencyPresetId ?? ""}
+            value={preference.mode === "custom" ? "custom" : preference.presetId}
             onChange={(event) => {
-              const next = event.target.value ? event.target.value : null;
-              void savePreset(next);
+              const next = event.target.value;
+              if (next === "custom") {
+                void saveSimulationDefaultsPreference({
+                  mode: "custom",
+                  presetId: preference.presetId,
+                  overridePresetDefaults: false,
+                  custom: activeDefaults,
+                });
+                return;
+              }
+              void saveSimulationDefaultsPreference({ mode: "preset", presetId: next, overridePresetDefaults: false });
             }}
           >
-            <option value="">App default (Oslo Local 869.618)</option>
+            <option value="custom">Custom preset</option>
             {frequencyPresetGroups(FREQUENCY_PRESETS).map((groupEntry) => (
               <optgroup key={groupEntry.group} label={groupEntry.group}>
                 {groupEntry.presets.map((preset) => (
@@ -135,6 +170,77 @@ export function PreferencesSection({ me, onMeUpdated }: PreferencesSectionProps)
             ))}
           </select>
         </div>
+
+        {preference.mode === "preset" ? (
+          <label className="field-grid">
+            <span>Override preset settings</span>
+            <input
+              aria-label="Override preset settings"
+              checked={preference.overridePresetDefaults}
+              onChange={(event) => {
+                void saveSimulationDefaultsPreference({
+                  ...preference,
+                  overridePresetDefaults: event.target.checked,
+                  overrides: event.target.checked ? activeDefaults : undefined,
+                });
+              }}
+              type="checkbox"
+            />
+          </label>
+        ) : null}
+
+        {preference.mode === "custom" || preference.overridePresetDefaults ? (
+          <div className="autosave-field">
+            <label className="field-grid">
+              <span>Frequency (MHz)</span>
+              <input type="number" value={activeDefaults.frequencyMHz} onChange={(event) => patchPreferenceDefaults({ frequencyMHz: Number(event.target.value), frequencyPresetId: preference.presetId })} />
+            </label>
+            <label className="field-grid">
+              <span>Bandwidth (kHz)</span>
+              <input type="number" value={activeDefaults.bandwidthKhz} onChange={(event) => patchPreferenceDefaults({ bandwidthKhz: Number(event.target.value) })} />
+            </label>
+            <label className="field-grid">
+              <span>Spread factor</span>
+              <input type="number" value={activeDefaults.spreadFactor} onChange={(event) => patchPreferenceDefaults({ spreadFactor: Number(event.target.value) })} />
+            </label>
+            <label className="field-grid">
+              <span>Coding rate</span>
+              <input type="number" value={activeDefaults.codingRate} onChange={(event) => patchPreferenceDefaults({ codingRate: Number(event.target.value) })} />
+            </label>
+            <label className="field-grid">
+              <span>Region code</span>
+              <input type="text" value={activeDefaults.regionCode ?? ""} onChange={(event) => patchPreferenceDefaults({ regionCode: event.target.value || undefined })} />
+            </label>
+            <label className="field-grid">
+              <span>RX target (dBm)</span>
+              <input type="number" value={activeDefaults.rxSensitivityTargetDbm} onChange={(event) => patchPreferenceDefaults({ rxSensitivityTargetDbm: Number(event.target.value) })} />
+            </label>
+            <label className="field-grid">
+              <span>Env loss (dB)</span>
+              <input min={0} type="number" value={activeDefaults.environmentLossDb} onChange={(event) => patchPreferenceDefaults({ environmentLossDb: Number(event.target.value) })} />
+            </label>
+            <label className="field-grid">
+              <span>Auto environment defaults</span>
+              <input aria-label="Auto environment defaults" checked={activeDefaults.autoPropagationEnvironment} onChange={(event) => patchPreferenceDefaults({ autoPropagationEnvironment: event.target.checked })} type="checkbox" />
+            </label>
+            <label className="field-grid">
+              <span>Radio climate</span>
+              <select className="locale-select" value={activeDefaults.propagationEnvironment.radioClimate} onChange={(event) => patchPreferenceDefaults({ propagationEnvironment: { ...activeDefaults.propagationEnvironment, radioClimate: event.target.value as SimulationDefaults["propagationEnvironment"]["radioClimate"] } })}>
+                <option value="Continental Temperate">Continental Temperate</option>
+                <option value="Maritime Temperate (Land)">Maritime Temperate (Land)</option>
+                <option value="Maritime Temperate (Sea)">Maritime Temperate (Sea)</option>
+                <option value="Desert">Desert</option>
+                <option value="Equatorial">Equatorial</option>
+                <option value="Continental Subtropical">Continental Subtropical</option>
+                <option value="Maritime Subtropical">Maritime Subtropical</option>
+              </select>
+            </label>
+            <label className="field-grid">
+              <span>Clutter height (m)</span>
+              <input type="number" value={activeDefaults.propagationEnvironment.clutterHeightM} onChange={(event) => patchPreferenceDefaults({ propagationEnvironment: { ...activeDefaults.propagationEnvironment, clutterHeightM: Number(event.target.value) } })} />
+            </label>
+          </div>
+        ) : null}
       </div>
     </section>
   );

--- a/src/lib/cloudUser.ts
+++ b/src/lib/cloudUser.ts
@@ -1,3 +1,5 @@
+import type { UserSimulationDefaultsPreference } from "./simulationDefaults";
+
 export type CloudUser = {
   id: string;
   username: string;
@@ -10,6 +12,7 @@ export type CloudUser = {
   avatarUrl: string;
   emailPublic?: boolean;
   defaultFrequencyPresetId?: string | null;
+  simulationDefaultsPreference?: UserSimulationDefaultsPreference | null;
   isAdmin: boolean;
   isModerator?: boolean;
   isApproved: boolean;
@@ -236,6 +239,7 @@ export const updateMyProfile = async (patch: {
   avatarUrl?: string;
   emailPublic?: boolean;
   defaultFrequencyPresetId?: string | null;
+  simulationDefaultsPreference?: UserSimulationDefaultsPreference | null;
 }): Promise<CloudUser> => {
   const data = await apiCall<{ user: CloudUser }>("/api/me", {
     method: "PATCH",

--- a/src/lib/frequencyPlans.ts
+++ b/src/lib/frequencyPlans.ts
@@ -6,6 +6,8 @@ import {
   type FrequencyPresetSource,
   type FrequencyPresetSourceFamily,
 } from "./frequencyPresets.data";
+import { defaultPropagationEnvironment } from "./propagationEnvironment";
+import type { PropagationEnvironment } from "../types/radio";
 
 export type FrequencyPreset = {
   id: string;
@@ -20,6 +22,10 @@ export type FrequencyPreset = {
   codingRate: number;
   regionCode?: string;
   notes?: string;
+  rxSensitivityTargetDbm: number;
+  environmentLossDb: number;
+  propagationEnvironment: PropagationEnvironment;
+  autoPropagationEnvironment: boolean;
 };
 
 const buildFrequencyPresets = (): FrequencyPreset[] => {
@@ -28,7 +34,14 @@ const buildFrequencyPresets = (): FrequencyPreset[] => {
   for (const groupEntry of FREQUENCY_PRESET_DATA_BY_GROUP) {
     for (const preset of groupEntry.presets) {
       sortOrder += 10;
-      presets.push({ ...preset, sortOrder });
+      presets.push({
+        ...preset,
+        sortOrder,
+        rxSensitivityTargetDbm: preset.rxSensitivityTargetDbm ?? -120,
+        environmentLossDb: preset.environmentLossDb ?? 0,
+        propagationEnvironment: preset.propagationEnvironment ?? defaultPropagationEnvironment(),
+        autoPropagationEnvironment: preset.autoPropagationEnvironment ?? true,
+      });
     }
   }
   return presets;

--- a/src/lib/frequencyPresets.data.ts
+++ b/src/lib/frequencyPresets.data.ts
@@ -1,3 +1,5 @@
+import type { PropagationEnvironment } from "../types/radio";
+
 export type FrequencyPresetGroup = "Meshtastic Regional" | "MeshCore Community" | "Amateur / Reference" | "Local / Community";
 export type FrequencyPresetSource = "Meshtastic" | "MeshCore" | "Reference" | "Local";
 export type FrequencyPresetSourceFamily = "meshtastic" | "meshcore" | "reference" | "local";
@@ -14,6 +16,10 @@ export type FrequencyPresetData = {
   codingRate: number;
   regionCode?: string;
   notes?: string;
+  rxSensitivityTargetDbm?: number;
+  environmentLossDb?: number;
+  propagationEnvironment?: PropagationEnvironment;
+  autoPropagationEnvironment?: boolean;
 };
 
 export const FREQUENCY_PRESET_GROUP_ORDER: FrequencyPresetGroup[] = [

--- a/src/lib/simulationDefaults.ts
+++ b/src/lib/simulationDefaults.ts
@@ -1,0 +1,96 @@
+import { defaultPropagationEnvironment } from "./propagationEnvironment";
+import { findPresetById } from "./frequencyPlans";
+import type { PropagationEnvironment } from "../types/radio";
+
+export type SimulationDefaults = {
+  frequencyPresetId: string;
+  frequencyMHz: number;
+  bandwidthKhz: number;
+  spreadFactor: number;
+  codingRate: number;
+  regionCode?: string;
+  rxSensitivityTargetDbm: number;
+  environmentLossDb: number;
+  propagationEnvironment: PropagationEnvironment;
+  autoPropagationEnvironment: boolean;
+};
+
+export type UserSimulationDefaultsPreference = {
+  mode: "preset" | "custom";
+  presetId: string;
+  overridePresetDefaults: boolean;
+  overrides?: Partial<SimulationDefaults>;
+  custom?: Partial<SimulationDefaults>;
+};
+
+export const FALLBACK_SIMULATION_PRESET_ID = "oslo-local-869618";
+
+export const simulationDefaultsFromPreset = (presetId: string): SimulationDefaults => {
+  const preset = findPresetById(presetId) ?? findPresetById(FALLBACK_SIMULATION_PRESET_ID);
+  if (!preset) {
+    return {
+      frequencyPresetId: FALLBACK_SIMULATION_PRESET_ID,
+      frequencyMHz: 869.618,
+      bandwidthKhz: 62,
+      spreadFactor: 8,
+      codingRate: 5,
+      regionCode: "EU_868",
+      rxSensitivityTargetDbm: -120,
+      environmentLossDb: 0,
+      propagationEnvironment: defaultPropagationEnvironment(),
+      autoPropagationEnvironment: true,
+    };
+  }
+  return {
+    frequencyPresetId: preset.id,
+    frequencyMHz: preset.frequencyMHz,
+    bandwidthKhz: preset.bandwidthKhz,
+    spreadFactor: preset.spreadFactor,
+    codingRate: preset.codingRate,
+    regionCode: preset.regionCode,
+    rxSensitivityTargetDbm: preset.rxSensitivityTargetDbm,
+    environmentLossDb: preset.environmentLossDb,
+    propagationEnvironment: preset.propagationEnvironment,
+    autoPropagationEnvironment: preset.autoPropagationEnvironment,
+  };
+};
+
+const cleanNumber = (value: unknown, fallback: number): number =>
+  typeof value === "number" && Number.isFinite(value) ? value : fallback;
+
+const mergeDefaults = (base: SimulationDefaults, patch?: Partial<SimulationDefaults>): SimulationDefaults => ({
+  ...base,
+  ...patch,
+  frequencyPresetId: typeof patch?.frequencyPresetId === "string" ? patch.frequencyPresetId : base.frequencyPresetId,
+  frequencyMHz: cleanNumber(patch?.frequencyMHz, base.frequencyMHz),
+  bandwidthKhz: cleanNumber(patch?.bandwidthKhz, base.bandwidthKhz),
+  spreadFactor: cleanNumber(patch?.spreadFactor, base.spreadFactor),
+  codingRate: cleanNumber(patch?.codingRate, base.codingRate),
+  rxSensitivityTargetDbm: cleanNumber(patch?.rxSensitivityTargetDbm, base.rxSensitivityTargetDbm),
+  environmentLossDb: Math.max(0, cleanNumber(patch?.environmentLossDb, base.environmentLossDb)),
+  propagationEnvironment: {
+    ...base.propagationEnvironment,
+    ...(patch?.propagationEnvironment ?? {}),
+  },
+  autoPropagationEnvironment:
+    typeof patch?.autoPropagationEnvironment === "boolean"
+      ? patch.autoPropagationEnvironment
+      : base.autoPropagationEnvironment,
+});
+
+export const resolveUserSimulationDefaults = (
+  preference?: UserSimulationDefaultsPreference | null,
+  legacyPresetId?: string | null,
+): SimulationDefaults => {
+  const presetId = preference?.presetId || legacyPresetId || FALLBACK_SIMULATION_PRESET_ID;
+  const presetDefaults = simulationDefaultsFromPreset(presetId);
+  if (preference?.mode === "custom") {
+    return mergeDefaults(presetDefaults, preference.custom);
+  }
+  return preference?.overridePresetDefaults ? mergeDefaults(presetDefaults, preference.overrides) : presetDefaults;
+};
+
+export const normalizeSimulationDefaults = (
+  value: Partial<SimulationDefaults> | undefined | null,
+  base = simulationDefaultsFromPreset(FALLBACK_SIMULATION_PRESET_ID),
+): SimulationDefaults => mergeDefaults(base, value ?? undefined);

--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -551,6 +551,42 @@ describe("appStore new simulation default frequency preset", () => {
     expect(created?.snapshot.selectedFrequencyPresetId).toBe("meshcore-us-narrow-910525-sf7-bw625-cr5");
   });
 
+  it("uses cloud simulation defaults when creating blank simulation", () => {
+    useAppStore.setState((state) => ({
+      currentUser: state.currentUser
+        ? {
+            ...state.currentUser,
+            simulationDefaultsPreference: {
+              mode: "custom",
+              presetId: "meshcore-us-narrow-910525-sf7-bw625-cr5",
+              overridePresetDefaults: false,
+              custom: {
+                frequencyPresetId: "meshcore-us-narrow-910525-sf7-bw625-cr5",
+                frequencyMHz: 910.525,
+                bandwidthKhz: 62.5,
+                spreadFactor: 7,
+                codingRate: 5,
+                regionCode: "US",
+                rxSensitivityTargetDbm: -131,
+                environmentLossDb: 4,
+                autoPropagationEnvironment: false,
+              },
+            },
+          }
+        : state.currentUser,
+    }));
+
+    const createdId = useAppStore
+      .getState()
+      .createBlankSimulationPreset("Cloud Simulation Defaults", { visibility: "private", ownerUserId: "owner-1" });
+    const created = useAppStore.getState().simulationPresets.find((entry) => entry.id === createdId);
+    expect(created?.snapshot.selectedFrequencyPresetId).toBe("meshcore-us-narrow-910525-sf7-bw625-cr5");
+    expect(created?.snapshot.rxSensitivityTargetDbm).toBe(-131);
+    expect(created?.snapshot.environmentLossDb).toBe(4);
+    expect(created?.snapshot.autoPropagationEnvironment).toBe(false);
+    expect(created?.snapshot.simulationDefaultsOverrideEnabled).toBe(false);
+  });
+
   it("falls back to app default when cloud default is invalid", () => {
     useAppStore.setState((state) => ({
       currentUser: state.currentUser

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -2,6 +2,13 @@ import { create } from "zustand";
 import { clearTerrainLossCache } from "../lib/coverage";
 import { setAppStoreBridge, useCoverageStore } from "./coverageStore";
 import { findPresetById } from "../lib/frequencyPlans";
+import {
+  FALLBACK_SIMULATION_PRESET_ID,
+  normalizeSimulationDefaults,
+  resolveUserSimulationDefaults,
+  simulationDefaultsFromPreset,
+  type SimulationDefaults,
+} from "../lib/simulationDefaults";
 import { haversineDistanceKm } from "../lib/geo";
 import { getUiErrorMessage } from "../lib/uiError";
 import { fetchCloudLibrary, pushCloudLibrary } from "../lib/cloudLibrary";
@@ -144,12 +151,20 @@ const requireAuth = (currentUser: CloudUser | null, action: string): CloudUser |
   return currentUser;
 };
 
-const FALLBACK_NEW_SIMULATION_PRESET_ID = "oslo-local-869618";
-
 const resolveDefaultFrequencyPresetIdForNewSimulation = (currentUser: CloudUser | null): string => {
-  const preferred = currentUser?.defaultFrequencyPresetId;
+  const preferred = currentUser?.simulationDefaultsPreference?.presetId ?? currentUser?.defaultFrequencyPresetId;
   if (typeof preferred === "string" && findPresetById(preferred)) return preferred;
-  return FALLBACK_NEW_SIMULATION_PRESET_ID;
+  return FALLBACK_SIMULATION_PRESET_ID;
+};
+
+const resolveEffectiveSimulationDefaultsForSnapshot = (
+  snapshot: Partial<SimulationPreset["snapshot"]> | undefined,
+  currentUser: CloudUser | null,
+): SimulationDefaults => {
+  if (snapshot?.simulationDefaultsOverrideEnabled && snapshot.simulationDefaultsOverride) {
+    return normalizeSimulationDefaults(snapshot.simulationDefaultsOverride);
+  }
+  return resolveUserSimulationDefaults(currentUser?.simulationDefaultsPreference, currentUser?.defaultFrequencyPresetId);
 };
 
 const isAuthRelatedErrorMessage = (message: string): boolean => {
@@ -316,6 +331,8 @@ type SimulationPreset = {
     autoPropagationEnvironment: boolean;
     terrainDataset: TerrainDataset;
     mapViewport?: MapViewport;
+    simulationDefaultsOverrideEnabled?: boolean;
+    simulationDefaultsOverride?: SimulationDefaults;
   };
 };
 
@@ -401,6 +418,8 @@ type AppState = {
   propagationEnvironment: PropagationEnvironment;
   autoPropagationEnvironment: boolean;
   propagationEnvironmentReason: string;
+  simulationDefaultsOverrideEnabled: boolean;
+  simulationDefaultsOverride: SimulationDefaults | null;
   terrainDataset: TerrainDataset;
   terrainFetchStatus: string;
   terrainRecommendation: string;
@@ -513,6 +532,9 @@ type AppState = {
   setAutoPropagationEnvironment: (value: boolean) => void;
   setPropagationEnvironment: (patch: Partial<PropagationEnvironment>) => void;
   applyClimateDefaults: (climate: PropagationEnvironment["radioClimate"]) => void;
+  setSimulationDefaultsOverrideEnabled: (value: boolean) => void;
+  setSimulationDefaultsOverride: (value: SimulationDefaults) => void;
+  getEffectiveSimulationDefaults: () => SimulationDefaults;
   setTerrainDataset: (dataset: TerrainDataset) => void;
   addSiteByCoordinates: (name: string, lat: number, lon: number) => void;
   deleteSite: (siteId: string) => void;
@@ -583,7 +605,10 @@ type AppState = {
   renameSimulationPreset: (presetId: string, name: string) => void;
   updateSimulationPresetEntry: (
     presetId: string,
-    patch: Partial<Pick<SimulationPreset, "name" | "description" | "visibility" | "sharedWith">>,
+    patch: Partial<Pick<SimulationPreset, "name" | "description" | "visibility" | "sharedWith">> & {
+      simulationDefaultsOverrideEnabled?: boolean;
+      simulationDefaultsOverride?: SimulationDefaults | null;
+    },
   ) => void;
   deleteSimulationPreset: (presetId: string) => void;
   importLibraryData: (
@@ -1245,6 +1270,8 @@ export const useAppStore = create<AppState>((set, get) => ({
   propagationEnvironment: defaultPropagationEnvironment(),
   autoPropagationEnvironment: true,
   propagationEnvironmentReason: "Auto defaults active.",
+  simulationDefaultsOverrideEnabled: false,
+  simulationDefaultsOverride: null,
   terrainDataset: "copernicus30",
   terrainFetchStatus: "",
   terrainRecommendation: "",
@@ -1301,6 +1328,13 @@ export const useAppStore = create<AppState>((set, get) => ({
   getDefaultFrequencyPresetIdForNewSimulation: () => {
     const state = get();
     return resolveDefaultFrequencyPresetIdForNewSimulation(state.currentUser);
+  },
+  getEffectiveSimulationDefaults: () => {
+    const state = get();
+    if (state.simulationDefaultsOverrideEnabled && state.simulationDefaultsOverride) {
+      return normalizeSimulationDefaults(state.simulationDefaultsOverride);
+    }
+    return resolveUserSimulationDefaults(state.currentUser?.simulationDefaultsPreference, state.currentUser?.defaultFrequencyPresetId);
   },
   setAuthState: (value) => set({ authState: value }),
   setIsOnline: (value) => set({ isOnline: value }),
@@ -2113,6 +2147,25 @@ export const useAppStore = create<AppState>((set, get) => ({
     useCoverageStore.getState().recomputeCoverage();
     get().updateCurrentSimulationSnapshot();
   },
+  setSimulationDefaultsOverrideEnabled: (value) => {
+    const defaults = value ? get().getEffectiveSimulationDefaults() : null;
+    set({ simulationDefaultsOverrideEnabled: value, simulationDefaultsOverride: defaults });
+    get().updateCurrentSimulationSnapshot();
+  },
+  setSimulationDefaultsOverride: (value) => {
+    const defaults = normalizeSimulationDefaults(value);
+    set({
+      simulationDefaultsOverrideEnabled: true,
+      simulationDefaultsOverride: defaults,
+      selectedFrequencyPresetId: defaults.frequencyPresetId,
+      rxSensitivityTargetDbm: defaults.rxSensitivityTargetDbm,
+      environmentLossDb: defaults.environmentLossDb,
+      propagationEnvironment: defaults.propagationEnvironment,
+      autoPropagationEnvironment: defaults.autoPropagationEnvironment,
+    });
+    useCoverageStore.getState().recomputeCoverage();
+    get().updateCurrentSimulationSnapshot();
+  },
   setTerrainDataset: (dataset) => {
     set({ terrainDataset: dataset });
     get().updateCurrentSimulationSnapshot();
@@ -2638,6 +2691,8 @@ export const useAppStore = create<AppState>((set, get) => ({
         propagationEnvironment: state.propagationEnvironment,
         autoPropagationEnvironment: state.autoPropagationEnvironment,
         terrainDataset: state.terrainDataset,
+        simulationDefaultsOverrideEnabled: state.simulationDefaultsOverrideEnabled,
+        simulationDefaultsOverride: state.simulationDefaultsOverride ?? undefined,
       };
 
     set((current) => {
@@ -2698,7 +2753,8 @@ export const useAppStore = create<AppState>((set, get) => ({
     const presetName = name.trim();
     if (!presetName) return null;
     if (hasDuplicateSimulationName(get().simulationPresets, presetName)) return null;
-    const defaultPresetId = resolveDefaultFrequencyPresetIdForNewSimulation(user);
+    const inheritedDefaults = resolveUserSimulationDefaults(user.simulationDefaultsPreference, user.defaultFrequencyPresetId);
+    const defaultPresetId = inheritedDefaults.frequencyPresetId;
     const selectedPresetId =
       typeof options?.frequencyPresetId === "string" && findPresetById(options.frequencyPresetId)
         ? options.frequencyPresetId
@@ -2716,11 +2772,12 @@ export const useAppStore = create<AppState>((set, get) => ({
         selectedOverlayRadiusOption: current.selectedOverlayRadiusOption,
         propagationModel: current.propagationModel,
         selectedFrequencyPresetId: selectedPresetId,
-        rxSensitivityTargetDbm: current.rxSensitivityTargetDbm,
-        environmentLossDb: current.environmentLossDb,
-        propagationEnvironment: current.propagationEnvironment,
-        autoPropagationEnvironment: options?.autoPropagationEnvironment ?? current.autoPropagationEnvironment,
+        rxSensitivityTargetDbm: inheritedDefaults.rxSensitivityTargetDbm,
+        environmentLossDb: inheritedDefaults.environmentLossDb,
+        propagationEnvironment: inheritedDefaults.propagationEnvironment,
+        autoPropagationEnvironment: inheritedDefaults.autoPropagationEnvironment,
         terrainDataset: current.terrainDataset,
+        simulationDefaultsOverrideEnabled: false,
       };
       const nextPreset: SimulationPreset = {
         id: makeId("sim"),
@@ -2782,6 +2839,8 @@ export const useAppStore = create<AppState>((set, get) => ({
         propagationEnvironment: state.propagationEnvironment,
         autoPropagationEnvironment: state.autoPropagationEnvironment,
         terrainDataset: state.terrainDataset,
+        simulationDefaultsOverrideEnabled: state.simulationDefaultsOverrideEnabled,
+        simulationDefaultsOverride: state.simulationDefaultsOverride ?? undefined,
       };
     set((current) => {
       const mergedLibrary =
@@ -2867,6 +2926,8 @@ export const useAppStore = create<AppState>((set, get) => ({
         propagationEnvironment: get().propagationEnvironment,
         autoPropagationEnvironment: get().autoPropagationEnvironment,
         terrainDataset: get().terrainDataset,
+        simulationDefaultsOverrideEnabled: get().simulationDefaultsOverrideEnabled,
+        simulationDefaultsOverride: get().simulationDefaultsOverride ?? undefined,
       },
       updatedAt: new Date().toISOString(),
       lastEditedByUserId: user.id,
@@ -2895,6 +2956,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     const rawSites = Array.isArray(snap.sites) ? snap.sites : [];
     const rawLinks = Array.isArray(snap.links) ? snap.links : [];
     const migratedSnap = migrateSitesAndLinksToSiteRadioDefaults(rawSites, rawLinks);
+    const effectiveDefaults = resolveEffectiveSimulationDefaultsForSnapshot(snap, get().currentUser);
     const isBlankSnapshot = rawSites.length === 0 && rawLinks.length === 0;
     if (isBlankSnapshot) {
       const snapshotSystems = Array.isArray(snap.systems) && snap.systems.length ? snap.systems : defaultScenario.systems;
@@ -2917,12 +2979,14 @@ export const useAppStore = create<AppState>((set, get) => ({
           ? snap.selectedOverlayRadiusOption
           : defaultOptionForSelectionCount(0),
         propagationModel: "ITM" as const,
-        selectedFrequencyPresetId: typeof snap.selectedFrequencyPresetId === "string" ? snap.selectedFrequencyPresetId : "custom",
-        rxSensitivityTargetDbm: typeof snap.rxSensitivityTargetDbm === "number" ? snap.rxSensitivityTargetDbm : -120,
-        environmentLossDb: typeof snap.environmentLossDb === "number" ? snap.environmentLossDb : 0,
-        propagationEnvironment: snap.propagationEnvironment ?? defaultPropagationEnvironment(),
-        autoPropagationEnvironment: snap.autoPropagationEnvironment ?? true,
-        propagationEnvironmentReason: (snap.autoPropagationEnvironment ?? true)
+        selectedFrequencyPresetId: effectiveDefaults.frequencyPresetId,
+        rxSensitivityTargetDbm: effectiveDefaults.rxSensitivityTargetDbm,
+        environmentLossDb: effectiveDefaults.environmentLossDb,
+        propagationEnvironment: effectiveDefaults.propagationEnvironment,
+        autoPropagationEnvironment: effectiveDefaults.autoPropagationEnvironment,
+        simulationDefaultsOverrideEnabled: Boolean(snap.simulationDefaultsOverrideEnabled),
+        simulationDefaultsOverride: snap.simulationDefaultsOverride ?? null,
+        propagationEnvironmentReason: effectiveDefaults.autoPropagationEnvironment
           ? "Auto defaults active."
           : "Manual override active.",
         terrainDataset: normalizeTerrainDataset(snap.terrainDataset),
@@ -2971,13 +3035,14 @@ export const useAppStore = create<AppState>((set, get) => ({
         ? snap.selectedOverlayRadiusOption
         : defaultOptionForSelectionCount(selectedSiteId ? 1 : 0),
       propagationModel: "ITM" as const,
-      selectedFrequencyPresetId: typeof snap.selectedFrequencyPresetId === "string" ? snap.selectedFrequencyPresetId : "custom",
-      rxSensitivityTargetDbm:
-        typeof snap.rxSensitivityTargetDbm === "number" ? snap.rxSensitivityTargetDbm : -120,
-      environmentLossDb: typeof snap.environmentLossDb === "number" ? snap.environmentLossDb : 0,
-      propagationEnvironment: snap.propagationEnvironment ?? defaultPropagationEnvironment(),
-      autoPropagationEnvironment: snap.autoPropagationEnvironment ?? true,
-      propagationEnvironmentReason: (snap.autoPropagationEnvironment ?? true)
+      selectedFrequencyPresetId: effectiveDefaults.frequencyPresetId,
+      rxSensitivityTargetDbm: effectiveDefaults.rxSensitivityTargetDbm,
+      environmentLossDb: effectiveDefaults.environmentLossDb,
+      propagationEnvironment: effectiveDefaults.propagationEnvironment,
+      autoPropagationEnvironment: effectiveDefaults.autoPropagationEnvironment,
+      simulationDefaultsOverrideEnabled: Boolean(snap.simulationDefaultsOverrideEnabled),
+      simulationDefaultsOverride: snap.simulationDefaultsOverride ?? null,
+      propagationEnvironmentReason: effectiveDefaults.autoPropagationEnvironment
         ? "Auto defaults active."
         : "Manual override active.",
       terrainDataset:
@@ -3066,9 +3131,24 @@ export const useAppStore = create<AppState>((set, get) => ({
           nextVisibilityRaw !== "private" && hasPrivateLibrarySiteReferences(preset.snapshot.sites, state.siteLibrary)
             ? "private"
             : nextVisibilityRaw;
+        const snapshotPatch =
+          patch.simulationDefaultsOverrideEnabled !== undefined || patch.simulationDefaultsOverride !== undefined
+            ? {
+                snapshot: {
+                  ...preset.snapshot,
+                  simulationDefaultsOverrideEnabled:
+                    patch.simulationDefaultsOverrideEnabled ?? preset.snapshot.simulationDefaultsOverrideEnabled,
+                  simulationDefaultsOverride:
+                    patch.simulationDefaultsOverride === null
+                      ? undefined
+                      : patch.simulationDefaultsOverride ?? preset.snapshot.simulationDefaultsOverride,
+                },
+              }
+            : {};
         return {
           ...preset,
           ...patch,
+          ...snapshotPatch,
           name: nextName,
           description: nextDescription,
           slug: nextSlug,
@@ -3244,6 +3324,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     const { selectedFrequencyPresetId, selectedNetworkId } = get();
     const preset = findPresetById(selectedFrequencyPresetId);
     if (!preset) return;
+    const defaults = simulationDefaultsFromPreset(preset.id);
 
     set((state) => ({
       networks: state.networks.map((network) =>
@@ -3260,6 +3341,10 @@ export const useAppStore = create<AppState>((set, get) => ({
           : network,
       ),
       links: state.links.map((link) => ({ ...link, frequencyMHz: preset.frequencyMHz })),
+      rxSensitivityTargetDbm: defaults.rxSensitivityTargetDbm,
+      environmentLossDb: defaults.environmentLossDb,
+      propagationEnvironment: defaults.propagationEnvironment,
+      autoPropagationEnvironment: defaults.autoPropagationEnvironment,
     }));
     useCoverageStore.getState().recomputeCoverage();
     get().updateCurrentSimulationSnapshot();


### PR DESCRIPTION
## Summary
- Add cloud-synced simulation defaults preferences with preset override/custom modes.
- Add simulation-level inherited defaults override controls for channel, RX target, and environment settings.
- Make RX target read-only in results and resolve inherited defaults dynamically for saved simulations without overrides.

## Verification
- npx vitest run --config config/vitest.config.ts src/store/appStore.test.ts
- npx tsc -b config/tsconfig.json
- npx vite build --config config/vite.config.ts

Note: standard npm test/build are blocked locally by an unrelated pre-existing deletion of scripts/generate-build-info.mjs.

Fixes #847