### PR TITLE
Fix manual environment defaults editing

### DIFF
--- a/src/components/map/MapEditorPanel.tsx
+++ b/src/components/map/MapEditorPanel.tsx
@@ -684,7 +684,38 @@ function SimulationEditorCard({
             </label>
             {form.simulationDefaultsDraft.autoPropagationEnvironment ? (
               <p className="field-help">Auto derives climate and clutter from terrain for each path. Turn it off to use fixed manual environment values.</p>
-            ) : null}
+            ) : (
+              <>
+                <label className="field-grid">
+                  <span>Radio climate</span>
+                  <select className="locale-select" value={form.simulationDefaultsDraft.propagationEnvironment.radioClimate} onChange={(e) => form.setSimulationDefaultsDraft({ propagationEnvironment: { ...form.simulationDefaultsDraft.propagationEnvironment, radioClimate: e.target.value as typeof form.simulationDefaultsDraft.propagationEnvironment.radioClimate } })}>
+                    <option value="Continental Temperate">Continental Temperate</option>
+                    <option value="Maritime Temperate (Land)">Maritime Temperate (Land)</option>
+                    <option value="Maritime Temperate (Sea)">Maritime Temperate (Sea)</option>
+                    <option value="Desert">Desert</option>
+                    <option value="Equatorial">Equatorial</option>
+                    <option value="Continental Subtropical">Continental Subtropical</option>
+                    <option value="Maritime Subtropical">Maritime Subtropical</option>
+                  </select>
+                </label>
+                <label className="field-grid">
+                  <span>Clutter height (m)</span>
+                  <input type="number" value={form.simulationDefaultsDraft.propagationEnvironment.clutterHeightM} onChange={(e) => form.setSimulationDefaultsDraft({ propagationEnvironment: { ...form.simulationDefaultsDraft.propagationEnvironment, clutterHeightM: Number(e.target.value) } })} />
+                </label>
+                <label className="field-grid">
+                  <span>Ground dielectric</span>
+                  <input type="number" value={form.simulationDefaultsDraft.propagationEnvironment.groundDielectric} onChange={(e) => form.setSimulationDefaultsDraft({ propagationEnvironment: { ...form.simulationDefaultsDraft.propagationEnvironment, groundDielectric: Number(e.target.value) } })} />
+                </label>
+                <label className="field-grid">
+                  <span>Ground conductivity</span>
+                  <input type="number" value={form.simulationDefaultsDraft.propagationEnvironment.groundConductivity} onChange={(e) => form.setSimulationDefaultsDraft({ propagationEnvironment: { ...form.simulationDefaultsDraft.propagationEnvironment, groundConductivity: Number(e.target.value) } })} />
+                </label>
+                <label className="field-grid">
+                  <span>Atmospheric bending (N-units)</span>
+                  <input type="number" value={form.simulationDefaultsDraft.propagationEnvironment.atmosphericBendingNUnits} onChange={(e) => form.setSimulationDefaultsDraft({ propagationEnvironment: { ...form.simulationDefaultsDraft.propagationEnvironment, atmosphericBendingNUnits: Number(e.target.value) } })} />
+                </label>
+              </>
+            )}
           </>
         )}
       </fieldset>

--- a/src/components/settings/sections/PreferencesSection.tsx
+++ b/src/components/settings/sections/PreferencesSection.tsx
@@ -243,6 +243,18 @@ export function PreferencesSection({ me, onMeUpdated }: PreferencesSectionProps)
                   <span>Clutter height (m)</span>
                   <input type="number" value={activeDefaults.propagationEnvironment.clutterHeightM} onChange={(event) => patchPreferenceDefaults({ propagationEnvironment: { ...activeDefaults.propagationEnvironment, clutterHeightM: Number(event.target.value) } })} />
                 </label>
+                <label className="field-grid">
+                  <span>Ground dielectric</span>
+                  <input type="number" value={activeDefaults.propagationEnvironment.groundDielectric} onChange={(event) => patchPreferenceDefaults({ propagationEnvironment: { ...activeDefaults.propagationEnvironment, groundDielectric: Number(event.target.value) } })} />
+                </label>
+                <label className="field-grid">
+                  <span>Ground conductivity</span>
+                  <input type="number" value={activeDefaults.propagationEnvironment.groundConductivity} onChange={(event) => patchPreferenceDefaults({ propagationEnvironment: { ...activeDefaults.propagationEnvironment, groundConductivity: Number(event.target.value) } })} />
+                </label>
+                <label className="field-grid">
+                  <span>Atmospheric bending (N-units)</span>
+                  <input type="number" value={activeDefaults.propagationEnvironment.atmosphericBendingNUnits} onChange={(event) => patchPreferenceDefaults({ propagationEnvironment: { ...activeDefaults.propagationEnvironment, atmosphericBendingNUnits: Number(event.target.value) } })} />
+                </label>
               </>
             )}
           </div>

