### PR TITLE
fix: size and animate the Pride notice icon

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1722,9 +1722,10 @@ button {
 
 .map-holiday-pride-icon {
   position: relative;
-  width: 15px;
+  width: 24px;
   aspect-ratio: 1;
   display: inline-block;
+  flex: 0 0 24px;
   overflow: hidden;
   -webkit-mask: center / contain no-repeat url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M4 16a8 8 0 0 1 16 0' fill='none' stroke='white' stroke-width='1.5' stroke-linecap='round'/%3E%3Cpath d='M7 16a5 5 0 0 1 10 0' fill='none' stroke='white' stroke-width='1.5' stroke-linecap='round'/%3E%3Cpath d='M10 16a2 2 0 0 1 4 0' fill='none' stroke='white' stroke-width='1.5' stroke-linecap='round'/%3E%3Ccircle cx='12' cy='16' r='1' fill='white'/%3E%3C/svg%3E");
   mask: center / contain no-repeat url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M4 16a8 8 0 0 1 16 0' fill='none' stroke='white' stroke-width='1.5' stroke-linecap='round'/%3E%3Cpath d='M7 16a5 5 0 0 1 10 0' fill='none' stroke='white' stroke-width='1.5' stroke-linecap='round'/%3E%3Cpath d='M10 16a2 2 0 0 1 4 0' fill='none' stroke='white' stroke-width='1.5' stroke-linecap='round'/%3E%3Ccircle cx='12' cy='16' r='1' fill='white'/%3E%3C/svg%3E");
@@ -1738,16 +1739,12 @@ button {
   height: 200%;
   background: var(--holiday-rainbow-icon-gradient);
   transform-origin: 50% 58.333%;
-  animation: pride-ripple 2.6s linear infinite;
+  animation: pride-icon-spin 2.6s linear infinite;
 }
 
-@keyframes pride-ripple {
-  from {
-    transform: scale(0.35);
-  }
-
+@keyframes pride-icon-spin {
   to {
-    transform: scale(1.35);
+    transform: rotate(1turn);
   }
 }
 


### PR DESCRIPTION
## Summary\n- Increase the Pride notice icon footprint so it reads closer to the holiday notice icon group.\n- Keep the Lucide Rainbow mask fixed and animate only the oversized rainbow paint layer.\n- Use the corrected conic-gradient origin for the masked icon paint.\n\n## Verification\n- npm test\n- npm run build