### PR TITLE
Make simulation preset defaults explicit

### DIFF
--- a/src/components/map/MapEditorPanel.tsx
+++ b/src/components/map/MapEditorPanel.tsx
@@ -1,7 +1,6 @@
 import { createPortal } from "react-dom";
 import { useEffect, useRef, useState } from "react";
 import { History, Loader2, RefreshCw, Search } from "lucide-react";
-import { FREQUENCY_PRESETS, frequencyPresetGroups } from "../../lib/frequencyPlans";
 import {
   fetchResourceChanges,
   fetchUserById,
@@ -638,39 +637,6 @@ function SimulationEditorCard({
           ownerUserId={form.ownerUserId}
           visibility={form.accessVisibility}
         />
-        {isNew ? (
-          <>
-            <label className="field-grid">
-              <span>Frequency Plan</span>
-              <select
-                className="locale-select"
-                onChange={(e) => form.setSimulationFrequencyPresetId(e.target.value)}
-                value={form.simulationFrequencyPresetId}
-              >
-                {frequencyPresetGroups(FREQUENCY_PRESETS).map((groupEntry) => (
-                  <optgroup key={groupEntry.group} label={groupEntry.group}>
-                    {groupEntry.presets.map((preset) => (
-                      <option key={preset.id} value={preset.id}>
-                        {preset.label}
-                      </option>
-                    ))}
-                  </optgroup>
-                ))}
-              </select>
-            </label>
-            <label className="field-grid">
-              <span>Auto environment defaults</span>
-              <select
-                className="locale-select"
-                onChange={(e) => form.setSimulationAutoPropagationEnvironment(e.target.value === "auto")}
-                value={form.simulationAutoPropagationEnvironment ? "auto" : "manual"}
-              >
-                <option value="auto">Auto (recommended)</option>
-                <option value="manual">Manual override</option>
-              </select>
-            </label>
-          </>
-        ) : null}
         <label className="field-grid">
           <span>Override inherited simulation defaults</span>
           <input
@@ -716,6 +682,9 @@ function SimulationEditorCard({
               <span>Auto environment defaults</span>
               <input aria-label="Auto environment defaults" checked={form.simulationDefaultsDraft.autoPropagationEnvironment} onChange={(e) => form.setSimulationDefaultsDraft({ autoPropagationEnvironment: e.target.checked })} type="checkbox" />
             </label>
+            {form.simulationDefaultsDraft.autoPropagationEnvironment ? (
+              <p className="field-help">Auto derives climate and clutter from terrain for each path. Turn it off to use fixed manual environment values.</p>
+            ) : null}
           </>
         )}
       </fieldset>

--- a/src/components/settings/sections/PreferencesSection.tsx
+++ b/src/components/settings/sections/PreferencesSection.tsx
@@ -223,22 +223,28 @@ export function PreferencesSection({ me, onMeUpdated }: PreferencesSectionProps)
               <span>Auto environment defaults</span>
               <input aria-label="Auto environment defaults" checked={activeDefaults.autoPropagationEnvironment} onChange={(event) => patchPreferenceDefaults({ autoPropagationEnvironment: event.target.checked })} type="checkbox" />
             </label>
-            <label className="field-grid">
-              <span>Radio climate</span>
-              <select className="locale-select" value={activeDefaults.propagationEnvironment.radioClimate} onChange={(event) => patchPreferenceDefaults({ propagationEnvironment: { ...activeDefaults.propagationEnvironment, radioClimate: event.target.value as SimulationDefaults["propagationEnvironment"]["radioClimate"] } })}>
-                <option value="Continental Temperate">Continental Temperate</option>
-                <option value="Maritime Temperate (Land)">Maritime Temperate (Land)</option>
-                <option value="Maritime Temperate (Sea)">Maritime Temperate (Sea)</option>
-                <option value="Desert">Desert</option>
-                <option value="Equatorial">Equatorial</option>
-                <option value="Continental Subtropical">Continental Subtropical</option>
-                <option value="Maritime Subtropical">Maritime Subtropical</option>
-              </select>
-            </label>
-            <label className="field-grid">
-              <span>Clutter height (m)</span>
-              <input type="number" value={activeDefaults.propagationEnvironment.clutterHeightM} onChange={(event) => patchPreferenceDefaults({ propagationEnvironment: { ...activeDefaults.propagationEnvironment, clutterHeightM: Number(event.target.value) } })} />
-            </label>
+            {activeDefaults.autoPropagationEnvironment ? (
+              <p className="field-help">Auto derives climate and clutter from terrain for each path. Turn it off to use fixed manual environment values.</p>
+            ) : (
+              <>
+                <label className="field-grid">
+                  <span>Radio climate</span>
+                  <select className="locale-select" value={activeDefaults.propagationEnvironment.radioClimate} onChange={(event) => patchPreferenceDefaults({ propagationEnvironment: { ...activeDefaults.propagationEnvironment, radioClimate: event.target.value as SimulationDefaults["propagationEnvironment"]["radioClimate"] } })}>
+                    <option value="Continental Temperate">Continental Temperate</option>
+                    <option value="Maritime Temperate (Land)">Maritime Temperate (Land)</option>
+                    <option value="Maritime Temperate (Sea)">Maritime Temperate (Sea)</option>
+                    <option value="Desert">Desert</option>
+                    <option value="Equatorial">Equatorial</option>
+                    <option value="Continental Subtropical">Continental Subtropical</option>
+                    <option value="Maritime Subtropical">Maritime Subtropical</option>
+                  </select>
+                </label>
+                <label className="field-grid">
+                  <span>Clutter height (m)</span>
+                  <input type="number" value={activeDefaults.propagationEnvironment.clutterHeightM} onChange={(event) => patchPreferenceDefaults({ propagationEnvironment: { ...activeDefaults.propagationEnvironment, clutterHeightM: Number(event.target.value) } })} />
+                </label>
+              </>
+            )}
           </div>
         ) : null}
       </div>

--- a/src/lib/frequencyPlans.test.ts
+++ b/src/lib/frequencyPlans.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { FREQUENCY_PRESETS, findPresetById } from "./frequencyPlans";
+
+describe("frequency presets", () => {
+  it("defines complete simulation defaults for every preset", () => {
+    for (const preset of FREQUENCY_PRESETS) {
+      expect(Number.isFinite(preset.rxSensitivityTargetDbm)).toBe(true);
+      expect(Number.isFinite(preset.environmentLossDb)).toBe(true);
+      expect(typeof preset.autoPropagationEnvironment).toBe("boolean");
+      expect(preset.propagationEnvironment.radioClimate).toBeTruthy();
+      expect(preset.propagationEnvironment.polarization).toBeTruthy();
+      expect(Number.isFinite(preset.propagationEnvironment.clutterHeightM)).toBe(true);
+      expect(Number.isFinite(preset.propagationEnvironment.groundDielectric)).toBe(true);
+      expect(Number.isFinite(preset.propagationEnvironment.groundConductivity)).toBe(true);
+      expect(Number.isFinite(preset.propagationEnvironment.atmosphericBendingNUnits)).toBe(true);
+    }
+  });
+
+  it("uses -130 dBm RX target for Oslo Local", () => {
+    expect(findPresetById("oslo-local-869618")?.rxSensitivityTargetDbm).toBe(-130);
+  });
+});

--- a/src/lib/frequencyPlans.ts
+++ b/src/lib/frequencyPlans.ts
@@ -6,7 +6,6 @@ import {
   type FrequencyPresetSource,
   type FrequencyPresetSourceFamily,
 } from "./frequencyPresets.data";
-import { defaultPropagationEnvironment } from "./propagationEnvironment";
 import type { PropagationEnvironment } from "../types/radio";
 
 export type FrequencyPreset = {
@@ -37,10 +36,10 @@ const buildFrequencyPresets = (): FrequencyPreset[] => {
       presets.push({
         ...preset,
         sortOrder,
-        rxSensitivityTargetDbm: preset.rxSensitivityTargetDbm ?? -120,
-        environmentLossDb: preset.environmentLossDb ?? 0,
-        propagationEnvironment: preset.propagationEnvironment ?? defaultPropagationEnvironment(),
-        autoPropagationEnvironment: preset.autoPropagationEnvironment ?? true,
+        rxSensitivityTargetDbm: preset.defaults.rxSensitivityTargetDbm,
+        environmentLossDb: preset.defaults.environmentLossDb,
+        propagationEnvironment: preset.defaults.propagationEnvironment,
+        autoPropagationEnvironment: preset.defaults.autoPropagationEnvironment,
       });
     }
   }

--- a/src/lib/frequencyPresets.data.ts
+++ b/src/lib/frequencyPresets.data.ts
@@ -4,6 +4,13 @@ export type FrequencyPresetGroup = "Meshtastic Regional" | "MeshCore Community" 
 export type FrequencyPresetSource = "Meshtastic" | "MeshCore" | "Reference" | "Local";
 export type FrequencyPresetSourceFamily = "meshtastic" | "meshcore" | "reference" | "local";
 
+export type FrequencyPresetDefaults = {
+  rxSensitivityTargetDbm: number;
+  environmentLossDb: number;
+  propagationEnvironment: PropagationEnvironment;
+  autoPropagationEnvironment: boolean;
+};
+
 export type FrequencyPresetData = {
   id: string;
   label: string;
@@ -16,10 +23,7 @@ export type FrequencyPresetData = {
   codingRate: number;
   regionCode?: string;
   notes?: string;
-  rxSensitivityTargetDbm?: number;
-  environmentLossDb?: number;
-  propagationEnvironment?: PropagationEnvironment;
-  autoPropagationEnvironment?: boolean;
+  defaults: FrequencyPresetDefaults;
 };
 
 export const FREQUENCY_PRESET_GROUP_ORDER: FrequencyPresetGroup[] = [
@@ -29,6 +33,22 @@ export const FREQUENCY_PRESET_GROUP_ORDER: FrequencyPresetGroup[] = [
   "Local / Community",
 ];
 
+const STANDARD_PROPAGATION_ENVIRONMENT: PropagationEnvironment = {
+  radioClimate: "Continental Temperate",
+  polarization: "Vertical",
+  clutterHeightM: 10,
+  groundDielectric: 15,
+  groundConductivity: 0.005,
+  atmosphericBendingNUnits: 301,
+};
+
+const standardDefaults = (rxSensitivityTargetDbm = -120): FrequencyPresetDefaults => ({
+  rxSensitivityTargetDbm,
+  environmentLossDb: 0,
+  propagationEnvironment: STANDARD_PROPAGATION_ENVIRONMENT,
+  autoPropagationEnvironment: true,
+});
+
 export const FREQUENCY_PRESET_DATA_BY_GROUP: Array<{
   group: FrequencyPresetGroup;
   presets: FrequencyPresetData[];
@@ -36,58 +56,58 @@ export const FREQUENCY_PRESET_DATA_BY_GROUP: Array<{
   {
     group: "Meshtastic Regional",
     presets: [
-      { id: "mt-us", label: "Meshtastic US", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 915.0, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "US", notes: "902-928 MHz region span" },
-      { id: "mt-eu_433", label: "Meshtastic EU_433", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 433.5, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "EU_433", notes: "433-434 MHz region span" },
-      { id: "mt-eu_868", label: "Meshtastic EU_868", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 869.525, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "EU_868", notes: "869.4-869.65 MHz region span" },
-      { id: "mt-cn", label: "Meshtastic CN", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 490.0, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "CN", notes: "470-510 MHz region span" },
-      { id: "mt-jp", label: "Meshtastic JP", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 924.3, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "JP", notes: "920.8-927.8 MHz region span" },
-      { id: "mt-anz", label: "Meshtastic ANZ", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 921.5, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "ANZ", notes: "915-928 MHz region span" },
-      { id: "mt-anz_433", label: "Meshtastic ANZ_433", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 433.92, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "ANZ_433", notes: "433.05-434.79 MHz region span" },
-      { id: "mt-kr", label: "Meshtastic KR", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 921.5, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "KR", notes: "920-923 MHz region span" },
-      { id: "mt-tw", label: "Meshtastic TW", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 922.5, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "TW", notes: "920-925 MHz region span" },
-      { id: "mt-ru", label: "Meshtastic RU", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 868.95, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "RU", notes: "868.7-869.2 MHz region span" },
-      { id: "mt-in", label: "Meshtastic IN", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 866.0, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "IN", notes: "865-867 MHz region span" },
-      { id: "mt-nz_865", label: "Meshtastic NZ_865", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 866.0, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "NZ_865", notes: "864-868 MHz region span" },
-      { id: "mt-th", label: "Meshtastic TH", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 922.5, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "TH", notes: "920-925 MHz region span" },
-      { id: "mt-ua_433", label: "Meshtastic UA_433", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 433.85, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "UA_433", notes: "433-434.7 MHz region span" },
-      { id: "mt-ua_868", label: "Meshtastic UA_868", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 868.3, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "UA_868", notes: "868-868.6 MHz region span" },
-      { id: "mt-my_433", label: "Meshtastic MY_433", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 434.0, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "MY_433", notes: "433-435 MHz region span" },
-      { id: "mt-my_919", label: "Meshtastic MY_919", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 921.5, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "MY_919", notes: "919-924 MHz region span" },
-      { id: "mt-sg_923", label: "Meshtastic SG_923", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 921.0, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "SG_923", notes: "917-925 MHz region span" },
-      { id: "mt-kz_433", label: "Meshtastic KZ_433", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 433.925, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "KZ_433", notes: "433.075-434.775 MHz region span" },
-      { id: "mt-kz_863", label: "Meshtastic KZ_863", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 865.5, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "KZ_863", notes: "863-868 MHz region span" },
-      { id: "mt-ph_433", label: "Meshtastic PH_433", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 433.85, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "PH_433", notes: "433-434.7 MHz region span" },
-      { id: "mt-ph_868", label: "Meshtastic PH_868", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 868.7, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "PH_868", notes: "868-869.4 MHz region span" },
-      { id: "mt-ph_915", label: "Meshtastic PH_915", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 916.5, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "PH_915", notes: "915-918 MHz region span" },
-      { id: "mt-br_902", label: "Meshtastic BR_902", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 904.75, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "BR_902", notes: "902-907.5 MHz region span" },
-      { id: "mt-np_865", label: "Meshtastic NP_865", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 866.5, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "NP_865", notes: "865-868 MHz region span" },
-      { id: "mt-lora_24", label: "Meshtastic LORA_24", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 2441.75, bandwidthKhz: 812.5, spreadFactor: 11, codingRate: 5, regionCode: "LORA_24", notes: "2400-2483.5 MHz region span" },
+      { id: "mt-us", label: "Meshtastic US", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 915.0, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "US", notes: "902-928 MHz region span", defaults: standardDefaults() },
+      { id: "mt-eu_433", label: "Meshtastic EU_433", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 433.5, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "EU_433", notes: "433-434 MHz region span", defaults: standardDefaults() },
+      { id: "mt-eu_868", label: "Meshtastic EU_868", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 869.525, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "EU_868", notes: "869.4-869.65 MHz region span", defaults: standardDefaults() },
+      { id: "mt-cn", label: "Meshtastic CN", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 490.0, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "CN", notes: "470-510 MHz region span", defaults: standardDefaults() },
+      { id: "mt-jp", label: "Meshtastic JP", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 924.3, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "JP", notes: "920.8-927.8 MHz region span", defaults: standardDefaults() },
+      { id: "mt-anz", label: "Meshtastic ANZ", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 921.5, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "ANZ", notes: "915-928 MHz region span", defaults: standardDefaults() },
+      { id: "mt-anz_433", label: "Meshtastic ANZ_433", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 433.92, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "ANZ_433", notes: "433.05-434.79 MHz region span", defaults: standardDefaults() },
+      { id: "mt-kr", label: "Meshtastic KR", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 921.5, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "KR", notes: "920-923 MHz region span", defaults: standardDefaults() },
+      { id: "mt-tw", label: "Meshtastic TW", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 922.5, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "TW", notes: "920-925 MHz region span", defaults: standardDefaults() },
+      { id: "mt-ru", label: "Meshtastic RU", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 868.95, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "RU", notes: "868.7-869.2 MHz region span", defaults: standardDefaults() },
+      { id: "mt-in", label: "Meshtastic IN", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 866.0, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "IN", notes: "865-867 MHz region span", defaults: standardDefaults() },
+      { id: "mt-nz_865", label: "Meshtastic NZ_865", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 866.0, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "NZ_865", notes: "864-868 MHz region span", defaults: standardDefaults() },
+      { id: "mt-th", label: "Meshtastic TH", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 922.5, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "TH", notes: "920-925 MHz region span", defaults: standardDefaults() },
+      { id: "mt-ua_433", label: "Meshtastic UA_433", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 433.85, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "UA_433", notes: "433-434.7 MHz region span", defaults: standardDefaults() },
+      { id: "mt-ua_868", label: "Meshtastic UA_868", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 868.3, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "UA_868", notes: "868-868.6 MHz region span", defaults: standardDefaults() },
+      { id: "mt-my_433", label: "Meshtastic MY_433", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 434.0, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "MY_433", notes: "433-435 MHz region span", defaults: standardDefaults() },
+      { id: "mt-my_919", label: "Meshtastic MY_919", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 921.5, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "MY_919", notes: "919-924 MHz region span", defaults: standardDefaults() },
+      { id: "mt-sg_923", label: "Meshtastic SG_923", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 921.0, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "SG_923", notes: "917-925 MHz region span", defaults: standardDefaults() },
+      { id: "mt-kz_433", label: "Meshtastic KZ_433", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 433.925, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "KZ_433", notes: "433.075-434.775 MHz region span", defaults: standardDefaults() },
+      { id: "mt-kz_863", label: "Meshtastic KZ_863", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 865.5, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "KZ_863", notes: "863-868 MHz region span", defaults: standardDefaults() },
+      { id: "mt-ph_433", label: "Meshtastic PH_433", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 433.85, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "PH_433", notes: "433-434.7 MHz region span", defaults: standardDefaults() },
+      { id: "mt-ph_868", label: "Meshtastic PH_868", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 868.7, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "PH_868", notes: "868-869.4 MHz region span", defaults: standardDefaults() },
+      { id: "mt-ph_915", label: "Meshtastic PH_915", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 916.5, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "PH_915", notes: "915-918 MHz region span", defaults: standardDefaults() },
+      { id: "mt-br_902", label: "Meshtastic BR_902", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 904.75, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "BR_902", notes: "902-907.5 MHz region span", defaults: standardDefaults() },
+      { id: "mt-np_865", label: "Meshtastic NP_865", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 866.5, bandwidthKhz: 250, spreadFactor: 11, codingRate: 5, regionCode: "NP_865", notes: "865-868 MHz region span", defaults: standardDefaults() },
+      { id: "mt-lora_24", label: "Meshtastic LORA_24", source: "Meshtastic", sourceFamily: "meshtastic", group: "Meshtastic Regional", frequencyMHz: 2441.75, bandwidthKhz: 812.5, spreadFactor: 11, codingRate: 5, regionCode: "LORA_24", notes: "2400-2483.5 MHz region span", defaults: standardDefaults() },
     ],
   },
   {
     group: "MeshCore Community",
     presets: [
-      { id: "meshcore-eu-narrow-869525-sf8-bw625-cr5", label: "MeshCore EU Narrow 869.525", source: "MeshCore", sourceFamily: "meshcore", group: "MeshCore Community", frequencyMHz: 869.525, bandwidthKhz: 62.5, spreadFactor: 8, codingRate: 5, regionCode: "EU_868", notes: "MeshCore community narrow profile" },
-      { id: "meshcore-eu-fast-869525-sf7-bw625-cr5", label: "MeshCore EU Fast 869.525", source: "MeshCore", sourceFamily: "meshcore", group: "MeshCore Community", frequencyMHz: 869.525, bandwidthKhz: 62.5, spreadFactor: 7, codingRate: 5, regionCode: "EU_868", notes: "MeshCore community fast profile" },
-      { id: "meshcore-us-narrow-910525-sf7-bw625-cr5", label: "MeshCore US Narrow 910.525", source: "MeshCore", sourceFamily: "meshcore", group: "MeshCore Community", frequencyMHz: 910.525, bandwidthKhz: 62.5, spreadFactor: 7, codingRate: 5, regionCode: "US", notes: "MeshCore community recommended profile" },
-      { id: "meshcore-us-balanced-910525-sf8-bw625-cr5", label: "MeshCore US Balanced 910.525", source: "MeshCore", sourceFamily: "meshcore", group: "MeshCore Community", frequencyMHz: 910.525, bandwidthKhz: 62.5, spreadFactor: 8, codingRate: 5, regionCode: "US", notes: "MeshCore community balanced profile" },
-      { id: "meshcore-anz-narrow-917525-sf7-bw625-cr5", label: "MeshCore ANZ Narrow 917.525", source: "MeshCore", sourceFamily: "meshcore", group: "MeshCore Community", frequencyMHz: 917.525, bandwidthKhz: 62.5, spreadFactor: 7, codingRate: 5, regionCode: "ANZ", notes: "MeshCore community narrow profile" },
+      { id: "meshcore-eu-narrow-869525-sf8-bw625-cr5", label: "MeshCore EU Narrow 869.525", source: "MeshCore", sourceFamily: "meshcore", group: "MeshCore Community", frequencyMHz: 869.525, bandwidthKhz: 62.5, spreadFactor: 8, codingRate: 5, regionCode: "EU_868", notes: "MeshCore community narrow profile", defaults: standardDefaults() },
+      { id: "meshcore-eu-fast-869525-sf7-bw625-cr5", label: "MeshCore EU Fast 869.525", source: "MeshCore", sourceFamily: "meshcore", group: "MeshCore Community", frequencyMHz: 869.525, bandwidthKhz: 62.5, spreadFactor: 7, codingRate: 5, regionCode: "EU_868", notes: "MeshCore community fast profile", defaults: standardDefaults() },
+      { id: "meshcore-us-narrow-910525-sf7-bw625-cr5", label: "MeshCore US Narrow 910.525", source: "MeshCore", sourceFamily: "meshcore", group: "MeshCore Community", frequencyMHz: 910.525, bandwidthKhz: 62.5, spreadFactor: 7, codingRate: 5, regionCode: "US", notes: "MeshCore community recommended profile", defaults: standardDefaults() },
+      { id: "meshcore-us-balanced-910525-sf8-bw625-cr5", label: "MeshCore US Balanced 910.525", source: "MeshCore", sourceFamily: "meshcore", group: "MeshCore Community", frequencyMHz: 910.525, bandwidthKhz: 62.5, spreadFactor: 8, codingRate: 5, regionCode: "US", notes: "MeshCore community balanced profile", defaults: standardDefaults() },
+      { id: "meshcore-anz-narrow-917525-sf7-bw625-cr5", label: "MeshCore ANZ Narrow 917.525", source: "MeshCore", sourceFamily: "meshcore", group: "MeshCore Community", frequencyMHz: 917.525, bandwidthKhz: 62.5, spreadFactor: 7, codingRate: 5, regionCode: "ANZ", notes: "MeshCore community narrow profile", defaults: standardDefaults() },
     ],
   },
   {
     group: "Amateur / Reference",
     presets: [
-      { id: "rm-vhf-2m", label: "VHF 2m Reference", source: "Reference", sourceFamily: "reference", group: "Amateur / Reference", frequencyMHz: 145.0, bandwidthKhz: 125, spreadFactor: 11, codingRate: 5 },
-      { id: "rm-uhf-70cm", label: "UHF 70cm Reference", source: "Reference", sourceFamily: "reference", group: "Amateur / Reference", frequencyMHz: 433.92, bandwidthKhz: 125, spreadFactor: 11, codingRate: 5 },
-      { id: "rm-23cm", label: "23cm Reference", source: "Reference", sourceFamily: "reference", group: "Amateur / Reference", frequencyMHz: 1296.0, bandwidthKhz: 125, spreadFactor: 11, codingRate: 5 },
-      { id: "rm-13cm", label: "13cm Reference", source: "Reference", sourceFamily: "reference", group: "Amateur / Reference", frequencyMHz: 2400.0, bandwidthKhz: 125, spreadFactor: 11, codingRate: 5 },
-      { id: "rm-6cm", label: "6cm Reference", source: "Reference", sourceFamily: "reference", group: "Amateur / Reference", frequencyMHz: 5800.0, bandwidthKhz: 125, spreadFactor: 11, codingRate: 5 },
+      { id: "rm-vhf-2m", label: "VHF 2m Reference", source: "Reference", sourceFamily: "reference", group: "Amateur / Reference", frequencyMHz: 145.0, bandwidthKhz: 125, spreadFactor: 11, codingRate: 5, defaults: standardDefaults() },
+      { id: "rm-uhf-70cm", label: "UHF 70cm Reference", source: "Reference", sourceFamily: "reference", group: "Amateur / Reference", frequencyMHz: 433.92, bandwidthKhz: 125, spreadFactor: 11, codingRate: 5, defaults: standardDefaults() },
+      { id: "rm-23cm", label: "23cm Reference", source: "Reference", sourceFamily: "reference", group: "Amateur / Reference", frequencyMHz: 1296.0, bandwidthKhz: 125, spreadFactor: 11, codingRate: 5, defaults: standardDefaults() },
+      { id: "rm-13cm", label: "13cm Reference", source: "Reference", sourceFamily: "reference", group: "Amateur / Reference", frequencyMHz: 2400.0, bandwidthKhz: 125, spreadFactor: 11, codingRate: 5, defaults: standardDefaults() },
+      { id: "rm-6cm", label: "6cm Reference", source: "Reference", sourceFamily: "reference", group: "Amateur / Reference", frequencyMHz: 5800.0, bandwidthKhz: 125, spreadFactor: 11, codingRate: 5, defaults: standardDefaults() },
     ],
   },
   {
     group: "Local / Community",
     presets: [
-      { id: "oslo-local-869618", label: "Oslo Local 869.618", source: "Local", sourceFamily: "local", group: "Local / Community", frequencyMHz: 869.618, bandwidthKhz: 62, spreadFactor: 8, codingRate: 5, regionCode: "EU_868", notes: "Local profile: BW 62kHz, SF8, CR 5" },
+      { id: "oslo-local-869618", label: "Oslo Local 869.618", source: "Local", sourceFamily: "local", group: "Local / Community", frequencyMHz: 869.618, bandwidthKhz: 62, spreadFactor: 8, codingRate: 5, regionCode: "EU_868", notes: "Local profile: BW 62kHz, SF8, CR 5", defaults: standardDefaults(-130) },
     ],
   },
 ];


### PR DESCRIPTION
## Summary
- Move preset RX/environment defaults into explicit per-preset data entries.
- Set Oslo Local RX target to -130 dBm.
- Clarify auto environment behavior by hiding manual fields while auto is enabled and removing duplicate new-simulation controls.

## Verification
- npx vitest run --config config/vitest.config.ts src/lib/frequencyPlans.test.ts src/store/appStore.test.ts src/components/map/MapEditorPanel.test.tsx
- npx tsc -b config/tsconfig.json
- npx vite build --config config/vite.config.ts

Follow-up for #847