### PR TITLE
Clarify simulation settings editing

### DIFF
--- a/src/components/map/MapEditorPanel.test.tsx
+++ b/src/components/map/MapEditorPanel.test.tsx
@@ -210,6 +210,82 @@ describe("MapEditorPanel", () => {
     expect(await screen.findByText("Change Log · Mesh Plan")).toBeInTheDocument();
   });
 
+  it("shows Simulation settings summary and enables override editing from the edit action", async () => {
+    useAppStore.setState({
+      selectedFrequencyPresetId: "custom",
+      rxSensitivityTargetDbm: -130,
+      autoPropagationEnvironment: true,
+      networks: [
+        {
+          id: "network-1",
+          name: "Primary Network",
+          frequencyMHz: 869.618,
+          frequencyOverrideMHz: 869.618,
+          bandwidthKhz: 62,
+          spreadFactor: 8,
+          codingRate: 5,
+          regionCode: "EU_868",
+          memberships: [],
+        },
+      ],
+      selectedNetworkId: "network-1",
+      simulationPresets: [
+        {
+          id: "sim-1",
+          name: "Mesh Plan",
+          description: "Shared plan",
+          visibility: "shared",
+          sharedWith: [],
+          ownerUserId: "owner-1",
+          effectiveRole: "owner",
+          createdByUserId: "owner-1",
+          createdByName: "Owner User",
+          createdByAvatarUrl: "",
+          lastEditedByUserId: "editor-1",
+          lastEditedByName: "Editor User",
+          lastEditedByAvatarUrl: "",
+          updatedAt: "2026-01-02T00:00:00.000Z",
+          snapshot: {
+            sites: [],
+            links: [],
+            systems: [],
+            networks: [],
+            selectedSiteId: "",
+            selectedLinkId: "",
+            selectedNetworkId: "",
+            selectedCoverageResolution: "24",
+            propagationModel: "ITM",
+            selectedFrequencyPresetId: "custom",
+            rxSensitivityTargetDbm: -130,
+            environmentLossDb: 0,
+            propagationEnvironment: useAppStore.getState().propagationEnvironment,
+            autoPropagationEnvironment: true,
+            terrainDataset: "copernicus30",
+          },
+        },
+      ],
+      mapEditor: {
+        kind: "simulation",
+        resourceId: "sim-1",
+        isNew: false,
+        label: "Mesh Plan",
+        anchorRect,
+      },
+    });
+
+    render(<MapEditorPanel isMobile={false} />);
+
+    expect(await screen.findByText("Simulation settings")).toBeInTheDocument();
+    expect(screen.getByText("869.618 MHz · 62 kHz · SF8 · CR5 · Region EU_868 · RX -130 dBm · Auto environment")).toBeInTheDocument();
+    expect(screen.queryByText("This Simulation inherits the owner's account defaults for channel, RX target, and environment.")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Frequency (MHz)")).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Override Simulation settings" }));
+
+    expect(screen.getByLabelText("Frequency (MHz)")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Use inherited defaults" })).toBeInTheDocument();
+  });
+
   it("keeps the editor open when new site creation fails", async () => {
     const addSiteLibraryEntry = vi.fn(() => "");
     const insertSiteFromLibrary = vi.fn();

--- a/src/components/map/MapEditorPanel.tsx
+++ b/src/components/map/MapEditorPanel.tsx
@@ -1,6 +1,6 @@
 import { createPortal } from "react-dom";
 import { useEffect, useRef, useState } from "react";
-import { History, Loader2, RefreshCw, Search } from "lucide-react";
+import { History, Loader2, Pencil, RefreshCw, Search } from "lucide-react";
 import {
   fetchResourceChanges,
   fetchUserById,
@@ -648,17 +648,34 @@ function SimulationEditorCard({
           ownerUserId={form.ownerUserId}
           visibility={form.accessVisibility}
         />
-        <label className="field-grid">
-          <span>Simulation settings: {simulationDefaultsSummary}</span>
-          <input
-            aria-label="Override Simulation settings"
-            checked={form.simulationDefaultsOverrideEnabled}
-            onChange={(e) => form.setSimulationDefaultsOverrideEnabled(e.target.checked)}
-            type="checkbox"
-          />
-        </label>
+        <div className="simulation-settings-block">
+          <div className="simulation-settings-header">
+            <span>Simulation settings</span>
+            <Button
+              aria-label={form.simulationDefaultsOverrideEnabled ? "Editing Simulation settings" : "Override Simulation settings"}
+              disabled={form.simulationDefaultsOverrideEnabled}
+              isSelected={form.simulationDefaultsOverrideEnabled}
+              onClick={() => form.setSimulationDefaultsOverrideEnabled(true)}
+              size="icon"
+              title={form.simulationDefaultsOverrideEnabled ? "Editing Simulation settings" : "Override Simulation settings"}
+              type="button"
+            >
+              <Pencil aria-hidden="true" size={14} />
+            </Button>
+          </div>
+          <p className="field-help simulation-settings-summary">{simulationDefaultsSummary}</p>
+        </div>
         {form.simulationDefaultsOverrideEnabled ? (
           <>
+            <div className="simulation-settings-actions">
+              <Button
+                onClick={() => form.setSimulationDefaultsOverrideEnabled(false)}
+                type="button"
+                variant="ghost"
+              >
+                Use inherited defaults
+              </Button>
+            </div>
             <label className="field-grid">
               <span>Frequency (MHz)</span>
               <input type="number" value={form.simulationDefaultsDraft.frequencyMHz} onChange={(e) => form.setSimulationDefaultsDraft({ frequencyMHz: Number(e.target.value) })} />

--- a/src/index.css
+++ b/src/index.css
@@ -608,6 +608,29 @@ button {
   flex-shrink: 0;
 }
 
+.simulation-settings-block {
+  display: grid;
+  gap: 6px;
+}
+
+.simulation-settings-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  font-size: 0.82rem;
+  color: var(--muted);
+}
+
+.simulation-settings-summary {
+  margin: 0;
+}
+
+.simulation-settings-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
 /* Upload label piggybacks off btn-ghost; only overrides live here */
 .upload-button {
   border-style: dashed;


### PR DESCRIPTION
## Summary
- Replace the ambiguous Simulation settings checkbox row with a section header, pencil edit action, and separate read-only current settings summary.
- Keep override behavior intact while adding a clear "Use inherited defaults" action when editing is enabled.
- Add focused editor coverage for the summary and edit affordance.

## Verification
- npx vitest run --config config/vitest.config.ts src/components/map/MapEditorPanel.test.tsx
- npx tsc -b config/tsconfig.json
- npx vite build --config config/vite.config.ts

Notes: Standard npm build wrappers remain blocked locally by unrelated deletion of scripts/generate-build-info.mjs in the worktree.