### PR TITLE
Fix read-only sidebar detail actions

### DIFF
--- a/src/components/Sidebar.readOnly.test.tsx
+++ b/src/components/Sidebar.readOnly.test.tsx
@@ -83,12 +83,87 @@ describe("Sidebar read-only simulation site actions", () => {
       selectedSiteId: "site-alpha",
       selectedSiteIds: ["site-alpha"],
       selectedLinkId: "",
+      selectedScenarioId: "sim-alpha",
       siteLibrary: [],
+      simulationPresets: [
+        {
+          id: "sim-alpha",
+          name: "Alpha Simulation",
+          description: "Shared simulation",
+          visibility: "shared",
+          sharedWith: [],
+          effectiveRole: "viewer",
+          ownerUserId: "owner-1",
+          updatedAt: "2026-01-02T00:00:00.000Z",
+          snapshot: {
+            sites: [
+              {
+                id: "site-alpha",
+                name: "Site Alpha",
+                position: { lat: 60.5, lon: 11.5 },
+                groundElevationM: 120,
+                antennaHeightM: 2,
+                txPowerDbm: 20,
+                txGainDbi: 2,
+                rxGainDbi: 2,
+                cableLossDb: 1,
+              },
+              {
+                id: "site-beta",
+                name: "Site Beta",
+                position: { lat: 60.6, lon: 11.6 },
+                groundElevationM: 130,
+                antennaHeightM: 4,
+                txPowerDbm: 21,
+                txGainDbi: 3,
+                rxGainDbi: 3,
+                cableLossDb: 1,
+              },
+            ],
+            links: [
+              {
+                id: "link-alpha",
+                name: "Alpha Link",
+                fromSiteId: "site-alpha",
+                toSiteId: "site-beta",
+                frequencyMHz: 868,
+              },
+            ],
+            systems: [],
+            networks: [],
+            selectedSiteId: "",
+            selectedLinkId: "",
+            selectedNetworkId: "",
+            selectedCoverageResolution: "24",
+            propagationModel: "ITM",
+            selectedFrequencyPresetId: "custom",
+            rxSensitivityTargetDbm: -120,
+            environmentLossDb: 0,
+            propagationEnvironment: useAppStore.getState().propagationEnvironment,
+            autoPropagationEnvironment: true,
+            terrainDataset: "copernicus30",
+          },
+        },
+      ],
     });
   });
 
   it("replaces read-only row edit buttons with view details actions", async () => {
     render(<Sidebar readOnly />);
+
+    const simulationSection = screen.getByText(/Simulation:/).closest("section");
+    expect(simulationSection).not.toBeNull();
+    expect(within(simulationSection as HTMLElement).queryByRole("button", { name: "Edit" })).not.toBeInTheDocument();
+
+    await userEvent.click(within(simulationSection as HTMLElement).getByRole("button", { name: "View details" }));
+
+    expect(useAppStore.getState().mapEditor).toMatchObject({
+      kind: "simulation",
+      resourceId: "sim-alpha",
+      isNew: false,
+      label: "Alpha Simulation",
+      readOnly: true,
+    });
 
     const sitesSection = screen.getByText("Sites").closest("section");
     expect(sitesSection).not.toBeNull();
@@ -109,6 +184,7 @@ describe("Sidebar read-only simulation site actions", () => {
       resourceId: "site-alpha",
       isNew: false,
       label: "Site Alpha",
+      readOnly: true,
     });
 
     const linksSection = screen.getByText("Links").closest("section");
@@ -130,6 +206,7 @@ describe("Sidebar read-only simulation site actions", () => {
       resourceId: "link-alpha",
       isNew: false,
       label: "Alpha Link",
+      readOnly: true,
     });
   });
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -354,6 +354,7 @@ export function Sidebar({
       isNew: false,
       label: preset.name,
       anchorRect: triggerEl?.getBoundingClientRect() ?? { top: 0, right: 0, bottom: 0, left: 0, width: 0, height: 0 },
+      readOnly,
     });
   };
   const collaboratorDirectoryById = useMemo(
@@ -673,7 +674,7 @@ export function Sidebar({
               </ActionButton>
               {selectedSimulationRef.startsWith("saved:") ? (
                 <ActionButton onClick={(e) => openActiveSimulationDetails(e.currentTarget)} type="button">
-                  Edit
+                  {readOnly ? "View details" : "Edit"}
                 </ActionButton>
               ) : null}
             </>

--- a/src/components/map/MapEditorPanel.test.tsx
+++ b/src/components/map/MapEditorPanel.test.tsx
@@ -379,6 +379,45 @@ describe("MapEditorPanel", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("honors forced read-only site details even when the user can edit the site", async () => {
+    useAppStore.setState({
+      currentUser,
+      siteLibrary: [
+        {
+          id: "site-lib-1",
+          name: "Alpha Site",
+          description: "Editable source",
+          visibility: "shared",
+          sharedWith: [],
+          ownerUserId: "owner-1",
+          effectiveRole: "owner",
+          position: { lat: 60.1, lon: 10.2 },
+          groundElevationM: 111,
+          antennaHeightM: 10,
+          txPowerDbm: 20,
+          txGainDbi: 2,
+          rxGainDbi: 2,
+          cableLossDb: 1,
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+      mapEditor: {
+        kind: "site",
+        resourceId: "site-lib-1",
+        isNew: false,
+        label: "Alpha Site",
+        anchorRect,
+        readOnly: true,
+      },
+    });
+
+    render(<MapEditorPanel isMobile={false} />);
+
+    expect(await screen.findByRole("heading", { name: "Alpha Site" })).toBeInTheDocument();
+    expect(screen.queryByDisplayValue("Alpha Site")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Save Site" })).not.toBeInTheDocument();
+  });
+
   it("renders read-only simulation details as static text", async () => {
     useAppStore.setState({
       simulationPresets: [

--- a/src/components/map/MapEditorPanel.tsx
+++ b/src/components/map/MapEditorPanel.tsx
@@ -213,7 +213,7 @@ function SiteEditorCard({
   onOpenUserProfile: (userId: string) => void;
 }) {
   const mapEditor = useAppStore((state) => state.mapEditor);
-  const isReadOnly = !form.canWrite && !isNew;
+  const isReadOnly = Boolean(mapEditor?.readOnly && !isNew) || (!form.canWrite && !isNew);
   const title = isNew ? "New Site" : (mapEditor?.label ?? form.nameDraft);
 
   return (
@@ -669,7 +669,7 @@ function SimulationEditorCard({
   onOpenUserProfile: (userId: string) => void;
 }) {
   const mapEditor = useAppStore((state) => state.mapEditor);
-  const isReadOnly = !form.canWrite && !isNew;
+  const isReadOnly = Boolean(mapEditor?.readOnly && !isNew) || (!form.canWrite && !isNew);
   const title = isNew ? "New Simulation" : (mapEditor?.label ?? form.nameDraft);
   const simulationDefaultsSummary = [
     `${form.simulationDefaultsDraft.frequencyMHz} MHz`,


### PR DESCRIPTION
## Summary
- Rename the read-only saved Simulation sidebar action from Edit to View details.
- Ensure forced read-only Site/Simulation editor opens stay static even when the underlying item is otherwise editable.
- Add regression coverage for read-only Simulation, Site, and Link sidebar detail actions.

## Verification
- [x] npm run test -- --run src/components/Sidebar.readOnly.test.tsx src/components/map/MapEditorPanel.test.tsx
- [x] npm test
- [x] npm run build
- [x] npm run dev:check

Follow-up for #842