### PR TITLE
fix release promotion guardrails

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,10 +26,10 @@
 
 ## Release checklist (required when base is `main`)
 
-- [ ] Source branch is `staging` (or `hotfix/*` for approved incidents).
-- [ ] Staging verification was done on the exact same commit.
+- [ ] Source branch is `staging`, `release/vX.Y.Z` for blocked normal promotions, or `hotfix/*` for approved incidents.
+- [ ] Staging verification was done on the exact same release tree.
 - [ ] SemVer bump is correct and intentional.
-- [ ] `vX.Y.Z` tag points to the commit being promoted.
+- [ ] `vX.Y.Z` tag points to the release tree being promoted.
 - [ ] Milestone release checklist completed: `docs/milestone-release-checklist.md`.
 
 ## Hotfix follow-up (required when source branch is `hotfix/*`)

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -75,6 +75,9 @@ jobs:
           VERSION="$(node -p "require('./package.json').version")"
           echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
 
+      - name: Validate production promotion tree
+        run: node scripts/validate-prod-promotion.mjs
+
       - name: Prepare release worktree
         run: git worktree add --detach "$RUNNER_TEMP/linksim-release" "${{ steps.release_tag.outputs.tag }}"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,16 +78,17 @@
   - `npm run deploy:staging:preview` → Preview URL
   - `npm run deploy:prod:main` → https://linksim.link
 - Staging deploy default:
-  - Use `npm run deploy:staging` from `staging` branch to deploy to https://staging.linksim.link
+  - Merge to `staging` and let CI deploy to https://staging.linksim.link.
+  - Do not run deploy scripts locally for normal verification.
   - Do not use preview deploys for normal verification; default is always the shared staging URL.
 - Never run raw `wrangler pages deploy` for release operations.
 - If a guarded deploy fails, fix the script/preflight issue and re-run the guarded script. Do not bypass with manual Wrangler deploys.
 - Promotion gate:
-  - Promote the exact same verified commit from local -> staging -> production.
+  - Promote the exact same verified release tree from local -> staging -> production. With squash merges, commit SHAs can differ; the production deploy gate must verify that `main` HEAD matches the `vX.Y.Z` tag tree.
   - If code changes after staging verification, rerun local verification and redeploy staging before production.
   - Normal production promotion PR must be `staging` -> `main`.
   - Hotfix promotion PR may be `hotfix/<slug>` -> `main` only with explicit user approval in-thread.
-- Normal squash-merged `staging` -> `main` production releases are not staging drift; the release content already came from `staging`, even though the squash commit is not in staging ancestry.
+- Normal squash-merged `staging` -> `main` and `release/vX.Y.Z` -> `main` production releases are not staging drift; the release content already came from `staging`, even though the squash commit is not in staging ancestry.
 - **After any hotfix merges to main**: immediately create a `chore/sync-main-to-staging` branch from `origin/staging`, apply the main-only hotfix/reconcile content in commits that can be squash-merged, PR into `staging`, merge, and let CI redeploy staging. Do not start new feature work until staging is back in sync. The `detect-staging-drift` workflow will open a GitHub Issue as a reminder if this is missed.
 - **Release-reconcile fallback rule**: if production promotion cannot be completed via direct `staging` -> `main` and uses a `hotfix/*` snapshot/reconcile PR instead, the same pass is not complete until `main` is synced back into `staging`, staging is redeployed, and the drift issue is closed.
 
@@ -116,10 +117,11 @@ When `staging` → `main` PR shows conflicts despite squash-merge policy:
   - Restart local server whenever runtime/config/env changes can affect behavior.
   - Re-verify affected flows after restart before marking work as done.
   - Do not leave local dev/watch servers running after a pass. Before handing back, run `npm run dev:check`; if it reports a LinkSim dev/watch server, run `npm run dev:stop` unless the user explicitly asked to keep it running.
-- Production preflight checklist (required before `deploy:prod:main`):
+- Production preflight checklist (required before production promotion):
   - `npm run test`
   - `npm run build:bundle`
   - Confirm build label matches intended SemVer channel rules
+  - Confirm the `vX.Y.Z` tag tree matches the production promotion tree
   - Confirm no unresolved issue/project status drift for items in the current pass
   - Confirm `CHANGELOG.md` is updated with user-readable highlights for the target release
 - Token-efficient execution:
