### PR TITLE
Refine heatmap target scale

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1830,6 +1830,13 @@ export function MapView({
     [coverageVizMode, overlayBounds, overlayPointMask, rxSensitivityTargetDbm, samplesForOverlay],
   );
   const showTargetContourLine = coverageVizMode === "contours" && targetContourFeatures.features.length > 0;
+  const coverageScaleRange = useMemo(() => {
+    if (!coverageOverlay || (coverageVizMode !== "heatmap" && coverageVizMode !== "contours" && coverageVizMode !== "weakest")) {
+      return null;
+    }
+    if (typeof coverageOverlay.minDbm !== "number" || typeof coverageOverlay.maxDbm !== "number") return null;
+    return { min: coverageOverlay.minDbm, max: coverageOverlay.maxDbm };
+  }, [coverageOverlay, coverageVizMode]);
 
   const relayRange = useMemo(() => {
     if (!coverageOverlay || coverageVizMode !== "relay") return null;
@@ -2653,7 +2660,7 @@ export function MapView({
   }, [selectionCount]);
   useEffect(() => {
     if (allowedOverlayModes.includes(coverageVizMode as "none" | "heatmap" | "contours" | "weakest" | "passfail" | "relay")) return;
-    setCoverageVizMode(selectionCount === 1 ? "passfail" : selectionCount === 2 ? "relay" : "heatmap");
+    setCoverageVizMode(selectionCount === 1 ? "passfail" : selectionCount === 2 ? "relay" : "contours");
   }, [allowedOverlayModes, coverageVizMode, selectionCount, setCoverageVizMode]);
   const simulationOverlaySelectValue = coverageVizMode;
   const siteVisibilityMode: "simulation" | "library" | "mqtt" =
@@ -3113,7 +3120,7 @@ export function MapView({
                   Shows overall coverage strength from your current simulation sites. Think of it as "how good signal
                   should feel if you stand here", using the best available Site signal.
                 </p>
-                <label className="map-inspector-map-setting">
+                <label className="map-inspector-map-setting map-inspector-map-setting-inline">
                   <span>Draw RX target threshold line</span>
                   <input
                     checked={false}
@@ -3124,11 +3131,12 @@ export function MapView({
                 <div className="overlay-scale">
                   <div className="overlay-scale-bar" />
                   <div className="overlay-scale-labels">
-                    <span>{fmtDbm(signalRange.min)}</span>
-                    <span>{fmtDbm(signalRange.max)}</span>
+                    <span>{fmtDbm(coverageScaleRange?.min ?? signalRange.min)}</span>
+                    <span>{fmtDbm(rxSensitivityTargetDbm)}</span>
+                    <span>{fmtDbm(coverageScaleRange?.max ?? signalRange.max)}</span>
                   </div>
                 </div>
-                <p className="overlay-scale-help">Left side is weaker signal (worse). Right side is stronger signal (better).</p>
+                <p className="overlay-scale-help">Centered on the RX target, widened to use more of the spectrum for this Simulation.</p>
               </>
             ) : null}
             {coverageVizMode === "weakest" ? (
@@ -3140,17 +3148,18 @@ export function MapView({
                 <div className="overlay-scale">
                   <div className="overlay-scale-bar" />
                   <div className="overlay-scale-labels">
-                    <span>{fmtDbm(weakestSignalRange.min)}</span>
-                    <span>{fmtDbm(weakestSignalRange.max)}</span>
+                    <span>{fmtDbm(coverageScaleRange?.min ?? weakestSignalRange.min)}</span>
+                    <span>{fmtDbm(rxSensitivityTargetDbm)}</span>
+                    <span>{fmtDbm(coverageScaleRange?.max ?? weakestSignalRange.max)}</span>
                   </div>
                 </div>
-                <p className="overlay-scale-help">Left side is weaker signal (worse). Right side is stronger signal (better).</p>
+                <p className="overlay-scale-help">Centered on the RX target, widened to use more of the spectrum for this Simulation.</p>
               </>
             ) : null}
             {coverageVizMode === "contours" ? (
               <>
                 <p>Shows the fixed-scale Heatmap with a line where best available Site signal crosses the Simulation RX target.</p>
-                <label className="map-inspector-map-setting">
+                <label className="map-inspector-map-setting map-inspector-map-setting-inline">
                   <span>Draw RX target threshold line</span>
                   <input
                     checked
@@ -3161,11 +3170,12 @@ export function MapView({
                 <div className="overlay-scale">
                   <div className="overlay-scale-bar" />
                   <div className="overlay-scale-labels">
-                    <span>{fmtDbm(rxSensitivityTargetDbm)}</span>
+                    <span>{fmtDbm(coverageScaleRange?.min ?? rxSensitivityTargetDbm - 20)}</span>
                     <span>RX target</span>
+                    <span>{fmtDbm(coverageScaleRange?.max ?? rxSensitivityTargetDbm + 30)}</span>
                   </div>
                 </div>
-                <p className="overlay-scale-help">Areas inside the line meet or exceed the configured RX target.</p>
+                <p className="overlay-scale-help">The line is the pass/fail threshold; the heatmap shows relative signal shape around it.</p>
               </>
             ) : null}
             {coverageVizMode === "passfail" ? (

--- a/src/index.css
+++ b/src/index.css
@@ -1684,6 +1684,12 @@ button {
   gap: 4px;
 }
 
+.map-inspector-map-setting-inline {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}
+
 .map-inspector-map-setting > span {
   color: var(--muted);
   font-size: 0.7rem;

--- a/src/lib/overlayRaster.test.ts
+++ b/src/lib/overlayRaster.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildCoverageOverlayPixelsAsync,
+  computeCoverageRxTargetScale,
   normalizeCoverageDbmForRxTarget,
   buildRelayCandidateOverlayPixelsAsync,
   buildSourcePassFailOverlayPixelsAsync,
@@ -69,9 +70,41 @@ const terrainSampler = () => 135;
 
 describe("overlayRaster async builders", () => {
   it("normalizes coverage colors against the RX target instead of sample min/max", () => {
-    expect(normalizeCoverageDbmForRxTarget(-140, -120)).toBe(0);
-    expect(normalizeCoverageDbmForRxTarget(-120, -120)).toBeCloseTo(0.4, 4);
-    expect(normalizeCoverageDbmForRxTarget(-90, -120)).toBe(1);
+    const scale = { min: -150, max: -90 };
+    expect(normalizeCoverageDbmForRxTarget(-150, -120, scale)).toBe(0);
+    expect(normalizeCoverageDbmForRxTarget(-120, -120, scale)).toBeCloseTo(0.5, 4);
+    expect(normalizeCoverageDbmForRxTarget(-90, -120, scale)).toBe(1);
+  });
+
+  it("centers the RX target scale while widening to observed signal distribution", () => {
+    const scale = computeCoverageRxTargetScale(
+      [
+        { lat: 0, lon: 0, valueDbm: -150 },
+        { lat: 0, lon: 1, valueDbm: -190 },
+        { lat: 1, lon: 0, valueDbm: -125 },
+        { lat: 1, lon: 1, valueDbm: -85 },
+      ],
+      -120,
+    );
+
+    expect(scale).toEqual({ min: -175, max: -65 });
+  });
+
+  it("reports the target-centered heatmap scale for the legend", async () => {
+    const raster = await buildCoverageOverlayPixelsAsync(
+      bounds,
+      samples,
+      "heatmap",
+      5,
+      { width: 16, height: 10 },
+      undefined,
+      terrainSampler,
+      { phase: "coverage", signature: "legend-scale-test" },
+      { rxTargetDbm: -100 },
+    );
+
+    expect(raster?.minDbm).toBeCloseTo(-125, 4);
+    expect(raster?.maxDbm).toBeCloseTo(-75, 4);
   });
 
   it("builds coverage raster pixels with expected metadata shape", async () => {

--- a/src/lib/overlayRaster.ts
+++ b/src/lib/overlayRaster.ts
@@ -72,6 +72,8 @@ const nextFrame = async (): Promise<void> => {
 
 const clamp = (value: number, min: number, max: number): number => Math.max(min, Math.min(max, value));
 
+const lerp = (a: number, b: number, t: number): number => a + (b - a) * t;
+
 const overlayCoordinates = (bounds: TerrainBounds): OverlayRasterPixels["coordinates"] => [
   [bounds.minLon, bounds.maxLat],
   [bounds.maxLon, bounds.maxLat],
@@ -172,9 +174,42 @@ const precomputeGridAxes = (
   return { latByRow, lonByCol };
 };
 
-export const normalizeCoverageDbmForRxTarget = (valueDbm: number, rxTargetDbm: number): number => {
-  const min = rxTargetDbm - 20;
-  const max = rxTargetDbm + 30;
+export type CoverageRxTargetScale = { min: number; max: number };
+
+const percentile = (values: number[], ratio: number): number => {
+  if (!values.length) return 0;
+  const index = clamp((values.length - 1) * ratio, 0, values.length - 1);
+  const lower = Math.floor(index);
+  const upper = Math.ceil(index);
+  if (lower === upper) return values[lower];
+  return lerp(values[lower], values[upper], index - lower);
+};
+
+export const computeCoverageRxTargetScale = (
+  samples: CoverageSampleLite[],
+  rxTargetDbm: number,
+): CoverageRxTargetScale => {
+  const values = samples
+    .map((sample) => sample.valueDbm)
+    .filter(Number.isFinite)
+    .sort((a, b) => a - b);
+  if (!values.length || !Number.isFinite(rxTargetDbm)) {
+    const target = Number.isFinite(rxTargetDbm) ? rxTargetDbm : -120;
+    return { min: target - 30, max: target + 30 };
+  }
+  const low = percentile(values, 0.05);
+  const high = percentile(values, 0.95);
+  const span = clamp(Math.max(rxTargetDbm - low, high - rxTargetDbm, 20), 20, 55);
+  return { min: rxTargetDbm - span, max: rxTargetDbm + span };
+};
+
+export const normalizeCoverageDbmForRxTarget = (
+  valueDbm: number,
+  rxTargetDbm: number,
+  scale: CoverageRxTargetScale = { min: rxTargetDbm - 20, max: rxTargetDbm + 30 },
+): number => {
+  const min = scale.min;
+  const max = scale.max;
   return clamp((valueDbm - min) / (max - min), 0, 1);
 };
 
@@ -211,8 +246,12 @@ const coverageColorAdaptive = (
   return coverageColorForDbm(clamp(normalized, -125, -62));
 };
 
-const coverageColorFixed = (valueDbm: number, rxTargetDbm: number): [number, number, number] =>
-  coverageColorForNormalized(normalizeCoverageDbmForRxTarget(valueDbm, rxTargetDbm));
+const coverageColorFixed = (
+  valueDbm: number,
+  rxTargetDbm: number,
+  scale?: CoverageRxTargetScale,
+): [number, number, number] =>
+  coverageColorForNormalized(normalizeCoverageDbmForRxTarget(valueDbm, rxTargetDbm, scale));
 
 const interpolateCoverageDbm = (samples: CoverageSampleLite[], lat: number, lon: number): number | null => {
   if (!samples.length) return null;
@@ -344,8 +383,9 @@ export const buildCoverageOverlayPixelsAsync = async (
   const width = dimensions.width;
   const height = dimensions.height;
   const { latByRow, lonByCol } = precomputeGridAxes(bounds, dimensions);
-  const adaptiveScale = options?.rxTargetDbm === undefined ? computeCoverageAdaptiveScale(samples) : null;
   const rxTargetDbm = options?.rxTargetDbm;
+  const adaptiveScale = rxTargetDbm === undefined ? computeCoverageAdaptiveScale(samples) : null;
+  const rxTargetScale = rxTargetDbm === undefined ? null : computeCoverageRxTargetScale(samples, rxTargetDbm);
   const pixels = new Uint8ClampedArray(width * height * 4);
   const valueAt = (lat: number, lon: number): number | null =>
     gridInterpolator ? gridInterpolator(lat, lon) : interpolateCoverageDbm(samples, lat, lon);
@@ -369,7 +409,7 @@ export const buildCoverageOverlayPixelsAsync = async (
       if (mode === "heatmap") {
         [r, g, b] = rxTargetDbm === undefined
           ? coverageColorAdaptive(valueDbm, adaptiveScale)
-          : coverageColorFixed(valueDbm, rxTargetDbm);
+          : coverageColorFixed(valueDbm, rxTargetDbm, rxTargetScale ?? undefined);
       } else {
         const target = rxTargetDbm;
         if (target === undefined) {
@@ -385,7 +425,7 @@ export const buildCoverageOverlayPixelsAsync = async (
           const crossesRight = rightValue !== null && (valueDbm - target) * (rightValue - target) <= 0;
           const crossesDown = downValue !== null && (valueDbm - target) * (downValue - target) <= 0;
           if (Math.abs(valueDbm - target) > toleranceDb && !crossesRight && !crossesDown) return;
-          [r, g, b] = coverageColorFixed(target, target);
+          [r, g, b] = coverageColorFixed(target, target, rxTargetScale ?? undefined);
           a = 230;
         }
       }
@@ -404,6 +444,8 @@ export const buildCoverageOverlayPixelsAsync = async (
     height,
     pixels,
     coordinates: overlayCoordinates(bounds),
+    minDbm: rxTargetScale?.min,
+    maxDbm: rxTargetScale?.max,
   };
 };
 

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1201,10 +1201,10 @@ const sameSiteSelection = (left: string[], right: string[]): boolean => {
 };
 
 const defaultOverlayModeForSelectionCount = (selectionCount: number): MapOverlayMode => {
-  if (selectionCount <= 0) return "heatmap";
+  if (selectionCount <= 0) return "contours";
   if (selectionCount === 1) return "passfail";
   if (selectionCount === 2) return "relay";
-  return "heatmap";
+  return "contours";
 };
 
 const applyDefaultsToScenarioNetworks = (networks: Network[], defaults: SimulationDefaults): Network[] =>
@@ -1319,7 +1319,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   showSiteLibraryRequest: false,
   pendingSiteLibraryOpenEntryId: null,
   scenarioOptions: BUILTIN_SCENARIOS.map((scenario) => ({ id: scenario.id, name: scenario.name })),
-  mapOverlayMode: "heatmap",
+  mapOverlayMode: "contours",
   discoveryLibraryVisible: false,
   discoveryMqttVisible: false,
   mapDiscoveryMqttNodes: [],


### PR DESCRIPTION
## Summary
- Make general Heatmap overlays default to Heatmap + Target Line so the RX target threshold is enabled by default.
- Put the `Draw RX target threshold line` checkbox inline with its label.
- Replace the fixed `target -20/+30 dB` heatmap ramp with a target-centered adaptive span using observed p5/p95 values, clamped to keep the RX target anchor meaningful while using more of the color spectrum.

## Verification
- npx tsc -b config/tsconfig.json
- npx vitest run --config config/vitest.config.ts src/lib/overlayRaster.test.ts
- npx vitest run --config config/vitest.config.ts
- npx vitest run --config config/vitest.config.ts src/lib/overlayRaster.test.ts src/store/appStore.test.ts src/store/appStore.selectionRecompute.test.ts
- npx vite build --config config/vite.config.ts

## Note
- `npm test` and `npm run build` are blocked locally by an unrelated missing `scripts/generate-build-info.mjs` file in the worktree.

Closes #814