### PR TITLE
fix: show duplicate simulation name inline

### DIFF
--- a/src/components/map/MapEditorPanel.test.tsx
+++ b/src/components/map/MapEditorPanel.test.tsx
@@ -571,6 +571,61 @@ describe("MapEditorPanel", () => {
     expect(state.links).toHaveLength(1);
   });
 
+  it("shows a field error when creating a duplicate simulation name", async () => {
+    useAppStore.setState({
+      currentUser,
+      simulationPresets: [
+        {
+          id: "sim-1",
+          name: "Grefsen",
+          visibility: "private",
+          sharedWith: [],
+          ownerUserId: "owner-1",
+          effectiveRole: "owner",
+          updatedAt: "2026-01-02T00:00:00.000Z",
+          snapshot: {
+            sites: [],
+            links: [],
+            systems: [],
+            networks: [],
+            selectedSiteId: "",
+            selectedLinkId: "",
+            selectedNetworkId: "",
+            selectedCoverageResolution: "24",
+            propagationModel: "ITM",
+            selectedFrequencyPresetId: "custom",
+            rxSensitivityTargetDbm: -120,
+            environmentLossDb: 0,
+            propagationEnvironment: useAppStore.getState().propagationEnvironment,
+            autoPropagationEnvironment: true,
+            terrainDataset: "copernicus30",
+          },
+        },
+      ],
+      mapEditor: {
+        kind: "simulation",
+        resourceId: null,
+        isNew: true,
+        label: "New Simulation",
+        anchorRect,
+      },
+    });
+
+    render(<MapEditorPanel isMobile={false} />);
+
+    const nameInput = await screen.findByLabelText("Name");
+    await userEvent.type(nameInput, "Grefsen");
+
+    expect(await screen.findByText("Name must be unique.")).toBeInTheDocument();
+    expect(nameInput).toHaveAttribute("aria-invalid", "true");
+    expect(nameInput).toHaveClass("input-error");
+
+    await userEvent.click(screen.getByRole("button", { name: "Create Simulation" }));
+
+    expect(screen.getByText("Name must be unique.")).toBeInTheDocument();
+    expect(useAppStore.getState().simulationPresets).toHaveLength(1);
+  });
+
   it("renders read-only link details as static text", async () => {
     useAppStore.setState({
       currentUser,

--- a/src/components/map/MapEditorPanel.tsx
+++ b/src/components/map/MapEditorPanel.tsx
@@ -712,6 +712,8 @@ function SimulationEditorCard({
         <label className="field-grid">
           <span>Name</span>
           <input
+            aria-invalid={form.simulationNameError ? true : undefined}
+            className={form.simulationNameError ? "input-error" : undefined}
             onChange={(e) => form.setNameDraft(e.target.value)}
             type="text"
             value={form.nameDraft}
@@ -858,6 +860,7 @@ function SimulationEditorCard({
         </div>
       ) : null}
 
+      {form.simulationNameError ? <p className="field-help field-help-error">{form.simulationNameError}</p> : null}
       {form.status ? <p className="field-help">{form.status}</p> : null}
 
       {!form.pendingVisibilityConfirm ? (

--- a/src/components/map/useMapEditorFormState.ts
+++ b/src/components/map/useMapEditorFormState.ts
@@ -8,6 +8,7 @@ import { fetchElevations } from "../../lib/elevationService";
 import { searchLocations, type GeocodeResult } from "../../lib/geocode";
 import { sampleSrtmElevation } from "../../lib/srtm";
 import { getUiErrorMessage } from "../../lib/uiError";
+import { hasDuplicateSimulationNameForOwner } from "../../lib/simulationNameValidation";
 import { useAppStore } from "../../store/appStore";
 import type { CollaboratorDirectoryUser } from "../../lib/cloudUser";
 import type { AccessRole, AccessVisibility } from "../AccessSettingsEditor";
@@ -88,6 +89,9 @@ export function useMapEditorFormState() {
   const [simulationDefaultsDraft, setSimulationDefaultsDraft] = useState<SimulationDefaults>(() =>
     normalizeSimulationDefaults(null),
   );
+  const [simulationNameError, setSimulationNameError] = useState("");
+
+  const setDuplicateSimulationNameError = () => setSimulationNameError("Name must be unique.");
 
   // ─── Link drafts ──────────────────────────────────────────────────────────────
   const [linkNameDraft, setLinkNameDraft] = useState("");
@@ -254,6 +258,28 @@ export function useMapEditorFormState() {
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mapEditor?.kind, mapEditor?.resourceId, mapEditor?.isNew]);
+
+  useEffect(() => {
+    if (mapEditor?.kind !== "simulation") {
+      setSimulationNameError("");
+      return;
+    }
+    const trimmedName = nameDraft.trim();
+    if (!trimmedName || !currentUser?.id) {
+      setSimulationNameError("");
+      return;
+    }
+    const timer = window.setTimeout(() => {
+      const isDuplicate = hasDuplicateSimulationNameForOwner(
+        simulationPresets,
+        trimmedName,
+        currentUser.id,
+        mapEditor.isNew ? undefined : mapEditor.resourceId ?? undefined,
+      );
+      setSimulationNameError(isDuplicate ? "Name must be unique." : "");
+    }, 300);
+    return () => window.clearTimeout(timer);
+  }, [currentUser?.id, mapEditor?.isNew, mapEditor?.kind, mapEditor?.resourceId, nameDraft, simulationPresets]);
 
   useEffect(() => {
     if (mapEditor?.kind !== "site" || !mapEditorSiteDraft) return;
@@ -620,6 +646,10 @@ export function useMapEditorFormState() {
         setStatus("Cannot create simulation until current user profile is loaded.");
         return false;
       }
+      if (hasDuplicateSimulationNameForOwner(simulationPresets, trimmedName, currentUser.id)) {
+        setDuplicateSimulationNameError();
+        return false;
+      }
       try {
         if (mapEditor.simulationSeed?.copyCurrentSimulation) {
           const createdId = createSimulationCopyFromCurrent(trimmedName, {
@@ -668,6 +698,19 @@ export function useMapEditorFormState() {
     }
 
     if (!mapEditor?.resourceId) return false;
+
+    if (
+      currentSimulationPreset &&
+      hasDuplicateSimulationNameForOwner(
+        simulationPresets,
+        trimmedName,
+        currentSimulationPreset.ownerUserId ?? "",
+        currentSimulationPreset.id,
+      )
+    ) {
+      setDuplicateSimulationNameError();
+      return false;
+    }
 
     // Check for private site refs that would need to be promoted
     if (normalizedVisibility === "shared") {
@@ -839,6 +882,7 @@ export function useMapEditorFormState() {
     simulationDefaultsOverrideEnabled,
     setSimulationDefaultsOverrideEnabled,
     simulationDefaultsDraft,
+    simulationNameError,
     setSimulationDefaultsDraft: (patch: Partial<SimulationDefaults>) =>
       setSimulationDefaultsDraft((current) => normalizeSimulationDefaults({ ...current, ...patch }, current)),
     handleSaveSimulation,


### PR DESCRIPTION
## Summary
- Add debounced live validation for simulation name uniqueness in the map editor.
- Highlight the name field and show a short inline error when a duplicate name is entered.
- Recheck on submit so fast Enter submits still fail safely.

## Verification
- npm test
- npm run build