### PR TITLE
fix: keep danger hover text readable

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -38,7 +38,7 @@
 
 :root[data-holiday-theme="pride"] {
   --holiday-rainbow-border: repeating-linear-gradient(
-    90deg,
+    45deg,
     #e40303 0 8px,
     #ff8c00 8px 16px,
     #ffed00 16px 24px,
@@ -50,7 +50,7 @@
 
 :root.theme-dark[data-holiday-theme="pride"] {
   --holiday-rainbow-border: repeating-linear-gradient(
-    90deg,
+    45deg,
     #ff5470 0 8px,
     #ff9f1a 8px 16px,
     #ffe45c 16px 24px,
@@ -3453,6 +3453,13 @@ html.panorama-gesture-lock body {
 .btn-danger {
   border-color: color-mix(in srgb, var(--danger) 78%, var(--border));
   background: var(--danger);
+  color: var(--danger-on);
+}
+
+.btn-danger:hover,
+.btn-danger:focus-visible {
+  border-color: color-mix(in srgb, var(--danger) 90%, var(--border));
+  background: color-mix(in srgb, var(--danger) 88%, var(--surface-2));
   color: var(--danger-on);
 }
 

--- a/src/themes/blueTheme.ts
+++ b/src/themes/blueTheme.ts
@@ -44,7 +44,7 @@ export const BLUE_THEME: ThemeDefinition = {
       "--shadow-elev-3": "0 8px 18px rgba(0, 0, 0, 0.16)",
       "--shadow-elev-4": "0 14px 30px rgba(0, 0, 0, 0.3)",
       "--shadow-elev-5": "0 10px 24px rgba(0, 0, 0, 0.26)",
-      "--holiday-rainbow-border": "repeating-linear-gradient(90deg, #e40303 0 8px, #ff8c00 8px 16px, #ffed00 16px 24px, #008026 24px 32px, #004dff 32px 40px, #750787 40px 48px)",
+      "--holiday-rainbow-border": "repeating-linear-gradient(45deg, #e40303 0 8px, #ff8c00 8px 16px, #ffed00 16px 24px, #008026 24px 32px, #004dff 32px 40px, #750787 40px 48px)",
     },
     map: {
       linkColor: "#00c2ff",
@@ -98,7 +98,7 @@ export const BLUE_THEME: ThemeDefinition = {
       "--shadow-elev-3": "0 8px 18px rgba(0, 0, 0, 0.16)",
       "--shadow-elev-4": "0 14px 30px rgba(0, 0, 0, 0.3)",
       "--shadow-elev-5": "0 10px 24px rgba(0, 0, 0, 0.26)",
-      "--holiday-rainbow-border": "repeating-linear-gradient(90deg, #ff5470 0 8px, #ff9f1a 8px 16px, #ffe45c 16px 24px, #34d17a 24px 32px, #4ea0ff 32px 40px, #b46bff 40px 48px)",
+      "--holiday-rainbow-border": "repeating-linear-gradient(45deg, #ff5470 0 8px, #ff9f1a 8px 16px, #ffe45c 16px 24px, #34d17a 24px 32px, #4ea0ff 32px 40px, #b46bff 40px 48px)",
     },
     map: {
       linkColor: "#00c2ff",

--- a/src/themes/greenTheme.ts
+++ b/src/themes/greenTheme.ts
@@ -44,7 +44,7 @@ export const GREEN_THEME: ThemeDefinition = {
       "--shadow-elev-3": "0 8px 18px rgba(0, 0, 0, 0.16)",
       "--shadow-elev-4": "0 14px 30px rgba(0, 0, 0, 0.3)",
       "--shadow-elev-5": "0 10px 24px rgba(0, 0, 0, 0.26)",
-      "--holiday-rainbow-border": "repeating-linear-gradient(90deg, #e40303 0 8px, #ff8c00 8px 16px, #ffed00 16px 24px, #008026 24px 32px, #004dff 32px 40px, #750787 40px 48px)",
+      "--holiday-rainbow-border": "repeating-linear-gradient(45deg, #e40303 0 8px, #ff8c00 8px 16px, #ffed00 16px 24px, #008026 24px 32px, #004dff 32px 40px, #750787 40px 48px)",
     },
     map: {
       linkColor: "#2fbf72",
@@ -98,7 +98,7 @@ export const GREEN_THEME: ThemeDefinition = {
       "--shadow-elev-3": "0 8px 18px rgba(0, 0, 0, 0.16)",
       "--shadow-elev-4": "0 14px 30px rgba(0, 0, 0, 0.3)",
       "--shadow-elev-5": "0 10px 24px rgba(0, 0, 0, 0.26)",
-      "--holiday-rainbow-border": "repeating-linear-gradient(90deg, #ff5470 0 8px, #ff9f1a 8px 16px, #ffe45c 16px 24px, #34d17a 24px 32px, #4ea0ff 32px 40px, #b46bff 40px 48px)",
+      "--holiday-rainbow-border": "repeating-linear-gradient(45deg, #ff5470 0 8px, #ff9f1a 8px 16px, #ffe45c 16px 24px, #34d17a 24px 32px, #4ea0ff 32px 40px, #b46bff 40px 48px)",
     },
     map: {
       linkColor: "#5fe58f",

--- a/src/themes/neutralTheme.ts
+++ b/src/themes/neutralTheme.ts
@@ -45,7 +45,7 @@ export const NEUTRAL_THEME: ThemeDefinition = {
       "--shadow-elev-4": "0 14px 30px rgba(0, 0, 0, 0.3)",
       "--shadow-elev-5": "0 10px 24px rgba(0, 0, 0, 0.26)",
       "--holiday-rainbow-border":
-        "repeating-linear-gradient(90deg, #e40303 0 8px, #ff8c00 8px 16px, #ffed00 16px 24px, #008026 24px 32px, #004dff 32px 40px, #750787 40px 48px)",
+        "repeating-linear-gradient(45deg, #e40303 0 8px, #ff8c00 8px 16px, #ffed00 16px 24px, #008026 24px 32px, #004dff 32px 40px, #750787 40px 48px)",
     },
     map: {
       linkColor: "#6d7a87",
@@ -100,7 +100,7 @@ export const NEUTRAL_THEME: ThemeDefinition = {
       "--shadow-elev-4": "0 14px 30px rgba(0, 0, 0, 0.3)",
       "--shadow-elev-5": "0 10px 24px rgba(0, 0, 0, 0.26)",
       "--holiday-rainbow-border":
-        "repeating-linear-gradient(90deg, #ff5470 0 8px, #ff9f1a 8px 16px, #ffe45c 16px 24px, #34d17a 24px 32px, #4ea0ff 32px 40px, #b46bff 40px 48px)",
+        "repeating-linear-gradient(45deg, #ff5470 0 8px, #ff9f1a 8px 16px, #ffe45c 16px 24px, #34d17a 24px 32px, #4ea0ff 32px 40px, #b46bff 40px 48px)",
     },
     map: {
       linkColor: "#a0aab4",

--- a/src/themes/pinkTheme.ts
+++ b/src/themes/pinkTheme.ts
@@ -44,7 +44,7 @@ export const PINK_THEME: ThemeDefinition = {
       "--shadow-elev-3": "0 8px 18px rgba(0, 0, 0, 0.16)",
       "--shadow-elev-4": "0 14px 30px rgba(0, 0, 0, 0.3)",
       "--shadow-elev-5": "0 10px 24px rgba(0, 0, 0, 0.26)",
-      "--holiday-rainbow-border": "repeating-linear-gradient(90deg, #e40303 0 8px, #ff8c00 8px 16px, #ffed00 16px 24px, #008026 24px 32px, #004dff 32px 40px, #750787 40px 48px)",
+      "--holiday-rainbow-border": "repeating-linear-gradient(45deg, #e40303 0 8px, #ff8c00 8px 16px, #ffed00 16px 24px, #008026 24px 32px, #004dff 32px 40px, #750787 40px 48px)",
     },
     map: {
       linkColor: "#ff73b4",
@@ -98,7 +98,7 @@ export const PINK_THEME: ThemeDefinition = {
       "--shadow-elev-3": "0 8px 18px rgba(0, 0, 0, 0.16)",
       "--shadow-elev-4": "0 14px 30px rgba(0, 0, 0, 0.3)",
       "--shadow-elev-5": "0 10px 24px rgba(0, 0, 0, 0.26)",
-      "--holiday-rainbow-border": "repeating-linear-gradient(90deg, #ff5470 0 8px, #ff9f1a 8px 16px, #ffe45c 16px 24px, #34d17a 24px 32px, #4ea0ff 32px 40px, #b46bff 40px 48px)",
+      "--holiday-rainbow-border": "repeating-linear-gradient(45deg, #ff5470 0 8px, #ff9f1a 8px 16px, #ffe45c 16px 24px, #34d17a 24px 32px, #4ea0ff 32px 40px, #b46bff 40px 48px)",
     },
     map: {
       linkColor: "#ff73b4",

--- a/src/themes/redTheme.ts
+++ b/src/themes/redTheme.ts
@@ -44,7 +44,7 @@ export const RED_THEME: ThemeDefinition = {
       "--shadow-elev-3": "0 8px 18px rgba(0, 0, 0, 0.18)",
       "--shadow-elev-4": "0 14px 30px rgba(0, 0, 0, 0.32)",
       "--shadow-elev-5": "0 10px 24px rgba(0, 0, 0, 0.28)",
-      "--holiday-rainbow-border": "repeating-linear-gradient(90deg, #e40303 0 8px, #ff8c00 8px 16px, #ffed00 16px 24px, #008026 24px 32px, #004dff 32px 40px, #750787 40px 48px)",
+      "--holiday-rainbow-border": "repeating-linear-gradient(45deg, #e40303 0 8px, #ff8c00 8px 16px, #ffed00 16px 24px, #008026 24px 32px, #004dff 32px 40px, #750787 40px 48px)",
     },
     map: {
       linkColor: "#ff3b47",
@@ -98,7 +98,7 @@ export const RED_THEME: ThemeDefinition = {
       "--shadow-elev-3": "0 8px 18px rgba(0, 0, 0, 0.18)",
       "--shadow-elev-4": "0 14px 30px rgba(0, 0, 0, 0.32)",
       "--shadow-elev-5": "0 10px 24px rgba(0, 0, 0, 0.28)",
-      "--holiday-rainbow-border": "repeating-linear-gradient(90deg, #ff5470 0 8px, #ff9f1a 8px 16px, #ffe45c 16px 24px, #34d17a 24px 32px, #4ea0ff 32px 40px, #b46bff 40px 48px)",
+      "--holiday-rainbow-border": "repeating-linear-gradient(45deg, #ff5470 0 8px, #ff9f1a 8px 16px, #ffe45c 16px 24px, #34d17a 24px 32px, #4ea0ff 32px 40px, #b46bff 40px 48px)",
     },
     map: {
       linkColor: "#ff4350",

--- a/src/themes/yellowTheme.ts
+++ b/src/themes/yellowTheme.ts
@@ -44,7 +44,7 @@ export const YELLOW_THEME: ThemeDefinition = {
       "--shadow-elev-3": "0 8px 18px rgba(0, 0, 0, 0.16)",
       "--shadow-elev-4": "0 14px 30px rgba(0, 0, 0, 0.3)",
       "--shadow-elev-5": "0 10px 24px rgba(0, 0, 0, 0.26)",
-      "--holiday-rainbow-border": "repeating-linear-gradient(90deg, #e40303 0 8px, #ff8c00 8px 16px, #ffed00 16px 24px, #008026 24px 32px, #004dff 32px 40px, #750787 40px 48px)",
+      "--holiday-rainbow-border": "repeating-linear-gradient(45deg, #e40303 0 8px, #ff8c00 8px 16px, #ffed00 16px 24px, #008026 24px 32px, #004dff 32px 40px, #750787 40px 48px)",
     },
     map: {
       linkColor: "#f2bb00",
@@ -98,7 +98,7 @@ export const YELLOW_THEME: ThemeDefinition = {
       "--shadow-elev-3": "0 8px 18px rgba(0, 0, 0, 0.16)",
       "--shadow-elev-4": "0 14px 30px rgba(0, 0, 0, 0.3)",
       "--shadow-elev-5": "0 10px 24px rgba(0, 0, 0, 0.26)",
-      "--holiday-rainbow-border": "repeating-linear-gradient(90deg, #ff5470 0 8px, #ff9f1a 8px 16px, #ffe45c 16px 24px, #34d17a 24px 32px, #4ea0ff 32px 40px, #b46bff 40px 48px)",
+      "--holiday-rainbow-border": "repeating-linear-gradient(45deg, #ff5470 0 8px, #ff9f1a 8px 16px, #ffe45c 16px 24px, #34d17a 24px 32px, #4ea0ff 32px 40px, #b46bff 40px 48px)",
     },
     map: {
       linkColor: "#ffd84f",


### PR DESCRIPTION
## Summary\n- Keep destructive buttons legible on hover in the neutral light theme.\n- Apply the same 45° Pride border tilt consistently across theme fallbacks.\n\n## Verification\n- npm test\n- npm run build