### PR TITLE
Add public stats page

### DIFF
--- a/functions/api/stats.test.ts
+++ b/functions/api/stats.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { onRequestGet } from "./stats";
+
+type MockTable = {
+  users: Array<{ id: string; username: string | null; avatar_url: string | null; created_at: string }>;
+  sites: Array<{ id: string; owner_user_id: string; created_at: string | null; payload_json: string }>;
+  simulations: Array<{ id: string; owner_user_id: string; created_at: string | null; payload_json: string }>;
+};
+
+const tables: MockTable = {
+  users: [],
+  sites: [],
+  simulations: [],
+};
+
+const env = {
+  DB: {
+    prepare: (sql: string) => ({
+      all: async () => {
+        if (sql.includes("FROM users")) return { results: tables.users };
+        if (sql.includes("FROM sites")) return { results: tables.sites };
+        if (sql.includes("FROM simulations")) return { results: tables.simulations };
+        return { results: [] };
+      },
+    }),
+  },
+} as unknown as { DB: D1Database };
+
+const mkCtx = (request = new Request("https://example.test/api/stats")) =>
+  ({ request, env } as unknown as Parameters<typeof onRequestGet>[0]);
+
+beforeEach(() => {
+  tables.users = [
+    { id: "u1", username: "Ada", avatar_url: "https://example.test/ada.png", created_at: "2026-01-03T00:00:00.000Z" },
+    { id: "u2", username: "Grace", avatar_url: null, created_at: "2026-02-10T00:00:00.000Z" },
+  ];
+  tables.sites = [
+    {
+      id: "site-1",
+      owner_user_id: "u1",
+      created_at: "2026-01-05T00:00:00.000Z",
+      payload_json: JSON.stringify({ id: "site-1", name: "Private peak", position: { lat: 60.123456, lon: 10.123456 } }),
+    },
+    {
+      id: "site-2",
+      owner_user_id: "u2",
+      created_at: "2026-02-05T00:00:00.000Z",
+      payload_json: JSON.stringify({ id: "site-2", name: "Valley", position: { lat: 60.987654, lon: 10.987654 } }),
+    },
+    {
+      id: "bad-site",
+      owner_user_id: "u2",
+      created_at: "2026-02-06T00:00:00.000Z",
+      payload_json: "{not json",
+    },
+  ];
+  tables.simulations = [
+    {
+      id: "sim-1",
+      owner_user_id: "u1",
+      created_at: "2026-01-07T00:00:00.000Z",
+      payload_json: JSON.stringify({
+        id: "sim-1",
+        name: "Private sim",
+        snapshot: {
+          sites: [{ id: "s1" }, { id: "s2" }, { id: "s3" }],
+          links: [{ id: "l1" }, { id: "l2" }],
+        },
+      }),
+    },
+    {
+      id: "sim-empty",
+      owner_user_id: "u2",
+      created_at: "2026-02-07T00:00:00.000Z",
+      payload_json: JSON.stringify({ id: "sim-empty", name: "Draft", snapshot: { sites: [], links: [] } }),
+    },
+    {
+      id: "sim-2",
+      owner_user_id: "u2",
+      created_at: "2026-02-08T00:00:00.000Z",
+      payload_json: JSON.stringify({
+        id: "sim-2",
+        name: "Shared sim",
+        snapshot: {
+          sites: [{ id: "s4" }],
+          links: [{ id: "l3" }],
+        },
+      }),
+    },
+  ];
+});
+
+describe("api/stats", () => {
+  it("returns public aggregate stats without auth", async () => {
+    const res = await onRequestGet(mkCtx());
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toContain("s-maxage=900");
+
+    const body = await res.json() as {
+      totals: { users: number; sites: number; simulations: number; nonEmptySimulations: number; links: number };
+      complexity: { averageSitesPerSimulation: number; medianSitesPerSimulation: number; averageLinksPerSimulation: number };
+    };
+
+    expect(body.totals).toMatchObject({
+      users: 2,
+      sites: 3,
+      simulations: 3,
+      nonEmptySimulations: 2,
+      links: 3,
+    });
+    expect(body.complexity.averageSitesPerSimulation).toBe(2);
+    expect(body.complexity.medianSitesPerSimulation).toBe(2);
+    expect(body.complexity.averageLinksPerSimulation).toBe(1.5);
+  });
+
+  it("returns monthly and weekly growth buckets", async () => {
+    const res = await onRequestGet(mkCtx());
+    const body = await res.json() as {
+      growth: {
+        monthly: Array<{ label: string; users: number; sites: number; simulations: number }>;
+        weekly: Array<{ users: number; sites: number; simulations: number }>;
+      };
+    };
+
+    expect(body.growth.monthly).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: "2026-01", users: 1, sites: 1, simulations: 1 }),
+        expect.objectContaining({ label: "2026-02", users: 1, sites: 2, simulations: 2 }),
+      ]),
+    );
+    expect(body.growth.weekly.length).toBeGreaterThan(0);
+  });
+
+  it("returns binned geography without raw coordinates or payloads", async () => {
+    const res = await onRequestGet(mkCtx());
+    const body = await res.json() as {
+      geography: { bins: Array<{ latBand: number; lonBand: number; count: number }> };
+    };
+    const raw = JSON.stringify(body);
+
+    expect(body.geography.bins).toEqual([{ latBand: 60, lonBand: 10, count: 2 }]);
+    expect(raw).not.toContain("60.123456");
+    expect(raw).not.toContain("Private peak");
+    expect(raw).not.toContain("payload_json");
+  });
+});