--- a/src/lib/simulationDefaults.ts
+++ b/src/lib/simulationDefaults.ts
@@ -35,7 +35,7 @@ export const simulationDefaultsFromPreset = (presetId: string): SimulationDefaul
       spreadFactor: 8,
       codingRate: 5,
       regionCode: "EU_868",
-      rxSensitivityTargetDbm: -120,
+      rxSensitivityTargetDbm: -130,
       environmentLossDb: 0,
       propagationEnvironment: defaultPropagationEnvironment(),
       autoPropagationEnvironment: true,

--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -601,6 +601,18 @@ describe("appStore new simulation default frequency preset", () => {
   });
 });
 
+describe("appStore built-in scenario defaults", () => {
+  beforeEach(() => {
+    storage.mock.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("uses the preset RX target for the starter workspace", () => {
+    useAppStore.getState().selectScenario("workspace-starter");
+    expect(useAppStore.getState().rxSensitivityTargetDbm).toBe(-130);
+  });
+});
+
 describe("appStore blank simulation loading", () => {
   beforeEach(() => {
     storage.mock.clear();

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -20,7 +20,6 @@ import {
   withSiteRadioDefaults,
 } from "../lib/linkRadio";
 import {
-  defaultPropagationEnvironment,
   deriveDynamicPropagationEnvironment,
   withClimateDefaults,
 } from "../lib/propagationEnvironment";
@@ -1208,6 +1207,24 @@ const defaultOverlayModeForSelectionCount = (selectionCount: number): MapOverlay
   return "heatmap";
 };
 
+const applyDefaultsToScenarioNetworks = (networks: Network[], defaults: SimulationDefaults): Network[] =>
+  networks.map((network, index) =>
+    index === 0
+      ? {
+          ...network,
+          frequencyMHz: defaults.frequencyMHz,
+          frequencyOverrideMHz: defaults.frequencyMHz,
+          bandwidthKhz: defaults.bandwidthKhz,
+          spreadFactor: defaults.spreadFactor,
+          codingRate: defaults.codingRate,
+          regionCode: defaults.regionCode,
+        }
+      : network,
+  );
+
+const applyDefaultsToScenarioLinks = (links: Link[], defaults: SimulationDefaults): Link[] =>
+  links.map((link) => ({ ...link, frequencyMHz: defaults.frequencyMHz }));
+
 type TerrainFetchBounds = { minLat: number; maxLat: number; minLon: number; maxLon: number };
 
 const bufferedBoundsForSites = (sites: Site[], radiusKm: number): TerrainFetchBounds | null => {
@@ -1238,6 +1255,8 @@ const normalizeCoverageResolution = (value: unknown): CoverageResolution => {
   return "24";
 };
 
+const initialScenarioDefaults = simulationDefaultsFromPreset(defaultScenario.defaultFrequencyPresetId);
+
 export const useAppStore = create<AppState>((set, get) => ({
   sites: [],
   links: [],
@@ -1265,11 +1284,11 @@ export const useAppStore = create<AppState>((set, get) => ({
   basemapStyleId: initialBasemapStyleId,
   selectedScenarioId: getInitialScenarioId(),
   selectedFrequencyPresetId: defaultScenario.defaultFrequencyPresetId,
-  rxSensitivityTargetDbm: -120,
-  environmentLossDb: 0,
-  propagationEnvironment: defaultPropagationEnvironment(),
-  autoPropagationEnvironment: true,
-  propagationEnvironmentReason: "Auto defaults active.",
+  rxSensitivityTargetDbm: initialScenarioDefaults.rxSensitivityTargetDbm,
+  environmentLossDb: initialScenarioDefaults.environmentLossDb,
+  propagationEnvironment: initialScenarioDefaults.propagationEnvironment,
+  autoPropagationEnvironment: initialScenarioDefaults.autoPropagationEnvironment,
+  propagationEnvironmentReason: initialScenarioDefaults.autoPropagationEnvironment ? "Auto defaults active." : "Manual override active.",
   simulationDefaultsOverrideEnabled: false,
   simulationDefaultsOverride: null,
   terrainDataset: "copernicus30",
@@ -1877,6 +1896,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   selectScenario: (id) => {
     const scenario = getScenarioById(id);
     if (!scenario) return;
+    const defaults = simulationDefaultsFromPreset(scenario.defaultFrequencyPresetId);
     const migratedScenario = migrateSitesAndLinksToSiteRadioDefaults(scenario.sites, scenario.links);
     const libraryBacked = ensureSitesBackedByLibrary(migratedScenario.sites, get().siteLibrary);
     if (libraryBacked.addedCount > 0) {
@@ -1885,9 +1905,9 @@ export const useAppStore = create<AppState>((set, get) => ({
     set({
       selectedScenarioId: scenario.id,
       sites: libraryBacked.sites,
-      links: migratedScenario.links,
+      links: applyDefaultsToScenarioLinks(migratedScenario.links, defaults),
       systems: scenario.systems,
-      networks: scenario.networks,
+      networks: applyDefaultsToScenarioNetworks(scenario.networks, defaults),
       selectedSiteId: scenario.defaultSiteId,
       selectedSiteIds: scenario.defaultSiteId ? [scenario.defaultSiteId] : [],
       selectedLinkId: scenario.defaultLinkId,
@@ -1896,11 +1916,11 @@ export const useAppStore = create<AppState>((set, get) => ({
       selectedNetworkId: scenario.defaultNetworkId,
       selectedFrequencyPresetId: scenario.defaultFrequencyPresetId,
       propagationModel: "ITM",
-      rxSensitivityTargetDbm: -120,
-      environmentLossDb: 0,
-      propagationEnvironment: defaultPropagationEnvironment(),
-      autoPropagationEnvironment: true,
-      propagationEnvironmentReason: "Auto defaults active.",
+      rxSensitivityTargetDbm: defaults.rxSensitivityTargetDbm,
+      environmentLossDb: defaults.environmentLossDb,
+      propagationEnvironment: defaults.propagationEnvironment,
+      autoPropagationEnvironment: defaults.autoPropagationEnvironment,
+      propagationEnvironmentReason: defaults.autoPropagationEnvironment ? "Auto defaults active." : "Manual override active.",
       terrainFetchStatus: "",
       terrainRecommendation: "",
       isHighResTerrainLoaded: false,
@@ -1919,6 +1939,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   },
   loadDemoScenario: () => {
     const scenario = DEMO_SCENARIO;
+    const defaults = simulationDefaultsFromPreset(scenario.defaultFrequencyPresetId);
     const libraryBacked = ensureSitesBackedByLibrary(scenario.sites, get().siteLibrary);
     if (libraryBacked.addedCount > 0) {
       writeStorage(SITE_LIBRARY_KEY, libraryBacked.siteLibrary);
@@ -1933,9 +1954,9 @@ export const useAppStore = create<AppState>((set, get) => ({
     set({
       // selectedScenarioId intentionally not set — demo stays invisible in scenario UI
       sites: libraryBacked.sites,
-      links: scenario.links,
+      links: applyDefaultsToScenarioLinks(scenario.links, defaults),
       systems: scenario.systems,
-      networks: scenario.networks,
+      networks: applyDefaultsToScenarioNetworks(scenario.networks, defaults),
       selectedSiteId: selectedSiteIds[0] ?? scenario.defaultSiteId,
       selectedSiteIds,
       selectedLinkId: scenario.defaultLinkId,
@@ -1944,11 +1965,11 @@ export const useAppStore = create<AppState>((set, get) => ({
       selectedNetworkId: scenario.defaultNetworkId,
       selectedFrequencyPresetId: scenario.defaultFrequencyPresetId,
       propagationModel: "ITM",
-      rxSensitivityTargetDbm: -120,
-      environmentLossDb: 0,
-      propagationEnvironment: defaultPropagationEnvironment(),
-      autoPropagationEnvironment: true,
-      propagationEnvironmentReason: "Auto defaults active.",
+      rxSensitivityTargetDbm: defaults.rxSensitivityTargetDbm,
+      environmentLossDb: defaults.environmentLossDb,
+      propagationEnvironment: defaults.propagationEnvironment,
+      autoPropagationEnvironment: defaults.autoPropagationEnvironment,
+      propagationEnvironmentReason: defaults.autoPropagationEnvironment ? "Auto defaults active." : "Manual override active.",
       terrainFetchStatus: "",
       terrainRecommendation: "",
       isHighResTerrainLoaded: false,


### PR DESCRIPTION
## Summary
- Reveal full manual propagation environment fields when auto environment defaults are disabled.
- Apply Oslo Local preset defaults to starter/demo scenario loads so RX target resolves to -130 dBm.
- Align hard fallback simulation defaults with the Oslo Local -130 dBm target.

## Verification
- npx vitest run --config config/vitest.config.ts src/lib/frequencyPlans.test.ts src/store/appStore.test.ts src/components/map/MapEditorPanel.test.tsx
- npx tsc -b config/tsconfig.json
- npx vite build --config config/vite.config.ts

Follow-up for #847