### PR TITLE
release: 0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.20.0] - 2026-05-08
+
+### Added
+- Added RX target heatmap scale and contour overlays to make target coverage easier to evaluate. (#814, #843)
+- Added read-only editor views and sidebar detail actions for shared/read-only Simulations. (#842)
+- Added Pride seasonal theme support, preview controls, and animated notice treatment. (#852)
+- Added a Matrix community footer link. (#844)
+
+### Changed
+- Clarified Simulation radio/default settings editing and made preset defaults more explicit. (#847)
+- Refined heatmap target scale rendering and muted target contour styling for better readability. (#814)
+- Hardened release promotion guardrails and aligned release documentation around PR/CI-only production deploys. (#837, #881)
+
+### Fixed
+- Fixed simulation copy flows so duplicated Simulations preserve active snapshots and referenced Sites. (#845)
+- Fixed Library Site visibility for accessible shared resources. (#848)
+- Fixed duplicate Simulation name feedback and copy-save ordering around blank Simulation creation. (#840, #845)
+- Fixed seasonal theme hover contrast and Pride notice icon sizing/animation. (#852)
+
 ## [0.19.0] - 2026-05-04
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linksim",
-  "version": "0.17.0",
+  "version": "0.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linksim",
-      "version": "0.17.0",
+      "version": "0.20.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "linksim",
   "private": true,
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "GPL-3.0-only",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bump LinkSim from 0.19.0 to 0.20.0
- Add human-readable CHANGELOG entry for 0.20.0
- Push release tag `v0.20.0` for the verified release tree

## Highlights
- RX target heatmap scale and contour overlays
- Simulation radio/default settings clarifications
- Read-only editor views and Simulation copy-flow fixes
- Pride seasonal theme and Matrix footer link
- Release promotion guardrail hardening

## Verification
- [x] `npm run test -- --run src/lib/stagingDriftPolicy.test.ts src/lib/prodPromotionPolicy.test.ts`
- [x] `npm test`
- [x] `npm run build`
- [x] `npm run dev:check`
- [x] `CHANGELOG.md` updated
- [x] Tag `v0.20.0` pushed