--- a/functions/api/stats.ts
+++ b/functions/api/stats.ts
@@ -1,0 +1,250 @@
+import { errorResponse, handleOptions, json, withCors } from "../_lib/http";
+import type { Env } from "../_lib/types";
+
+type UserRow = {
+  id: string;
+  username: string | null;
+  avatar_url: string | null;
+  created_at: string;
+};
+
+type ResourceRow = {
+  id: string;
+  owner_user_id: string;
+  created_at: string | null;
+  payload_json: string;
+};
+
+type GrowthBucket = {
+  label: string;
+  users: number;
+  sites: number;
+  simulations: number;
+  cumulativeUsers: number;
+  cumulativeSites: number;
+  cumulativeSimulations: number;
+};
+
+type SitePayload = {
+  position?: {
+    lat?: unknown;
+    lon?: unknown;
+  };
+};
+
+type SimulationPayload = {
+  snapshot?: {
+    sites?: unknown;
+    links?: unknown;
+  };
+};
+
+const CACHE_CONTROL = "public, max-age=300, s-maxage=900, stale-while-revalidate=3600";
+
+const parseJsonObject = <T>(raw: string): T | null => {
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? (parsed as T) : null;
+  } catch {
+    return null;
+  }
+};
+
+const parseDate = (value: string | null): Date | null => {
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isFinite(date.getTime()) ? date : null;
+};
+
+const monthLabel = (date: Date): string =>
+  `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}`;
+
+const weekLabel = (date: Date): string => {
+  const start = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  const day = start.getUTCDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  start.setUTCDate(start.getUTCDate() + diff);
+  return start.toISOString().slice(0, 10);
+};
+
+const increment = (map: Map<string, { users: number; sites: number; simulations: number }>, label: string, key: "users" | "sites" | "simulations") => {
+  const current = map.get(label) ?? { users: 0, sites: 0, simulations: 0 };
+  current[key] += 1;
+  map.set(label, current);
+};
+
+const buildGrowth = (
+  users: UserRow[],
+  sites: ResourceRow[],
+  simulations: ResourceRow[],
+  labelFor: (date: Date) => string,
+): GrowthBucket[] => {
+  const buckets = new Map<string, { users: number; sites: number; simulations: number }>();
+  users.forEach((row) => {
+    const date = parseDate(row.created_at);
+    if (date) increment(buckets, labelFor(date), "users");
+  });
+  sites.forEach((row) => {
+    const date = parseDate(row.created_at);
+    if (date) increment(buckets, labelFor(date), "sites");
+  });
+  simulations.forEach((row) => {
+    const date = parseDate(row.created_at);
+    if (date) increment(buckets, labelFor(date), "simulations");
+  });
+
+  let cumulativeUsers = 0;
+  let cumulativeSites = 0;
+  let cumulativeSimulations = 0;
+  return Array.from(buckets.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([label, counts]) => {
+      cumulativeUsers += counts.users;
+      cumulativeSites += counts.sites;
+      cumulativeSimulations += counts.simulations;
+      return {
+        label,
+        ...counts,
+        cumulativeUsers,
+        cumulativeSites,
+        cumulativeSimulations,
+      };
+    });
+};
+
+const median = (values: number[]): number => {
+  if (!values.length) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+};
+
+const average = (values: number[]): number =>
+  values.length ? values.reduce((sum, value) => sum + value, 0) / values.length : 0;
+
+const round1 = (value: number): number => Math.round(value * 10) / 10;
+
+const bucketSimulationSize = (siteCount: number): "1-2" | "3-5" | "6-10" | "11+" => {
+  if (siteCount <= 2) return "1-2";
+  if (siteCount <= 5) return "3-5";
+  if (siteCount <= 10) return "6-10";
+  return "11+";
+};
+
+const isFiniteNumber = (value: unknown): value is number => typeof value === "number" && Number.isFinite(value);
+
+export const onRequestOptions: PagesFunction<Env> = async ({ request }) => handleOptions(request);
+
+export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
+  try {
+    const [usersResult, sitesResult, simulationsResult] = await Promise.all([
+      env.DB.prepare("SELECT id, username, avatar_url, created_at FROM users").all<UserRow>(),
+      env.DB.prepare("SELECT id, owner_user_id, created_at, payload_json FROM sites").all<ResourceRow>(),
+      env.DB.prepare("SELECT id, owner_user_id, created_at, payload_json FROM simulations").all<ResourceRow>(),
+    ]);
+
+    const users = usersResult.results ?? [];
+    const sites = sitesResult.results ?? [];
+    const simulations = simulationsResult.results ?? [];
+    const userById = new Map(users.map((user) => [user.id, user]));
+    const contributorCounts = new Map<string, { userId: string; username: string; avatarUrl: string; contributions: number }>();
+
+    const addContribution = (userId: string) => {
+      const user = userById.get(userId);
+      if (!user) return;
+      const current = contributorCounts.get(userId) ?? {
+        userId,
+        username: user.username?.trim() || "Unknown user",
+        avatarUrl: user.avatar_url ?? "",
+        contributions: 0,
+      };
+      current.contributions += 1;
+      contributorCounts.set(userId, current);
+    };
+
+    const geoBins = new Map<string, { latBand: number; lonBand: number; count: number }>();
+    sites.forEach((site) => {
+      addContribution(site.owner_user_id);
+      const payload = parseJsonObject<SitePayload>(site.payload_json);
+      const lat = payload?.position?.lat;
+      const lon = payload?.position?.lon;
+      if (!isFiniteNumber(lat) || !isFiniteNumber(lon)) return;
+      const latBand = Math.floor(lat);
+      const lonBand = Math.floor(lon);
+      const key = `${latBand}:${lonBand}`;
+      const current = geoBins.get(key) ?? { latBand, lonBand, count: 0 };
+      current.count += 1;
+      geoBins.set(key, current);
+    });
+
+    let totalLinks = 0;
+    const nonEmptySiteCounts: number[] = [];
+    const nonEmptyLinkCounts: number[] = [];
+    const sizeBuckets = { "1-2": 0, "3-5": 0, "6-10": 0, "11+": 0 };
+
+    simulations.forEach((simulation) => {
+      addContribution(simulation.owner_user_id);
+      const payload = parseJsonObject<SimulationPayload>(simulation.payload_json);
+      const siteCount = Array.isArray(payload?.snapshot?.sites) ? payload.snapshot.sites.length : 0;
+      const linkCount = Array.isArray(payload?.snapshot?.links) ? payload.snapshot.links.length : 0;
+      totalLinks += linkCount;
+      if (siteCount <= 0) return;
+      nonEmptySiteCounts.push(siteCount);
+      nonEmptyLinkCounts.push(linkCount);
+      sizeBuckets[bucketSimulationSize(siteCount)] += 1;
+    });
+
+    const newestMembers = [...users]
+      .sort((a, b) => (parseDate(b.created_at)?.getTime() ?? 0) - (parseDate(a.created_at)?.getTime() ?? 0))
+      .slice(0, 5)
+      .map((user) => ({
+        userId: user.id,
+        username: user.username?.trim() || "Unknown user",
+        avatarUrl: user.avatar_url ?? "",
+        createdAt: user.created_at,
+      }));
+
+    const body = {
+      generatedAt: new Date().toISOString(),
+      totals: {
+        users: users.length,
+        sites: sites.length,
+        simulations: simulations.length,
+        nonEmptySimulations: nonEmptySiteCounts.length,
+        links: totalLinks,
+      },
+      growth: {
+        monthly: buildGrowth(users, sites, simulations, monthLabel),
+        weekly: buildGrowth(users, sites, simulations, weekLabel).slice(-52),
+      },
+      geography: {
+        binSizeDegrees: 1,
+        bins: Array.from(geoBins.values()).sort((a, b) => b.count - a.count || a.latBand - b.latBand || a.lonBand - b.lonBand),
+      },
+      complexity: {
+        averageSitesPerSimulation: round1(average(nonEmptySiteCounts)),
+        medianSitesPerSimulation: round1(median(nonEmptySiteCounts)),
+        averageLinksPerSimulation: round1(average(nonEmptyLinkCounts)),
+        medianLinksPerSimulation: round1(median(nonEmptyLinkCounts)),
+        sizeBuckets,
+      },
+      highlights: {
+        topContributors: Array.from(contributorCounts.values())
+          .sort((a, b) => b.contributions - a.contributions || a.username.localeCompare(b.username))
+          .slice(0, 5),
+        newestMembers,
+      },
+    };
+
+    return withCors(
+      request,
+      json(body, {
+        headers: {
+          "cache-control": CACHE_CONTROL,
+        },
+      }),
+    );
+  } catch (error) {
+    return errorResponse(request, error, 500);
+  }
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,29 @@
-import { AppShell } from "./components/AppShell";
-import { UiGalleryPage } from "./components/UiGalleryPage";
+import { lazy, Suspense } from "react";
+
+const AppShell = lazy(() => import("./components/AppShell").then((module) => ({ default: module.AppShell })));
+const UiGalleryPage = lazy(() => import("./components/UiGalleryPage").then((module) => ({ default: module.UiGalleryPage })));
+const StatsPage = lazy(() => import("./components/StatsPage").then((module) => ({ default: module.StatsPage })));
 
 function App() {
   if (window.location.pathname === "/ui-gallery") {
-    return <UiGalleryPage />;
+    return (
+      <Suspense fallback={<div className="route-loading">Loading UI gallery...</div>}>
+        <UiGalleryPage />
+      </Suspense>
+    );
   }
-  return <AppShell />;
+  if (window.location.pathname === "/stats") {
+    return (
+      <Suspense fallback={<div className="route-loading">Loading stats...</div>}>
+        <StatsPage />
+      </Suspense>
+    );
+  }
+  return (
+    <Suspense fallback={<div className="route-loading">Loading LinkSim...</div>}>
+      <AppShell />
+    </Suspense>
+  );
 }
 
 export default App;

