### PR TITLE
Draw RX target contour over heatmap

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -14,6 +14,7 @@ import Map, {
 } from "react-map-gl/maplibre";
 import type { LayerProps } from "react-map-gl/maplibre";
 import { computeCoverageGridDimensions } from "../lib/coverage";
+import { buildCoverageTargetContourFeatures } from "../lib/coverageContour";
 import { STANDARD_SITE_RADIO } from "../lib/linkRadio";
 import { sampleSrtmElevation } from "../lib/srtm";
 import { getUiErrorMessage } from "../lib/uiError";
@@ -175,6 +176,26 @@ const coverageRasterLayer: LayerProps = {
     "raster-saturation": 0.02,
   },
 };
+
+const targetContourHaloLayer = (color: string): LayerProps => ({
+  id: "coverage-target-contour-halo-layer",
+  type: "line",
+  paint: {
+    "line-color": color,
+    "line-width": 5,
+    "line-opacity": 0.82,
+  },
+});
+
+const targetContourLineLayer = (color: string): LayerProps => ({
+  id: "coverage-target-contour-line-layer",
+  type: "line",
+  paint: {
+    "line-color": color,
+    "line-width": 2.4,
+    "line-opacity": 0.96,
+  },
+});
 
 const terrainRasterPaint = {
   "raster-opacity": 0.62,
@@ -1638,7 +1659,7 @@ export function MapView({
             rasterPixels = await buildCoverageOverlayPixelsAsync(
               overlayBounds,
               overlaySamples,
-              mode === "weakest" ? "heatmap" : mode,
+              mode === "contours" || mode === "weakest" ? "heatmap" : mode,
               effectiveBandStepDb,
               overlayDimensions,
               overlayPointMask,
@@ -1801,6 +1822,15 @@ export function MapView({
     return { min, max };
   }, [samplesForOverlay]);
 
+  const targetContourFeatures = useMemo(
+    () =>
+      coverageVizMode === "contours"
+        ? buildCoverageTargetContourFeatures(samplesForOverlay, rxSensitivityTargetDbm, overlayBounds)
+        : { type: "FeatureCollection" as const, features: [] },
+    [coverageVizMode, overlayBounds, rxSensitivityTargetDbm, samplesForOverlay],
+  );
+  const showTargetContourLine = coverageVizMode === "contours" && targetContourFeatures.features.length > 0;
+
   const relayRange = useMemo(() => {
     if (!coverageOverlay || coverageVizMode !== "relay") return null;
     if (typeof coverageOverlay.minDbm !== "number" || typeof coverageOverlay.maxDbm !== "number") return null;
@@ -1812,7 +1842,7 @@ export function MapView({
       : coverageVizMode === "heatmap"
       ? "Heatmap"
       : coverageVizMode === "contours"
-        ? "Target Contour"
+        ? "Heatmap + Target Line"
         : coverageVizMode === "weakest"
           ? "Weakest Site"
         : coverageVizMode === "passfail"
@@ -3008,7 +3038,7 @@ export function MapView({
                   <option value="none">Hidden</option>
                   {allowedOverlayModes.includes("heatmap") ? <option value="heatmap">Heatmap</option> : null}
                   {allowedOverlayModes.includes("weakest") ? <option value="weakest">Weakest Site</option> : null}
-                  {allowedOverlayModes.includes("contours") ? <option value="contours">Target Contour</option> : null}
+                  {allowedOverlayModes.includes("contours") ? <option value="contours">Heatmap + Target Line</option> : null}
                   {allowedOverlayModes.includes("passfail") ? <option value="passfail">Pass/Fail</option> : null}
                   {allowedOverlayModes.includes("relay") ? <option value="relay">Relay</option> : null}
                 </select>
@@ -3129,7 +3159,7 @@ export function MapView({
             ) : null}
             {coverageVizMode === "contours" ? (
               <>
-                <p>Shows the line where best available Site signal crosses the Simulation RX target.</p>
+                <p>Shows the fixed-scale Heatmap with a line where best available Site signal crosses the Simulation RX target.</p>
                 <div className="overlay-inline-controls">
                   <span>Style</span>
                   <div className="chip-group">
@@ -3420,6 +3450,13 @@ export function MapView({
             url={coverageOverlay.url}
           >
             <Layer {...coverageRasterLayer} />
+          </Source>
+        ) : null}
+
+        {showTargetContourLine ? (
+          <Source data={targetContourFeatures} id="coverage-target-contour-source" type="geojson">
+            <Layer {...targetContourHaloLayer(variant.cssVars["--bg"] ?? linkColor)} />
+            <Layer {...targetContourLineLayer(selectedLinkColor)} />
           </Source>
         ) : null}
 

--- a/src/lib/coverageContour.test.ts
+++ b/src/lib/coverageContour.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { buildCoverageTargetContourFeatures } from "./coverageContour";
+import type { CoverageSampleLite } from "./overlayRaster";
+
+const grid = (values: number[]): CoverageSampleLite[] => [
+  { lat: 0, lon: 0, valueDbm: values[0] },
+  { lat: 0, lon: 1, valueDbm: values[1] },
+  { lat: 1, lon: 0, valueDbm: values[2] },
+  { lat: 1, lon: 1, valueDbm: values[3] },
+];
+
+describe("buildCoverageTargetContourFeatures", () => {
+  it("returns no line when all samples are below target", () => {
+    const contour = buildCoverageTargetContourFeatures(grid([-130, -129, -128, -127]), -120);
+    expect(contour.features).toHaveLength(0);
+  });
+
+  it("returns no line when all samples are above target", () => {
+    const contour = buildCoverageTargetContourFeatures(grid([-110, -109, -108, -107]), -120);
+    expect(contour.features).toHaveLength(0);
+  });
+
+  it("creates a vertical contour where values cross the target", () => {
+    const contour = buildCoverageTargetContourFeatures(grid([-130, -110, -130, -110]), -120);
+
+    expect(contour.features).toHaveLength(1);
+    expect(contour.features[0].geometry.coordinates).toEqual([
+      [0.5, 0],
+      [0.5, 1],
+    ]);
+  });
+});

--- a/src/lib/coverageContour.ts
+++ b/src/lib/coverageContour.ts
@@ -1,0 +1,132 @@
+import type { CoverageSampleLite, TerrainBounds } from "./overlayRaster";
+
+export type ContourLineFeatureCollection = {
+  type: "FeatureCollection";
+  features: Array<{
+    type: "Feature";
+    properties: { targetDbm: number };
+    geometry: {
+      type: "LineString";
+      coordinates: [[number, number], [number, number]];
+    };
+  }>;
+};
+
+type GridCell = {
+  lat0: number;
+  lat1: number;
+  lon0: number;
+  lon1: number;
+  v00: number;
+  v10: number;
+  v11: number;
+  v01: number;
+};
+
+const emptyContour = (): ContourLineFeatureCollection => ({ type: "FeatureCollection", features: [] });
+
+const lerp = (a: number, b: number, t: number): number => a + (b - a) * t;
+
+const edgeCrossing = (
+  a: { lat: number; lon: number; value: number },
+  b: { lat: number; lon: number; value: number },
+  targetDbm: number,
+): [number, number] | null => {
+  const da = a.value - targetDbm;
+  const db = b.value - targetDbm;
+  if (da === 0 && db === 0) return null;
+  if (da * db > 0) return null;
+  const denominator = b.value - a.value;
+  const t = denominator === 0 ? 0.5 : (targetDbm - a.value) / denominator;
+  return [lerp(a.lon, b.lon, t), lerp(a.lat, b.lat, t)];
+};
+
+const cellSegments = (cell: GridCell, targetDbm: number): Array<[[number, number], [number, number]]> => {
+  const bottomLeft = { lat: cell.lat0, lon: cell.lon0, value: cell.v00 };
+  const bottomRight = { lat: cell.lat0, lon: cell.lon1, value: cell.v10 };
+  const topRight = { lat: cell.lat1, lon: cell.lon1, value: cell.v11 };
+  const topLeft = { lat: cell.lat1, lon: cell.lon0, value: cell.v01 };
+  const crossings = [
+    edgeCrossing(bottomLeft, bottomRight, targetDbm),
+    edgeCrossing(bottomRight, topRight, targetDbm),
+    edgeCrossing(topRight, topLeft, targetDbm),
+    edgeCrossing(topLeft, bottomLeft, targetDbm),
+  ].filter((point): point is [number, number] => point !== null);
+
+  if (crossings.length < 2) return [];
+  if (crossings.length === 2) return [[crossings[0], crossings[1]]];
+  return [
+    [crossings[0], crossings[1]],
+    [crossings[2], crossings[3]],
+  ];
+};
+
+export const buildCoverageTargetContourFeatures = (
+  samples: CoverageSampleLite[],
+  targetDbm: number,
+  bounds?: TerrainBounds | null,
+): ContourLineFeatureCollection => {
+  if (samples.length < 4 || !Number.isFinite(targetDbm)) return emptyContour();
+
+  const lats = Array.from(new Set(samples.map((sample) => sample.lat))).sort((a, b) => a - b);
+  const lons = Array.from(new Set(samples.map((sample) => sample.lon))).sort((a, b) => a - b);
+  if (lats.length < 2 || lons.length < 2 || lats.length * lons.length !== samples.length) return emptyContour();
+
+  const latIndex = new Map<number, number>();
+  const lonIndex = new Map<number, number>();
+  lats.forEach((lat, index) => latIndex.set(lat, index));
+  lons.forEach((lon, index) => lonIndex.set(lon, index));
+
+  const values = new Float64Array(lats.length * lons.length);
+  const seen = new Uint8Array(lats.length * lons.length);
+  for (const sample of samples) {
+    const yi = latIndex.get(sample.lat);
+    const xi = lonIndex.get(sample.lon);
+    if (yi === undefined || xi === undefined) return emptyContour();
+    const idx = yi * lons.length + xi;
+    values[idx] = sample.valueDbm;
+    seen[idx] = 1;
+  }
+  for (const mark of seen) {
+    if (mark !== 1) return emptyContour();
+  }
+
+  const features: ContourLineFeatureCollection["features"] = [];
+  for (let y = 0; y < lats.length - 1; y += 1) {
+    for (let x = 0; x < lons.length - 1; x += 1) {
+      const lat0 = lats[y];
+      const lat1 = lats[y + 1];
+      const lon0 = lons[x];
+      const lon1 = lons[x + 1];
+      if (
+        bounds &&
+        (lat1 < bounds.minLat || lat0 > bounds.maxLat || lon1 < bounds.minLon || lon0 > bounds.maxLon)
+      ) {
+        continue;
+      }
+      const idx = y * lons.length + x;
+      const segments = cellSegments(
+        {
+          lat0,
+          lat1,
+          lon0,
+          lon1,
+          v00: values[idx],
+          v10: values[idx + 1],
+          v11: values[idx + lons.length + 1],
+          v01: values[idx + lons.length],
+        },
+        targetDbm,
+      );
+      for (const segment of segments) {
+        features.push({
+          type: "Feature",
+          properties: { targetDbm },
+          geometry: { type: "LineString", coordinates: segment },
+        });
+      }
+    }
+  }
+
+  return { type: "FeatureCollection", features };
+};


### PR DESCRIPTION
## Summary
- Render Target Contour as the fixed-scale Heatmap with a uniform-width RX target line on top.
- Add marching-squares-style contour extraction from the coverage sample grid.
- Keep the contour line in MapLibre line layers so width stays screen-space consistent across resolution and zoom.

## Verification
- npx vitest run --config config/vitest.config.ts
- npx tsc -b config/tsconfig.json
- npx vite build --config config/vite.config.ts

Note: npm test and npm run build are blocked in this local worktree by a pre-existing deletion of scripts/generate-build-info.mjs, which is intentionally not part of this PR.

Follow-up for #814