@@ -152,7 +154,7 @@ When `staging` → `main` PR shows conflicts despite squash-merge policy:
   - Run and report: `git log --oneline origin/staging -5`
   - Run and report: `git log --oneline origin/main -5`
   - Run and report: `git cherry -v origin/staging origin/main`
-  - If `git cherry` only reports the latest normal squash-merged `staging` -> `main` production release commit, treat it as expected ancestry-only drift and proceed.
+  - If `git cherry` only reports the latest normal squash-merged `staging` -> `main` or `release/vX.Y.Z` -> `main` production release commit, treat it as expected ancestry-only drift and proceed.
   - If new main-only hotfix/reconcile content appears, create a dedicated `chore/sync-main-to-staging` PR before feature work.
 - Verification gates for deep-link/API-affecting work:
   - `npm run test -- --run src/lib/deepLink.test.ts`
@@ -170,7 +172,7 @@ When `staging` → `main` PR shows conflicts despite squash-merge policy:
 - Milestone promotion model:
   - Complete and verify all milestone issues on `staging` first.
   - Promote to production in one batch with a direct PR from `staging` to `main`.
-  - Use the exact verified staging commit for production; no code changes between staging sign-off and production deploy.
+  - Use the exact verified release tree for production; no code changes between staging sign-off and production deploy.
   - Freeze milestone scope at sign-off: no new feature work lands on `staging` until production deploy completes.
   - After production deploy, continue new issue work from the updated `origin/staging` baseline.
 

