### PR TITLE
Fix heatmap signal semantics

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -259,7 +259,7 @@ type TerrainBounds = {
   minLon: number;
   maxLon: number;
 };
-type CoverageSampleLite = { lat: number; lon: number; valueDbm: number };
+type CoverageSampleLite = { lat: number; lon: number; valueDbm: number; weakestDbm?: number };
 type BandStepMode = "auto" | 3 | 5 | 8 | 10;
 type OverlayRaster = {
   url: string;
@@ -1655,11 +1655,18 @@ export function MapView({
             onProgress,
           } as const;
           let rasterPixels: OverlayRasterPixels | null = null;
-          if (mode === "heatmap" || mode === "contours") {
+          if (mode === "heatmap" || mode === "contours" || mode === "weakest") {
+            const overlaySamples =
+              mode === "weakest"
+                ? samplesForOverlay.map((sample) => ({
+                    ...sample,
+                    valueDbm: sample.weakestDbm ?? sample.valueDbm,
+                  }))
+                : samplesForOverlay;
             rasterPixels = await buildCoverageOverlayPixelsAsync(
               overlayBounds,
-              samplesForOverlay,
-              mode,
+              overlaySamples,
+              mode === "weakest" ? "heatmap" : mode,
               effectiveBandStepDb,
               overlayDimensions,
               overlayPointMask,
@@ -1811,6 +1818,18 @@ export function MapView({
     return { min, max };
   }, [samplesForOverlay]);
 
+  const weakestSignalRange = useMemo(() => {
+    if (!samplesForOverlay.length) return { min: -125, max: -62 };
+    let min = Number.POSITIVE_INFINITY;
+    let max = Number.NEGATIVE_INFINITY;
+    for (const sample of samplesForOverlay) {
+      const value = sample.weakestDbm ?? sample.valueDbm;
+      min = Math.min(min, value);
+      max = Math.max(max, value);
+    }
+    return { min, max };
+  }, [samplesForOverlay]);
+
   const relayRange = useMemo(() => {
     if (!coverageOverlay || coverageVizMode !== "relay") return null;
     if (typeof coverageOverlay.minDbm !== "number" || typeof coverageOverlay.maxDbm !== "number") return null;
@@ -1823,6 +1842,8 @@ export function MapView({
       ? "Heatmap"
       : coverageVizMode === "contours"
         ? "Bands"
+        : coverageVizMode === "weakest"
+          ? "Weakest Site"
         : coverageVizMode === "passfail"
           ? "Pass/Fail"
           : "Relay";
@@ -2623,21 +2644,17 @@ export function MapView({
     fitChromePadding.top,
     fitChromePadding.bottom,
   ]);
-  const allowedOverlayModes = useMemo<Array<"none" | "heatmap" | "contours" | "passfail" | "relay">>(() => {
-    if (selectionCount <= 0) return ["none", "heatmap", "contours"];
-    if (selectionCount === 1) return ["none", "passfail", "heatmap", "contours"];
-    if (selectionCount === 2) return ["none", "relay", "heatmap", "contours"];
-    return ["none", "heatmap", "contours"];
+  const allowedOverlayModes = useMemo<Array<"none" | "heatmap" | "contours" | "weakest" | "passfail" | "relay">>(() => {
+    if (selectionCount <= 0) return ["none", "heatmap", "weakest", "contours"];
+    if (selectionCount === 1) return ["none", "passfail", "heatmap", "weakest", "contours"];
+    if (selectionCount === 2) return ["none", "relay", "heatmap", "weakest", "contours"];
+    return ["none", "heatmap", "weakest", "contours"];
   }, [selectionCount]);
   useEffect(() => {
-    if (coverageVizMode === "heatmap") {
-      setCoverageVizMode("contours");
-      return;
-    }
-    if (allowedOverlayModes.includes(coverageVizMode as "none" | "heatmap" | "contours" | "passfail" | "relay")) return;
-    setCoverageVizMode(selectionCount === 1 ? "passfail" : selectionCount === 2 ? "relay" : "contours");
+    if (allowedOverlayModes.includes(coverageVizMode as "none" | "heatmap" | "contours" | "weakest" | "passfail" | "relay")) return;
+    setCoverageVizMode(selectionCount === 1 ? "passfail" : selectionCount === 2 ? "relay" : "heatmap");
   }, [allowedOverlayModes, coverageVizMode, selectionCount, setCoverageVizMode]);
-  const simulationOverlaySelectValue = coverageVizMode === "contours" ? "heatmap" : coverageVizMode;
+  const simulationOverlaySelectValue = coverageVizMode;
   const siteVisibilityMode: "simulation" | "library" | "mqtt" =
     showDiscoveryMqtt ? "mqtt" : showDiscoverySites ? "library" : "simulation";
   const selectedSite = selectedSites[0] ?? null;
@@ -3004,7 +3021,7 @@ export function MapView({
                 <select
                   className="locale-select"
                   onChange={(event) => {
-                    const mode = event.target.value as "none" | "heatmap" | "contours" | "passfail" | "relay";
+                    const mode = event.target.value as "none" | "heatmap" | "contours" | "weakest" | "passfail" | "relay";
                     if (mode === "heatmap") {
                       setCoverageVizMode("heatmap");
                       return;
@@ -3019,6 +3036,7 @@ export function MapView({
                 >
                   <option value="none">Hidden</option>
                   {allowedOverlayModes.includes("heatmap") ? <option value="heatmap">Heatmap</option> : null}
+                  {allowedOverlayModes.includes("weakest") ? <option value="weakest">Weakest Site</option> : null}
                   {allowedOverlayModes.includes("contours") ? <option value="contours">Contours</option> : null}
                   {allowedOverlayModes.includes("passfail") ? <option value="passfail">Pass/Fail</option> : null}
                   {allowedOverlayModes.includes("relay") ? <option value="relay">Relay</option> : null}
@@ -3092,7 +3110,7 @@ export function MapView({
               <>
                 <p>
                   Shows overall coverage strength from your current simulation sites. Think of it as "how good signal
-                  should feel if you stand here".
+                  should feel if you stand here", using the best available Site signal.
                 </p>
                 <div className="overlay-inline-controls">
                   <span>Style</span>
@@ -3117,6 +3135,22 @@ export function MapView({
                   <div className="overlay-scale-labels">
                     <span>{fmtDbm(signalRange.min)}</span>
                     <span>{fmtDbm(signalRange.max)}</span>
+                  </div>
+                </div>
+                <p className="overlay-scale-help">Left side is weaker signal (worse). Right side is stronger signal (better).</p>
+              </>
+            ) : null}
+            {coverageVizMode === "weakest" ? (
+              <>
+                <p>
+                  Shows the weakest signal from this point to any Site in the Simulation. Use this when the point must
+                  be able to reach every Site, not just the nearest or strongest one.
+                </p>
+                <div className="overlay-scale">
+                  <div className="overlay-scale-bar" />
+                  <div className="overlay-scale-labels">
+                    <span>{fmtDbm(weakestSignalRange.min)}</span>
+                    <span>{fmtDbm(weakestSignalRange.max)}</span>
                   </div>
                 </div>
                 <p className="overlay-scale-help">Left side is weaker signal (worse). Right side is stronger signal (better).</p>

--- a/src/lib/coverage.test.ts
+++ b/src/lib/coverage.test.ts
@@ -70,6 +70,19 @@ describe("buildCoverage", () => {
     expect(high.length).toBeGreaterThan(normal.length);
   });
 
+  it("uses strongest site signal as the default value and keeps weakest signal separately", () => {
+    const result = buildCoverage(NORMAL_GRID, network, sites, systems, defaultPropagationEnvironment());
+    const samplesWithDifferentBestAndWeakest = result.filter(
+      (sample) => typeof sample.weakestDbm === "number" && sample.valueDbm > sample.weakestDbm,
+    );
+
+    expect(samplesWithDifferentBestAndWeakest.length).toBeGreaterThan(0);
+    for (const sample of result) {
+      expect(sample.weakestDbm).toEqual(expect.any(Number));
+      expect(sample.valueDbm).toBeGreaterThanOrEqual(sample.weakestDbm!);
+    }
+  });
+
   it("buildCoverageAsync matches sync output shape", async () => {
     const sync = buildCoverage(NORMAL_GRID, network, sites, systems, defaultPropagationEnvironment());
     const asyncResult = await buildCoverageAsync(NORMAL_GRID, network, sites, systems, defaultPropagationEnvironment());

--- a/src/lib/coverage.ts
+++ b/src/lib/coverage.ts
@@ -242,9 +242,10 @@ export const buildCoverage = (
       })
       .filter((v): v is number => v !== null);
 
-    const valueDbm = rxLevels.length ? Math.min(...rxLevels) : -140;
+    const valueDbm = rxLevels.length ? Math.max(...rxLevels) : -140;
+    const weakestDbm = rxLevels.length ? Math.min(...rxLevels) : -140;
 
-    results.push({ ...sample, valueDbm });
+    results.push({ ...sample, valueDbm, weakestDbm });
     if ((i + 1) % notifyEvery === 0 || i === samples.length - 1) {
       onProgress?.((i + 1) / total);
     }
@@ -327,9 +328,10 @@ export const buildCoverageAsync = async (
       })
       .filter((v): v is number => v !== null);
 
-    const valueDbm = rxLevels.length ? Math.min(...rxLevels) : -140;
+    const valueDbm = rxLevels.length ? Math.max(...rxLevels) : -140;
+    const weakestDbm = rxLevels.length ? Math.min(...rxLevels) : -140;
 
-    results.push({ ...sample, valueDbm });
+    results.push({ ...sample, valueDbm, weakestDbm });
     if ((i + 1) % notifyEvery === 0 || i === samples.length - 1) {
       onProgress?.((i + 1) / total);
     }

--- a/src/lib/overlayTaskBudget.ts
+++ b/src/lib/overlayTaskBudget.ts
@@ -1,4 +1,4 @@
-export type OverlayTaskMode = "heatmap" | "contours" | "passfail" | "relay" | "terrain";
+export type OverlayTaskMode = "heatmap" | "contours" | "weakest" | "passfail" | "relay" | "terrain";
 
 export type OverlayTaskBudget = {
   frameBudgetMs: number;
@@ -8,6 +8,7 @@ export type OverlayTaskBudget = {
 const BUDGET_BY_MODE: Record<OverlayTaskMode, OverlayTaskBudget> = {
   heatmap: { frameBudgetMs: 9, longTaskMs: 30 },
   contours: { frameBudgetMs: 9, longTaskMs: 30 },
+  weakest: { frameBudgetMs: 9, longTaskMs: 30 },
   passfail: { frameBudgetMs: 14, longTaskMs: 42 },
   relay: { frameBudgetMs: 14, longTaskMs: 42 },
   terrain: { frameBudgetMs: 8, longTaskMs: 28 },

--- a/src/lib/simulationPerf.ts
+++ b/src/lib/simulationPerf.ts
@@ -9,7 +9,7 @@ type CoveragePerfRecord = {
 
 type OverlayPerfRecord = {
   runId: string;
-  mode: "heatmap" | "contours" | "passfail" | "relay" | "terrain";
+  mode: "heatmap" | "contours" | "weakest" | "passfail" | "relay" | "terrain";
   buildDurationMs: number;
   encodeDurationMs: number;
   width: number;

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -257,7 +257,7 @@ const adoptOrphanedSimulations = (
   return fixed;
 };
 
-export type MapOverlayMode = "none" | "heatmap" | "contours" | "passfail" | "relay";
+export type MapOverlayMode = "none" | "heatmap" | "contours" | "weakest" | "passfail" | "relay";
 export type AuthSessionState = "checking" | "signed_in" | "signed_out";
 
 type SiteLibraryEntry = {

--- a/src/types/radio.ts
+++ b/src/types/radio.ts
@@ -136,4 +136,5 @@ export type CoverageSample = {
   lat: number;
   lon: number;
   valueDbm: number;
+  weakestDbm?: number;
 };


### PR DESCRIPTION
## Summary
- Change the default Heatmap metric to use the best available Site signal at each point.
- Preserve the previous weakest/all-sites metric as a manual Weakest Site overlay.
- Add coverage test coverage for strongest/default and weakest preserved signal values.

## Verification
- npx vitest run --config config/vitest.config.ts
- npx tsc -b config/tsconfig.json
- npx vite build --config config/vite.config.ts

Note: npm test and npm run build are blocked in this worktree by a pre-existing deletion of scripts/generate-build-info.mjs, which is intentionally not part of this PR.

Fixes #843