### PR TITLE
fix map library site visibility

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1074,12 +1074,10 @@ export function MapView({
       ),
     [sites],
   );
-  const sharedOrPublicLibrarySites = useMemo(
+  const visibleLibrarySites = useMemo(
     () =>
       siteLibrary.filter(
-        (entry) =>
-          (entry.visibility === "shared" || entry.visibility === "public") &&
-          !simulationLibrarySiteIds.has(entry.id),
+        (entry) => !simulationLibrarySiteIds.has(entry.id),
       ),
     [siteLibrary, simulationLibrarySiteIds],
   );
@@ -2668,7 +2666,7 @@ export function MapView({
   const selectedSite = selectedSites[0] ?? null;
   const selectedDiscoveryLibraryEntry =
     selectedDiscoveryLibraryEntryId
-      ? sharedOrPublicLibrarySites.find((entry) => entry.id === selectedDiscoveryLibraryEntryId) ?? null
+      ? visibleLibrarySites.find((entry) => entry.id === selectedDiscoveryLibraryEntryId) ?? null
       : null;
   const selectedLibraryEntry =
     selectedSite?.libraryEntryId
@@ -2706,8 +2704,8 @@ export function MapView({
   if (showDiscoverySites) {
     inspectorLines.push(
       canPersist
-        ? `Shared/Public Library Sites visible: ${sharedOrPublicLibrarySites.length}. Click a marker to inspect, then choose Add to Simulation.`
-        : `Shared/Public Library Sites visible: ${sharedOrPublicLibrarySites.length}. Click a marker to inspect it.`,
+        ? `Library Sites visible: ${visibleLibrarySites.length}. Click a marker to inspect, then choose Add to Simulation.`
+        : `Library Sites visible: ${visibleLibrarySites.length}. Click a marker to inspect it.`,
     );
   }
   if (selectedDiscoveryLibraryEntry && !canPersist) inspectorLines.push(READ_ONLY_SIMULATION_SITE_HELP);
@@ -3520,7 +3518,7 @@ export function MapView({
         })}
 
         {showDiscoverySites
-          ? sharedOrPublicLibrarySites.map((entry) => (
+          ? visibleLibrarySites.map((entry) => (
               <Marker
                 anchor="bottom"
                 key={`discover-site-${entry.id}`}

--- a/src/components/MapView.userLocation.test.tsx
+++ b/src/components/MapView.userLocation.test.tsx
@@ -261,6 +261,35 @@ describe("MapView user location flow", () => {
     expect(screen.getByText("Read-only: you need edit permission to add sites to this simulation.")).toBeInTheDocument();
   });
 
+  it("shows private library sites that are already accessible", () => {
+    useAppStore.setState({
+      siteLibrary: [
+        {
+          id: "lib-private",
+          name: "Private Hill",
+          visibility: "private",
+          sharedWith: [],
+          ownerUserId: "owner-1",
+          effectiveRole: "viewer",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          position: { lat: 60.5, lon: 11.5 },
+          groundElevationM: 120,
+          antennaHeightM: 2,
+          txPowerDbm: 20,
+          txGainDbi: 2,
+          rxGainDbi: 2,
+          cableLossDb: 1,
+        },
+      ],
+    });
+    renderMapView({ showInspector: true });
+
+    fireEvent.click(screen.getByText("Map"));
+    fireEvent.change(screen.getByLabelText("Visible Sites"), { target: { value: "library" } });
+
+    expect(screen.getByRole("button", { name: "Private Hill" })).toBeInTheDocument();
+  });
+
   it("explains why selected simulation sites cannot be edited in read-only mode", () => {
     useAppStore.setState({
       sites: [


### PR DESCRIPTION
## Summary\n- include accessible private library sites in map library browsing\n- keep the existing simulation-linked exclusion intact\n- add regression coverage for private site visibility\n\n## Verification\n- npm test\n- npm run build