--- a/docs/milestone-release-checklist.md
+++ b/docs/milestone-release-checklist.md
@@ -11,12 +11,12 @@ Use this checklist before opening a normal production promotion PR (`staging` ->
 - [ ] `npm test` passes on the release candidate.
 - [ ] `npm run build` passes on the release candidate.
 - [ ] Staging verification was completed on `https://staging.linksim.link`.
-- [ ] Verified production promotion will use the exact same staging commit SHA.
+- [ ] Verified production promotion will use the exact same release tree that was verified on staging.
 
 ## Version and notes
 - [ ] SemVer bump is present and intentional.
 - [ ] `CHANGELOG.md` has a human-readable entry for this release.
-- [ ] Release tag `vX.Y.Z` points to the production commit.
+- [ ] Release tag `vX.Y.Z` points to the verified release tree that production will deploy.
 
 ## PR attestation (required)
 Include this checked line in the PR body for `staging` -> `main`:

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -27,11 +27,12 @@
 
 3. Production
 - Promote only after explicit user approval.
-- Open PR `staging` -> `main` (direct path — branch policy allows `staging` as head branch).
+- Open PR `staging` -> `main` first (direct path — branch policy allows `staging` as head branch).
+- If GitHub reports conflicts because prior production releases were squash-merged, use the approved fallback: create `release/vX.Y.Z` from `main`, squash-merge `origin/staging`, resolve conflicts by keeping the verified staging release tree, tag `vX.Y.Z`, then PR `release/vX.Y.Z` -> `main`.
 - CI automatically deploys to production on every merge to `main`. Monitor the `Deploy LinkSim Pages / deploy-prod-main` GitHub Actions job and report the commit SHA when complete.
-- Note: the CI deploy job runs `validate-prod-release.mjs` which requires a SemVer version bump and git tag at HEAD — ensure these are in place before merging to `main`.
+- Note: the CI deploy job validates that the release tag exists, the `main` HEAD tree matches the tag tree, and the tagged release commit has the required SemVer bump.
 - After production deploy, continue all new work from updated `origin/staging`.
-- If direct `staging` -> `main` promotion is blocked and a `hotfix/*` reconcile/snapshot PR to `main` is used, treat that as an exception path and immediately run main->staging sync before starting any new work.
+- If a `hotfix/*` reconcile/snapshot PR to `main` is used, treat that as an incident exception path and immediately run main->staging sync before starting any new work.
 
 ## Guardrails
 - No direct production hotfixes unless explicitly requested by the user.
@@ -53,9 +54,9 @@
   - `hotfix/<slug>`
   - `chore/<slug>`
 - PRs into `main` must come from:
-  - `staging` (default and only normal release path — branch policy explicitly allows this)
+  - `staging` (default normal release path — branch policy explicitly allows this)
   - `hotfix/<slug>` (approved production incidents only)
-  - `release/vX.Y.Z` (legacy exception path, not used for normal releases)
+  - `release/vX.Y.Z` (approved normal-release fallback when direct `staging` -> `main` conflicts)
 - Merge strategy: squash merge only.
 - Auto-delete merged branches enabled.
 
@@ -81,7 +82,7 @@
   2. Verify (`npm test`, `npm run build`, manual QA).
   3. Commit and push.
   4. Open PR to `staging` and merge once approved.
-  5. Deploy `staging` using `npm run deploy:staging` and verify at https://staging.linksim.link.
+  5. Merge to `staging`; CI automatically deploys https://staging.linksim.link. Do not run deploy scripts locally.
   6. Promote via `staging` -> `main` PR only with explicit approval.
 - No hidden scope changes during promotion; if code changes after staging verification, restart the loop.
 
@@ -92,7 +93,7 @@
   3. freeze milestone scope at release sign-off (no new feature merges into `staging`)
   4. promote with a single `staging` -> `main` PR
   5. deploy production from the merged `main` commit
-- Promotion must use the same verified staging commit SHA.
+- Promotion must use the same verified release tree. With GitHub squash merges, commit SHAs can differ; the production gate verifies that `main` HEAD matches the `vX.Y.Z` tag tree before deploy.
 - If any code changes after staging sign-off, restart staging verification before production.
 - Before opening the promotion PR, require:
   - all in-scope milestone issues are either closed after staging sign-off or explicitly labeled `released`
@@ -126,7 +127,7 @@
 - Issue branches must be created from latest `origin/staging`.
 - PRs into `staging` or `main` must be up-to-date with the base branch before merge.
 - Never promote from `issue/*` or `chore/*` directly into `main`.
-- Normal squash-merged `staging` -> `main` production releases are not staging drift. The release content already came from `staging`, even though the squash commit is not in staging ancestry.
+- Normal squash-merged `staging` -> `main` and `release/vX.Y.Z` -> `main` production releases are not staging drift. The release content already came from `staging`, even though the squash commit is not in staging ancestry.
 - After any `hotfix/*` merge into `main` (including release-reconcile fallback), immediately:
   1. create `chore/sync-main-to-staging` from `origin/staging`
   2. apply the main-only hotfix/reconcile content in commits that can be squash-merged

--- a/docs/staging-environment.md
+++ b/docs/staging-environment.md
@@ -16,11 +16,9 @@ This project supports a separate staging stack with production-like data.
 
 ### Deploy to staging (test environment)
 
-```bash
-npm run deploy:staging
-```
+Merge a PR into `staging`. CI automatically runs the guarded staging deploy to https://staging.linksim.link.
 
-This deploys the current branch to `main` branch in Cloudflare Pages, which is served by https://staging.linksim.link
+Do not run `npm run deploy:staging` locally for routine verification; Cloudflare deploy credentials are only expected in CI.
 
 ### Deploy to preview (side-by-side comparison)
 
@@ -56,14 +54,12 @@ npm run refresh:staging:r2
 
 ### Full refresh + deploy
 
-```bash
-npm run refresh-and-deploy:staging
-```
+Run the refresh scripts only when explicitly needed, then merge a staging PR and let CI deploy. Do not run deploy scripts locally for routine staging verification.
 
 ## Recommended cadence
 
-- Every commit/PR: `npm run deploy:staging` → test at https://staging.linksim.link
-- Before acceptance/regression testing: `npm run refresh-and-deploy:staging`
+- Every merged staging PR: CI deploys automatically → test at https://staging.linksim.link
+- Before acceptance/regression testing: refresh staging data only when needed, then rely on CI for deploy
 
 ## Safety notes
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "refresh:staging:d1": "./scripts/refresh-staging-d1.sh",
     "refresh:staging:r2": "./scripts/refresh-staging-r2.sh",
     "refresh:staging": "npm run refresh:staging:d1 && npm run refresh:staging:r2",
-    "refresh-and-deploy:staging": "npm run refresh:staging && npm run deploy:staging",
+    "refresh-and-deploy:staging": "node scripts/deploy-staging.mjs",
     "tf:bootstrap:state": "infra/terraform/scripts/bootstrap-state-backend.sh",
     "tf:fmt": "infra/terraform/scripts/fmt-check.sh",
     "tf:validate": "infra/terraform/scripts/validate.sh",

--- a/scripts/deploy-staging.mjs
+++ b/scripts/deploy-staging.mjs
@@ -3,7 +3,7 @@ console.error(
     "[deploy:staging] This script is deprecated and intentionally disabled.",
     "Use guarded deploy commands instead:",
     "- npm run deploy:staging:preview",
-    "- npm run deploy:staging:main",
+    "- npm run deploy:staging",
     "- npm run deploy:prod:main",
   ].join("\n"),
 );

