### PR TITLE
Add RX target heatmap scale

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -260,7 +260,6 @@ type TerrainBounds = {
   maxLon: number;
 };
 type CoverageSampleLite = { lat: number; lon: number; valueDbm: number; weakestDbm?: number };
-type BandStepMode = "auto" | 3 | 5 | 8 | 10;
 type OverlayRaster = {
   url: string;
   coordinates: [[number, number], [number, number], [number, number], [number, number]];
@@ -427,29 +426,6 @@ const boundsDiagonalKm = (bounds: TerrainBounds): number => {
     111.32 *
     Math.max(0.1, Math.cos((centerLat * Math.PI) / 180));
   return Math.hypot(latSpanKm, lonSpanKm);
-};
-
-const autoBandStepDb = (samples: CoverageSampleLite[], bounds: TerrainBounds): 3 | 5 | 8 | 10 => {
-  if (samples.length < 2) return 5;
-  let min = Number.POSITIVE_INFINITY;
-  let max = Number.NEGATIVE_INFINITY;
-  for (const sample of samples) {
-    min = Math.min(min, sample.valueDbm);
-    max = Math.max(max, sample.valueDbm);
-  }
-  const dynamicRange = Math.max(0, max - min);
-  const centerLat = (bounds.minLat + bounds.maxLat) / 2;
-  const latSpanKm = Math.abs(bounds.maxLat - bounds.minLat) * 111.32;
-  const lonSpanKm =
-    Math.abs(bounds.maxLon - bounds.minLon) *
-    111.32 *
-    Math.max(0.1, Math.cos((centerLat * Math.PI) / 180));
-  const diagonalKm = Math.hypot(latSpanKm, lonSpanKm);
-
-  if (diagonalKm > 90 || dynamicRange > 45) return 10;
-  if (diagonalKm > 45 || dynamicRange > 30) return 8;
-  if (diagonalKm > 20 || dynamicRange > 18) return 5;
-  return 3;
 };
 
 const computeOverlayDimensions = (
@@ -761,7 +737,6 @@ export function MapView({
   const recommendAndFetchTerrainForCurrentArea = useAppStore((state) => state.recommendAndFetchTerrainForCurrentArea);
   const selectedOverlayRadiusOption = useAppStore((state) => state.selectedOverlayRadiusOption);
   const setSelectedOverlayRadiusOption = useAppStore((state) => state.setSelectedOverlayRadiusOption);
-  const [bandStepMode, setBandStepMode] = useState<BandStepMode>("auto");
   const [showTerrainOverlay, setShowTerrainOverlay] = useState(false);
   const [showResultsSummary, setShowResultsSummary] = useState(() => readSectionBool(UI_SECTION_KEYS.mapViewResults, true));
   const [showSimulationSummary, setShowSimulationSummary] = useState(() => readSectionBool(UI_SECTION_KEYS.mapViewSimSummary, false));
@@ -1417,10 +1392,7 @@ export function MapView({
       };
     });
   }, [overlayBounds]);
-  const effectiveBandStepDb = useMemo(() => {
-    if (!overlayBounds) return 5;
-    return bandStepMode === "auto" ? autoBandStepDb(samplesForOverlay, overlayBounds) : bandStepMode;
-  }, [overlayBounds, samplesForOverlay, bandStepMode]);
+  const effectiveBandStepDb = 5;
   const overlayLongTaskWarnedRef = useRef<Set<string>>(new Set());
   const showOverlayDiagnostics =
     import.meta.env.DEV || (typeof window !== "undefined" && window.location.hostname === "localhost");
@@ -1672,6 +1644,7 @@ export function MapView({
               overlayPointMask,
               terrainSampler,
               context,
+              { rxTargetDbm: rxSensitivityTargetDbm },
             );
           } else if (mode === "passfail") {
             const receiverAntennaHeightM = selectedToSite?.antennaHeightM ?? selectedFromSite!.antennaHeightM ?? 2;
@@ -1805,8 +1778,6 @@ export function MapView({
     setOverlayPipelineProgress,
     logOverlaySchedulerEvent,
   ]);
-  const currentBandStepDb = effectiveBandStepDb;
-
   const signalRange = useMemo(() => {
     if (!samplesForOverlay.length) return { min: -125, max: -62 };
     let min = Number.POSITIVE_INFINITY;
@@ -1841,7 +1812,7 @@ export function MapView({
       : coverageVizMode === "heatmap"
       ? "Heatmap"
       : coverageVizMode === "contours"
-        ? "Bands"
+        ? "Target Contour"
         : coverageVizMode === "weakest"
           ? "Weakest Site"
         : coverageVizMode === "passfail"
@@ -3037,7 +3008,7 @@ export function MapView({
                   <option value="none">Hidden</option>
                   {allowedOverlayModes.includes("heatmap") ? <option value="heatmap">Heatmap</option> : null}
                   {allowedOverlayModes.includes("weakest") ? <option value="weakest">Weakest Site</option> : null}
-                  {allowedOverlayModes.includes("contours") ? <option value="contours">Contours</option> : null}
+                  {allowedOverlayModes.includes("contours") ? <option value="contours">Target Contour</option> : null}
                   {allowedOverlayModes.includes("passfail") ? <option value="passfail">Pass/Fail</option> : null}
                   {allowedOverlayModes.includes("relay") ? <option value="relay">Relay</option> : null}
                 </select>
@@ -3126,7 +3097,7 @@ export function MapView({
                       onClick={() => setCoverageVizMode("contours")}
                       variant="labeled"
                     >
-                      Bands
+                      Target Line
                     </MapControlButton>
                   </div>
                 </div>
@@ -3158,7 +3129,7 @@ export function MapView({
             ) : null}
             {coverageVizMode === "contours" ? (
               <>
-                <p>Same data as Heatmap, but grouped into steps so boundaries are easier to read.</p>
+                <p>Shows the line where best available Site signal crosses the Simulation RX target.</p>
                 <div className="overlay-inline-controls">
                   <span>Style</span>
                   <div className="chip-group">
@@ -3173,42 +3144,18 @@ export function MapView({
                       onClick={() => setCoverageVizMode("contours")}
                       variant="labeled"
                     >
-                      Bands
+                      Target Line
                     </MapControlButton>
                   </div>
-                </div>
-                <div className="overlay-inline-controls">
-                  <span>Band step</span>
-                  <select
-                    className="locale-select"
-                    onChange={(event) => {
-                      const value = event.target.value;
-                      if (value === "auto") {
-                        setBandStepMode("auto");
-                        return;
-                      }
-                      const parsed = Number(value);
-                      if (parsed === 3 || parsed === 5 || parsed === 8 || parsed === 10) {
-                        setBandStepMode(parsed);
-                      }
-                    }}
-                    value={String(bandStepMode)}
-                  >
-                    <option value="auto">Auto ({currentBandStepDb} dB)</option>
-                    <option value="3">3 dB</option>
-                    <option value="5">5 dB</option>
-                    <option value="8">8 dB</option>
-                    <option value="10">10 dB</option>
-                  </select>
                 </div>
                 <div className="overlay-scale">
                   <div className="overlay-scale-bar" />
                   <div className="overlay-scale-labels">
-                    <span>{fmtDbm(signalRange.min)}</span>
-                    <span>{fmtDbm(signalRange.max)}</span>
+                    <span>{fmtDbm(rxSensitivityTargetDbm)}</span>
+                    <span>RX target</span>
                   </div>
                 </div>
-                <p className="overlay-scale-help">Left side is weaker signal (worse). Right side is stronger signal (better).</p>
+                <p className="overlay-scale-help">Areas inside the line meet or exceed the configured RX target.</p>
               </>
             ) : null}
             {coverageVizMode === "passfail" ? (

--- a/src/lib/overlayRaster.test.ts
+++ b/src/lib/overlayRaster.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildCoverageOverlayPixelsAsync,
+  normalizeCoverageDbmForRxTarget,
   buildRelayCandidateOverlayPixelsAsync,
   buildSourcePassFailOverlayPixelsAsync,
   buildTerrainShadeOverlayPixelsAsync,
@@ -67,6 +68,12 @@ const environment: PropagationEnvironment = {
 const terrainSampler = () => 135;
 
 describe("overlayRaster async builders", () => {
+  it("normalizes coverage colors against the RX target instead of sample min/max", () => {
+    expect(normalizeCoverageDbmForRxTarget(-140, -120)).toBe(0);
+    expect(normalizeCoverageDbmForRxTarget(-120, -120)).toBeCloseTo(0.4, 4);
+    expect(normalizeCoverageDbmForRxTarget(-90, -120)).toBe(1);
+  });
+
   it("builds coverage raster pixels with expected metadata shape", async () => {
     const raster = await buildCoverageOverlayPixelsAsync(
       bounds,
@@ -89,6 +96,31 @@ describe("overlayRaster async builders", () => {
       [bounds.maxLon, bounds.minLat],
       [bounds.minLon, bounds.minLat],
     ]);
+  });
+
+  it("draws contour pixels only near the RX target threshold", async () => {
+    const raster = await buildCoverageOverlayPixelsAsync(
+      bounds,
+      [
+        { lat: 59.8, lon: 10.6, valueDbm: -130 },
+        { lat: 59.8, lon: 10.8, valueDbm: -110 },
+        { lat: 60.0, lon: 10.6, valueDbm: -130 },
+        { lat: 60.0, lon: 10.8, valueDbm: -110 },
+      ],
+      "contours",
+      5,
+      { width: 24, height: 8 },
+      undefined,
+      terrainSampler,
+      { phase: "coverage", signature: "target-contour-test" },
+      { rxTargetDbm: -120 },
+    );
+
+    expect(raster).not.toBeNull();
+    const alphas = Array.from(raster!.pixels).filter((_, index) => index % 4 === 3);
+    const visiblePixels = alphas.filter((alpha) => alpha > 0).length;
+    expect(visiblePixels).toBeGreaterThan(0);
+    expect(visiblePixels).toBeLessThan(alphas.length / 2);
   });
 
   it("supports all overlay modes through async chunked builders", async () => {

--- a/src/lib/overlayRaster.ts
+++ b/src/lib/overlayRaster.ts
@@ -12,6 +12,10 @@ export type TerrainBounds = {
 
 export type CoverageSampleLite = { lat: number; lon: number; valueDbm: number };
 
+export type CoverageOverlayOptions = {
+  rxTargetDbm?: number;
+};
+
 export type OverlayRasterPixels = {
   width: number;
   height: number;
@@ -168,11 +172,19 @@ const precomputeGridAxes = (
   return { latByRow, lonByCol };
 };
 
-const coverageColorForDbm = (valueDbm: number): [number, number, number] => {
-  const normalized = (valueDbm + 125) / 63;
+export const normalizeCoverageDbmForRxTarget = (valueDbm: number, rxTargetDbm: number): number => {
+  const min = rxTargetDbm - 20;
+  const max = rxTargetDbm + 30;
+  return clamp((valueDbm - min) / (max - min), 0, 1);
+};
+
+const coverageColorForNormalized = (normalized: number): [number, number, number] => {
   const color = interpolateHeatmapColor(normalized);
   return [color.r, color.g, color.b];
 };
+
+const coverageColorForDbm = (valueDbm: number): [number, number, number] =>
+  coverageColorForNormalized((valueDbm + 125) / 63);
 
 const computeCoverageAdaptiveScale = (
   samples: CoverageSampleLite[],
@@ -198,6 +210,9 @@ const coverageColorAdaptive = (
   const normalized = -125 + ((valueDbm - scale.min) / scale.range) * 63;
   return coverageColorForDbm(clamp(normalized, -125, -62));
 };
+
+const coverageColorFixed = (valueDbm: number, rxTargetDbm: number): [number, number, number] =>
+  coverageColorForNormalized(normalizeCoverageDbmForRxTarget(valueDbm, rxTargetDbm));
 
 const interpolateCoverageDbm = (samples: CoverageSampleLite[], lat: number, lon: number): number | null => {
   if (!samples.length) return null;
@@ -322,14 +337,18 @@ export const buildCoverageOverlayPixelsAsync = async (
   pointMask?: (lat: number, lon: number) => boolean,
   terrainSampler?: (lat: number, lon: number) => number | null,
   context?: OverlayTaskContext,
+  options?: CoverageOverlayOptions,
 ): Promise<OverlayRasterPixels | null> => {
   if (!samples.length) return null;
   const gridInterpolator = makeGridInterpolator(samples);
   const width = dimensions.width;
   const height = dimensions.height;
   const { latByRow, lonByCol } = precomputeGridAxes(bounds, dimensions);
-  const adaptiveScale = computeCoverageAdaptiveScale(samples);
+  const adaptiveScale = options?.rxTargetDbm === undefined ? computeCoverageAdaptiveScale(samples) : null;
+  const rxTargetDbm = options?.rxTargetDbm;
   const pixels = new Uint8ClampedArray(width * height * 4);
+  const valueAt = (lat: number, lon: number): number | null =>
+    gridInterpolator ? gridInterpolator(lat, lon) : interpolateCoverageDbm(samples, lat, lon);
 
   await runCooperativeLoop(
     width * height,
@@ -340,9 +359,7 @@ export const buildCoverageOverlayPixelsAsync = async (
       const lon = lonByCol[x];
       if (pointMask && !pointMask(lat, lon)) return;
       if (terrainSampler && terrainSampler(lat, lon) === null) return;
-      const valueDbm = gridInterpolator
-        ? gridInterpolator(lat, lon)
-        : interpolateCoverageDbm(samples, lat, lon);
+      const valueDbm = valueAt(lat, lon);
       if (valueDbm === null) return;
 
       let r = 0;
@@ -350,11 +367,27 @@ export const buildCoverageOverlayPixelsAsync = async (
       let b = 0;
       let a = 180;
       if (mode === "heatmap") {
-        [r, g, b] = coverageColorAdaptive(valueDbm, adaptiveScale);
+        [r, g, b] = rxTargetDbm === undefined
+          ? coverageColorAdaptive(valueDbm, adaptiveScale)
+          : coverageColorFixed(valueDbm, rxTargetDbm);
       } else {
-        const banded = Math.round(valueDbm / Math.max(1, bandStepDb)) * Math.max(1, bandStepDb);
-        [r, g, b] = coverageColorAdaptive(banded, adaptiveScale);
-        a = 170;
+        const target = rxTargetDbm;
+        if (target === undefined) {
+          const banded = Math.round(valueDbm / Math.max(1, bandStepDb)) * Math.max(1, bandStepDb);
+          [r, g, b] = coverageColorAdaptive(banded, adaptiveScale);
+          a = 170;
+        } else {
+          const toleranceDb = 1.25;
+          const nextLon = lonByCol[Math.min(width - 1, x + 1)];
+          const nextLat = latByRow[Math.min(height - 1, y + 1)];
+          const rightValue = x < width - 1 ? valueAt(lat, nextLon) : null;
+          const downValue = y < height - 1 ? valueAt(nextLat, lon) : null;
+          const crossesRight = rightValue !== null && (valueDbm - target) * (rightValue - target) <= 0;
+          const crossesDown = downValue !== null && (valueDbm - target) * (downValue - target) <= 0;
+          if (Math.abs(valueDbm - target) > toleranceDb && !crossesRight && !crossesDown) return;
+          [r, g, b] = coverageColorFixed(target, target);
+          a = 230;
+        }
       }
 
       const px = index * 4;


### PR DESCRIPTION
## Summary
- Use the simulation RX target as the fixed scale basis for Heatmap and Weakest Site overlays.
- Replace the previous adaptive banded Contours behavior with a Target Contour overlay at the RX threshold.
- Add raster tests for RX-target normalization and target contour rendering.

## Verification
- npx vitest run --config config/vitest.config.ts
- npx tsc -b config/tsconfig.json
- npx vite build --config config/vite.config.ts

Note: npm test and npm run build are blocked in this local worktree by a pre-existing deletion of scripts/generate-build-info.mjs, which is intentionally not part of this PR.

Fixes #814