### PR TITLE
fix: copy the active simulation snapshot

### DIFF
--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -697,6 +697,88 @@ describe("appStore simulation copy", () => {
     expect(useAppStore.getState().sites).toHaveLength(2);
     expect(useAppStore.getState().links).toHaveLength(1);
   });
+
+  it("copies the active saved simulation snapshot when the live workspace state is empty", () => {
+    useAppStore.setState((state) => ({
+      ...state,
+      selectedScenarioId: "sim-1",
+      sites: [],
+      links: [],
+      selectedSiteId: "",
+      selectedSiteIds: [],
+      selectedLinkId: "",
+      simulationPresets: [
+        {
+          id: "sim-1",
+          name: "Source Session",
+          description: "Original snapshot",
+          visibility: "private",
+          sharedWith: [],
+          ownerUserId: "owner-1",
+          effectiveRole: "owner",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+          snapshot: {
+            sites: [
+              {
+                id: "site-alpha",
+                name: "Site Alpha",
+                position: { lat: 60.5, lon: 11.5 },
+                groundElevationM: 120,
+                antennaHeightM: 2,
+                txPowerDbm: 20,
+                txGainDbi: 2,
+                rxGainDbi: 2,
+                cableLossDb: 1,
+              },
+              {
+                id: "site-beta",
+                name: "Site Beta",
+                position: { lat: 60.6, lon: 11.6 },
+                groundElevationM: 130,
+                antennaHeightM: 4,
+                txPowerDbm: 21,
+                txGainDbi: 3,
+                rxGainDbi: 3,
+                cableLossDb: 1,
+              },
+            ],
+            links: [
+              {
+                id: "link-alpha",
+                name: "Alpha Link",
+                fromSiteId: "site-alpha",
+                toSiteId: "site-beta",
+                frequencyMHz: 868,
+              },
+            ],
+            systems: [],
+            networks: [],
+            selectedSiteId: "site-alpha",
+            selectedLinkId: "link-alpha",
+            selectedNetworkId: "",
+            selectedCoverageResolution: "24",
+            propagationModel: "ITM",
+            selectedFrequencyPresetId: "custom",
+            rxSensitivityTargetDbm: -120,
+            environmentLossDb: 0,
+            propagationEnvironment: state.propagationEnvironment,
+            autoPropagationEnvironment: true,
+            terrainDataset: "copernicus30",
+          },
+        },
+      ],
+    }));
+
+    const createdId = useAppStore.getState().createSimulationCopyFromCurrent("Workspace Copy", {
+      description: "Copied from active preset",
+    });
+
+    expect(createdId).toBeTruthy();
+    const created = useAppStore.getState().simulationPresets.find((entry) => entry.id === createdId);
+    expect(created?.snapshot.sites).toHaveLength(2);
+    expect(created?.snapshot.links).toHaveLength(1);
+    expect(created?.snapshot.sites.map((site) => site.name)).toEqual(["Site Alpha", "Site Beta"]);
+  });
 });
 
 describe("appStore built-in scenario defaults", () => {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -2819,8 +2819,26 @@ export const useAppStore = create<AppState>((set, get) => ({
     if (!presetName) return null;
     const state = get();
     if (hasDuplicateSimulationName(state.simulationPresets, presetName)) return null;
-    const normalized = ensureSitesBackedByLibrary(state.sites, state.siteLibrary);
-    const normalizedLinks = state.links.map((link) =>
+    const activePreset = state.selectedScenarioId
+      ? state.simulationPresets.find((preset) => preset.id === state.selectedScenarioId) ?? null
+      : null;
+    const sourceState =
+      state.sites.length || state.links.length
+        ? state
+        : activePreset
+          ? {
+              ...state,
+              sites: Array.isArray(activePreset.snapshot.sites) ? activePreset.snapshot.sites : [],
+              links: Array.isArray(activePreset.snapshot.links) ? activePreset.snapshot.links : [],
+              systems: Array.isArray(activePreset.snapshot.systems) ? activePreset.snapshot.systems : [],
+              networks: Array.isArray(activePreset.snapshot.networks) ? activePreset.snapshot.networks : [],
+              selectedSiteId: activePreset.snapshot.selectedSiteId ?? state.selectedSiteId,
+              selectedLinkId: activePreset.snapshot.selectedLinkId ?? state.selectedLinkId,
+              selectedNetworkId: activePreset.snapshot.selectedNetworkId ?? state.selectedNetworkId,
+            }
+          : state;
+    const normalized = ensureSitesBackedByLibrary(sourceState.sites, sourceState.siteLibrary);
+    const normalizedLinks = sourceState.links.map((link) =>
       stripRedundantLinkRadioOverrides(
         link,
         normalized.sites.find((site) => site.id === link.fromSiteId),
@@ -2828,14 +2846,15 @@ export const useAppStore = create<AppState>((set, get) => ({
       ),
     );
     const snapshot: SimulationPreset["snapshot"] = {
-      ...buildSimulationSnapshotFromState(state),
+      ...buildSimulationSnapshotFromState(sourceState),
       sites: normalized.sites,
       links: normalizedLinks,
-      selectedFrequencyPresetId: options?.frequencyPresetId ?? state.selectedFrequencyPresetId,
-      autoPropagationEnvironment: options?.autoPropagationEnvironment ?? state.autoPropagationEnvironment,
+      selectedFrequencyPresetId: options?.frequencyPresetId ?? sourceState.selectedFrequencyPresetId,
+      autoPropagationEnvironment: options?.autoPropagationEnvironment ?? sourceState.autoPropagationEnvironment,
       simulationDefaultsOverrideEnabled:
-        options?.simulationDefaultsOverrideEnabled ?? state.simulationDefaultsOverrideEnabled,
-      simulationDefaultsOverride: options?.simulationDefaultsOverride ?? state.simulationDefaultsOverride ?? undefined,
+        options?.simulationDefaultsOverrideEnabled ?? sourceState.simulationDefaultsOverrideEnabled,
+      simulationDefaultsOverride:
+        options?.simulationDefaultsOverride ?? sourceState.simulationDefaultsOverride ?? undefined,
     };
     set((current) => {
       const mergedLibrary =


### PR DESCRIPTION
## Summary\n- Fall back to the active saved simulation snapshot when the live workspace state is unexpectedly empty\n- Keep copied simulations hydrated with sites and links instead of creating blank copies\n- Add a regression test for the empty-workspace mismatch case\n\n## Verification\n- npm test -- --run src/store/appStore.test.ts src/components/AppShell.copyFlow.test.tsx src/components/Sidebar.readOnly.test.tsx\n- npm run build