--- a/scripts/release-prod.mjs
+++ b/scripts/release-prod.mjs
@@ -1,92 +1,14 @@
 #!/usr/bin/env node
-import { readFile } from "node:fs/promises";
-import { spawn } from "node:child_process";
-import path from "node:path";
 
-const root = process.cwd();
-const packageJsonPath = path.join(root, "package.json");
-
-const parseArg = (name) => {
-  const direct = process.argv.find((arg) => arg.startsWith(`--${name}=`));
-  if (direct) return direct.split("=").slice(1).join("=");
-  const idx = process.argv.indexOf(`--${name}`);
-  if (idx >= 0) return process.argv[idx + 1];
-  return "";
-};
-
-const run = (cmd, args, options = {}) =>
-  new Promise((resolve, reject) => {
-    const child = spawn(cmd, args, {
-      cwd: root,
-      shell: process.platform === "win32",
-      env: process.env,
-      stdio: options.capture ? ["ignore", "pipe", "pipe"] : "inherit",
-    });
-
-    if (options.capture) {
-      let stdout = "";
-      let stderr = "";
-      child.stdout.on("data", (chunk) => {
-        stdout += chunk.toString();
-      });
-      child.stderr.on("data", (chunk) => {
-        stderr += chunk.toString();
-      });
-      child.on("error", reject);
-      child.on("exit", (code) => {
-        if (code === 0) resolve({ stdout, stderr });
-        else reject(new Error(`${cmd} ${args.join(" ")} failed (${code ?? "unknown"}): ${stderr || stdout}`));
-      });
-      return;
-    }
-
-    child.on("error", reject);
-    child.on("exit", (code) => {
-      if (code === 0) resolve({ stdout: "", stderr: "" });
-      else reject(new Error(`${cmd} ${args.join(" ")} failed (${code ?? "unknown"})`));
-    });
-  });
-
-const assert = (condition, message) => {
-  if (!condition) throw new Error(message);
-};
-
-async function main() {
-  const bump = parseArg("bump") || "patch";
-  assert(
-    bump === "patch" || bump === "minor" || bump === "major",
-    "Invalid --bump value. Allowed: patch, minor, major",
-  );
-
-  const { stdout: branchStdout } = await run("git", ["rev-parse", "--abbrev-ref", "HEAD"], { capture: true });
-  const branch = branchStdout.trim();
-  assert(branch === "main", "Release flow requires current branch to be 'main'.");
-
-  const { stdout: statusStdout } = await run("git", ["status", "--porcelain"], { capture: true });
-  assert(statusStdout.trim().length === 0, "Release flow requires a clean git working tree.");
-
-  const packageBefore = JSON.parse(await readFile(packageJsonPath, "utf8"));
-  const versionBefore = String(packageBefore.version ?? "").trim();
-  assert(versionBefore.length > 0, "package.json version is missing.");
-
-  await run("npm", ["version", bump, "--no-git-tag-version"]);
-  await run("npm", ["run", "build:meta"]);
-
-  const packageAfter = JSON.parse(await readFile(packageJsonPath, "utf8"));
-  const versionAfter = String(packageAfter.version ?? "").trim();
-  assert(versionAfter !== versionBefore, "Version bump did not change package.json version.");
-
-  const tag = `v${versionAfter}`;
-  await run("git", ["add", "package.json", "package-lock.json"]);
-  await run("git", ["commit", "-m", `release: bump version to ${versionAfter}`]);
-  await run("git", ["tag", "-a", tag, "-m", `Release ${tag}`]);
-  await run("git", ["push", "origin", "main", "--follow-tags"]);
-
-  await run("npm", ["run", "deploy:staging:main"]);
-  await run("npm", ["run", "deploy:prod:main"]);
-}
-
-main().catch(async (error) => {
-  console.error(`[release:prod] ${error instanceof Error ? error.message : String(error)}`);
-  process.exit(1);
-});
+console.error(
+  [
+    "[release:prod] This local production release script is intentionally disabled.",
+    "Production releases must use the protected PR + CI flow:",
+    "1. Prepare release notes/version on chore/release-X-Y-Z and merge to staging.",
+    "2. Verify staging deployment.",
+    "3. Promote with a PR from staging to main, or release/vX.Y.Z to main if direct promotion conflicts.",
+    "4. Let CI deploy production after protected-branch checks and approvals pass.",
+    "Do not push directly to main or run production deploys locally.",
+  ].join("\n"),
+);
+process.exit(1);

