### PR TITLE
Refine stats page charts and geography

### DIFF
--- a/functions/api/stats.test.ts
+++ b/functions/api/stats.test.ts
@@ -118,15 +118,15 @@ describe("api/stats", () => {
     const res = await onRequestGet(mkCtx());
     const body = await res.json() as {
       growth: {
-        monthly: Array<{ label: string; users: number; sites: number; simulations: number }>;
-        weekly: Array<{ users: number; sites: number; simulations: number }>;
+        monthly: Array<{ label: string; users: number; sites: number; simulations: number; links: number; cumulativeLinks: number }>;
+        weekly: Array<{ users: number; sites: number; simulations: number; links: number }>;
       };
     };
 
     expect(body.growth.monthly).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ label: "2026-01", users: 1, sites: 1, simulations: 1 }),
-        expect.objectContaining({ label: "2026-02", users: 1, sites: 2, simulations: 2 }),
+        expect.objectContaining({ label: "2026-01", users: 1, sites: 1, simulations: 1, links: 2, cumulativeLinks: 2 }),
+        expect.objectContaining({ label: "2026-02", users: 1, sites: 2, simulations: 2, links: 1, cumulativeLinks: 3 }),
       ]),
     );
     expect(body.growth.weekly.length).toBeGreaterThan(0);