--- a/src/components/AppShell.copyFlow.test.tsx
+++ b/src/components/AppShell.copyFlow.test.tsx
@@ -4,6 +4,25 @@ import { act, render, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useAppStore } from "../store/appStore";
 
+vi.hoisted(() => {
+  const values = new Map<string, string>();
+  const localStorageMock = {
+    get length() {
+      return values.size;
+    },
+    clear: vi.fn(() => values.clear()),
+    getItem: vi.fn((key: string) => values.get(key) ?? null),
+    key: vi.fn((index: number) => Array.from(values.keys())[index] ?? null),
+    removeItem: vi.fn((key: string) => {
+      values.delete(key);
+    }),
+    setItem: vi.fn((key: string, value: string) => {
+      values.set(key, String(value));
+    }),
+  };
+  vi.stubGlobal("localStorage", localStorageMock);
+});
+
 const sidebarCalls: Array<{ readOnly?: boolean; panelToggleControl?: unknown }> = [];
 
 vi.mock("../lib/cloudUser", () => ({

--- a/src/components/StatsPage.test.tsx
+++ b/src/components/StatsPage.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("../hooks/useThemeVariant", () => ({
+  useThemeVariant: () => ({ theme: "light", variant: { cssVars: {} }, activeHolidayTheme: null }),
+}));
+
+import { StatsPage } from "./StatsPage";
+
+const statsPayload = {
+  generatedAt: "2026-05-11T00:00:00.000Z",
+  totals: {
+    users: 12,
+    sites: 34,
+    simulations: 8,
+    nonEmptySimulations: 6,
+    links: 21,
+  },
+  growth: {
+    monthly: [
+      { label: "2026-01", users: 2, sites: 4, simulations: 1, cumulativeUsers: 2, cumulativeSites: 4, cumulativeSimulations: 1 },
+      { label: "2026-02", users: 3, sites: 6, simulations: 2, cumulativeUsers: 5, cumulativeSites: 10, cumulativeSimulations: 3 },
+    ],
+    weekly: [
+      { label: "2026-05-04", users: 1, sites: 2, simulations: 1, cumulativeUsers: 1, cumulativeSites: 2, cumulativeSimulations: 1 },
+    ],
+  },
+  geography: {
+    binSizeDegrees: 1,
+    bins: [{ latBand: 60, lonBand: 10, count: 5 }],
+  },
+  complexity: {
+    averageSitesPerSimulation: 3,
+    medianSitesPerSimulation: 2.5,
+    averageLinksPerSimulation: 1.5,
+    medianLinksPerSimulation: 1,
+    sizeBuckets: { "1-2": 2, "3-5": 3, "6-10": 1, "11+": 0 },
+  },
+  highlights: {
+    topContributors: [],
+    newestMembers: [],
+  },
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok: true,
+      json: async () => statsPayload,
+    })),
+  );
+});
+
+describe("StatsPage", () => {
+  it("renders public infographic sections from /api/stats", async () => {
+    render(<StatsPage />);
+
+    await screen.findByText("Stats");
+    expect(await screen.findByText("12")).toBeInTheDocument();
+    expect(screen.getByText("34")).toBeInTheDocument();
+    expect(screen.getByText("6")).toBeInTheDocument();
+    expect(screen.getByText("21")).toBeInTheDocument();
+    expect(screen.getByText("Growth")).toBeInTheDocument();
+    expect(screen.getByText("Site Geography")).toBeInTheDocument();
+    expect(screen.getByText("Contributor Highlights")).toBeInTheDocument();
+    expect(screen.getByText("Simulation Complexity")).toBeInTheDocument();
+    expect(screen.getByText("Radio And Network Flavor")).toBeInTheDocument();
+    expect(screen.getByText("Geography Details")).toBeInTheDocument();
+    expect(screen.queryByText("Moderator Snapshot")).not.toBeInTheDocument();
+    expect(fetch).toHaveBeenCalledWith("/api/stats", { method: "GET" });
+  });
+
+  it("switches the growth chart between all-time and recent buckets", async () => {
+    render(<StatsPage />);
+    await screen.findByText("All time");
+
+    expect(screen.getByText(/2026-01:/)).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Recent"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/2026-05-04:/)).toBeInTheDocument();
+    });
+  });
+
+  it("renders polished empty states", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          ...statsPayload,
+          growth: { monthly: [], weekly: [] },
+          geography: { binSizeDegrees: 1, bins: [] },
+        }),
+      })),
+    );
+
+    render(<StatsPage />);
+
+    expect(await screen.findByText("Stats will appear here after community data exists.")).toBeInTheDocument();
+    expect(screen.getByText("Site density will appear after Sites with coordinates are created.")).toBeInTheDocument();
+  });
+});