--- a/scripts/staging-drift-policy.mjs
+++ b/scripts/staging-drift-policy.mjs
@@ -15,6 +15,15 @@ export const isNormalStagingPromotion = (pullRequest) => {
   return normalized.baseRefName === "main" && normalized.headRefName === "staging" && Boolean(normalized.mergedAt);
 };
 
+export const isNormalReleasePromotion = (pullRequest) => {
+  const normalized = normalizePullRequest(pullRequest);
+  return (
+    normalized.baseRefName === "main" &&
+    /^release\/v[0-9]+\.[0-9]+\.[0-9]+$/.test(normalized.headRefName) &&
+    Boolean(normalized.mergedAt)
+  );
+};
+
 export const shouldOpenStagingDriftIssue = ({ driftCount, associatedPullRequests }) => {
   const count = asCount(driftCount);
   if (count === 0) {
@@ -26,6 +35,13 @@ export const shouldOpenStagingDriftIssue = ({ driftCount, associatedPullRequests
     return {
       openIssue: false,
       reason: `normal squash-merged staging->main promotion: ${stagingPromotion.htmlUrl || "associated PR"}`,
+    };
+  }
+  const releasePromotion = pullRequests.map(normalizePullRequest).find(isNormalReleasePromotion);
+  if (releasePromotion) {
+    return {
+      openIssue: false,
+      reason: `normal squash-merged release/vX.Y.Z->main promotion: ${releasePromotion.htmlUrl || "associated PR"}`,
     };
   }
   return { openIssue: true, reason: `${count} main commit(s) are not represented by a staging promotion PR` };

--- a/scripts/validate-prod-promotion.mjs
+++ b/scripts/validate-prod-promotion.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+import { readFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import path from "node:path";
+
+const root = process.cwd();
+
+const run = (cmd, args) =>
+  new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      cwd: root,
+      shell: process.platform === "win32",
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) resolve({ stdout, stderr });
+      else reject(new Error(`${cmd} ${args.join(" ")} failed (${code ?? "unknown"}): ${stderr || stdout}`));
+    });
+  });
+
+export const validatePromotionInputs = ({ version, tagCommit, treesMatch }) => {
+  const normalizedVersion = String(version ?? "").trim();
+  if (!normalizedVersion) {
+    throw new Error("Prod promotion gate failed: package.json version is missing.");
+  }
+  if (!String(tagCommit ?? "").trim()) {
+    throw new Error(`Prod promotion gate failed: release tag v${normalizedVersion} does not exist.`);
+  }
+  if (!treesMatch) {
+    throw new Error(
+      `Prod promotion gate failed: main HEAD tree differs from release tag v${normalizedVersion}. ` +
+        "Do not deploy production-only changes; recreate the promotion from the verified staging release tree.",
+    );
+  }
+  return `v${normalizedVersion}`;
+};
+
+async function main() {
+  const pkg = JSON.parse(await readFile(path.join(root, "package.json"), "utf8"));
+  const version = String(pkg.version ?? "").trim();
+  const tag = `v${version}`;
+  const tagCommit = (await run("git", ["rev-parse", "--verify", `${tag}^{commit}`])).stdout.trim();
+  let treesMatch = true;
+  try {
+    await run("git", ["diff", "--quiet", "HEAD", tag, "--"]);
+  } catch {
+    treesMatch = false;
+  }
+
+  validatePromotionInputs({ version, tagCommit, treesMatch });
+  console.log(`[validate-prod-promotion] ok tag=${tag} tagCommit=${tagCommit.slice(0, 8)}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(`[validate-prod-promotion] ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  });
+}