--- a/functions/api/stats.ts
+++ b/functions/api/stats.ts
@@ -20,9 +20,11 @@ type GrowthBucket = {
   users: number;
   sites: number;
   simulations: number;
+  links: number;
   cumulativeUsers: number;
   cumulativeSites: number;
   cumulativeSimulations: number;
+  cumulativeLinks: number;
 };
 
 type SitePayload = {
@@ -67,10 +69,20 @@ const weekLabel = (date: Date): string => {
   return start.toISOString().slice(0, 10);
 };
 
-const increment = (map: Map<string, { users: number; sites: number; simulations: number }>, label: string, key: "users" | "sites" | "simulations") => {
-  const current = map.get(label) ?? { users: 0, sites: 0, simulations: 0 };
-  current[key] += 1;
+type GrowthCountKey = "users" | "sites" | "simulations" | "links";
+type GrowthCounts = Record<GrowthCountKey, number>;
+
+const emptyGrowthCounts = (): GrowthCounts => ({ users: 0, sites: 0, simulations: 0, links: 0 });
+
+const increment = (map: Map<string, GrowthCounts>, label: string, key: GrowthCountKey, amount = 1) => {
+  const current = map.get(label) ?? emptyGrowthCounts();
+  current[key] += amount;
   map.set(label, current);
+};
+
+const simulationLinkCount = (simulation: ResourceRow): number => {
+  const payload = parseJsonObject<SimulationPayload>(simulation.payload_json);
+  return Array.isArray(payload?.snapshot?.links) ? payload.snapshot.links.length : 0;
 };
 
 const buildGrowth = (
@@ -79,7 +91,7 @@ const buildGrowth = (
   simulations: ResourceRow[],
   labelFor: (date: Date) => string,
 ): GrowthBucket[] => {
-  const buckets = new Map<string, { users: number; sites: number; simulations: number }>();
+  const buckets = new Map<string, GrowthCounts>();
   users.forEach((row) => {
     const date = parseDate(row.created_at);
     if (date) increment(buckets, labelFor(date), "users");
@@ -90,24 +102,30 @@ const buildGrowth = (
   });
   simulations.forEach((row) => {
     const date = parseDate(row.created_at);
-    if (date) increment(buckets, labelFor(date), "simulations");
+    if (!date) return;
+    const label = labelFor(date);
+    increment(buckets, label, "simulations");
+    increment(buckets, label, "links", simulationLinkCount(row));
   });
 
   let cumulativeUsers = 0;
   let cumulativeSites = 0;
   let cumulativeSimulations = 0;
+  let cumulativeLinks = 0;
   return Array.from(buckets.entries())
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([label, counts]) => {
       cumulativeUsers += counts.users;
       cumulativeSites += counts.sites;
       cumulativeSimulations += counts.simulations;
+      cumulativeLinks += counts.links;
       return {
         label,
         ...counts,
         cumulativeUsers,
         cumulativeSites,
         cumulativeSimulations,
+        cumulativeLinks,
       };
     });
 };

--- a/src/components/StatsPage.test.tsx
+++ b/src/components/StatsPage.test.tsx
@@ -19,11 +19,11 @@ const statsPayload = {
   },
   growth: {
     monthly: [
-      { label: "2026-01", users: 2, sites: 4, simulations: 1, cumulativeUsers: 2, cumulativeSites: 4, cumulativeSimulations: 1 },
-      { label: "2026-02", users: 3, sites: 6, simulations: 2, cumulativeUsers: 5, cumulativeSites: 10, cumulativeSimulations: 3 },
+      { label: "2026-01", users: 2, sites: 4, simulations: 1, links: 5, cumulativeUsers: 2, cumulativeSites: 4, cumulativeSimulations: 1, cumulativeLinks: 5 },
+      { label: "2026-02", users: 3, sites: 6, simulations: 2, links: 7, cumulativeUsers: 5, cumulativeSites: 10, cumulativeSimulations: 3, cumulativeLinks: 12 },
     ],
     weekly: [
-      { label: "2026-05-04", users: 1, sites: 2, simulations: 1, cumulativeUsers: 1, cumulativeSites: 2, cumulativeSimulations: 1 },
+      { label: "2026-05-04", users: 1, sites: 2, simulations: 1, links: 3, cumulativeUsers: 1, cumulativeSites: 2, cumulativeSimulations: 1, cumulativeLinks: 3 },
     ],
   },
   geography: {
@@ -61,7 +61,7 @@ describe("StatsPage", () => {
     await screen.findByText("Stats");
     expect(await screen.findByText("12")).toBeInTheDocument();
     expect(screen.getByText("34")).toBeInTheDocument();
-    expect(screen.getByText("6")).toBeInTheDocument();
+    expect(screen.getByText("8")).toBeInTheDocument();
     expect(screen.getByText("21")).toBeInTheDocument();
     expect(screen.getByText("Growth")).toBeInTheDocument();
     expect(screen.getByText("Site Geography")).toBeInTheDocument();
@@ -70,6 +70,8 @@ describe("StatsPage", () => {
     expect(screen.getByText("Radio And Network Flavor")).toBeInTheDocument();
     expect(screen.getByText("Geography Details")).toBeInTheDocument();
     expect(screen.queryByText("Moderator Snapshot")).not.toBeInTheDocument();
+    expect(screen.queryByText(/draft/i)).not.toBeInTheDocument();
+    expect(screen.queryByText("ready")).not.toBeInTheDocument();
     expect(fetch).toHaveBeenCalledWith("/api/stats", { method: "GET" });
   });
 
@@ -77,11 +79,11 @@ describe("StatsPage", () => {
     render(<StatsPage />);
     await screen.findByText("All time");
 
-    expect(screen.getByText(/2026-01:/)).toBeInTheDocument();
+    expect(screen.getAllByText(/2026-01:/).length).toBeGreaterThan(0);
     fireEvent.click(screen.getByText("Recent"));
 
     await waitFor(() => {
-      expect(screen.getByText(/2026-05-04:/)).toBeInTheDocument();
+      expect(screen.getAllByText(/2026-05-04:/).length).toBeGreaterThan(0);
     });
   });
 
@@ -100,7 +102,7 @@ describe("StatsPage", () => {
 
     render(<StatsPage />);
 
-    expect(await screen.findByText("Stats will appear here after community data exists.")).toBeInTheDocument();
+    expect(await screen.findAllByText("No growth data yet.")).toHaveLength(4);
     expect(screen.getByText("Site density will appear after Sites with coordinates are created.")).toBeInTheDocument();
   });
 });

--- a/src/components/StatsPage.tsx
+++ b/src/components/StatsPage.tsx
@@ -4,19 +4,35 @@ import { fetchStats, type StatsGrowthBucket, type StatsPayload } from "../lib/st
 import { useThemeVariant } from "../hooks/useThemeVariant";
 
 type GrowthMode = "monthly" | "weekly";
+type MetricKey = "users" | "sites" | "simulations" | "links";
 
 const formatNumber = (value: number): string => new Intl.NumberFormat("en").format(value);
 
 const metricLabel = (value: number, singular: string, plural = `${singular}s`): string =>
   `${formatNumber(value)} ${value === 1 ? singular : plural}`;
 
-const StatCounter = ({ label, value, detail }: { label: string; value: number; detail: string }) => (
-  <div className="stats-counter">
-    <span className="stats-counter-value">{formatNumber(value)}</span>
-    <span className="stats-counter-label">{label}</span>
-    <span className="stats-counter-detail">{detail}</span>
-  </div>
-);
+const metricConfig: Record<MetricKey, { label: string; detail: string; cumulativeKey: keyof StatsGrowthBucket }> = {
+  users: {
+    label: "Users",
+    detail: "Registered community members.",
+    cumulativeKey: "cumulativeUsers",
+  },
+  sites: {
+    label: "Sites",
+    detail: "Saved planning locations.",
+    cumulativeKey: "cumulativeSites",
+  },
+  simulations: {
+    label: "Simulations",
+    detail: "Saved Simulations.",
+    cumulativeKey: "cumulativeSimulations",
+  },
+  links: {
+    label: "Links",
+    detail: "Saved Paths inside Simulations.",
+    cumulativeKey: "cumulativeLinks",
+  },
+};
 
 const EmptyPanel = ({ title, children }: { title: string; children: string }) => (
   <article className="stats-placeholder panel-section">
@@ -28,33 +44,37 @@ const EmptyPanel = ({ title, children }: { title: string; children: string }) =>
   </article>
 );
 
-const GrowthChart = ({ buckets }: { buckets: StatsGrowthBucket[] }) => {
-  const width = 760;
-  const height = 260;
-  const maxValue = Math.max(1, ...buckets.map((bucket) => bucket.cumulativeUsers + bucket.cumulativeSites + bucket.cumulativeSimulations));
+const MetricChart = ({ buckets, metric }: { buckets: StatsGrowthBucket[]; metric: MetricKey }) => {
+  const width = 320;
+  const height = 150;
+  const config = metricConfig[metric];
+  const maxValue = Math.max(1, ...buckets.map((bucket) => Number(bucket[config.cumulativeKey])));
   const points = buckets.map((bucket, index) => {
-    const x = buckets.length <= 1 ? width / 2 : (index / (buckets.length - 1)) * width;
-    const total = bucket.cumulativeUsers + bucket.cumulativeSites + bucket.cumulativeSimulations;
-    const y = height - (total / maxValue) * (height - 34) - 17;
-    return { x, y, total, bucket };
+    const x = buckets.length <= 1 ? width - 28 : 26 + (index / (buckets.length - 1)) * (width - 54);
+    const value = Number(bucket[config.cumulativeKey]);
+    const y = height - 28 - (value / maxValue) * (height - 54);
+    return { x, y, value, bucket };
   });
   const path = points.map((point, index) => `${index === 0 ? "M" : "L"}${point.x.toFixed(1)},${point.y.toFixed(1)}`).join(" ");
 
   if (!buckets.length) {
-    return <div className="stats-empty">Stats will appear here after community data exists.</div>;
+    return <div className="stats-mini-empty">No growth data yet.</div>;
   }
 
   return (
-    <div className="stats-chart-wrap" aria-label="Community growth chart">
-      <svg className="stats-growth-chart" role="img" viewBox={`0 0 ${width} ${height}`} aria-label="Cumulative users, Sites, and Simulations over time">
-        <path className="stats-chart-grid" d={`M0 ${height - 18} H${width}`} />
-        <path className="stats-chart-area" d={`${path} L${width},${height - 18} L0,${height - 18} Z`} />
+    <div className="stats-mini-chart-wrap">
+      <svg className="stats-growth-chart" role="img" viewBox={`0 0 ${width} ${height}`} aria-label={`${config.label} growth over time`}>
+        <text className="stats-axis-label stats-axis-label-y" x="2" y="18">Total</text>
+        <text className="stats-axis-label stats-axis-label-x" x={width - 60} y={height - 4}>Time</text>
+        <path className="stats-chart-grid" d={`M26 ${height - 28} H${width - 18}`} />
+        <path className="stats-chart-grid stats-chart-axis-y" d={`M26 16 V${height - 28}`} />
+        <path className="stats-chart-area" d={`${path} L${width - 18},${height - 28} L26,${height - 28} Z`} />
         <path className="stats-chart-line" d={path} />
         {points.map((point) => (
           <g key={point.bucket.label}>
             <circle className="stats-chart-dot" cx={point.x} cy={point.y} r="4" />
             <title>
-              {point.bucket.label}: {metricLabel(point.bucket.users, "user")}, {metricLabel(point.bucket.sites, "Site")}, {metricLabel(point.bucket.simulations, "Simulation")}
+              {point.bucket.label}: {metricLabel(point.value, config.label.slice(0, -1) || config.label)}
             </title>
           </g>
         ))}
@@ -63,9 +83,39 @@ const GrowthChart = ({ buckets }: { buckets: StatsGrowthBucket[] }) => {
   );
 };
 
+const StatCard = ({
+  buckets,
+  metric,
+  value,
+}: {
+  buckets: StatsGrowthBucket[];
+  metric: MetricKey;
+  value: number;
+}) => {
+  const config = metricConfig[metric];
+  return (
+    <article className="stats-counter">
+      <div className="stats-counter-copy">
+        <span className="stats-counter-value">{formatNumber(value)}</span>
+        <span className="stats-counter-label">{config.label}</span>
+        <span className="stats-counter-detail">{config.detail}</span>
+      </div>
+      <MetricChart buckets={buckets} metric={metric} />
+    </article>
+  );
+};
+
 const GeoDensity = ({ stats }: { stats: StatsPayload }) => {
   const bins = stats.geography.bins.slice(0, 180);
   const maxCount = Math.max(1, ...bins.map((bin) => bin.count));
+  const minLat = Math.min(...bins.map((bin) => bin.latBand));
+  const maxLat = Math.max(...bins.map((bin) => bin.latBand));
+  const minLon = Math.min(...bins.map((bin) => bin.lonBand));
+  const maxLon = Math.max(...bins.map((bin) => bin.lonBand));
+  const rawLatSpan = maxLat - minLat;
+  const rawLonSpan = maxLon - minLon;
+  const latSpan = Math.max(1, rawLatSpan);
+  const lonSpan = Math.max(1, rawLonSpan);
 
   if (!bins.length) {
     return <div className="stats-empty">Site density will appear after Sites with coordinates are created.</div>;
@@ -75,11 +125,14 @@ const GeoDensity = ({ stats }: { stats: StatsPayload }) => {
     <div className="stats-geo-wrap" aria-label="Binned Site geography">
       <svg className="stats-geo-map" role="img" viewBox="0 0 720 360" aria-label="Binned density map of entered Site locations">
         <rect className="stats-geo-frame" x="1" y="1" width="718" height="358" rx="18" />
+        <text className="stats-axis-label" x="24" y="28">North</text>
+        <text className="stats-axis-label" x="24" y="342">South</text>
+        <text className="stats-axis-label" x="650" y="342">East</text>
         <path className="stats-geo-equator" d="M24 180 H696" />
         <path className="stats-geo-meridian" d="M360 24 V336" />
         {bins.map((bin) => {
-          const x = ((bin.lonBand + 180) / 360) * 672 + 24;
-          const y = ((90 - bin.latBand) / 180) * 312 + 24;
+          const x = rawLonSpan === 0 ? 360 : ((bin.lonBand - minLon) / lonSpan) * 592 + 64;
+          const y = rawLatSpan === 0 ? 180 : ((maxLat - bin.latBand) / latSpan) * 252 + 54;
           const radius = 3 + (bin.count / maxCount) * 18;
           return (
             <circle
@@ -151,10 +204,6 @@ export function StatsPage() {
             Public aggregate signals from entered Sites, saved Simulations, and community growth.
           </p>
         </div>
-        <div className="stats-hero-status">
-          <span className={`stats-status-dot is-${status}`} aria-hidden="true" />
-          <span className="stats-chip">{status}</span>
-        </div>
       </section>
 
       {status === "error" ? (
@@ -166,32 +215,29 @@ export function StatsPage() {
         </section>
       ) : null}
 
-      <section className="stats-counter-grid" aria-label="Community totals">
-        <StatCounter label="Users" value={stats?.totals.users ?? 0} detail="registered community members" />
-        <StatCounter label="Sites" value={stats?.totals.sites ?? 0} detail="entered planning locations" />
-        <StatCounter label="Simulations" value={stats?.totals.nonEmptySimulations ?? 0} detail={`${formatNumber(stats?.totals.simulations ?? 0)} total including drafts`} />
-        <StatCounter label="Links" value={stats?.totals.links ?? 0} detail="saved Paths inside Simulations" />
+      <section className="stats-growth-header">
+        <div>
+          <h2>Growth</h2>
+          <p className="field-help">Each chart shows one cumulative metric over time.</p>
+        </div>
+        <div className="chip-group">
+          <ActionButton aria-pressed={growthMode === "monthly"} onClick={() => setGrowthMode("monthly")} type="button">
+            All time
+          </ActionButton>
+          <ActionButton aria-pressed={growthMode === "weekly"} onClick={() => setGrowthMode("weekly")} type="button">
+            Recent
+          </ActionButton>
+        </div>
+      </section>
+
+      <section className="stats-counter-grid" aria-label="Community totals and growth">
+        <StatCard buckets={activeGrowth} metric="users" value={stats?.totals.users ?? 0} />
+        <StatCard buckets={activeGrowth} metric="sites" value={stats?.totals.sites ?? 0} />
+        <StatCard buckets={activeGrowth} metric="simulations" value={stats?.totals.simulations ?? 0} />
+        <StatCard buckets={activeGrowth} metric="links" value={stats?.totals.links ?? 0} />
       </section>
 
       <section className="stats-grid">
-        <article className="stats-panel stats-panel-wide panel-section">
-          <div className="section-heading stats-section-heading">
-            <div>
-              <h2>Growth</h2>
-              <p className="field-help">Cumulative Users, Sites, and Simulations.</p>
-            </div>
-            <div className="chip-group">
-              <ActionButton aria-pressed={growthMode === "monthly"} onClick={() => setGrowthMode("monthly")} type="button">
-                All time
-              </ActionButton>
-              <ActionButton aria-pressed={growthMode === "weekly"} onClick={() => setGrowthMode("weekly")} type="button">
-                Recent
-              </ActionButton>
-            </div>
-          </div>
-          {status === "loading" ? <div className="stats-empty">Loading growth stats...</div> : <GrowthChart buckets={activeGrowth} />}
-        </article>
-
         <article className="stats-panel stats-panel-wide panel-section">
           <div className="section-heading stats-section-heading">
             <div>

--- a/src/index.css
+++ b/src/index.css
@@ -939,7 +939,7 @@ button {
 }
 
 .stats-hero {
-  min-height: min(42lvh, 360px);
+  min-height: 260px;
   display: flex;
   align-items: flex-end;
   justify-content: space-between;
@@ -976,33 +976,10 @@ button {
   line-height: 1.45;
 }
 
-.stats-hero-status,
 .stats-section-heading {
   display: flex;
   align-items: center;
   gap: 10px;
-}
-
-.stats-hero-status {
-  align-self: flex-start;
-}
-
-.stats-status-dot {
-  width: 9px;
-  height: 9px;
-  border-radius: var(--radius-pill);
-  background: var(--warning);
-  box-shadow: 0 0 0 5px color-mix(in srgb, var(--warning) 16%, transparent);
-}
-
-.stats-status-dot.is-ready {
-  background: var(--success);
-  box-shadow: 0 0 0 5px color-mix(in srgb, var(--success) 16%, transparent);
-}
-
-.stats-status-dot.is-error {
-  background: var(--danger);
-  box-shadow: 0 0 0 5px color-mix(in srgb, var(--danger) 16%, transparent);
 }
 
 .stats-chip {
@@ -1025,16 +1002,23 @@ button {
 }
 
 .stats-counter {
-  min-height: 150px;
+  min-height: 300px;
   border: 1px solid color-mix(in srgb, var(--border) 76%, transparent);
   border-radius: 8px;
   background: color-mix(in srgb, var(--surface) 88%, transparent);
   box-shadow: var(--shadow-elev-1);
   padding: 16px;
   display: grid;
-  align-content: end;
-  gap: 4px;
+  grid-template-rows: auto minmax(140px, 1fr);
+  align-items: stretch;
+  gap: 10px;
   overflow: hidden;
+}
+
+.stats-counter-copy {
+  display: grid;
+  align-content: start;
+  gap: 4px;
 }
 
 .stats-counter-value {
@@ -1051,6 +1035,20 @@ button {
 .stats-counter-detail {
   color: var(--muted);
   font-size: 0.82rem;
+}
+
+.stats-growth-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  align-items: flex-end;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 74%, transparent);
+  padding-bottom: 10px;
+}
+
+.stats-growth-header h2,
+.stats-growth-header .field-help {
+  margin: 0;
 }
 
 .stats-grid {
@@ -1077,17 +1075,34 @@ button {
   margin: 2px 0 0;
 }
 
-.stats-chart-wrap,
+.stats-mini-chart-wrap,
 .stats-geo-wrap {
-  min-height: 280px;
   display: grid;
   place-items: center;
+}
+
+.stats-mini-chart-wrap {
+  min-height: 150px;
+}
+
+.stats-geo-wrap {
+  min-height: 280px;
 }
 
 .stats-growth-chart,
 .stats-geo-map {
   width: 100%;
   max-height: 360px;
+}
+
+.stats-growth-chart {
+  height: 100%;
+}
+
+.stats-axis-label {
+  fill: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
 }
 
 .stats-chart-grid {
@@ -1144,6 +1159,18 @@ button {
   padding: 16px;
 }
 
+.stats-mini-empty {
+  min-height: 150px;
+  display: grid;
+  place-items: center;
+  border: 1px dashed color-mix(in srgb, var(--border) 70%, transparent);
+  border-radius: 8px;
+  color: var(--muted);
+  text-align: center;
+  padding: 12px;
+  font-size: 0.82rem;
+}
+
 .stats-placeholder {
   min-height: 168px;
   display: grid;
@@ -1180,13 +1207,19 @@ button {
   }
 }
 
+@media (max-width: 1180px) {
+  .stats-counter-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
 @media (max-width: 840px) {
   .stats-page {
     padding: 16px;
   }
 
   .stats-hero {
-    min-height: 260px;
+    min-height: 220px;
     align-items: flex-start;
     flex-direction: column;
     justify-content: flex-end;
@@ -1198,10 +1231,15 @@ button {
   }
 
   .stats-counter {
-    min-height: 118px;
+    min-height: 300px;
   }
 
   .stats-section-heading {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .stats-growth-header {
     align-items: stretch;
     flex-direction: column;
   }

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -3,9 +3,11 @@ export type StatsGrowthBucket = {
   users: number;
   sites: number;
   simulations: number;
+  links: number;
   cumulativeUsers: number;
   cumulativeSites: number;
   cumulativeSimulations: number;
+  cumulativeLinks: number;
 };
 
 export type StatsPayload = {


### PR DESCRIPTION
## Summary
- remove ambiguous ready/status and draft wording from /stats
- split the combined growth chart into four per-metric cards with a shared All time/Recent toggle
- add axis labels, Links growth data, and fitted binned geography rendering

## Verification
- npm test -- --run functions/api/stats.test.ts
- npm test -- --run src/components/StatsPage.test.tsx
- npm test
- npm run build
- Playwright rendered QA for /stats desktop/mobile with mocked /api/stats response: 4 charts, axis labels, 5 visible map bins, no ready/draft copy, no console errors, working timeframe toggle

Follow-up to #886 for #853.