### PR TITLE
feat: add seasonal theme preview toggle

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -526,7 +526,7 @@ export function AppShell() {
     const root = document.documentElement;
     root.classList.remove("theme-light", "theme-dark");
     root.classList.add(theme === "dark" ? "theme-dark" : "theme-light");
-    if (activeHolidayTheme?.key === "pride") root.dataset.holidayTheme = "pride";
+    if (activeHolidayTheme) root.dataset.holidayTheme = activeHolidayTheme.key;
     else delete root.dataset.holidayTheme;
     for (const [key, value] of Object.entries(variant.cssVars)) {
       root.style.setProperty(key, value);

--- a/src/components/UiGalleryPage.tsx
+++ b/src/components/UiGalleryPage.tsx
@@ -213,7 +213,7 @@ export function UiGalleryPage() {
     const root = document.documentElement;
     root.classList.remove("theme-light", "theme-dark");
     root.classList.add(theme === "dark" ? "theme-dark" : "theme-light");
-    if (activeHolidayTheme?.key === "pride") root.dataset.holidayTheme = "pride";
+    if (activeHolidayTheme) root.dataset.holidayTheme = activeHolidayTheme.key;
     else delete root.dataset.holidayTheme;
     for (const [key, value] of Object.entries(variant.cssVars)) {
       root.style.setProperty(key, value);

--- a/src/components/settings/sections/PreferencesSection.tsx
+++ b/src/components/settings/sections/PreferencesSection.tsx
@@ -10,7 +10,9 @@ import {
 import { getUiErrorMessage } from "../../../lib/uiError";
 import { useAppStore } from "../../../store/appStore";
 import { useThemeVariant } from "../../../hooks/useThemeVariant";
-import type { UiColorTheme } from "../../../themes/types";
+import { getHolidayThemeCatalog } from "../../../themes/holidayThemes";
+import { setHolidayThemePreview } from "../../../themes/holidayThemeDev";
+import type { HolidayThemeKey, UiColorTheme } from "../../../themes/types";
 import { AutoSaveIndicator, type AutoSaveState } from "../../ui/AutoSaveIndicator";
 import { InfoTip } from "../../InfoTip";
 
@@ -33,7 +35,7 @@ export function PreferencesSection({ me, onMeUpdated }: PreferencesSectionProps)
   const setUiColorTheme = useAppStore((state) => state.setUiColorTheme);
   const setCurrentUser = useAppStore((state) => state.setCurrentUser);
   const setAuthState = useAppStore((state) => state.setAuthState);
-  const { activeHolidayTheme } = useThemeVariant();
+  const { activeHolidayTheme, holidayThemesVisible } = useThemeVariant();
 
   const [presetState, setPresetState] = useState<SelectFieldState>(IDLE_SELECT);
 
@@ -43,6 +45,8 @@ export function PreferencesSection({ me, onMeUpdated }: PreferencesSectionProps)
     overridePresetDefaults: false,
   };
   const activeDefaults = resolveUserSimulationDefaults(preference, me?.defaultFrequencyPresetId);
+  const holidayThemes = getHolidayThemeCatalog();
+  const selectedColorThemeValue = activeHolidayTheme?.key ? `holiday:${activeHolidayTheme.key}` : uiColorTheme;
 
   const saveSimulationDefaultsPreference = useCallback(
     async (nextPreference: UserSimulationDefaultsPreference) => {
@@ -75,6 +79,19 @@ export function PreferencesSection({ me, onMeUpdated }: PreferencesSectionProps)
       ...(preference.mode === "custom" ? { custom: nextDefaults } : { overrides: nextDefaults }),
     });
   };
+
+  const setHolidayThemeSelection = (holidayThemeKey: HolidayThemeKey | null) => {
+    setHolidayThemePreview(holidayThemeKey);
+    if (!holidayThemeKey) return;
+    const holidayTheme = holidayThemes.find((theme) => theme.key === holidayThemeKey);
+    if (holidayTheme) setUiColorTheme(holidayTheme.colorTheme as UiColorTheme);
+  };
+
+  const renderHolidayThemeOption = (holidayThemeKey: HolidayThemeKey, label: string) => (
+    <option key={holidayThemeKey} value={`holiday:${holidayThemeKey}`}>
+      {label}
+    </option>
+  );
 
   return (
     <section className="settings-section" aria-labelledby="settings-preferences-heading">
@@ -115,20 +132,28 @@ export function PreferencesSection({ me, onMeUpdated }: PreferencesSectionProps)
           <select
             id="pref-color-theme"
             className="locale-select"
-            value={uiColorTheme}
-            onChange={(event) => setUiColorTheme(event.target.value as UiColorTheme)}
+            value={selectedColorThemeValue}
+            onChange={(event) => {
+              const next = event.target.value;
+              if (next.startsWith("holiday:")) {
+                setHolidayThemeSelection(next.slice("holiday:".length) as HolidayThemeKey);
+                return;
+              }
+              setHolidayThemePreview(null);
+              setUiColorTheme(next as UiColorTheme);
+            }}
           >
             <option value="blue">Blue</option>
             <option value="pink">Pink</option>
             <option value="red">Red</option>
             <option value="green">Green</option>
-            {activeHolidayTheme?.key === "pride" ? (
-              <option value="neutral">{activeHolidayTheme.title.replace(" Theme", "")}</option>
-            ) : (
-              <option value="neutral">Neutral</option>
-            )}
-            {activeHolidayTheme && activeHolidayTheme.key !== "pride" ? (
-              <option value={activeHolidayTheme.colorTheme}>{activeHolidayTheme.title.replace(" Theme", "")}</option>
+            <option value="neutral">Neutral</option>
+            {holidayThemesVisible ? (
+              <optgroup label="Seasonal">
+                {holidayThemes.map((theme) => renderHolidayThemeOption(theme.key, theme.title.replace(" Theme", "")))}
+              </optgroup>
+            ) : activeHolidayTheme ? (
+              <option value={`holiday:${activeHolidayTheme.key}`}>{activeHolidayTheme.title.replace(" Theme", "")}</option>
             ) : null}
           </select>
         </div>

--- a/src/hooks/useHolidayThemeDevState.ts
+++ b/src/hooks/useHolidayThemeDevState.ts
@@ -1,0 +1,5 @@
+import { useSyncExternalStore } from "react";
+import { getDevHolidayThemeState, subscribeDevHolidayThemeState } from "../themes/holidayThemeDev";
+
+export const useHolidayThemeDevState = () =>
+  useSyncExternalStore(subscribeDevHolidayThemeState, getDevHolidayThemeState, getDevHolidayThemeState);

--- a/src/hooks/useThemeVariant.ts
+++ b/src/hooks/useThemeVariant.ts
@@ -3,16 +3,18 @@ import { getThemeVariant } from "../themes";
 import { resolveEffectiveColorTheme } from "../themes/holidayThemes";
 import { useUiTheme } from "./useUiTheme";
 import { useAppStore } from "../store/appStore";
+import { useHolidayThemeDevState } from "./useHolidayThemeDevState";
 
 export const useThemeVariant = () => {
   const ui = useUiTheme();
   const holidayWindowState = useAppStore((s) => s.holidayWindowState);
   const revertHolidayThemeForWindow = useAppStore((s) => s.revertHolidayThemeForWindow);
   const dismissHolidayThemeNotice = useAppStore((s) => s.dismissHolidayThemeNotice);
+  const devHolidayThemeState = useHolidayThemeDevState();
 
   const { colorTheme, activeHolidayTheme, isHolidayThemeForced } = useMemo(
-    () => resolveEffectiveColorTheme(ui.colorTheme, new Date(), holidayWindowState.reverted),
-    [ui.colorTheme, holidayWindowState.reverted],
+    () => resolveEffectiveColorTheme(ui.colorTheme, new Date(), holidayWindowState.reverted, devHolidayThemeState.holidayThemePreviewKey),
+    [devHolidayThemeState.holidayThemePreviewKey, holidayWindowState.reverted, ui.colorTheme],
   );
   const holidayWindowId = activeHolidayTheme?.windowId ?? null;
   const isHolidayThemeNoticeDismissed = holidayWindowId
@@ -27,6 +29,7 @@ export const useThemeVariant = () => {
     activeHolidayTheme,
     showHolidayThemeNotice: Boolean(activeHolidayTheme && !isHolidayThemeNoticeDismissed),
     isHolidayThemeForced,
+    holidayThemesVisible: devHolidayThemeState.holidayThemesVisible,
     dismissHolidayThemeNotice,
     revertHolidayThemeForWindow,
   };

--- a/src/lib/holidayThemeConsole.ts
+++ b/src/lib/holidayThemeConsole.ts
@@ -1,0 +1,29 @@
+import { getHolidayThemeCatalog } from "../themes/holidayThemes";
+import {
+  resetHolidayThemeDevState,
+  setHolidayThemePreview,
+  setHolidayThemesVisible,
+} from "../themes/holidayThemeDev";
+import type { HolidayThemeKey } from "../themes/types";
+
+type LinkSimThemeConsole = {
+  listHolidayThemes: () => Array<{ key: HolidayThemeKey; title: string; colorTheme: string }>;
+  setHolidayThemesVisible: (visible: boolean) => void;
+  setHolidayThemePreview: (holidayThemeKey: HolidayThemeKey | null) => void;
+  reset: () => void;
+};
+
+declare global {
+  interface Window {
+    linksimTheme?: LinkSimThemeConsole;
+  }
+}
+
+export const installHolidayThemeConsole = (): void => {
+  window.linksimTheme = {
+    listHolidayThemes: () => getHolidayThemeCatalog(),
+    setHolidayThemesVisible,
+    setHolidayThemePreview,
+    reset: resetHolidayThemeDevState,
+  };
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import "maplibre-gl/dist/maplibre-gl.css";
 import "./index.css";
 import App from "./App";
 import { getCurrentRuntimeEnvironment } from "./lib/environment";
+import { installHolidayThemeConsole } from "./lib/holidayThemeConsole";
 
 if (window.location.hostname === "127.0.0.1") {
   const redirectUrl =
@@ -16,6 +17,10 @@ if (window.location.hostname === "127.0.0.1") {
 const runtimeEnvironment = getCurrentRuntimeEnvironment();
 document.documentElement.classList.remove("env-local", "env-staging", "env-production");
 document.documentElement.classList.add(`env-${runtimeEnvironment}`);
+
+if (runtimeEnvironment !== "production") {
+  installHolidayThemeConsole();
+}
 
 const applyEnvironmentBranding = () => {
   document.title =

--- a/src/themes/holidayThemeDev.test.ts
+++ b/src/themes/holidayThemeDev.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  getDevHolidayThemeState,
+  resetHolidayThemeDevState,
+  setHolidayThemePreview,
+  setHolidayThemesVisible,
+} from "./holidayThemeDev";
+
+describe("holidayThemeDev", () => {
+  beforeEach(() => {
+    resetHolidayThemeDevState();
+  });
+
+  it("defaults to hidden themes and no preview", () => {
+    expect(getDevHolidayThemeState()).toEqual({ holidayThemesVisible: false, holidayThemePreviewKey: null });
+  });
+
+  it("persists visibility and preview state", () => {
+    setHolidayThemesVisible(true);
+    setHolidayThemePreview("pride");
+    expect(getDevHolidayThemeState()).toEqual({ holidayThemesVisible: true, holidayThemePreviewKey: "pride" });
+  });
+
+  it("resets visibility and preview state", () => {
+    setHolidayThemesVisible(true);
+    setHolidayThemePreview("easter");
+    resetHolidayThemeDevState();
+    expect(getDevHolidayThemeState()).toEqual({ holidayThemesVisible: false, holidayThemePreviewKey: null });
+  });
+});

--- a/src/themes/holidayThemeDev.ts
+++ b/src/themes/holidayThemeDev.ts
@@ -1,0 +1,87 @@
+import { getHolidayThemeCatalog } from "./holidayThemes";
+import type { HolidayThemeKey } from "./types";
+
+const HOLIDAY_THEMES_VISIBLE_KEY = "linksim.dev.holidayThemesVisible";
+const HOLIDAY_THEME_PREVIEW_KEY = "linksim.dev.holidayThemePreview";
+
+type DevHolidayThemeState = {
+  holidayThemesVisible: boolean;
+  holidayThemePreviewKey: HolidayThemeKey | null;
+};
+
+const hasWindow = typeof window !== "undefined";
+const listeners = new Set<() => void>();
+
+let devState: DevHolidayThemeState = {
+  holidayThemesVisible: false,
+  holidayThemePreviewKey: null,
+};
+
+const persistState = (): void => {
+  if (!hasWindow) return;
+  try {
+    if (devState.holidayThemesVisible) window.localStorage.setItem(HOLIDAY_THEMES_VISIBLE_KEY, "true");
+    else window.localStorage.removeItem(HOLIDAY_THEMES_VISIBLE_KEY);
+    if (devState.holidayThemePreviewKey) window.localStorage.setItem(HOLIDAY_THEME_PREVIEW_KEY, devState.holidayThemePreviewKey);
+    else window.localStorage.removeItem(HOLIDAY_THEME_PREVIEW_KEY);
+  } catch {}
+};
+
+const notifyChange = (): void => {
+  for (const listener of listeners) listener();
+};
+
+const readPersistedState = (): DevHolidayThemeState => {
+  if (!hasWindow) return devState;
+  try {
+    const holidayThemesVisible = window.localStorage.getItem(HOLIDAY_THEMES_VISIBLE_KEY) === "true";
+    const preview = window.localStorage.getItem(HOLIDAY_THEME_PREVIEW_KEY);
+    const holidayThemePreviewKey = preview === "easter" || preview === "pride" ? preview : null;
+    return { holidayThemesVisible, holidayThemePreviewKey };
+  } catch {
+    return devState;
+  }
+};
+
+devState = readPersistedState();
+
+export const getDevHolidayThemeState = (): DevHolidayThemeState => {
+  return devState;
+};
+
+export const subscribeDevHolidayThemeState = (listener: () => void): (() => void) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+export const setHolidayThemesVisible = (visible: boolean): void => {
+  const next = { ...devState, holidayThemesVisible: visible };
+  if (next.holidayThemesVisible === devState.holidayThemesVisible) return;
+  devState = next;
+  persistState();
+  notifyChange();
+};
+
+export const setHolidayThemePreview = (holidayThemeKey: HolidayThemeKey | null): void => {
+  const next = { ...devState, holidayThemePreviewKey: holidayThemeKey };
+  if (next.holidayThemePreviewKey === devState.holidayThemePreviewKey) return;
+  devState = next;
+  persistState();
+  notifyChange();
+};
+
+export const resetHolidayThemeDevState = (): void => {
+  const next = { holidayThemesVisible: false, holidayThemePreviewKey: null };
+  if (next.holidayThemesVisible === devState.holidayThemesVisible && next.holidayThemePreviewKey === devState.holidayThemePreviewKey) return;
+  devState = next;
+  persistState();
+  notifyChange();
+};
+
+export const listHolidayThemeKeys = (): HolidayThemeKey[] => getHolidayThemeCatalog().map((theme) => theme.key);
+
+export const getHolidayThemesVisible = (): boolean => getDevHolidayThemeState().holidayThemesVisible;
+
+export const getHolidayThemePreviewKey = (): HolidayThemeKey | null => getDevHolidayThemeState().holidayThemePreviewKey;

--- a/src/themes/holidayThemes.test.ts
+++ b/src/themes/holidayThemes.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   computeGregorianEasterSunday,
+  getHolidayThemeCatalog,
   getActiveHolidayTheme,
   resolveEffectiveColorTheme,
   resolveEasterWindow,
@@ -27,6 +28,10 @@ describe("holidayThemes", () => {
     const pride2026 = resolvePrideWindow(2026);
     expect(isoDay(pride2026.startUtc)).toBe("2026-06-17");
     expect(isoDay(pride2026.endUtc)).toBe("2026-06-27");
+  });
+
+  it("lists all seasonal themes for dev picker use", () => {
+    expect(getHolidayThemeCatalog().map((theme) => theme.key)).toEqual(["easter", "pride"]);
   });
 
   it("activates Easter theme during the configured annual window", () => {
@@ -70,6 +75,13 @@ describe("holidayThemes", () => {
     expect(resolved.colorTheme).toBe("neutral");
     expect(resolved.isHolidayThemeForced).toBe(true);
     expect(resolved.activeHolidayTheme?.windowId).toBe("pride:2026");
+  });
+
+  it("supports previewing any seasonal theme", () => {
+    const resolved = resolveEffectiveColorTheme("blue", new Date("2026-01-01T12:00:00.000Z"), [], "pride");
+    expect(resolved.colorTheme).toBe("neutral");
+    expect(resolved.isHolidayThemeForced).toBe(true);
+    expect(resolved.activeHolidayTheme?.key).toBe("pride");
   });
 
   it("uses preferred theme when holiday window was reverted", () => {

--- a/src/themes/holidayThemes.ts
+++ b/src/themes/holidayThemes.ts
@@ -78,7 +78,25 @@ const HOLIDAY_THEME_RULES: HolidayThemeRule[] = [
   },
 ];
 
-export const getActiveHolidayTheme = (date: Date): HolidayTheme | null => {
+export const getHolidayThemeCatalog = (): Array<Pick<HolidayTheme, "key" | "title" | "colorTheme">> =>
+  HOLIDAY_THEME_RULES.map(({ key, title, colorTheme }) => ({ key, title, colorTheme }));
+
+const resolveHolidayThemeByKey = (holidayKey: HolidayTheme["key"]): HolidayThemeRule | null =>
+  HOLIDAY_THEME_RULES.find((rule) => rule.key === holidayKey) ?? null;
+
+export const getActiveHolidayTheme = (date: Date, previewHolidayKey: HolidayTheme["key"] | null = null): HolidayTheme | null => {
+  if (previewHolidayKey) {
+    const rule = resolveHolidayThemeByKey(previewHolidayKey);
+    if (!rule) return null;
+    const window = rule.resolveWindow(date.getUTCFullYear());
+    return {
+      key: rule.key,
+      title: rule.title,
+      message: rule.message,
+      colorTheme: rule.colorTheme,
+      windowId: toHolidayWindowId(rule.key, window),
+    };
+  }
   const year = date.getUTCFullYear();
   for (const rule of HOLIDAY_THEME_RULES) {
     for (const candidateYear of [year - 1, year, year + 1]) {
@@ -100,8 +118,9 @@ export const resolveEffectiveColorTheme = (
   preferredColorTheme: UiColorTheme,
   date: Date,
   revertedHolidayWindows: string[] = [],
+  previewHolidayKey: HolidayTheme["key"] | null = null,
 ): { colorTheme: UiColorTheme; activeHolidayTheme: HolidayTheme | null; isHolidayThemeForced: boolean } => {
-  const activeHolidayTheme = getActiveHolidayTheme(date);
+  const activeHolidayTheme = getActiveHolidayTheme(date, previewHolidayKey);
   if (!activeHolidayTheme) {
     return { colorTheme: preferredColorTheme, activeHolidayTheme: null, isHolidayThemeForced: false };
   }


### PR DESCRIPTION
## Summary\n- Add a dev-only console API to reveal all seasonal themes in the picker and preview any holiday theme.\n- Keep the existing date-based activation rules intact while making out-of-season testing repeatable on staging/local.\n- Wire the picker to show all holiday themes when the console toggle is enabled.\n\n## Verification\n- npm test\n- npm run build