--- a/src/lib/prodPromotionPolicy.test.ts
+++ b/src/lib/prodPromotionPolicy.test.ts
@@ -1,0 +1,59 @@
+/// <reference types="node" />
+
+import { describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+
+const scriptPath = resolve(process.cwd(), "scripts/validate-prod-promotion.mjs");
+
+const evaluatePolicy = (expression: string) => {
+  const output = execFileSync(
+    process.execPath,
+    [
+      "--input-type=module",
+      "--eval",
+      `import { validatePromotionInputs } from ${JSON.stringify(scriptPath)};
+       try {
+         const result = ${expression};
+         console.log(JSON.stringify({ ok: true, value: result }));
+       } catch (error) {
+         console.log(JSON.stringify({ ok: false, message: error instanceof Error ? error.message : String(error) }));
+       }`,
+    ],
+    { encoding: "utf8" },
+  );
+  return JSON.parse(output) as { ok: true; value: unknown } | { ok: false; message: string };
+};
+
+describe("prod promotion policy", () => {
+  it("accepts a release tag whose tree matches main HEAD", () => {
+    const result = evaluatePolicy(`validatePromotionInputs({
+        version: "0.19.0",
+        tagCommit: "15269c7682a0671824a7dfe532f67e30b3b052da",
+        treesMatch: true,
+      })`);
+
+    expect(result).toEqual({ ok: true, value: "v0.19.0" });
+  });
+
+  it("rejects missing release tags", () => {
+    const result = evaluatePolicy(`validatePromotionInputs({
+        version: "0.19.0",
+        tagCommit: "",
+        treesMatch: true,
+      })`);
+
+    expect(result).toEqual({ ok: false, message: "Prod promotion gate failed: release tag v0.19.0 does not exist." });
+  });
+
+  it("rejects production-only tree changes", () => {
+    const result = evaluatePolicy(`validatePromotionInputs({
+        version: "0.19.0",
+        tagCommit: "15269c7682a0671824a7dfe532f67e30b3b052da",
+        treesMatch: false,
+      })`);
+
+    expect(result.ok).toBe(false);
+    expect(result.ok ? "" : result.message).toContain("main HEAD tree differs from release tag v0.19.0");
+  });
+});

--- a/src/lib/stagingDriftPolicy.test.ts
+++ b/src/lib/stagingDriftPolicy.test.ts
@@ -12,7 +12,7 @@ const evaluatePolicy = (expression: string) => {
     [
       "--input-type=module",
       "--eval",
-      `import { isNormalStagingPromotion, shouldOpenStagingDriftIssue } from ${JSON.stringify(scriptPath)};
+      `import { isNormalReleasePromotion, isNormalStagingPromotion, shouldOpenStagingDriftIssue } from ${JSON.stringify(scriptPath)};
        const result = ${expression};
        console.log(JSON.stringify(result));`,
     ],
@@ -54,6 +54,23 @@ describe("staging drift policy", () => {
     expect(result.openIssue).toBe(true);
   });
 
+  it("does not open a drift issue for a squash-merged release branch promotion", () => {
+    const result = evaluatePolicy(`shouldOpenStagingDriftIssue({
+      driftCount: 1,
+      associatedPullRequests: [
+        {
+          head: { ref: "release/v0.19.0" },
+          base: { ref: "main" },
+          merged_at: "2026-05-04T07:16:21Z",
+          html_url: "https://github.com/wilhel1812/LinkSim/pull/836",
+        },
+      ],
+    })`) as { openIssue: boolean; reason: string };
+
+    expect(result.openIssue).toBe(false);
+    expect(result.reason).toContain("release/vX.Y.Z");
+  });
+
   it("does not open a drift issue when there are no main-only commits", () => {
     const result = evaluatePolicy(`shouldOpenStagingDriftIssue({
       driftCount: 0,
@@ -78,5 +95,22 @@ describe("staging drift policy", () => {
         mergedAt: "2026-04-27T12:00:00Z",
       })`),
     ).toBe(true);
+  });
+
+  it("recognizes release/vX.Y.Z promotions as normal production promotions", () => {
+    expect(
+      evaluatePolicy(`isNormalReleasePromotion({
+        head: { ref: "release/v0.19.0" },
+        base: { ref: "main" },
+        merged_at: "2026-05-04T07:16:21Z",
+      })`),
+    ).toBe(true);
+    expect(
+      evaluatePolicy(`isNormalReleasePromotion({
+        head: { ref: "release/0-19-0" },
+        base: { ref: "main" },
+        merged_at: "2026-05-04T07:16:21Z",
+      })`),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Fixes #837
- Treat `release/vX.Y.Z -> main` promotions as normal release promotions in drift detection
- Add a production promotion gate requiring `main` HEAD to match the resolved `vX.Y.Z` tag tree
- Disable stale local production release automation and align release docs/templates with PR/CI-only releases

## Verification
- [x] `npm run test -- --run src/lib/stagingDriftPolicy.test.ts src/lib/prodPromotionPolicy.test.ts`
- [x] `npm test`
- [x] `npm run build`
- [x] `npm run dev:check`