### PR TITLE
Fix simulation copy flow

### DIFF
--- a/src/components/Sidebar.readOnly.test.tsx
+++ b/src/components/Sidebar.readOnly.test.tsx
@@ -84,6 +84,8 @@ describe("Sidebar read-only simulation site actions", () => {
       selectedSiteIds: ["site-alpha"],
       selectedLinkId: "",
       selectedScenarioId: "sim-alpha",
+      selectedFrequencyPresetId: "meshcore-us-narrow-910525-sf7-bw625-cr5",
+      autoPropagationEnvironment: true,
       siteLibrary: [],
       simulationPresets: [
         {
@@ -155,14 +157,19 @@ describe("Sidebar read-only simulation site actions", () => {
     expect(simulationSection).not.toBeNull();
     expect(within(simulationSection as HTMLElement).queryByRole("button", { name: "Edit" })).not.toBeInTheDocument();
 
-    await userEvent.click(within(simulationSection as HTMLElement).getByRole("button", { name: "View details" }));
+    await userEvent.click(within(simulationSection as HTMLElement).getByRole("button", { name: "Save a copy" }));
 
     expect(useAppStore.getState().mapEditor).toMatchObject({
       kind: "simulation",
-      resourceId: "sim-alpha",
-      isNew: false,
-      label: "Alpha Simulation",
-      readOnly: true,
+      resourceId: null,
+      isNew: true,
+      label: "Save a copy",
+      simulationSeed: {
+        copyCurrentSimulation: true,
+        name: "Alpha Simulation Copy",
+        description: "Shared simulation",
+        autoPropagationEnvironment: true,
+      },
     });
 
     const sitesSection = screen.getByText("Sites").closest("section");
@@ -207,6 +214,30 @@ describe("Sidebar read-only simulation site actions", () => {
       isNew: false,
       label: "Alpha Link",
       readOnly: true,
+    });
+  });
+
+  it("opens the same copy flow from the simulation library", async () => {
+    render(<Sidebar readOnly />);
+
+    const simulationSection = screen.getByText(/Simulation:/).closest("section");
+    expect(simulationSection).not.toBeNull();
+    await userEvent.click(within(simulationSection as HTMLElement).getByRole("button", { name: "Library" }));
+
+    const dialog = screen.getByRole("dialog", { name: "Simulation Library" });
+    await userEvent.click(within(dialog).getByRole("button", { name: "Save a copy" }));
+
+    expect(useAppStore.getState().mapEditor).toMatchObject({
+      kind: "simulation",
+      resourceId: null,
+      isNew: true,
+      label: "Save a copy",
+      simulationSeed: {
+        copyCurrentSimulation: true,
+        name: "Alpha Simulation Copy",
+        description: "Shared simulation",
+        autoPropagationEnvironment: true,
+      },
     });
   });
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -120,7 +120,10 @@ export function Sidebar({
   const simulationPresets = useAppStore((state) => state.simulationPresets);
   const selectedLinkId = useAppStore((state) => state.selectedLinkId);
   const selectedSiteIds = useAppStore((state) => state.selectedSiteIds);
+  const selectedFrequencyPresetId = useAppStore((state) => state.selectedFrequencyPresetId);
   const autoPropagationEnvironment = useAppStore((state) => state.autoPropagationEnvironment);
+  const simulationDefaultsOverrideEnabled = useAppStore((state) => state.simulationDefaultsOverrideEnabled);
+  const simulationDefaultsOverride = useAppStore((state) => state.simulationDefaultsOverride);
   const selectedScenarioId = useAppStore((state) => state.selectedScenarioId);
   const scenarioOptions = useAppStore((state) => state.scenarioOptions);
   const locale = useAppStore((state) => state.locale);
@@ -138,7 +141,6 @@ export function Sidebar({
   const deleteSiteLibraryEntries = useAppStore((state) => state.deleteSiteLibraryEntries);
   const deleteSite = useAppStore((state) => state.deleteSite);
   const deleteLink = useAppStore((state) => state.deleteLink);
-  const saveCurrentSimulationPreset = useAppStore((state) => state.saveCurrentSimulationPreset);
   const loadSimulationPreset = useAppStore((state) => state.loadSimulationPreset);
   const showNewSimulationRequest = useAppStore((state) => state.showNewSimulationRequest);
   const setShowNewSimulationRequest = useAppStore((state) => state.setShowNewSimulationRequest);
@@ -162,8 +164,6 @@ export function Sidebar({
         : links,
     [hasNonAutoLinks, links],
   );
-  const [newPresetName, setNewPresetName] = useState("");
-  const [simulationSaveStatus, setSimulationSaveStatus] = useState("");
   const [showSimulationLibraryManager, setShowSimulationLibraryManager] = useState(false);
   const [showSiteLibraryManager, setShowSiteLibraryManager] = useState(false);
   const [siteLibraryFilters, setSiteLibraryFilters] = useState<LibraryFilterState>(() =>
@@ -357,6 +357,27 @@ export function Sidebar({
       readOnly,
     });
   };
+  const openSimulationCopyEditor = (triggerEl?: Element | null) => {
+    const activeSavedPreset = selectedScenarioId ? simulationPresets.find((preset) => preset.id === selectedScenarioId) : null;
+    const baseName = activeSavedPreset?.name ?? simulationDisplayLabel ?? activeSimulationLabel;
+    const suggestedName = baseName && baseName !== "no simulation selected" ? `${baseName} Copy` : "Copy of current simulation";
+    openMapEditor({
+      kind: "simulation",
+      resourceId: null,
+      isNew: true,
+      label: "Save a copy",
+      anchorRect: triggerEl?.getBoundingClientRect() ?? { top: 96, right: 320, bottom: 96, left: 320, width: 0, height: 0 },
+      simulationSeed: {
+        copyCurrentSimulation: true,
+        name: suggestedName,
+        description: activeSavedPreset?.description,
+        frequencyPresetId: selectedFrequencyPresetId,
+        autoPropagationEnvironment,
+        simulationDefaultsOverrideEnabled,
+        simulationDefaultsOverride: simulationDefaultsOverrideEnabled ? simulationDefaultsOverride : null,
+      },
+    });
+  };
   const collaboratorDirectoryById = useMemo(
     () => new globalThis.Map(resourceCollaboratorDirectory.map((user) => [user.id, user])),
     [resourceCollaboratorDirectory],
@@ -516,21 +537,6 @@ export function Sidebar({
   ) => {
     setDeleteConfirm({ title, message, confirmLabel, onConfirm });
   };
-
-  const saveSimulationAsNew = () => {
-    const trimmed = newPresetName.trim();
-    if (!trimmed) {
-      setSimulationSaveStatus("");
-      return;
-    }
-    const savedId = saveCurrentSimulationPreset(trimmed);
-    if (savedId) {
-      const ref = `saved:${savedId}`;
-      persistSelectedSimulationRef(ref);
-      setSimulationSaveStatus(`Saved copy: ${trimmed}`);
-    }
-    setNewPresetName("");
-  };
   const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
   const displayLinkName = (linkId: string, linkName?: string) => {
     const trimmedName = linkName?.trim();
@@ -669,8 +675,8 @@ export function Sidebar({
               >
                 New
               </ActionButton>
-              <ActionButton onClick={saveSimulationAsNew} type="button">
-                Duplicate
+              <ActionButton onClick={(event) => openSimulationCopyEditor(event.currentTarget)} type="button">
+                Save a copy
               </ActionButton>
               {selectedSimulationRef.startsWith("saved:") ? (
                 <ActionButton onClick={(e) => openActiveSimulationDetails(e.currentTarget)} type="button">
@@ -682,7 +688,6 @@ export function Sidebar({
             <span className="field-help">Sign in to browse the simulation library.</span>
           )}
         </div>
-        {simulationSaveStatus ? <p className="field-help">{simulationSaveStatus}</p> : null}
       </section>
 
       <section className="panel-section section-sites">
@@ -1022,6 +1027,10 @@ export function Sidebar({
                   autoPropagationEnvironment,
                 },
               });
+            }}
+            onCopySimulation={(triggerEl) => {
+              setShowSimulationLibraryManager(false);
+              openSimulationCopyEditor(triggerEl);
             }}
           />
         </ModalOverlay>

--- a/src/components/SimulationLibraryPanel.tsx
+++ b/src/components/SimulationLibraryPanel.tsx
@@ -61,6 +61,7 @@ type SimulationLibraryPanelProps = {
   onLoadSimulation: (presetId: string) => void;
   onOpenDetails?: (params: ResourceOpenParams) => void;
   onCreateSimulation?: (triggerEl: Element | null) => void;
+  onCopySimulation?: (triggerEl: Element | null) => void;
   hideSaveCopy?: boolean;
 };
 
@@ -69,11 +70,11 @@ export default function SimulationLibraryPanel({
   onLoadSimulation,
   onOpenDetails,
   onCreateSimulation,
+  onCopySimulation,
   hideSaveCopy = false,
 }: SimulationLibraryPanelProps) {
   const simulationPresets = useAppStore((state) => state.simulationPresets);
   const currentUser = useAppStore((state) => state.currentUser);
-  const saveCurrentSimulationPreset = useAppStore((state) => state.saveCurrentSimulationPreset);
   const [filters, setFilters] = useState<LibraryFilterState>(() =>
     readLibraryFilterState(SIMULATION_LIBRARY_FILTERS_KEY),
   );
@@ -81,10 +82,6 @@ export default function SimulationLibraryPanel({
   const [roleDraft, setRoleDraft] = useState<LibraryFilterRole[] | null>(null);
   const [visibilityDraft, setVisibilityDraft] = useState<LibraryFilterVisibility[] | null>(null);
   const filterToolbarRef = useRef<HTMLDivElement | null>(null);
-
-  const [newPresetName, setNewPresetName] = useState("");
-  const [newPresetNameError, setNewPresetNameError] = useState("");
-  const [simulationSaveStatus, setSimulationSaveStatus] = useState("");
 
   useEffect(() => {
     persistLibraryFilterState(SIMULATION_LIBRARY_FILTERS_KEY, filters);
@@ -156,21 +153,6 @@ export default function SimulationLibraryPanel({
     setOpenFilterGroup(null);
     setRoleDraft(null);
     setVisibilityDraft(null);
-  };
-
-  const saveSimulationAsNew = () => {
-    const trimmed = newPresetName.trim();
-    if (!trimmed) {
-      setNewPresetNameError("A name is required.");
-      setSimulationSaveStatus("");
-      return;
-    }
-    setNewPresetNameError("");
-    const savedId = saveCurrentSimulationPreset(trimmed);
-    if (savedId) {
-      setSimulationSaveStatus(`Saved copy: ${trimmed}`);
-    }
-    setNewPresetName("");
   };
 
   const openResourceDetails = (preset: {
@@ -321,34 +303,22 @@ export default function SimulationLibraryPanel({
         </ActionButton>
       </div>
       {!hideSaveCopy ? (
-        <>
-          <label className="field-grid">
-            <span>Save a copy</span>
-            <input
-              className={newPresetNameError ? "input-error" : ""}
-              onChange={(event) => {
-                setNewPresetName(event.target.value);
-                if (newPresetNameError) setNewPresetNameError("");
-              }}
-              placeholder="My simulation"
-              type="text"
-              value={newPresetName}
-            />
-          </label>
-          {newPresetNameError ? <p className="field-help field-help-error">{newPresetNameError}</p> : null}
-          <div className="chip-group">
-            <ActionButton onClick={saveSimulationAsNew}>
-              Save Copy
-            </ActionButton>
-            <ActionButton
-              onClick={(event) => {
-                onCreateSimulation?.(event.currentTarget);
-              }}
-            >
-              New Simulation
-            </ActionButton>
-          </div>
-        </>
+        <div className="chip-group">
+          <ActionButton
+            onClick={(event) => {
+              (onCopySimulation ?? onCreateSimulation)?.(event.currentTarget);
+            }}
+          >
+            Save a copy
+          </ActionButton>
+          <ActionButton
+            onClick={(event) => {
+              onCreateSimulation?.(event.currentTarget);
+            }}
+          >
+            New Simulation
+          </ActionButton>
+        </div>
       ) : (
         <div className="chip-group">
           <ActionButton
@@ -360,7 +330,6 @@ export default function SimulationLibraryPanel({
           </ActionButton>
         </div>
       )}
-      {simulationSaveStatus ? <p className="field-help">{simulationSaveStatus}</p> : null}
       <div className="library-editor">
         <h3>Saved simulations</h3>
         <div className="library-manager-list">

--- a/src/components/map/MapEditorPanel.tsx
+++ b/src/components/map/MapEditorPanel.tsx
@@ -670,7 +670,8 @@ function SimulationEditorCard({
 }) {
   const mapEditor = useAppStore((state) => state.mapEditor);
   const isReadOnly = Boolean(mapEditor?.readOnly && !isNew) || (!form.canWrite && !isNew);
-  const title = isNew ? "New Simulation" : (mapEditor?.label ?? form.nameDraft);
+  const isCopySimulation = Boolean(mapEditor?.simulationSeed?.copyCurrentSimulation);
+  const title = isNew ? (isCopySimulation ? "Save a copy" : "New Simulation") : (mapEditor?.label ?? form.nameDraft);
   const simulationDefaultsSummary = [
     `${form.simulationDefaultsDraft.frequencyMHz} MHz`,
     `${form.simulationDefaultsDraft.bandwidthKhz} kHz`,
@@ -863,7 +864,7 @@ function SimulationEditorCard({
         <div className="chip-group">
           {!isReadOnly ? (
             <ActionButton onClick={form.handleSaveSimulation} type="button">
-              {isNew ? "Create Simulation" : "Save"}
+              {isNew ? (isCopySimulation ? "Save a copy" : "Create Simulation") : "Save"}
             </ActionButton>
           ) : null}
           <ActionButton onClick={onClose} type="button">

--- a/src/components/map/useMapEditorFormState.ts
+++ b/src/components/map/useMapEditorFormState.ts
@@ -37,6 +37,7 @@ export function useMapEditorFormState() {
   const insertSiteFromLibrary = useAppStore((state) => state.insertSiteFromLibrary);
   const updateSimulationPresetEntry = useAppStore((state) => state.updateSimulationPresetEntry);
   const createBlankSimulationPreset = useAppStore((state) => state.createBlankSimulationPreset);
+  const createSimulationCopyFromCurrent = useAppStore((state) => state.createSimulationCopyFromCurrent);
   const loadSimulationPreset = useAppStore((state) => state.loadSimulationPreset);
   const selectedFrequencyPresetId = useAppStore((state) => state.selectedFrequencyPresetId);
   const autoPropagationEnvironment = useAppStore((state) => state.autoPropagationEnvironment);
@@ -173,18 +174,26 @@ export function useMapEditorFormState() {
       }
     } else if (mapEditor.kind === "simulation") {
       if (mapEditor.isNew) {
-        setNameDraft("");
-        setDescriptionDraft("");
+        const seed = mapEditor.simulationSeed;
+        setNameDraft(seed?.name ?? "");
+        setDescriptionDraft(seed?.description ?? "");
         setAccessVisibility("private");
         setCollaboratorUserIds([]);
         setCollaboratorRoles({});
-        setSimulationFrequencyPresetId(mapEditor.simulationSeed?.frequencyPresetId ?? selectedFrequencyPresetId);
-        setSimulationAutoPropagationEnvironment(
-          mapEditor.simulationSeed?.autoPropagationEnvironment ?? autoPropagationEnvironment,
-        );
-        const inherited = resolveUserSimulationDefaults(currentUser?.simulationDefaultsPreference, currentUser?.defaultFrequencyPresetId);
-        setSimulationDefaultsOverrideEnabled(false);
-        setSimulationDefaultsDraft(inherited);
+        setSimulationFrequencyPresetId(seed?.frequencyPresetId ?? selectedFrequencyPresetId);
+        setSimulationAutoPropagationEnvironment(seed?.autoPropagationEnvironment ?? autoPropagationEnvironment);
+        if (seed?.copyCurrentSimulation) {
+          setSimulationDefaultsOverrideEnabled(Boolean(seed.simulationDefaultsOverrideEnabled));
+          setSimulationDefaultsDraft(
+            seed.simulationDefaultsOverride
+              ? normalizeSimulationDefaults(seed.simulationDefaultsOverride)
+              : resolveUserSimulationDefaults(currentUser?.simulationDefaultsPreference, currentUser?.defaultFrequencyPresetId),
+          );
+        } else {
+          const inherited = resolveUserSimulationDefaults(currentUser?.simulationDefaultsPreference, currentUser?.defaultFrequencyPresetId);
+          setSimulationDefaultsOverrideEnabled(false);
+          setSimulationDefaultsDraft(inherited);
+        }
       } else {
         const preset = simulationPresets.find((p) => p.id === mapEditor.resourceId);
         setNameDraft(preset?.name ?? mapEditor.label);
@@ -668,6 +677,23 @@ export function useMapEditorFormState() {
     }
 
     try {
+      if (mapEditor.simulationSeed?.copyCurrentSimulation) {
+        const createdId = createSimulationCopyFromCurrent(trimmedName, {
+          description: descriptionDraft.trim() || undefined,
+          frequencyPresetId: simulationFrequencyPresetId,
+          autoPropagationEnvironment: simulationAutoPropagationEnvironment,
+          simulationDefaultsOverrideEnabled,
+          simulationDefaultsOverride: simulationDefaultsOverrideEnabled ? simulationDefaultsDraft : null,
+        });
+        if (!createdId) {
+          setStatus("Failed creating simulation copy. Check the name and try again.");
+          return false;
+        }
+        loadSimulationPreset(createdId);
+        closeMapEditor();
+        return true;
+      }
+
       updateSimulationPresetEntry(mapEditor.resourceId, {
         name: trimmedName,
         description: descriptionDraft.trim() || undefined,

--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -601,6 +601,97 @@ describe("appStore new simulation default frequency preset", () => {
   });
 });
 
+describe("appStore simulation copy", () => {
+  beforeEach(() => {
+    storage.mock.clear();
+    vi.restoreAllMocks();
+    useAppStore.setState({
+      currentUser: {
+        id: "owner-1",
+        username: "owner",
+        avatarUrl: "",
+        role: "user",
+        accountState: "approved",
+        isApproved: true,
+        isAdmin: false,
+        isModerator: false,
+        createdAt: "",
+        updatedAt: null,
+        approvedAt: null,
+        approvedByUserId: null,
+        email: undefined,
+        emailPublic: true,
+        bio: "",
+      },
+      selectedScenarioId: "sim-alpha",
+      selectedFrequencyPresetId: "custom",
+      autoPropagationEnvironment: false,
+      simulationDefaultsOverrideEnabled: false,
+      simulationDefaultsOverride: null,
+      sites: [
+        {
+          id: "site-alpha",
+          name: "Site Alpha",
+          position: { lat: 60.5, lon: 11.5 },
+          groundElevationM: 120,
+          antennaHeightM: 2,
+          txPowerDbm: 20,
+          txGainDbi: 2,
+          rxGainDbi: 2,
+          cableLossDb: 1,
+        },
+        {
+          id: "site-beta",
+          name: "Site Beta",
+          position: { lat: 60.6, lon: 11.6 },
+          groundElevationM: 130,
+          antennaHeightM: 4,
+          txPowerDbm: 21,
+          txGainDbi: 3,
+          rxGainDbi: 3,
+          cableLossDb: 1,
+        },
+      ],
+      links: [
+        {
+          id: "link-alpha",
+          name: "Alpha Link",
+          fromSiteId: "site-alpha",
+          toSiteId: "site-beta",
+          frequencyMHz: 868,
+        },
+      ],
+      siteLibrary: [],
+      simulationPresets: [],
+    });
+  });
+
+  it("creates a private copy with the current sites and links", () => {
+    const createdId = useAppStore
+      .getState()
+      .createSimulationCopyFromCurrent("Copied Session", { description: "Copied from alpha" });
+
+    expect(createdId).toBeTruthy();
+
+    const created = useAppStore.getState().simulationPresets.find((entry) => entry.id === createdId);
+    expect(created).toMatchObject({
+      name: "Copied Session",
+      description: "Copied from alpha",
+      visibility: "private",
+      sharedWith: [],
+      ownerUserId: "owner-1",
+    });
+    expect(created?.snapshot.sites).toHaveLength(2);
+    expect(created?.snapshot.sites.map((site) => site.name)).toEqual(["Site Alpha", "Site Beta"]);
+    expect(created?.snapshot.links).toHaveLength(1);
+    expect(created?.snapshot.links[0]).toMatchObject({
+      fromSiteId: "site-alpha",
+      toSiteId: "site-beta",
+      name: "Alpha Link",
+    });
+  });
+});
+
 describe("appStore built-in scenario defaults", () => {
   beforeEach(() => {
     storage.mock.clear();

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -461,8 +461,13 @@ type AppState = {
       awaitMapClick?: boolean;
     };
     simulationSeed?: {
+      name?: string;
+      description?: string;
       frequencyPresetId?: string;
       autoPropagationEnvironment?: boolean;
+      copyCurrentSimulation?: boolean;
+      simulationDefaultsOverrideEnabled?: boolean;
+      simulationDefaultsOverride?: SimulationDefaults | null;
     };
     readOnly?: boolean;
   } | null;
@@ -583,6 +588,16 @@ type AppState = {
   deleteSiteLibraryEntry: (entryId: string) => void;
   deleteSiteLibraryEntries: (entryIds: string[]) => void;
   saveCurrentSimulationPreset: (name: string) => string | null;
+  createSimulationCopyFromCurrent: (
+    name: string,
+    options?: {
+      description?: string;
+      frequencyPresetId?: string;
+      autoPropagationEnvironment?: boolean;
+      simulationDefaultsOverrideEnabled?: boolean;
+      simulationDefaultsOverride?: SimulationDefaults | null;
+    },
+  ) => string | null;
   createBlankSimulationPreset: (
     name: string,
     options?: {
@@ -725,6 +740,49 @@ const hasDuplicateSimulationName = (
   if (!target) return false;
   return presets.some((preset) => preset.id !== ignorePresetId && preset.name.trim().toLowerCase() === target);
 };
+
+const buildSimulationSnapshotFromState = (
+  state: Pick<
+    AppState,
+    | "sites"
+    | "links"
+    | "systems"
+    | "networks"
+    | "selectedSiteId"
+    | "selectedLinkId"
+    | "selectedNetworkId"
+    | "selectedCoverageResolution"
+    | "selectedOverlayRadiusOption"
+    | "propagationModel"
+    | "selectedFrequencyPresetId"
+    | "rxSensitivityTargetDbm"
+    | "environmentLossDb"
+    | "propagationEnvironment"
+    | "autoPropagationEnvironment"
+    | "terrainDataset"
+    | "simulationDefaultsOverrideEnabled"
+    | "simulationDefaultsOverride"
+  >,
+): SimulationPreset["snapshot"] => ({
+  sites: state.sites,
+  links: state.links,
+  systems: state.systems,
+  networks: state.networks,
+  selectedSiteId: state.selectedSiteId,
+  selectedLinkId: state.selectedLinkId,
+  selectedNetworkId: state.selectedNetworkId,
+  selectedCoverageResolution: state.selectedCoverageResolution,
+  selectedOverlayRadiusOption: state.selectedOverlayRadiusOption,
+  propagationModel: state.propagationModel,
+  selectedFrequencyPresetId: state.selectedFrequencyPresetId,
+  rxSensitivityTargetDbm: state.rxSensitivityTargetDbm,
+  environmentLossDb: state.environmentLossDb,
+  propagationEnvironment: state.propagationEnvironment,
+  autoPropagationEnvironment: state.autoPropagationEnvironment,
+  terrainDataset: state.terrainDataset,
+  simulationDefaultsOverrideEnabled: state.simulationDefaultsOverrideEnabled,
+  simulationDefaultsOverride: state.simulationDefaultsOverride ?? undefined,
+});
 
 const legacyDemoSiteFingerprint = new Set([
   "bislett|59.925000|10.732000",
@@ -2697,25 +2755,10 @@ export const useAppStore = create<AppState>((set, get) => ({
       ),
     );
     const snapshot: SimulationPreset["snapshot"] = {
+      ...buildSimulationSnapshotFromState(state),
       sites: normalized.sites,
       links: normalizedLinks,
-      systems: state.systems,
-      networks: state.networks,
-      selectedSiteId: state.selectedSiteId,
-      selectedLinkId: state.selectedLinkId,
-      selectedNetworkId: state.selectedNetworkId,
-      selectedCoverageResolution: state.selectedCoverageResolution,
-      selectedOverlayRadiusOption: state.selectedOverlayRadiusOption,
-      propagationModel: state.propagationModel,
-      selectedFrequencyPresetId: state.selectedFrequencyPresetId,
-      rxSensitivityTargetDbm: state.rxSensitivityTargetDbm,
-        environmentLossDb: state.environmentLossDb,
-        propagationEnvironment: state.propagationEnvironment,
-        autoPropagationEnvironment: state.autoPropagationEnvironment,
-        terrainDataset: state.terrainDataset,
-        simulationDefaultsOverrideEnabled: state.simulationDefaultsOverrideEnabled,
-        simulationDefaultsOverride: state.simulationDefaultsOverride ?? undefined,
-      };
+    };
 
     set((current) => {
       const mergedLibrary =
@@ -2765,6 +2808,59 @@ export const useAppStore = create<AppState>((set, get) => ({
         siteLibrary: mergedLibrary,
         sites: normalized.sites,
       };
+    });
+    return get().simulationPresets[0]?.id ?? null;
+  },
+  createSimulationCopyFromCurrent: (name, options) => {
+    const { currentUser } = get();
+    const user = requireAuth(currentUser, "createSimulationCopyFromCurrent");
+    if (!user) return null;
+    const presetName = name.trim();
+    if (!presetName) return null;
+    const state = get();
+    if (hasDuplicateSimulationName(state.simulationPresets, presetName)) return null;
+    const normalized = ensureSitesBackedByLibrary(state.sites, state.siteLibrary);
+    const normalizedLinks = state.links.map((link) =>
+      stripRedundantLinkRadioOverrides(
+        link,
+        normalized.sites.find((site) => site.id === link.fromSiteId),
+        normalized.sites.find((site) => site.id === link.toSiteId),
+      ),
+    );
+    const snapshot: SimulationPreset["snapshot"] = {
+      ...buildSimulationSnapshotFromState(state),
+      sites: normalized.sites,
+      links: normalizedLinks,
+      selectedFrequencyPresetId: options?.frequencyPresetId ?? state.selectedFrequencyPresetId,
+      autoPropagationEnvironment: options?.autoPropagationEnvironment ?? state.autoPropagationEnvironment,
+      simulationDefaultsOverrideEnabled:
+        options?.simulationDefaultsOverrideEnabled ?? state.simulationDefaultsOverrideEnabled,
+      simulationDefaultsOverride: options?.simulationDefaultsOverride ?? state.simulationDefaultsOverride ?? undefined,
+    };
+    set((current) => {
+      const nextPreset: SimulationPreset = {
+        id: makeId("sim"),
+        name: presetName,
+        ...(options?.description?.trim() ? { description: options.description.trim() } : {}),
+        slug: slugifyValue(presetName),
+        slugAliases: [],
+        visibility: "private",
+        sharedWith: [],
+        updatedAt: new Date().toISOString(),
+        snapshot,
+        ownerUserId: user.id,
+        createdByUserId: user.id,
+        createdByName: user.username,
+        createdByAvatarUrl: user.avatarUrl ?? "",
+        lastEditedByUserId: user.id,
+        lastEditedByName: user.username,
+        lastEditedByAvatarUrl: user.avatarUrl ?? "",
+        effectiveRole: "owner",
+      };
+      markDirtySim(nextPreset.id);
+      const next = [nextPreset, ...current.simulationPresets];
+      writeStorage(SIM_PRESETS_KEY, next);
+      return { simulationPresets: next };
     });
     return get().simulationPresets[0]?.id ?? null;
   },


### PR DESCRIPTION
## Summary\n- Unify the sidebar and simulation library "Save a copy" actions behind the same new-simulation popover.\n- Copy the current simulation state into the new private simulation, including sites and links.\n- Add coverage for the shared copy flow and store-level duplication behavior.\n\n## Verification\n- npm test\n- npm run build