### PR TITLE
Tone down RX target contour

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -182,7 +182,7 @@ const targetContourHaloLayer = (color: string): LayerProps => ({
   type: "line",
   paint: {
     "line-color": color,
-    "line-width": 5,
+    "line-width": 2.5,
     "line-opacity": 0.82,
   },
 });
@@ -192,7 +192,7 @@ const targetContourLineLayer = (color: string): LayerProps => ({
   type: "line",
   paint: {
     "line-color": color,
-    "line-width": 2.4,
+    "line-width": 1.2,
     "line-opacity": 0.96,
   },
 });
@@ -2660,7 +2660,7 @@ export function MapView({
   }, [selectionCount]);
   useEffect(() => {
     if (allowedOverlayModes.includes(coverageVizMode as "none" | "heatmap" | "contours" | "weakest" | "passfail" | "relay")) return;
-    setCoverageVizMode(selectionCount === 1 ? "passfail" : selectionCount === 2 ? "relay" : "contours");
+    setCoverageVizMode(selectionCount === 1 ? "passfail" : selectionCount === 2 ? "relay" : "heatmap");
   }, [allowedOverlayModes, coverageVizMode, selectionCount, setCoverageVizMode]);
   const simulationOverlaySelectValue = coverageVizMode;
   const siteVisibilityMode: "simulation" | "library" | "mqtt" =
@@ -3446,7 +3446,7 @@ export function MapView({
         {showTargetContourLine ? (
           <Source data={targetContourFeatures} id="coverage-target-contour-source" type="geojson">
             <Layer {...targetContourHaloLayer(variant.cssVars["--bg"] ?? linkColor)} />
-            <Layer {...targetContourLineLayer(selectedLinkColor)} />
+            <Layer {...targetContourLineLayer(variant.cssVars["--muted"] ?? selectedLinkColor)} />
           </Source>
         ) : null}
 

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1201,10 +1201,10 @@ const sameSiteSelection = (left: string[], right: string[]): boolean => {
 };
 
 const defaultOverlayModeForSelectionCount = (selectionCount: number): MapOverlayMode => {
-  if (selectionCount <= 0) return "contours";
+  if (selectionCount <= 0) return "heatmap";
   if (selectionCount === 1) return "passfail";
   if (selectionCount === 2) return "relay";
-  return "contours";
+  return "heatmap";
 };
 
 const applyDefaultsToScenarioNetworks = (networks: Network[], defaults: SimulationDefaults): Network[] =>
@@ -1319,7 +1319,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   showSiteLibraryRequest: false,
   pendingSiteLibraryOpenEntryId: null,
   scenarioOptions: BUILTIN_SCENARIOS.map((scenario) => ({ id: scenario.id, name: scenario.name })),
-  mapOverlayMode: "contours",
+  mapOverlayMode: "heatmap",
   discoveryLibraryVisible: false,
   discoveryMqttVisible: false,
   mapDiscoveryMqttNodes: [],


### PR DESCRIPTION
## Summary
- Change the RX target contour main line to use the theme `--muted` color.
- Halve the target contour halo and main line widths.
- Make the general Heatmap overlay default to target-line off again.

## Verification
- npx tsc -b config/tsconfig.json
- npx vitest run --config config/vitest.config.ts src/store/appStore.test.ts src/store/appStore.selectionRecompute.test.ts
- npx vite build --config config/vite.config.ts

## Note
- `npm test` and `npm run build` are blocked locally by an unrelated missing `scripts/generate-build-info.mjs` file in the worktree.