### PR TITLE
Refine RX target contour rendering

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1825,9 +1825,9 @@ export function MapView({
   const targetContourFeatures = useMemo(
     () =>
       coverageVizMode === "contours"
-        ? buildCoverageTargetContourFeatures(samplesForOverlay, rxSensitivityTargetDbm, overlayBounds)
+        ? buildCoverageTargetContourFeatures(samplesForOverlay, rxSensitivityTargetDbm, overlayBounds, overlayPointMask)
         : { type: "FeatureCollection" as const, features: [] },
-    [coverageVizMode, overlayBounds, rxSensitivityTargetDbm, samplesForOverlay],
+    [coverageVizMode, overlayBounds, overlayPointMask, rxSensitivityTargetDbm, samplesForOverlay],
   );
   const showTargetContourLine = coverageVizMode === "contours" && targetContourFeatures.features.length > 0;
 
@@ -3113,24 +3113,14 @@ export function MapView({
                   Shows overall coverage strength from your current simulation sites. Think of it as "how good signal
                   should feel if you stand here", using the best available Site signal.
                 </p>
-                <div className="overlay-inline-controls">
-                  <span>Style</span>
-                  <div className="chip-group">
-                    <MapControlButton
-                      isSelected
-                      onClick={() => setCoverageVizMode("heatmap")}
-                      variant="labeled"
-                    >
-                      Smooth
-                    </MapControlButton>
-                    <MapControlButton
-                      onClick={() => setCoverageVizMode("contours")}
-                      variant="labeled"
-                    >
-                      Target Line
-                    </MapControlButton>
-                  </div>
-                </div>
+                <label className="map-inspector-map-setting">
+                  <span>Draw RX target threshold line</span>
+                  <input
+                    checked={false}
+                    onChange={(event) => setCoverageVizMode(event.currentTarget.checked ? "contours" : "heatmap")}
+                    type="checkbox"
+                  />
+                </label>
                 <div className="overlay-scale">
                   <div className="overlay-scale-bar" />
                   <div className="overlay-scale-labels">
@@ -3160,24 +3150,14 @@ export function MapView({
             {coverageVizMode === "contours" ? (
               <>
                 <p>Shows the fixed-scale Heatmap with a line where best available Site signal crosses the Simulation RX target.</p>
-                <div className="overlay-inline-controls">
-                  <span>Style</span>
-                  <div className="chip-group">
-                    <MapControlButton
-                      onClick={() => setCoverageVizMode("heatmap")}
-                      variant="labeled"
-                    >
-                      Smooth
-                    </MapControlButton>
-                    <MapControlButton
-                      isSelected
-                      onClick={() => setCoverageVizMode("contours")}
-                      variant="labeled"
-                    >
-                      Target Line
-                    </MapControlButton>
-                  </div>
-                </div>
+                <label className="map-inspector-map-setting">
+                  <span>Draw RX target threshold line</span>
+                  <input
+                    checked
+                    onChange={(event) => setCoverageVizMode(event.currentTarget.checked ? "contours" : "heatmap")}
+                    type="checkbox"
+                  />
+                </label>
                 <div className="overlay-scale">
                   <div className="overlay-scale-bar" />
                   <div className="overlay-scale-labels">

--- a/src/lib/coverageContour.test.ts
+++ b/src/lib/coverageContour.test.ts
@@ -29,4 +29,34 @@ describe("buildCoverageTargetContourFeatures", () => {
       [0.5, 1],
     ]);
   });
+
+  it("stitches adjacent contour segments into a continuous line", () => {
+    const samples: CoverageSampleLite[] = [
+      { lat: 0, lon: 0, valueDbm: -130 },
+      { lat: 0, lon: 1, valueDbm: -110 },
+      { lat: 0, lon: 2, valueDbm: -110 },
+      { lat: 1, lon: 0, valueDbm: -130 },
+      { lat: 1, lon: 1, valueDbm: -110 },
+      { lat: 1, lon: 2, valueDbm: -110 },
+      { lat: 2, lon: 0, valueDbm: -130 },
+      { lat: 2, lon: 1, valueDbm: -110 },
+      { lat: 2, lon: 2, valueDbm: -110 },
+    ];
+
+    const contour = buildCoverageTargetContourFeatures(samples, -120);
+
+    expect(contour.features).toHaveLength(1);
+    expect(contour.features[0].geometry.coordinates.length).toBeGreaterThan(3);
+  });
+
+  it("clips segments outside the supplied point mask", () => {
+    const contour = buildCoverageTargetContourFeatures(
+      grid([-130, -110, -130, -110]),
+      -120,
+      null,
+      (lat) => lat <= 0.5,
+    );
+
+    expect(contour.features).toHaveLength(0);
+  });
 });

--- a/src/lib/coverageContour.ts
+++ b/src/lib/coverageContour.ts
@@ -7,7 +7,7 @@ export type ContourLineFeatureCollection = {
     properties: { targetDbm: number };
     geometry: {
       type: "LineString";
-      coordinates: [[number, number], [number, number]];
+      coordinates: Array<[number, number]>;
     };
   }>;
 };
@@ -24,6 +24,8 @@ type GridCell = {
 };
 
 const emptyContour = (): ContourLineFeatureCollection => ({ type: "FeatureCollection", features: [] });
+
+const pointKey = (point: [number, number]): string => `${point[0].toFixed(8)},${point[1].toFixed(8)}`;
 
 const lerp = (a: number, b: number, t: number): number => a + (b - a) * t;
 
@@ -61,10 +63,68 @@ const cellSegments = (cell: GridCell, targetDbm: number): Array<[[number, number
   ];
 };
 
+const stitchSegments = (segments: Array<[[number, number], [number, number]]>): Array<Array<[number, number]>> => {
+  const unused = [...segments];
+  const lines: Array<Array<[number, number]>> = [];
+
+  while (unused.length) {
+    const current = unused.pop()!;
+    const line = [current[0], current[1]];
+    let extended = true;
+
+    while (extended) {
+      extended = false;
+      const startKey = pointKey(line[0]);
+      const endKey = pointKey(line[line.length - 1]);
+      for (let i = unused.length - 1; i >= 0; i -= 1) {
+        const [a, b] = unused[i];
+        const aKey = pointKey(a);
+        const bKey = pointKey(b);
+        if (bKey === startKey) {
+          line.unshift(a);
+        } else if (aKey === startKey) {
+          line.unshift(b);
+        } else if (aKey === endKey) {
+          line.push(b);
+        } else if (bKey === endKey) {
+          line.push(a);
+        } else {
+          continue;
+        }
+        unused.splice(i, 1);
+        extended = true;
+        break;
+      }
+    }
+
+    lines.push(line);
+  }
+
+  return lines;
+};
+
+const smoothLine = (line: Array<[number, number]>): Array<[number, number]> => {
+  if (line.length < 3) return line;
+  let smoothed = line;
+  for (let pass = 0; pass < 2; pass += 1) {
+    const next: Array<[number, number]> = [smoothed[0]];
+    for (let i = 0; i < smoothed.length - 1; i += 1) {
+      const [x0, y0] = smoothed[i];
+      const [x1, y1] = smoothed[i + 1];
+      next.push([x0 * 0.75 + x1 * 0.25, y0 * 0.75 + y1 * 0.25]);
+      next.push([x0 * 0.25 + x1 * 0.75, y0 * 0.25 + y1 * 0.75]);
+    }
+    next.push(smoothed[smoothed.length - 1]);
+    smoothed = next;
+  }
+  return smoothed;
+};
+
 export const buildCoverageTargetContourFeatures = (
   samples: CoverageSampleLite[],
   targetDbm: number,
   bounds?: TerrainBounds | null,
+  pointMask?: ((lat: number, lon: number) => boolean) | null,
 ): ContourLineFeatureCollection => {
   if (samples.length < 4 || !Number.isFinite(targetDbm)) return emptyContour();
 
@@ -91,7 +151,7 @@ export const buildCoverageTargetContourFeatures = (
     if (mark !== 1) return emptyContour();
   }
 
-  const features: ContourLineFeatureCollection["features"] = [];
+  const segments: Array<[[number, number], [number, number]]> = [];
   for (let y = 0; y < lats.length - 1; y += 1) {
     for (let x = 0; x < lons.length - 1; x += 1) {
       const lat0 = lats[y];
@@ -105,7 +165,7 @@ export const buildCoverageTargetContourFeatures = (
         continue;
       }
       const idx = y * lons.length + x;
-      const segments = cellSegments(
+      const cellLineSegments = cellSegments(
         {
           lat0,
           lat1,
@@ -118,15 +178,27 @@ export const buildCoverageTargetContourFeatures = (
         },
         targetDbm,
       );
-      for (const segment of segments) {
-        features.push({
-          type: "Feature",
-          properties: { targetDbm },
-          geometry: { type: "LineString", coordinates: segment },
-        });
+      for (const segment of cellLineSegments) {
+        const midLon = (segment[0][0] + segment[1][0]) / 2;
+        const midLat = (segment[0][1] + segment[1][1]) / 2;
+        if (
+          pointMask &&
+          (!pointMask(segment[0][1], segment[0][0]) ||
+            !pointMask(midLat, midLon) ||
+            !pointMask(segment[1][1], segment[1][0]))
+        ) {
+          continue;
+        }
+        segments.push(segment);
       }
     }
   }
+
+  const features: ContourLineFeatureCollection["features"] = stitchSegments(segments).map((line) => ({
+    type: "Feature",
+    properties: { targetDbm },
+    geometry: { type: "LineString", coordinates: smoothLine(line) },
+  }));
 
   return { type: "FeatureCollection", features };
 };


### PR DESCRIPTION
## Summary
- Stitch and smooth RX target contour segments so the threshold line renders as a continuous uniform-width curve.
- Clip target contour segments through the same overlay point mask used by the heatmap.
- Replace the heatmap style chips with a simple RX target threshold line checkbox.

## Verification
- npx tsc -b config/tsconfig.json
- npx vitest run --config config/vitest.config.ts src/lib/coverageContour.test.ts src/lib/overlayRaster.test.ts
- npx vite build --config config/vite.config.ts

## Note
- `npm test` and `npm run build` are blocked locally by an unrelated missing `scripts/generate-build-info.mjs` file in the worktree.

Closes #814