--- a/src/components/StatsPage.tsx
+++ b/src/components/StatsPage.tsx
@@ -1,0 +1,221 @@
+import { useEffect, useMemo, useState } from "react";
+import { ActionButton } from "./ActionButton";
+import { fetchStats, type StatsGrowthBucket, type StatsPayload } from "../lib/stats";
+import { useThemeVariant } from "../hooks/useThemeVariant";
+
+type GrowthMode = "monthly" | "weekly";
+
+const formatNumber = (value: number): string => new Intl.NumberFormat("en").format(value);
+
+const metricLabel = (value: number, singular: string, plural = `${singular}s`): string =>
+  `${formatNumber(value)} ${value === 1 ? singular : plural}`;
+
+const StatCounter = ({ label, value, detail }: { label: string; value: number; detail: string }) => (
+  <div className="stats-counter">
+    <span className="stats-counter-value">{formatNumber(value)}</span>
+    <span className="stats-counter-label">{label}</span>
+    <span className="stats-counter-detail">{detail}</span>
+  </div>
+);
+
+const EmptyPanel = ({ title, children }: { title: string; children: string }) => (
+  <article className="stats-placeholder panel-section">
+    <div className="section-heading">
+      <h2>{title}</h2>
+      <span className="stats-chip">planned</span>
+    </div>
+    <p className="field-help">{children}</p>
+  </article>
+);
+
+const GrowthChart = ({ buckets }: { buckets: StatsGrowthBucket[] }) => {
+  const width = 760;
+  const height = 260;
+  const maxValue = Math.max(1, ...buckets.map((bucket) => bucket.cumulativeUsers + bucket.cumulativeSites + bucket.cumulativeSimulations));
+  const points = buckets.map((bucket, index) => {
+    const x = buckets.length <= 1 ? width / 2 : (index / (buckets.length - 1)) * width;
+    const total = bucket.cumulativeUsers + bucket.cumulativeSites + bucket.cumulativeSimulations;
+    const y = height - (total / maxValue) * (height - 34) - 17;
+    return { x, y, total, bucket };
+  });
+  const path = points.map((point, index) => `${index === 0 ? "M" : "L"}${point.x.toFixed(1)},${point.y.toFixed(1)}`).join(" ");
+
+  if (!buckets.length) {
+    return <div className="stats-empty">Stats will appear here after community data exists.</div>;
+  }
+
+  return (
+    <div className="stats-chart-wrap" aria-label="Community growth chart">
+      <svg className="stats-growth-chart" role="img" viewBox={`0 0 ${width} ${height}`} aria-label="Cumulative users, Sites, and Simulations over time">
+        <path className="stats-chart-grid" d={`M0 ${height - 18} H${width}`} />
+        <path className="stats-chart-area" d={`${path} L${width},${height - 18} L0,${height - 18} Z`} />
+        <path className="stats-chart-line" d={path} />
+        {points.map((point) => (
+          <g key={point.bucket.label}>
+            <circle className="stats-chart-dot" cx={point.x} cy={point.y} r="4" />
+            <title>
+              {point.bucket.label}: {metricLabel(point.bucket.users, "user")}, {metricLabel(point.bucket.sites, "Site")}, {metricLabel(point.bucket.simulations, "Simulation")}
+            </title>
+          </g>
+        ))}
+      </svg>
+    </div>
+  );
+};
+
+const GeoDensity = ({ stats }: { stats: StatsPayload }) => {
+  const bins = stats.geography.bins.slice(0, 180);
+  const maxCount = Math.max(1, ...bins.map((bin) => bin.count));
+
+  if (!bins.length) {
+    return <div className="stats-empty">Site density will appear after Sites with coordinates are created.</div>;
+  }
+
+  return (
+    <div className="stats-geo-wrap" aria-label="Binned Site geography">
+      <svg className="stats-geo-map" role="img" viewBox="0 0 720 360" aria-label="Binned density map of entered Site locations">
+        <rect className="stats-geo-frame" x="1" y="1" width="718" height="358" rx="18" />
+        <path className="stats-geo-equator" d="M24 180 H696" />
+        <path className="stats-geo-meridian" d="M360 24 V336" />
+        {bins.map((bin) => {
+          const x = ((bin.lonBand + 180) / 360) * 672 + 24;
+          const y = ((90 - bin.latBand) / 180) * 312 + 24;
+          const radius = 3 + (bin.count / maxCount) * 18;
+          return (
+            <circle
+              className="stats-geo-bin"
+              cx={x}
+              cy={y}
+              key={`${bin.latBand}:${bin.lonBand}`}
+              r={radius}
+            >
+              <title>
+                {bin.count} Sites near {bin.latBand} degrees latitude, {bin.lonBand} degrees longitude
+              </title>
+            </circle>
+          );
+        })}
+      </svg>
+    </div>
+  );
+};
+
+export function StatsPage() {
+  const { theme, variant, activeHolidayTheme } = useThemeVariant();
+  const [stats, setStats] = useState<StatsPayload | null>(null);
+  const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
+  const [errorMessage, setErrorMessage] = useState("");
+  const [growthMode, setGrowthMode] = useState<GrowthMode>("monthly");
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.remove("theme-light", "theme-dark");
+    root.classList.add(theme === "dark" ? "theme-dark" : "theme-light");
+    if (activeHolidayTheme) root.dataset.holidayTheme = activeHolidayTheme.key;
+    else delete root.dataset.holidayTheme;
+    for (const [key, value] of Object.entries(variant.cssVars)) {
+      root.style.setProperty(key, value);
+    }
+    root.style.colorScheme = theme;
+  }, [activeHolidayTheme, theme, variant]);
+
+  useEffect(() => {
+    document.title = "LinkSim Stats";
+    let cancelled = false;
+    setStatus("loading");
+    fetchStats()
+      .then((payload) => {
+        if (cancelled) return;
+        setStats(payload);
+        setStatus("ready");
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        setErrorMessage(error instanceof Error ? error.message : "Stats unavailable.");
+        setStatus("error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const activeGrowth = useMemo(() => stats?.growth[growthMode] ?? [], [growthMode, stats]);
+
+  return (
+    <main className="stats-page">
+      <section className="stats-hero">
+        <div className="stats-hero-copy">
+          <span className="stats-kicker">LinkSim community telemetry</span>
+          <h1>Stats</h1>
+          <p>
+            Public aggregate signals from entered Sites, saved Simulations, and community growth.
+          </p>
+        </div>
+        <div className="stats-hero-status">
+          <span className={`stats-status-dot is-${status}`} aria-hidden="true" />
+          <span className="stats-chip">{status}</span>
+        </div>
+      </section>
+
+      {status === "error" ? (
+        <section className="stats-panel panel-section">
+          <div className="section-heading">
+            <h2>Stats unavailable</h2>
+          </div>
+          <p className="field-help field-help-error">{errorMessage}</p>
+        </section>
+      ) : null}
+
+      <section className="stats-counter-grid" aria-label="Community totals">
+        <StatCounter label="Users" value={stats?.totals.users ?? 0} detail="registered community members" />
+        <StatCounter label="Sites" value={stats?.totals.sites ?? 0} detail="entered planning locations" />
+        <StatCounter label="Simulations" value={stats?.totals.nonEmptySimulations ?? 0} detail={`${formatNumber(stats?.totals.simulations ?? 0)} total including drafts`} />
+        <StatCounter label="Links" value={stats?.totals.links ?? 0} detail="saved Paths inside Simulations" />
+      </section>
+
+      <section className="stats-grid">
+        <article className="stats-panel stats-panel-wide panel-section">
+          <div className="section-heading stats-section-heading">
+            <div>
+              <h2>Growth</h2>
+              <p className="field-help">Cumulative Users, Sites, and Simulations.</p>
+            </div>
+            <div className="chip-group">
+              <ActionButton aria-pressed={growthMode === "monthly"} onClick={() => setGrowthMode("monthly")} type="button">
+                All time
+              </ActionButton>
+              <ActionButton aria-pressed={growthMode === "weekly"} onClick={() => setGrowthMode("weekly")} type="button">
+                Recent
+              </ActionButton>
+            </div>
+          </div>
+          {status === "loading" ? <div className="stats-empty">Loading growth stats...</div> : <GrowthChart buckets={activeGrowth} />}
+        </article>
+
+        <article className="stats-panel stats-panel-wide panel-section">
+          <div className="section-heading stats-section-heading">
+            <div>
+              <h2>Site Geography</h2>
+              <p className="field-help">Binned density from user-entered Site coordinates.</p>
+            </div>
+            <span className="stats-chip">{stats ? `${stats.geography.binSizeDegrees} degree bins` : "loading"}</span>
+          </div>
+          {status === "loading" || !stats ? <div className="stats-empty">Loading Site geography...</div> : <GeoDensity stats={stats} />}
+        </article>
+
+        <EmptyPanel title="Contributor Highlights">
+          Planned: top 5 contributors, newest 5 members, and recent community activity using normal profile-safe fields.
+        </EmptyPanel>
+        <EmptyPanel title="Simulation Complexity">
+          Planned: average and median Sites and Links per non-empty Simulation, plus size distribution buckets.
+        </EmptyPanel>
+        <EmptyPanel title="Radio And Network Flavor">
+          Planned: common frequencies, bands, link distance distribution, and common presets or Channels.
+        </EmptyPanel>
+        <EmptyPanel title="Geography Details">
+          Planned: densest regions, cardinal extent bins, and a future longest passing Path spotlight.
+        </EmptyPanel>
+      </section>
+    </main>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -922,6 +922,291 @@ button {
   font-weight: 500;
 }
 
+.route-loading {
+  min-height: 100lvh;
+  display: grid;
+  place-items: center;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.stats-page {
+  min-height: 100lvh;
+  padding: clamp(18px, 4vw, 48px);
+  display: grid;
+  gap: 18px;
+  align-content: start;
+}
+
+.stats-hero {
+  min-height: min(42lvh, 360px);
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 18px;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 74%, transparent);
+  padding-bottom: 22px;
+}
+
+.stats-hero-copy {
+  max-width: 760px;
+  display: grid;
+  gap: 10px;
+}
+
+.stats-kicker {
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+  text-transform: uppercase;
+}
+
+.stats-hero h1 {
+  margin: 0;
+  font-size: clamp(3rem, 9vw, 7.8rem);
+  line-height: 0.9;
+  letter-spacing: 0;
+}
+
+.stats-hero p {
+  margin: 0;
+  max-width: 620px;
+  color: var(--muted);
+  font-size: clamp(1rem, 2vw, 1.25rem);
+  line-height: 1.45;
+}
+
+.stats-hero-status,
+.stats-section-heading {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.stats-hero-status {
+  align-self: flex-start;
+}
+
+.stats-status-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: var(--radius-pill);
+  background: var(--warning);
+  box-shadow: 0 0 0 5px color-mix(in srgb, var(--warning) 16%, transparent);
+}
+
+.stats-status-dot.is-ready {
+  background: var(--success);
+  box-shadow: 0 0 0 5px color-mix(in srgb, var(--success) 16%, transparent);
+}
+
+.stats-status-dot.is-error {
+  background: var(--danger);
+  box-shadow: 0 0 0 5px color-mix(in srgb, var(--danger) 16%, transparent);
+}
+
+.stats-chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+  border-radius: var(--radius-pill);
+  padding: 3px 9px;
+  background: color-mix(in srgb, var(--surface-2) 70%, transparent);
+  color: var(--muted);
+  font-size: 0.75rem;
+  white-space: nowrap;
+}
+
+.stats-counter-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.stats-counter {
+  min-height: 150px;
+  border: 1px solid color-mix(in srgb, var(--border) 76%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  box-shadow: var(--shadow-elev-1);
+  padding: 16px;
+  display: grid;
+  align-content: end;
+  gap: 4px;
+  overflow: hidden;
+}
+
+.stats-counter-value {
+  font-family: var(--font-mono);
+  font-size: clamp(2rem, 5vw, 4rem);
+  line-height: 0.95;
+  animation: stats-rise-in 520ms ease-out both;
+}
+
+.stats-counter-label {
+  font-weight: 700;
+}
+
+.stats-counter-detail {
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.stats-panel,
+.stats-placeholder {
+  border-radius: 8px;
+}
+
+.stats-panel-wide {
+  grid-column: 1 / -1;
+}
+
+.stats-section-heading {
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.stats-section-heading .field-help {
+  margin: 2px 0 0;
+}
+
+.stats-chart-wrap,
+.stats-geo-wrap {
+  min-height: 280px;
+  display: grid;
+  place-items: center;
+}
+
+.stats-growth-chart,
+.stats-geo-map {
+  width: 100%;
+  max-height: 360px;
+}
+
+.stats-chart-grid {
+  stroke: color-mix(in srgb, var(--border) 72%, transparent);
+  stroke-width: 1;
+}
+
+.stats-chart-area {
+  fill: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.stats-chart-line {
+  fill: none;
+  stroke: var(--accent);
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 4;
+  filter: drop-shadow(0 6px 18px color-mix(in srgb, var(--accent) 24%, transparent));
+}
+
+.stats-chart-dot {
+  fill: var(--surface);
+  stroke: var(--accent);
+  stroke-width: 3;
+}
+
+.stats-geo-frame {
+  fill: color-mix(in srgb, var(--surface-2) 72%, transparent);
+  stroke: color-mix(in srgb, var(--border) 72%, transparent);
+}
+
+.stats-geo-equator,
+.stats-geo-meridian {
+  fill: none;
+  stroke: color-mix(in srgb, var(--border) 44%, transparent);
+  stroke-dasharray: 6 8;
+}
+
+.stats-geo-bin {
+  fill: color-mix(in srgb, var(--los) 50%, transparent);
+  stroke: color-mix(in srgb, var(--surface) 90%, transparent);
+  stroke-width: 1.5;
+  animation: stats-pulse-in 620ms ease-out both;
+}
+
+.stats-empty {
+  min-height: 180px;
+  display: grid;
+  place-items: center;
+  border: 1px dashed color-mix(in srgb, var(--border) 70%, transparent);
+  border-radius: 8px;
+  color: var(--muted);
+  text-align: center;
+  padding: 16px;
+}
+
+.stats-placeholder {
+  min-height: 168px;
+  display: grid;
+  align-content: start;
+  gap: 10px;
+}
+
+@keyframes stats-rise-in {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes stats-pulse-in {
+  from {
+    opacity: 0;
+    transform: scale(0.72);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .stats-counter-value,
+  .stats-geo-bin {
+    animation: none;
+  }
+}
+
+@media (max-width: 840px) {
+  .stats-page {
+    padding: 16px;
+  }
+
+  .stats-hero {
+    min-height: 260px;
+    align-items: flex-start;
+    flex-direction: column;
+    justify-content: flex-end;
+  }
+
+  .stats-counter-grid,
+  .stats-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .stats-counter {
+    min-height: 118px;
+  }
+
+  .stats-section-heading {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}
+
 .workspace-panel {
   position: relative;
   display: grid;

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -1,0 +1,61 @@
+export type StatsGrowthBucket = {
+  label: string;
+  users: number;
+  sites: number;
+  simulations: number;
+  cumulativeUsers: number;
+  cumulativeSites: number;
+  cumulativeSimulations: number;
+};
+
+export type StatsPayload = {
+  generatedAt: string;
+  totals: {
+    users: number;
+    sites: number;
+    simulations: number;
+    nonEmptySimulations: number;
+    links: number;
+  };
+  growth: {
+    monthly: StatsGrowthBucket[];
+    weekly: StatsGrowthBucket[];
+  };
+  geography: {
+    binSizeDegrees: number;
+    bins: Array<{
+      latBand: number;
+      lonBand: number;
+      count: number;
+    }>;
+  };
+  complexity: {
+    averageSitesPerSimulation: number;
+    medianSitesPerSimulation: number;
+    averageLinksPerSimulation: number;
+    medianLinksPerSimulation: number;
+    sizeBuckets: Record<"1-2" | "3-5" | "6-10" | "11+", number>;
+  };
+  highlights: {
+    topContributors: Array<{
+      userId: string;
+      username: string;
+      avatarUrl: string;
+      contributions: number;
+    }>;
+    newestMembers: Array<{
+      userId: string;
+      username: string;
+      avatarUrl: string;
+      createdAt: string;
+    }>;
+  };
+};
+
+export const fetchStats = async (): Promise<StatsPayload> => {
+  const response = await fetch("/api/stats", { method: "GET" });
+  if (!response.ok) {
+    throw new Error(`Stats unavailable (${response.status})`);
+  }
+  return (await response.json()) as StatsPayload;
+};


### PR DESCRIPTION
## Summary
- add public /api/stats aggregate endpoint with cache headers and shaped totals/growth/geography/complexity payload
- add lazy-loaded /stats infographic page with counters, growth toggle, binned Site geography, and planned placeholder panels
- lazy-load AppShell/UI gallery routes so public stats does not eagerly pull the workspace shell

## Verification
- npm test -- --run functions/api/stats.test.ts
- npm test -- --run src/components/StatsPage.test.tsx
- npm test
- npm run build
- Playwright rendered QA for /stats desktop/mobile with mocked /api/stats response and no console errors

Closes #853