### PR TITLE
Fix copied simulation site persistence

### DIFF
--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -689,6 +689,8 @@ describe("appStore simulation copy", () => {
       toSiteId: "site-beta",
       name: "Alpha Link",
     });
+    expect(useAppStore.getState().siteLibrary).toHaveLength(2);
+    expect(useAppStore.getState().siteLibrary.map((entry) => entry.name)).toEqual(["Site Beta", "Site Alpha"]);
   });
 });
 

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -2838,6 +2838,10 @@ export const useAppStore = create<AppState>((set, get) => ({
       simulationDefaultsOverride: options?.simulationDefaultsOverride ?? state.simulationDefaultsOverride ?? undefined,
     };
     set((current) => {
+      const mergedLibrary =
+        normalized.addedCount > 0
+          ? normalizeSiteLibrary([...normalized.siteLibrary, ...current.siteLibrary])
+          : current.siteLibrary;
       const nextPreset: SimulationPreset = {
         id: makeId("sim"),
         name: presetName,
@@ -2860,7 +2864,13 @@ export const useAppStore = create<AppState>((set, get) => ({
       markDirtySim(nextPreset.id);
       const next = [nextPreset, ...current.simulationPresets];
       writeStorage(SIM_PRESETS_KEY, next);
-      return { simulationPresets: next };
+      if (normalized.addedCount > 0) {
+        writeStorage(SITE_LIBRARY_KEY, mergedLibrary);
+      }
+      return {
+        simulationPresets: next,
+        ...(normalized.addedCount > 0 ? { siteLibrary: mergedLibrary } : {}),
+      };
     });
     return get().simulationPresets[0]?.id ?? null;
   },


### PR DESCRIPTION
## Summary\n- Persist the site-library backing entries when creating a simulation copy.\n- Keep copied simulations editable by ensuring the duplicated sites transfer with the new preset.\n- Add regression coverage for the copied-site library state.\n\n## Verification\n- npm test\n- npm run build