### PR TITLE
Add read-only editor views

### DIFF
--- a/src/components/Sidebar.readOnly.test.tsx
+++ b/src/components/Sidebar.readOnly.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import React from "react";
 import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.hoisted(() => {
@@ -24,9 +25,13 @@ vi.hoisted(() => {
 
 vi.mock("react-map-gl/maplibre", () => {
   return {
-    default: ({ children }: { children?: React.ReactNode }) => <div data-testid="mock-map">{children}</div>,
+    default: ({ children }: { children?: React.ReactNode }) => (
+      <div data-testid="mock-map">{children}</div>
+    ),
     Layer: () => null,
-    Marker: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    Marker: ({ children }: { children?: React.ReactNode }) => (
+      <div>{children}</div>
+    ),
     Source: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
   };
 });
@@ -54,12 +59,77 @@ describe("Sidebar read-only simulation site actions", () => {
           rxGainDbi: 2,
           cableLossDb: 1,
         },
+        {
+          id: "site-beta",
+          name: "Site Beta",
+          position: { lat: 60.6, lon: 11.6 },
+          groundElevationM: 130,
+          antennaHeightM: 4,
+          txPowerDbm: 21,
+          txGainDbi: 3,
+          rxGainDbi: 3,
+          cableLossDb: 1,
+        },
       ],
-      links: [],
+      links: [
+        {
+          id: "link-alpha",
+          name: "Alpha Link",
+          fromSiteId: "site-alpha",
+          toSiteId: "site-beta",
+          frequencyMHz: 868,
+        },
+      ],
       selectedSiteId: "site-alpha",
       selectedSiteIds: ["site-alpha"],
       selectedLinkId: "",
       siteLibrary: [],
+    });
+  });
+
+  it("replaces read-only row edit buttons with view details actions", async () => {
+    render(<Sidebar readOnly />);
+
+    const sitesSection = screen.getByText("Sites").closest("section");
+    expect(sitesSection).not.toBeNull();
+    expect(
+      within(sitesSection as HTMLElement).queryByRole("button", {
+        name: "Edit site",
+      }),
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(
+      within(sitesSection as HTMLElement).getAllByRole("button", {
+        name: /View site details/,
+      })[0],
+    );
+
+    expect(useAppStore.getState().mapEditor).toMatchObject({
+      kind: "site",
+      resourceId: "site-alpha",
+      isNew: false,
+      label: "Site Alpha",
+    });
+
+    const linksSection = screen.getByText("Links").closest("section");
+    expect(linksSection).not.toBeNull();
+    expect(
+      within(linksSection as HTMLElement).queryByRole("button", {
+        name: "Edit link",
+      }),
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(
+      within(linksSection as HTMLElement).getByRole("button", {
+        name: /View link details/,
+      }),
+    );
+
+    expect(useAppStore.getState().mapEditor).toMatchObject({
+      kind: "link",
+      resourceId: "link-alpha",
+      isNew: false,
+      label: "Alpha Link",
     });
   });
 
@@ -68,7 +138,11 @@ describe("Sidebar read-only simulation site actions", () => {
 
     const sitesSection = screen.getByText("Sites").closest("section");
     expect(sitesSection).not.toBeNull();
-    expect(within(sitesSection as HTMLElement).queryByRole("button", { name: "Edit" })).not.toBeInTheDocument();
+    expect(
+      within(sitesSection as HTMLElement).queryByRole("button", {
+        name: "Edit",
+      }),
+    ).not.toBeInTheDocument();
     expect(
       within(sitesSection as HTMLElement).getByText(
         "Read-only: you need edit permission to add or edit sites in this simulation.",

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import clsx from "clsx";
-import { CircleMinus, Funnel, Handshake, HatGlasses, Pencil } from "lucide-react";
+import { CircleMinus, Funnel, Handshake, HatGlasses, Info, Pencil } from "lucide-react";
 import { useThemeVariant } from "../hooks/useThemeVariant";
 import { t } from "../i18n/locales";
 import { getCurrentRuntimeEnvironment } from "../lib/environment";
@@ -48,6 +48,8 @@ import { UserAdminPanel } from "./UserAdminPanel";
 
 const READ_ONLY_SIMULATION_SITE_HELP =
   "Read-only: you need edit permission to add or edit sites in this simulation.";
+const READ_ONLY_VIEW_DETAILS_HELP =
+  "Read-only: you can view this item, but need edit permission to change it.";
 
 const UserBadge = ({ name, avatarUrl }: { name: string; avatarUrl?: string | null }) => (
   <span className="user-list-row">
@@ -698,16 +700,35 @@ export function Sidebar({
               >
                 {site.name}
               </button>
-              {!readOnly && (
-                <div className="row-actions">
+              <div className="row-actions">
+                {readOnly ? (
                   <ActionButton
-                    aria-label="Edit site"
+                    aria-label={`View site details: ${site.name}. ${READ_ONLY_VIEW_DETAILS_HELP}`}
                     size="icon"
-                    title="Edit site"
-                    onClick={(e) => openLibraryForSite(site, e.currentTarget)}
+                    title={READ_ONLY_VIEW_DETAILS_HELP}
+                    onClick={(e) => {
+                      openMapEditor({
+                        kind: "site",
+                        resourceId: site.id,
+                        isNew: false,
+                        label: site.name,
+                        anchorRect: e.currentTarget.getBoundingClientRect(),
+                        readOnly: true,
+                      });
+                    }}
                   >
-                    <Pencil aria-hidden="true" strokeWidth={1.8} />
+                    <Info aria-hidden="true" strokeWidth={1.8} />
                   </ActionButton>
+                ) : (
+                  <>
+                    <ActionButton
+                      aria-label="Edit site"
+                      size="icon"
+                      title="Edit site"
+                      onClick={(e) => openLibraryForSite(site, e.currentTarget)}
+                    >
+                      <Pencil aria-hidden="true" strokeWidth={1.8} />
+                    </ActionButton>
                   <ActionButton
                     aria-label="Remove site"
                     disabled={sites.length <= 1}
@@ -724,8 +745,9 @@ export function Sidebar({
                   >
                     <CircleMinus aria-hidden="true" strokeWidth={1.8} />
                   </ActionButton>
-                </div>
-              )}
+                  </>
+                )}
+              </div>
             </div>
           ))}
         </div>
@@ -766,12 +788,12 @@ export function Sidebar({
               >
                 <span className="link-title">{displayLinkName(link.id, link.name)}</span>
               </button>
-              {!readOnly && (
-                <div className="row-actions">
+              <div className="row-actions">
+                {readOnly ? (
                   <ActionButton
-                    aria-label="Edit link"
+                    aria-label={`View link details: ${displayLinkName(link.id, link.name)}. ${READ_ONLY_VIEW_DETAILS_HELP}`}
                     size="icon"
-                    title="Edit link"
+                    title={READ_ONLY_VIEW_DETAILS_HELP}
                     onClick={(e) => {
                       openMapEditor({
                         kind: "link",
@@ -779,11 +801,30 @@ export function Sidebar({
                         isNew: false,
                         label: link.name ?? displayLinkName(link.id),
                         anchorRect: e.currentTarget.getBoundingClientRect(),
+                        readOnly: true,
                       });
                     }}
                   >
-                    <Pencil aria-hidden="true" strokeWidth={1.8} />
+                    <Info aria-hidden="true" strokeWidth={1.8} />
                   </ActionButton>
+                ) : (
+                  <>
+                    <ActionButton
+                      aria-label="Edit link"
+                      size="icon"
+                      title="Edit link"
+                      onClick={(e) => {
+                        openMapEditor({
+                          kind: "link",
+                          resourceId: link.id,
+                          isNew: false,
+                          label: link.name ?? displayLinkName(link.id),
+                          anchorRect: e.currentTarget.getBoundingClientRect(),
+                        });
+                      }}
+                    >
+                      <Pencil aria-hidden="true" strokeWidth={1.8} />
+                    </ActionButton>
                   <ActionButton
                     aria-label="Remove link"
                     size="icon"
@@ -798,8 +839,9 @@ export function Sidebar({
                   >
                     <CircleMinus aria-hidden="true" strokeWidth={1.8} />
                   </ActionButton>
-                </div>
-              )}
+                  </>
+                )}
+              </div>
             </div>
           ))}
         </div>

--- a/src/components/map/MapEditorPanel.test.tsx
+++ b/src/components/map/MapEditorPanel.test.tsx
@@ -27,13 +27,30 @@ const storage = vi.hoisted(() => {
 });
 
 vi.mock("../../lib/cloudUser", async () => {
-  const actual = await vi.importActual<typeof import("../../lib/cloudUser")>("../../lib/cloudUser");
+  const actual = await vi.importActual<typeof import("../../lib/cloudUser")>(
+    "../../lib/cloudUser",
+  );
   return {
     ...actual,
     fetchCollaboratorDirectory: vi.fn(async () => [
-      { id: "owner-1", username: "Owner User", email: "owner@example.com", avatarUrl: "" },
-      { id: "editor-1", username: "Editor User", email: "editor@example.com", avatarUrl: "" },
-      { id: "collab-1", username: "Collaborator User", email: "collab@example.com", avatarUrl: "" },
+      {
+        id: "owner-1",
+        username: "Owner User",
+        email: "owner@example.com",
+        avatarUrl: "",
+      },
+      {
+        id: "editor-1",
+        username: "Editor User",
+        email: "editor@example.com",
+        avatarUrl: "",
+      },
+      {
+        id: "collab-1",
+        username: "Collaborator User",
+        email: "collab@example.com",
+        avatarUrl: "",
+      },
     ]),
     fetchResourceChanges: vi.fn(async () => [
       {
@@ -82,15 +99,26 @@ const currentUser = {
   updatedAt: null,
 };
 
-const anchorRect = { top: 100, right: 200, bottom: 120, left: 160, width: 40, height: 20 };
+const anchorRect = {
+  top: 100,
+  right: 200,
+  bottom: 120,
+  left: 160,
+  width: 40,
+  height: 20,
+};
 
 describe("MapEditorPanel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     storage.mock.clear();
     useAppStore.setState(useAppStore.getInitialState(), true);
-    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => window.setTimeout(callback, 0));
-    vi.stubGlobal("cancelAnimationFrame", (id: number) => window.clearTimeout(id));
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) =>
+      window.setTimeout(callback, 0),
+    );
+    vi.stubGlobal("cancelAnimationFrame", (id: number) =>
+      window.clearTimeout(id),
+    );
     vi.stubGlobal(
       "ResizeObserver",
       class {
@@ -144,10 +172,14 @@ describe("MapEditorPanel", () => {
     expect(screen.getByText("Last edited")).toBeInTheDocument();
     expect(screen.queryByText("Editor User")).not.toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole("button", { name: "Open change log" }));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Open change log" }),
+    );
 
     expect(fetchResourceChanges).toHaveBeenCalledWith("site", "site-lib-1");
-    expect(await screen.findByText("Change Log · Alpha Site")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Change Log · Alpha Site"),
+    ).toBeInTheDocument();
     expect(screen.getByText("Moved site")).toBeInTheDocument();
   });
 
@@ -182,7 +214,8 @@ describe("MapEditorPanel", () => {
             selectedFrequencyPresetId: "custom",
             rxSensitivityTargetDbm: -120,
             environmentLossDb: 0,
-            propagationEnvironment: useAppStore.getState().propagationEnvironment,
+            propagationEnvironment:
+              useAppStore.getState().propagationEnvironment,
             autoPropagationEnvironment: true,
             terrainDataset: "copernicus30",
           },
@@ -204,10 +237,14 @@ describe("MapEditorPanel", () => {
     expect(screen.getByText("Last edited")).toBeInTheDocument();
     expect(screen.queryByText("Editor User")).not.toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole("button", { name: "Open change log" }));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Open change log" }),
+    );
 
     expect(fetchResourceChanges).toHaveBeenCalledWith("simulation", "sim-1");
-    expect(await screen.findByText("Change Log · Mesh Plan")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Change Log · Mesh Plan"),
+    ).toBeInTheDocument();
   });
 
   it("shows Simulation settings summary and enables override editing from the edit action", async () => {
@@ -258,7 +295,8 @@ describe("MapEditorPanel", () => {
             selectedFrequencyPresetId: "custom",
             rxSensitivityTargetDbm: -130,
             environmentLossDb: 0,
-            propagationEnvironment: useAppStore.getState().propagationEnvironment,
+            propagationEnvironment:
+              useAppStore.getState().propagationEnvironment,
             autoPropagationEnvironment: true,
             terrainDataset: "copernicus30",
           },
@@ -276,14 +314,183 @@ describe("MapEditorPanel", () => {
     render(<MapEditorPanel isMobile={false} />);
 
     expect(await screen.findByText("Simulation settings")).toBeInTheDocument();
-    expect(screen.getByText("869.618 MHz · 62 kHz · SF8 · CR5 · Region EU_868 · RX -130 dBm · Auto environment")).toBeInTheDocument();
-    expect(screen.queryByText("This Simulation inherits the owner's account defaults for channel, RX target, and environment.")).not.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "869.618 MHz · 62 kHz · SF8 · CR5 · Region EU_868 · RX -130 dBm · Auto environment",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "This Simulation inherits the owner's account defaults for channel, RX target, and environment.",
+      ),
+    ).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Frequency (MHz)")).not.toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole("button", { name: "Override Simulation settings" }));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Override Simulation settings" }),
+    );
 
     expect(screen.getByLabelText("Frequency (MHz)")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Use inherited defaults" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Use inherited defaults" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders read-only site details as static text", async () => {
+    useAppStore.setState({
+      siteLibrary: [
+        {
+          id: "site-lib-1",
+          name: "Alpha Site",
+          description: "",
+          visibility: "shared",
+          sharedWith: [{ userId: "owner-1", role: "viewer" }],
+          ownerUserId: "editor-1",
+          effectiveRole: "viewer",
+          position: { lat: 60.1, lon: 10.2 },
+          groundElevationM: 111,
+          antennaHeightM: 10,
+          txPowerDbm: 20,
+          txGainDbi: 2,
+          rxGainDbi: 2,
+          cableLossDb: 1,
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+      mapEditor: {
+        kind: "site",
+        resourceId: "site-lib-1",
+        isNew: false,
+        label: "Alpha Site",
+        anchorRect,
+      },
+    });
+
+    render(<MapEditorPanel isMobile={false} />);
+
+    expect(
+      await screen.findByRole("heading", { name: "Alpha Site" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByDisplayValue("Alpha Site")).not.toBeInTheDocument();
+    expect(screen.getByText("60.1")).toBeInTheDocument();
+    expect(screen.getByLabelText("Description")).toHaveTextContent("");
+    expect(
+      screen.queryByRole("button", { name: "Save Site" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders read-only simulation details as static text", async () => {
+    useAppStore.setState({
+      simulationPresets: [
+        {
+          id: "sim-1",
+          name: "Mesh Plan",
+          description: "Shared plan",
+          visibility: "shared",
+          sharedWith: [{ userId: "owner-1", role: "viewer" }],
+          ownerUserId: "editor-1",
+          effectiveRole: "viewer",
+          updatedAt: "2026-01-02T00:00:00.000Z",
+          snapshot: {
+            sites: [],
+            links: [],
+            systems: [],
+            networks: [],
+            selectedSiteId: "",
+            selectedLinkId: "",
+            selectedNetworkId: "",
+            selectedCoverageResolution: "24",
+            propagationModel: "ITM",
+            selectedFrequencyPresetId: "custom",
+            rxSensitivityTargetDbm: -130,
+            environmentLossDb: 0,
+            propagationEnvironment:
+              useAppStore.getState().propagationEnvironment,
+            autoPropagationEnvironment: true,
+            terrainDataset: "copernicus30",
+          },
+        },
+      ],
+      mapEditor: {
+        kind: "simulation",
+        resourceId: "sim-1",
+        isNew: false,
+        label: "Mesh Plan",
+        anchorRect,
+      },
+    });
+
+    render(<MapEditorPanel isMobile={false} />);
+
+    expect(
+      await screen.findByRole("heading", { name: "Mesh Plan" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByDisplayValue("Mesh Plan")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Description")).toHaveTextContent(
+      "Shared plan",
+    );
+    expect(
+      screen.queryByRole("button", { name: "Save" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders read-only link details as static text", async () => {
+    useAppStore.setState({
+      currentUser,
+      sites: [
+        {
+          id: "site-a",
+          name: "Site A",
+          position: { lat: 1, lon: 2 },
+          groundElevationM: 3,
+          antennaHeightM: 4,
+          txPowerDbm: 5,
+          txGainDbi: 6,
+          rxGainDbi: 7,
+          cableLossDb: 8,
+        },
+        {
+          id: "site-b",
+          name: "Site B",
+          position: { lat: 9, lon: 10 },
+          groundElevationM: 11,
+          antennaHeightM: 12,
+          txPowerDbm: 13,
+          txGainDbi: 14,
+          rxGainDbi: 15,
+          cableLossDb: 16,
+        },
+      ],
+      links: [
+        {
+          id: "link-1",
+          name: "Path A",
+          fromSiteId: "site-a",
+          toSiteId: "site-b",
+          frequencyMHz: 868,
+        },
+      ],
+      mapEditor: {
+        kind: "link",
+        resourceId: "link-1",
+        isNew: false,
+        label: "Path A",
+        anchorRect,
+        readOnly: true,
+      },
+    });
+
+    render(<MapEditorPanel isMobile={false} />);
+
+    expect(
+      await screen.findByRole("heading", { name: "Path A" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByDisplayValue("Path A")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("From site")).toHaveTextContent("Site A");
+    expect(screen.getByLabelText("To site")).toHaveTextContent("Site B");
+    expect(
+      screen.queryByRole("button", { name: "Save Link" }),
+    ).not.toBeInTheDocument();
   });
 
   it("keeps the editor open when new site creation fails", async () => {
@@ -312,7 +519,9 @@ describe("MapEditorPanel", () => {
     expect(addSiteLibraryEntry).toHaveBeenCalled();
     expect(updateSiteLibraryEntry).not.toHaveBeenCalled();
     expect(insertSiteFromLibrary).not.toHaveBeenCalled();
-    expect(screen.getByText("Failed creating site. Check the name and try again.")).toBeInTheDocument();
+    expect(
+      screen.getByText("Failed creating site. Check the name and try again."),
+    ).toBeInTheDocument();
     expect(useAppStore.getState().mapEditor).not.toBeNull();
   });
 });

--- a/src/components/map/MapEditorPanel.tsx
+++ b/src/components/map/MapEditorPanel.tsx
@@ -77,6 +77,22 @@ type ResourceMetadata = {
   };
 };
 
+const formatStaticValue = (value: string | number | null | undefined): string => {
+  if (value === null || value === undefined) return "";
+  return String(value);
+};
+
+function StaticField({ label, value }: { label: string; value: string | number | null | undefined }) {
+  return (
+    <div className="field-grid">
+      <span>{label}</span>
+      <span aria-label={label} className="field-help static-field-value">
+        {formatStaticValue(value)}
+      </span>
+    </div>
+  );
+}
+
 const UserBadge = ({ name, avatarUrl }: { name: string; avatarUrl?: string | null }) => (
   <span className="user-list-row">
     <AvatarBadge avatarUrl={avatarUrl} imageClassName="profile-avatar" name={name} />
@@ -197,19 +213,54 @@ function SiteEditorCard({
   onOpenUserProfile: (userId: string) => void;
 }) {
   const mapEditor = useAppStore((state) => state.mapEditor);
+  const isReadOnly = !form.canWrite && !isNew;
+  const title = isNew ? "New Site" : (mapEditor?.label ?? form.nameDraft);
 
   return (
     <>
       <div className="library-manager-header">
-        <h2>{isNew ? "New Site" : `Edit · ${mapEditor?.label ?? "Site"}`}</h2>
+        <h2>{title}</h2>
         <InlineCloseIconButton onClick={onClose} />
       </div>
 
-      {!form.canWrite && !isNew && (
+      {isReadOnly && (
         <p className="field-help warning-text">Read-only: you can view this site but cannot edit it.</p>
       )}
 
-      <fieldset className="resource-edit-fieldset" disabled={!form.canWrite && !isNew}>
+      {isReadOnly ? (
+        <div className="resource-edit-fieldset">
+          <StaticField label="Name" value={form.nameDraft} />
+          <StaticField label="Description" value={form.descriptionDraft} />
+          <StaticField label="Visibility" value={form.accessVisibility} />
+          <StaticField label="Latitude" value={form.latDraft} />
+          <StaticField label="Longitude" value={form.lonDraft} />
+          <StaticField label="Ground elev (m)" value={form.groundDraft} />
+          <div className="beam-visualizer-field-group">
+            <StaticField label="Antenna (m)" value={form.antennaDraft} />
+            <StaticField label="Tx power (dBm)" value={form.txPowerDraft} />
+            {form.separateGain ? (
+              <>
+                <StaticField label="Tx gain (dBi)" value={form.txGainDraft} />
+                <StaticField label="Rx gain (dBi)" value={form.rxGainDraft} />
+              </>
+            ) : (
+              <StaticField label="Gain (dBi)" value={form.txGainDraft} />
+            )}
+            <StaticField label="Separate RX/TX gain" value={form.separateGain ? "Yes" : "No"} />
+            <StaticField label="Cable loss (dB)" value={form.cableLossDraft} />
+          </div>
+          <SiteBeamVisualizer
+            values={{
+              antennaHeightM: form.antennaDraft,
+              txPowerDbm: form.txPowerDraft,
+              txGainDbi: form.txGainDraft,
+              rxGainDbi: form.rxGainDraft,
+              cableLossDb: form.cableLossDraft,
+            }}
+          />
+        </div>
+      ) : (
+      <fieldset className="resource-edit-fieldset">
         <label className="field-grid">
           <span>Name</span>
           <input
@@ -418,17 +469,16 @@ function SiteEditorCard({
           }}
         />
       </fieldset>
+      )}
 
       {form.status ? <p className="field-help">{form.status}</p> : null}
 
       <div className="chip-group">
-        <ActionButton
-          disabled={!form.canWrite && !isNew}
-          onClick={form.handleSaveSite}
-          type="button"
-        >
-          {isNew ? "Create Site" : "Save Site"}
-        </ActionButton>
+        {!isReadOnly ? (
+          <ActionButton onClick={form.handleSaveSite} type="button">
+            {isNew ? "Create Site" : "Save Site"}
+          </ActionButton>
+        ) : null}
         <ActionButton onClick={onClose} type="button">
           Cancel
         </ActionButton>
@@ -457,14 +507,37 @@ function LinkEditorCard({
   onClose: () => void;
 }) {
   const mapEditor = useAppStore((state) => state.mapEditor);
+  const isReadOnly = Boolean(mapEditor?.readOnly && !isNew);
+  const title = isNew ? "New Link" : (mapEditor?.label ?? form.linkNameDraft) || "Link";
+  const fromSiteName = form.sites.find((site) => site.id === form.linkFromSiteId)?.name ?? "";
+  const toSiteName = form.sites.find((site) => site.id === form.linkToSiteId)?.name ?? "";
 
   return (
     <>
       <div className="library-manager-header">
-        <h2>{isNew ? "New Link" : `Edit · ${mapEditor?.label ?? "Link"}`}</h2>
+        <h2>{title}</h2>
         <InlineCloseIconButton onClick={onClose} />
       </div>
 
+      {isReadOnly ? <p className="field-help warning-text">Read-only: you can view this link but cannot edit it.</p> : null}
+
+      {isReadOnly ? (
+        <div className="resource-edit-fieldset">
+          <StaticField label="Link name" value={form.linkNameDraft} />
+          <StaticField label="From site" value={fromSiteName} />
+          <StaticField label="To site" value={toSiteName} />
+          <StaticField label="Override site radio settings" value={form.overrideRadio ? "Yes" : "No"} />
+          {form.overrideRadio ? (
+            <>
+              <StaticField label="Tx power (dBm)" value={form.linkTxPower} />
+              <StaticField label="Tx gain (dBi)" value={form.linkTxGain} />
+              <StaticField label="Rx gain (dBi)" value={form.linkRxGain} />
+              <StaticField label="Cable loss (dB)" value={form.linkCableLoss} />
+            </>
+          ) : null}
+        </div>
+      ) : (
+        <>
       <label className="field-grid">
         <span>Link name</span>
         <input
@@ -561,13 +634,17 @@ function LinkEditorCard({
             </label>
           </>
         ) : null}
+        </>
+      )}
 
       {form.status ? <p className="field-help">{form.status}</p> : null}
 
       <div className="chip-group">
-        <ActionButton onClick={form.handleSaveLink} type="button">
-          {isNew ? "Create Link" : "Save Link"}
-        </ActionButton>
+        {!isReadOnly ? (
+          <ActionButton onClick={form.handleSaveLink} type="button">
+            {isNew ? "Create Link" : "Save Link"}
+          </ActionButton>
+        ) : null}
         <ActionButton onClick={onClose} type="button">
           Cancel
         </ActionButton>
@@ -592,6 +669,8 @@ function SimulationEditorCard({
   onOpenUserProfile: (userId: string) => void;
 }) {
   const mapEditor = useAppStore((state) => state.mapEditor);
+  const isReadOnly = !form.canWrite && !isNew;
+  const title = isNew ? "New Simulation" : (mapEditor?.label ?? form.nameDraft);
   const simulationDefaultsSummary = [
     `${form.simulationDefaultsDraft.frequencyMHz} MHz`,
     `${form.simulationDefaultsDraft.bandwidthKhz} kHz`,
@@ -607,15 +686,28 @@ function SimulationEditorCard({
   return (
     <>
       <div className="library-manager-header">
-        <h2>{isNew ? "New Simulation" : `Edit · ${mapEditor?.label ?? "Simulation"}`}</h2>
+        <h2>{title}</h2>
         <InlineCloseIconButton onClick={onClose} />
       </div>
 
-      {!form.canWrite && !isNew && (
+      {isReadOnly && (
         <p className="field-help warning-text">Read-only: you can view this simulation but cannot edit it.</p>
       )}
 
-      <fieldset className="resource-edit-fieldset" disabled={!form.canWrite && !isNew}>
+      {isReadOnly ? (
+        <div className="resource-edit-fieldset">
+          <StaticField label="Name" value={form.nameDraft} />
+          <StaticField label="Description" value={form.descriptionDraft} />
+          <StaticField label="Visibility" value={form.accessVisibility} />
+          <div className="simulation-settings-block">
+            <div className="simulation-settings-header">
+              <span>Simulation settings</span>
+            </div>
+            <p className="field-help simulation-settings-summary">{simulationDefaultsSummary}</p>
+          </div>
+        </div>
+      ) : (
+      <fieldset className="resource-edit-fieldset">
         <label className="field-grid">
           <span>Name</span>
           <input
@@ -745,6 +837,7 @@ function SimulationEditorCard({
           </>
         ) : null}
       </fieldset>
+      )}
 
       {/* Pending visibility confirmation prompt */}
       {form.pendingVisibilityConfirm ? (
@@ -768,9 +861,11 @@ function SimulationEditorCard({
 
       {!form.pendingVisibilityConfirm ? (
         <div className="chip-group">
-          <ActionButton disabled={!form.canWrite} onClick={form.handleSaveSimulation} type="button">
-            {isNew ? "Create Simulation" : "Save"}
-          </ActionButton>
+          {!isReadOnly ? (
+            <ActionButton onClick={form.handleSaveSimulation} type="button">
+              {isNew ? "Create Simulation" : "Save"}
+            </ActionButton>
+          ) : null}
           <ActionButton onClick={onClose} type="button">
             Cancel
           </ActionButton>

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -464,6 +464,7 @@ type AppState = {
       frequencyPresetId?: string;
       autoPropagationEnvironment?: boolean;
     };
+    readOnly?: boolean;
   } | null;
   mapEditorSiteDraft: { lat: number; lon: number; groundElevationM: number | null } | null;
   openMapEditor: (payload: NonNullable<AppState["mapEditor"]>) => void;


### PR DESCRIPTION
## Summary
- Render Site, Simulation, and Link editor cards as static read-only details instead of disabled inputs.
- Replace read-only sidebar row edit buttons with info-style view-detail actions.
- Cover read-only editor/sidebar behavior with focused tests.

## Verification
- [x] npm test
- [x] npm run build
- [x] npm run dev:check

Closes #842