### PR TITLE
Redesign stats page as Atlas dashboard

### DIFF
--- a/functions/_lib/db.sharedSimulation.test.ts
+++ b/functions/_lib/db.sharedSimulation.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { upsertLibrarySnapshot } from "./db";
+import { fetchPublicSimulationBundle, upsertLibrarySnapshot } from "./db";
 
 type AnyRow = Record<string, unknown>;
 
@@ -150,14 +150,24 @@ class FakeDb {
       if (!row) return null;
       return { id: row.id, visibility: row.visibility };
     }
+    if (sql.includes("SELECT id, payload_json, visibility FROM simulations WHERE id = ?")) {
+      const id = String(bound[0] ?? "");
+      return this.simulations.get(id) ?? null;
+    }
+    if (sql.includes("SELECT role FROM simulation_roles")) {
+      return null;
+    }
     return null;
   }
 
-  all(sql: string): AnyRow[] {
+  all(sql: string, bound: unknown[] = []): AnyRow[] {
     const pragmaMatch = sql.match(/^PRAGMA table_info\(([^)]+)\)$/i);
     if (pragmaMatch) {
       const table = pragmaMatch[1] ?? "";
       return (TABLE_COLUMNS[table] ?? []).map((name) => ({ name }));
+    }
+    if (sql.includes("SELECT id, payload_json, visibility FROM sites WHERE id IN")) {
+      return bound.map((id) => this.sites.get(String(id))).filter((row): row is AnyRow => Boolean(row));
     }
     return [];
   }
@@ -305,6 +315,33 @@ describe("upsertLibrarySnapshot shared simulations", () => {
     expect(stored?.visibility).toBe("public_write");
     const payload = JSON.parse(String(stored?.payload_json ?? "{}")) as { snapshot?: { sites?: Array<{ libraryEntryId?: string }> } };
     expect(payload.snapshot?.sites?.[0]?.libraryEntryId).toBe("site-private");
+  });
+
+  it("loads unlisted private simulation bundles with referenced private sites", async () => {
+    const db = new FakeDb();
+    db.sites.set("site-private", {
+      id: "site-private",
+      visibility: "private",
+      payload_json: JSON.stringify({ id: "site-private", name: "Private Site" }),
+    });
+    db.simulations.set("sim-private", {
+      id: "sim-private",
+      visibility: "private",
+      payload_json: JSON.stringify({
+        id: "sim-private",
+        visibility: "private",
+        snapshot: { sites: [{ id: "site-a", libraryEntryId: "site-private" }], links: [] },
+      }),
+    });
+
+    const result = await fetchPublicSimulationBundle(
+      { DB: db } as unknown as Parameters<typeof fetchPublicSimulationBundle>[0],
+      { simulationId: "sim-private", actorId: null, allowUnlisted: true },
+    );
+
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") return;
+    expect(result.sites).toEqual([expect.objectContaining({ id: "site-private", visibility: "private" })]);
   });
 
   afterEach(() => {

--- a/functions/_lib/db.ts
+++ b/functions/_lib/db.ts
@@ -2076,7 +2076,7 @@ export const resolveSimulationIdByOwnerSlug = async (
 
 export const fetchPublicSimulationBundle = async (
   env: Env,
-  options: { simulationId?: string; username?: string; simulationSlug?: string; actorId?: string | null },
+  options: { simulationId?: string; username?: string; simulationSlug?: string; actorId?: string | null; allowUnlisted?: boolean },
 ): Promise<
   | { status: "missing" | "forbidden" }
   | {
@@ -2100,16 +2100,19 @@ export const fetchPublicSimulationBundle = async (
     .first<{ id: string; payload_json: string; visibility: DbVisibility }>();
   if (!simulationRow) return { status: "missing" };
   const visibility = visibilityFromDbVisibility(simulationRow.visibility);
+  const allowUnlisted = options.allowUnlisted === true;
 
   let actorSimulationRole: string | null = null;
   if (visibility === "private") {
-    if (!options.actorId) return { status: "forbidden" };
-    const roleRow = await env.DB
-      .prepare("SELECT role FROM simulation_roles WHERE simulation_id = ? AND user_id = ? LIMIT 1")
-      .bind(resolvedId, options.actorId)
-      .first<{ role: string }>();
-    if (!roleRow) return { status: "forbidden" };
-    actorSimulationRole = roleRow.role;
+    if (!options.actorId && !allowUnlisted) return { status: "forbidden" };
+    if (options.actorId) {
+      const roleRow = await env.DB
+        .prepare("SELECT role FROM simulation_roles WHERE simulation_id = ? AND user_id = ? LIMIT 1")
+        .bind(resolvedId, options.actorId)
+        .first<{ role: string }>();
+      if (roleRow) actorSimulationRole = roleRow.role;
+      else if (!allowUnlisted) return { status: "forbidden" };
+    }
   }
 
   let simulation: CloudResourceRecord;
@@ -2139,9 +2142,8 @@ export const fetchPublicSimulationBundle = async (
     .all<{ id: string; payload_json: string; visibility: DbVisibility }>();
   const sites: CloudResourceRecord[] = [];
   for (const row of rows.results) {
-    // When actor has an explicit simulation role (private access), include all referenced
-    // sites regardless of their individual visibility — simulation-level access covers its sites.
-    if (actorSimulationRole === null && visibilityFromDbVisibility(row.visibility) === "private") continue;
+    // Unlisted Simulation access includes the referenced Sites needed to render that Simulation.
+    if (actorSimulationRole === null && !allowUnlisted && visibilityFromDbVisibility(row.visibility) === "private") continue;
     try {
       const site = JSON.parse(row.payload_json) as CloudResourceRecord;
       site.id = row.id;

--- a/functions/api/public-simulation.test.ts
+++ b/functions/api/public-simulation.test.ts
@@ -47,7 +47,7 @@ describe("api/public-simulation", () => {
     await onRequestGet(mkCtx(new Request("https://example.test/api/public-simulation?sim=sim-1")));
     expect(fetchPublicSimulationBundleMock).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ actorId: null }),
+      expect.objectContaining({ actorId: null, allowUnlisted: true }),
     );
   });
 
@@ -64,7 +64,7 @@ describe("api/public-simulation", () => {
     await onRequestGet(mkCtx(new Request("https://example.test/api/public-simulation?username=Owner&slug=my-sim")));
     expect(fetchPublicSimulationBundleMock).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ username: "Owner", simulationSlug: "my-sim" }),
+      expect.objectContaining({ username: "Owner", simulationSlug: "my-sim", allowUnlisted: true }),
     );
   });
 

--- a/functions/api/public-simulation.ts
+++ b/functions/api/public-simulation.ts
@@ -25,6 +25,7 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
       username: username || undefined,
       simulationSlug: simulationSlug || undefined,
       actorId,
+      allowUnlisted: true,
     });
 
     if (bundle.status !== "ok") {

--- a/functions/api/stats.test.ts
+++ b/functions/api/stats.test.ts
@@ -5,7 +5,7 @@ import { onRequestGet } from "./stats";
 type MockTable = {
   users: Array<{ id: string; username: string | null; avatar_url: string | null; created_at: string }>;
   sites: Array<{ id: string; owner_user_id: string; created_at: string | null; payload_json: string }>;
-  simulations: Array<{ id: string; owner_user_id: string; created_at: string | null; payload_json: string }>;
+  simulations: Array<{ id: string; owner_user_id: string; created_at: string | null; name?: string; payload_json: string }>;
 };
 
 const tables: MockTable = {
@@ -64,8 +64,15 @@ beforeEach(() => {
         id: "sim-1",
         name: "Private sim",
         snapshot: {
-          sites: [{ id: "s1" }, { id: "s2" }, { id: "s3" }],
-          links: [{ id: "l1" }, { id: "l2" }],
+          sites: [
+            { id: "s1", name: "North", position: { lat: 60, lon: 10 } },
+            { id: "s2", name: "South", position: { lat: 60.1, lon: 10.1 } },
+            { id: "s3", name: "East", position: { lat: 61, lon: 11 } },
+          ],
+          links: [
+            { id: "l1", fromSiteId: "s1", toSiteId: "s2", frequencyMHz: 868 },
+            { id: "l2", fromSiteId: "s2", toSiteId: "s3", frequencyMHz: 915 },
+          ],
         },
       }),
     },
@@ -82,8 +89,9 @@ beforeEach(() => {
       payload_json: JSON.stringify({
         id: "sim-2",
         name: "Shared sim",
+        slug: "Shared-sim",
         snapshot: {
-          sites: [{ id: "s4" }],
+          sites: [{ id: "s4", name: "Solo", position: { lat: 62, lon: 12 } }],
           links: [{ id: "l3" }],
         },
       }),
@@ -112,6 +120,47 @@ describe("api/stats", () => {
     expect(body.complexity.averageSitesPerSimulation).toBe(2);
     expect(body.complexity.medianSitesPerSimulation).toBe(2);
     expect(body.complexity.averageLinksPerSimulation).toBe(1.5);
+  });
+
+  it("returns latest non-empty simulations and link distance buckets without leaking payloads", async () => {
+    const res = await onRequestGet(mkCtx());
+    const body = await res.json() as {
+      latestSimulations: Array<{
+        id: string;
+        name: string;
+        href: string;
+        owner: { userId: string; username: string; avatarUrl: string };
+        siteCount: number;
+        linkCount: number;
+      }>;
+      linkDistanceDistribution: Array<{ label: string; minKm: number; maxKm: number | null; count: number }>;
+      siteDensitySummary: Array<{ label: string; count: number }>;
+    };
+    const raw = JSON.stringify(body);
+
+    expect(body.latestSimulations).toEqual([
+      expect.objectContaining({
+        id: "sim-2",
+        name: "Shared sim",
+        href: "/Grace/Shared-sim",
+        owner: { userId: "u2", username: "Grace", avatarUrl: "" },
+        siteCount: 1,
+        linkCount: 1,
+      }),
+      expect.objectContaining({
+        id: "sim-1",
+        name: "Private sim",
+        href: "/Ada/Private-sim",
+        siteCount: 3,
+        linkCount: 2,
+      }),
+    ]);
+    expect(body.latestSimulations.some((entry) => entry.id === "sim-empty")).toBe(false);
+    expect(body.linkDistanceDistribution.reduce((sum, bucket) => sum + bucket.count, 0)).toBe(2);
+    expect(body.siteDensitySummary).toEqual([{ label: "60°N, 10°E", count: 2 }]);
+    expect(raw).not.toContain("North");
+    expect(raw).not.toContain("South");
+    expect(raw).not.toContain("payload_json");
   });
 
   it("returns monthly and weekly growth buckets", async () => {

--- a/functions/api/stats.ts
+++ b/functions/api/stats.ts
@@ -12,6 +12,7 @@ type ResourceRow = {
   id: string;
   owner_user_id: string;
   created_at: string | null;
+  name?: string | null;
   payload_json: string;
 };
 
@@ -35,10 +36,28 @@ type SitePayload = {
 };
 
 type SimulationPayload = {
+  id?: unknown;
+  name?: unknown;
+  slug?: unknown;
   snapshot?: {
     sites?: unknown;
     links?: unknown;
   };
+};
+
+type SnapshotSite = {
+  id?: unknown;
+  name?: unknown;
+  position?: {
+    lat?: unknown;
+    lon?: unknown;
+  };
+};
+
+type SnapshotLink = {
+  id?: unknown;
+  fromSiteId?: unknown;
+  toSiteId?: unknown;
 };
 
 const CACHE_CONTROL = "public, max-age=300, s-maxage=900, stale-while-revalidate=3600";
@@ -151,6 +170,61 @@ const bucketSimulationSize = (siteCount: number): "1-2" | "3-5" | "6-10" | "11+"
 
 const isFiniteNumber = (value: unknown): value is number => typeof value === "number" && Number.isFinite(value);
 
+const slugifySegment = (value: string): string =>
+  value
+    .trim()
+    .normalize("NFKC")
+    .replace(/[\uFE0E\uFE0F]/g, "")
+    .replace(/[+<>~/]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-");
+
+const hrefForSimulation = (owner: UserRow | undefined, simulation: ResourceRow, payload: SimulationPayload | null): string => {
+  const username = slugifySegment(owner?.username?.trim() || "");
+  const name = typeof payload?.slug === "string" && payload.slug.trim()
+    ? payload.slug
+    : typeof payload?.name === "string" && payload.name.trim()
+      ? payload.name
+      : simulation.name ?? "";
+  const simulationSlug = slugifySegment(name);
+  if (username && simulationSlug) return `/${username}/${simulationSlug}`;
+  return `/?sim=${encodeURIComponent(simulation.id)}`;
+};
+
+const formatGeoLabel = (latBand: number, lonBand: number): string => {
+  const latSuffix = latBand >= 0 ? "N" : "S";
+  const lonSuffix = lonBand >= 0 ? "E" : "W";
+  return `${Math.abs(latBand)}°${latSuffix}, ${Math.abs(lonBand)}°${lonSuffix}`;
+};
+
+const haversineKm = (a: { lat: number; lon: number }, b: { lat: number; lon: number }): number => {
+  const toRadians = (degrees: number) => (degrees * Math.PI) / 180;
+  const lat1 = toRadians(a.lat);
+  const lat2 = toRadians(b.lat);
+  const dLat = lat2 - lat1;
+  const dLon = toRadians(b.lon - a.lon);
+  const value = Math.sin(dLat / 2) ** 2 + Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLon / 2) ** 2;
+  return 6371 * (2 * Math.asin(Math.sqrt(value)));
+};
+
+const DISTANCE_BUCKETS = [
+  { label: "0-10 km", minKm: 0, maxKm: 10 },
+  { label: "10-25 km", minKm: 10, maxKm: 25 },
+  { label: "25-50 km", minKm: 25, maxKm: 50 },
+  { label: "50-100 km", minKm: 50, maxKm: 100 },
+  { label: "100+ km", minKm: 100, maxKm: null },
+];
+
+const bucketForDistance = (distanceKm: number) =>
+  DISTANCE_BUCKETS.find((bucket) => distanceKm >= bucket.minKm && (bucket.maxKm === null || distanceKm < bucket.maxKm));
+
+const snapshotSites = (payload: SimulationPayload | null): SnapshotSite[] =>
+  Array.isArray(payload?.snapshot?.sites) ? (payload.snapshot.sites as SnapshotSite[]) : [];
+
+const snapshotLinks = (payload: SimulationPayload | null): SnapshotLink[] =>
+  Array.isArray(payload?.snapshot?.links) ? (payload.snapshot.links as SnapshotLink[]) : [];
+
 export const onRequestOptions: PagesFunction<Env> = async ({ request }) => handleOptions(request);
 
 export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
@@ -158,7 +232,7 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
     const [usersResult, sitesResult, simulationsResult] = await Promise.all([
       env.DB.prepare("SELECT id, username, avatar_url, created_at FROM users").all<UserRow>(),
       env.DB.prepare("SELECT id, owner_user_id, created_at, payload_json FROM sites").all<ResourceRow>(),
-      env.DB.prepare("SELECT id, owner_user_id, created_at, payload_json FROM simulations").all<ResourceRow>(),
+      env.DB.prepare("SELECT id, owner_user_id, created_at, name, payload_json FROM simulations").all<ResourceRow>(),
     ]);
 
     const users = usersResult.results ?? [];
@@ -200,16 +274,62 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
     const nonEmptyLinkCounts: number[] = [];
     const sizeBuckets = { "1-2": 0, "3-5": 0, "6-10": 0, "11+": 0 };
 
+    const latestSimulations: Array<{
+      id: string;
+      name: string;
+      href: string;
+      createdAt: string | null;
+      owner: { userId: string; username: string; avatarUrl: string };
+      siteCount: number;
+      linkCount: number;
+    }> = [];
+    const linkDistanceCounts = DISTANCE_BUCKETS.map((bucket) => ({ ...bucket, count: 0 }));
+
     simulations.forEach((simulation) => {
       addContribution(simulation.owner_user_id);
       const payload = parseJsonObject<SimulationPayload>(simulation.payload_json);
-      const siteCount = Array.isArray(payload?.snapshot?.sites) ? payload.snapshot.sites.length : 0;
-      const linkCount = Array.isArray(payload?.snapshot?.links) ? payload.snapshot.links.length : 0;
+      const sitesInSimulation = snapshotSites(payload);
+      const linksInSimulation = snapshotLinks(payload);
+      const siteCount = sitesInSimulation.length;
+      const linkCount = linksInSimulation.length;
       totalLinks += linkCount;
       if (siteCount <= 0) return;
       nonEmptySiteCounts.push(siteCount);
       nonEmptyLinkCounts.push(linkCount);
       sizeBuckets[bucketSimulationSize(siteCount)] += 1;
+
+      const owner = userById.get(simulation.owner_user_id);
+      latestSimulations.push({
+        id: simulation.id,
+        name: typeof payload?.name === "string" && payload.name.trim() ? payload.name.trim() : simulation.name?.trim() || "Untitled Simulation",
+        href: hrefForSimulation(owner, simulation, payload),
+        createdAt: simulation.created_at,
+        owner: {
+          userId: simulation.owner_user_id,
+          username: owner?.username?.trim() || "Unknown user",
+          avatarUrl: owner?.avatar_url ?? "",
+        },
+        siteCount,
+        linkCount,
+      });
+
+      const sitesById = new Map(
+        sitesInSimulation
+          .filter((site) => typeof site.id === "string")
+          .map((site) => [site.id as string, site]),
+      );
+      linksInSimulation.forEach((link) => {
+        if (typeof link.fromSiteId !== "string" || typeof link.toSiteId !== "string") return;
+        const from = sitesById.get(link.fromSiteId);
+        const to = sitesById.get(link.toSiteId);
+        const fromLat = from?.position?.lat;
+        const fromLon = from?.position?.lon;
+        const toLat = to?.position?.lat;
+        const toLon = to?.position?.lon;
+        if (!isFiniteNumber(fromLat) || !isFiniteNumber(fromLon) || !isFiniteNumber(toLat) || !isFiniteNumber(toLon)) return;
+        const bucket = bucketForDistance(haversineKm({ lat: fromLat, lon: fromLon }, { lat: toLat, lon: toLon }));
+        if (bucket) linkDistanceCounts.find((entry) => entry.label === bucket.label)!.count += 1;
+      });
     });
 
     const newestMembers = [...users]
@@ -239,6 +359,10 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
         binSizeDegrees: 1,
         bins: Array.from(geoBins.values()).sort((a, b) => b.count - a.count || a.latBand - b.latBand || a.lonBand - b.lonBand),
       },
+      siteDensitySummary: Array.from(geoBins.values())
+        .sort((a, b) => b.count - a.count || a.latBand - b.latBand || a.lonBand - b.lonBand)
+        .slice(0, 5)
+        .map((bin) => ({ label: formatGeoLabel(bin.latBand, bin.lonBand), count: bin.count })),
       complexity: {
         averageSitesPerSimulation: round1(average(nonEmptySiteCounts)),
         medianSitesPerSimulation: round1(median(nonEmptySiteCounts)),
@@ -246,6 +370,10 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
         medianLinksPerSimulation: round1(median(nonEmptyLinkCounts)),
         sizeBuckets,
       },
+      latestSimulations: latestSimulations
+        .sort((a, b) => (parseDate(b.createdAt)?.getTime() ?? 0) - (parseDate(a.createdAt)?.getTime() ?? 0))
+        .slice(0, 5),
+      linkDistanceDistribution: linkDistanceCounts,
       highlights: {
         topContributors: Array.from(contributorCounts.values())
           .sort((a, b) => b.contributions - a.contributions || a.username.localeCompare(b.username))

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react-dom": "^19.2.0",
         "react-map-gl": "^8.1.0",
         "react-markdown": "^9.1.0",
+        "recharts": "^3.8.1",
         "remark-gfm": "^4.0.1",
         "simple-icons": "^16.14.0",
         "zod": "^4.3.6",
@@ -2078,6 +2079,42 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -2459,7 +2496,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@testing-library/dom": {
@@ -2620,24 +2662,63 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
       "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
       "license": "MIT"
     },
     "node_modules/@types/d3-scale": {
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
       "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
       }
     },
     "node_modules/@types/d3-time": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
       "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
     "node_modules/@types/debug": {
@@ -2750,6 +2831,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3792,6 +3879,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-format": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
@@ -3813,6 +3909,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-scale": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
@@ -3824,6 +3929,18 @@
         "d3-interpolate": "1.2.0 - 3",
         "d3-time": "2.1.1 - 3",
         "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
       },
       "engines": {
         "node": ">=12"
@@ -3849,6 +3966,15 @@
       "dependencies": {
         "d3-time": "1 - 3"
       },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -3889,6 +4015,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
@@ -3993,6 +4125,16 @@
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -4262,6 +4404,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -4605,6 +4753,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -6489,7 +6647,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -6544,6 +6701,29 @@
         "react": ">=18"
       }
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
@@ -6552,6 +6732,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/redent": {
@@ -6566,6 +6776,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/remark-gfm": {
@@ -6643,6 +6868,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -7058,6 +7289,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -7431,6 +7668,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/vfile": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
@@ -7457,6 +7703,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "react-dom": "^19.2.0",
     "react-map-gl": "^8.1.0",
     "react-markdown": "^9.1.0",
+    "recharts": "^3.8.1",
     "remark-gfm": "^4.0.1",
     "simple-icons": "^16.14.0",
     "zod": "^4.3.6",

--- a/src/components/StatsDensityMap.tsx
+++ b/src/components/StatsDensityMap.tsx
@@ -1,0 +1,204 @@
+import { useMemo, useRef, useState, type CSSProperties } from "react";
+import Map, { Layer, NavigationControl, Source, type MapRef } from "react-map-gl/maplibre";
+import type { FeatureCollection, Point } from "geojson";
+import { getCartoFallbackStyle } from "../lib/basemaps";
+import type { StatsPayload } from "../lib/stats";
+import type { UiColorTheme } from "../themes/types";
+
+type StatsDensityMapProps = {
+  bins: StatsPayload["geography"]["bins"];
+  theme: "light" | "dark";
+  colorTheme?: UiColorTheme;
+  accentColor: string;
+  surfaceColor: string;
+};
+
+type DensityProperties = {
+  count: number;
+  label: string;
+};
+
+type HoveredBin = {
+  count: number;
+  label: string;
+  xPercent: number;
+  yPercent: number;
+};
+
+const colorVar = (name: string): string =>
+  typeof window === "undefined"
+    ? ""
+    : getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+
+const binLabel = (latBand: number, lonBand: number): string => {
+  const latSuffix = latBand >= 0 ? "N" : "S";
+  const lonSuffix = lonBand >= 0 ? "E" : "W";
+  return `${Math.abs(latBand)} degrees ${latSuffix}, ${Math.abs(lonBand)} degrees ${lonSuffix}`;
+};
+
+const fitBins = (map: MapRef | null, bins: StatsDensityMapProps["bins"]) => {
+  if (!map || !bins.length) return;
+  const points = bins.map((bin) => [bin.lonBand + 0.5, bin.latBand + 0.5] as [number, number]);
+  if (points.length === 1) {
+    map.flyTo({ center: points[0], zoom: 6, duration: 500 });
+    return;
+  }
+  const lons = points.map(([lon]) => lon);
+  const lats = points.map(([, lat]) => lat);
+  map.fitBounds(
+    [
+      [Math.min(...lons) - 0.8, Math.min(...lats) - 0.8],
+      [Math.max(...lons) + 0.8, Math.max(...lats) + 0.8],
+    ],
+    { padding: 58, duration: 600 },
+  );
+};
+
+export function StatsDensityMap({ bins, theme, colorTheme = "blue", accentColor, surfaceColor }: StatsDensityMapProps) {
+  const mapRef = useRef<MapRef | null>(null);
+  const [hovered, setHovered] = useState<HoveredBin | null>(null);
+  const maxCount = Math.max(1, ...bins.map((bin) => bin.count));
+  const overlayBins = useMemo(() => {
+    if (!bins.length) return [];
+    const points = bins.map((bin) => ({
+      count: bin.count,
+      label: binLabel(bin.latBand, bin.lonBand),
+      longitude: bin.lonBand + 0.5,
+      latitude: bin.latBand + 0.5,
+    }));
+    const lons = points.map((point) => point.longitude);
+    const lats = points.map((point) => point.latitude);
+    const minLon = Math.min(...lons);
+    const maxLon = Math.max(...lons);
+    const minLat = Math.min(...lats);
+    const maxLat = Math.max(...lats);
+    const lonSpan = Math.max(1, maxLon - minLon);
+    const latSpan = Math.max(1, maxLat - minLat);
+    return points.map((point) => ({
+      ...point,
+      xPercent: 8 + ((point.longitude - minLon) / lonSpan) * 76,
+      yPercent: 84 - ((point.latitude - minLat) / latSpan) * 66,
+    }));
+  }, [bins]);
+  const featureCollection = useMemo<FeatureCollection<Point, DensityProperties>>(
+    () => ({
+      type: "FeatureCollection",
+      features: bins.map((bin) => ({
+        type: "Feature",
+        geometry: {
+          type: "Point",
+          coordinates: [bin.lonBand + 0.5, bin.latBand + 0.5],
+        },
+        properties: {
+          count: bin.count,
+          label: binLabel(bin.latBand, bin.lonBand),
+        },
+      })),
+    }),
+    [bins],
+  );
+
+  const initialCenter = bins.length
+    ? {
+        longitude: bins.reduce((sum, bin) => sum + bin.lonBand + 0.5, 0) / bins.length,
+        latitude: bins.reduce((sum, bin) => sum + bin.latBand + 0.5, 0) / bins.length,
+      }
+    : { longitude: 10, latitude: 60 };
+
+  if (!bins.length) {
+    return <div className="stats-empty">Site density will appear after Sites with coordinates are created.</div>;
+  }
+
+  return (
+    <div className="stats-map-shell">
+      <Map
+        ref={mapRef}
+        initialViewState={{ ...initialCenter, zoom: bins.length === 1 ? 5 : 3 }}
+        mapStyle={getCartoFallbackStyle(theme, colorTheme)}
+        attributionControl={{ compact: true }}
+        cooperativeGestures
+        onError={() => setHovered(null)}
+        onLoad={(event) => fitBins(event.target as unknown as MapRef, bins)}
+        onMouseLeave={() => setHovered(null)}
+        interactiveLayerIds={["stats-density-bins"]}
+      >
+        <NavigationControl position="top-left" showCompass={false} />
+        <Source data={featureCollection} id="stats-density" type="geojson">
+          <Layer
+            id="stats-density-bins"
+            type="circle"
+            paint={{
+              "circle-color": accentColor || colorVar("--accent"),
+              "circle-opacity": 0.34,
+              "circle-stroke-color": surfaceColor || colorVar("--surface"),
+              "circle-stroke-opacity": 0.94,
+              "circle-stroke-width": 2,
+              "circle-radius": [
+                "interpolate",
+                ["linear"],
+                ["get", "count"],
+                1,
+                9,
+                maxCount,
+                30,
+              ],
+            }}
+          />
+        </Source>
+      </Map>
+      <div className="stats-map-marker-layer" aria-label="Binned Site density markers">
+        {overlayBins.map((bin) => {
+          const intensity = Math.max(0.35, bin.count / maxCount);
+          const size = 24 + intensity * 42;
+          return (
+            <button
+              aria-label={`${bin.count} Sites near ${bin.label}`}
+              className="stats-map-marker"
+              key={bin.label}
+              onBlur={() => setHovered(null)}
+              onClick={(event) => {
+                event.stopPropagation();
+                setHovered(bin);
+              }}
+              onFocus={() => setHovered(bin)}
+              onMouseEnter={() => setHovered(bin)}
+              onMouseLeave={() => setHovered(null)}
+              style={
+                {
+                  "--marker-size": `${size}px`,
+                  left: `${bin.xPercent}%`,
+                  top: `${bin.yPercent}%`,
+                } as CSSProperties
+              }
+              title={`${bin.count} Sites near ${bin.label}`}
+              type="button"
+            >
+              <span>{bin.count}</span>
+            </button>
+          );
+        })}
+        {hovered ? (
+          <div
+            className="stats-map-popup"
+            style={{ left: `${hovered.xPercent}%`, top: `${hovered.yPercent}%` }}
+          >
+            <strong>{hovered.count} Sites</strong>
+            <span>{hovered.label}</span>
+          </div>
+        ) : null}
+      </div>
+      <button
+        aria-label="Reset Site density map fit"
+        className="stats-map-reset btn-ghost"
+        onClick={() => fitBins(mapRef.current, bins)}
+        type="button"
+      >
+        Reset fit
+      </button>
+      <div className="stats-map-legend" aria-label="Site density legend">
+        <span>Site density</span>
+        <i />
+      </div>
+    </div>
+  );
+}

--- a/src/components/StatsPage.test.tsx
+++ b/src/components/StatsPage.test.tsx
@@ -6,6 +6,14 @@ vi.mock("../hooks/useThemeVariant", () => ({
   useThemeVariant: () => ({ theme: "light", variant: { cssVars: {} }, activeHolidayTheme: null }),
 }));
 
+vi.mock("./StatsDensityMap", () => ({
+  StatsDensityMap: ({ bins }: { bins: Array<{ count: number }> }) => (
+    bins.length
+      ? <div data-testid="stats-density-map">Map bins: {bins.length}</div>
+      : <div>Site density will appear after Sites with coordinates are created.</div>
+  ),
+}));
+
 import { StatsPage } from "./StatsPage";
 
 const statsPayload = {
@@ -37,9 +45,25 @@ const statsPayload = {
     medianLinksPerSimulation: 1,
     sizeBuckets: { "1-2": 2, "3-5": 3, "6-10": 1, "11+": 0 },
   },
+  latestSimulations: [
+    {
+      id: "sim-2",
+      name: "Shared Ridge",
+      href: "/Grace/Shared-Ridge",
+      createdAt: "2026-05-10T00:00:00.000Z",
+      owner: { userId: "u2", username: "Grace", avatarUrl: "" },
+      siteCount: 3,
+      linkCount: 2,
+    },
+  ],
+  linkDistanceDistribution: [
+    { label: "0-10 km", minKm: 0, maxKm: 10, count: 1 },
+    { label: "10-25 km", minKm: 10, maxKm: 25, count: 2 },
+  ],
+  siteDensitySummary: [{ label: "60°N, 10°E", count: 5 }],
   highlights: {
-    topContributors: [],
-    newestMembers: [],
+    topContributors: [{ userId: "u1", username: "Ada", avatarUrl: "", contributions: 4 }],
+    newestMembers: [{ userId: "u2", username: "Grace", avatarUrl: "", createdAt: "2026-05-01T00:00:00.000Z" }],
   },
 };
 
@@ -63,13 +87,18 @@ describe("StatsPage", () => {
     expect(screen.getByText("34")).toBeInTheDocument();
     expect(screen.getByText("8")).toBeInTheDocument();
     expect(screen.getByText("21")).toBeInTheDocument();
-    expect(screen.getByText("Growth")).toBeInTheDocument();
+    expect(screen.getByText("Growth over time")).toBeInTheDocument();
     expect(screen.getByText("Site Geography")).toBeInTheDocument();
     expect(screen.getByText("Contributor Highlights")).toBeInTheDocument();
+    expect(screen.getByText("Latest Simulations")).toBeInTheDocument();
     expect(screen.getByText("Simulation Complexity")).toBeInTheDocument();
-    expect(screen.getByText("Radio And Network Flavor")).toBeInTheDocument();
-    expect(screen.getByText("Geography Details")).toBeInTheDocument();
+    expect(screen.getByText("Simulations by Size")).toBeInTheDocument();
+    expect(screen.getByText("Site Density")).toBeInTheDocument();
+    expect(screen.getByText("Link Distance Distribution")).toBeInTheDocument();
+    expect(screen.getByTestId("stats-density-map")).toHaveTextContent("Map bins: 1");
+    expect(screen.getByRole("link", { name: /Shared Ridge/i })).toHaveAttribute("href", "/Grace/Shared-Ridge");
     expect(screen.queryByText("Moderator Snapshot")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Longest Passing Path/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/draft/i)).not.toBeInTheDocument();
     expect(screen.queryByText("ready")).not.toBeInTheDocument();
     expect(fetch).toHaveBeenCalledWith("/api/stats", { method: "GET" });
@@ -77,13 +106,13 @@ describe("StatsPage", () => {
 
   it("switches the growth chart between all-time and recent buckets", async () => {
     render(<StatsPage />);
-    await screen.findByText("All time");
+    await screen.findByRole("button", { name: "All time" });
 
-    expect(screen.getAllByText(/2026-01:/).length).toBeGreaterThan(0);
-    fireEvent.click(screen.getByText("Recent"));
+    expect(screen.getByText(/2026-01 to 2026-02/)).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Last 30 days"));
 
     await waitFor(() => {
-      expect(screen.getAllByText(/2026-05-04:/).length).toBeGreaterThan(0);
+      expect(screen.getByText(/2026-05-04 to 2026-05-04/)).toBeInTheDocument();
     });
   });
 
@@ -96,13 +125,17 @@ describe("StatsPage", () => {
           ...statsPayload,
           growth: { monthly: [], weekly: [] },
           geography: { binSizeDegrees: 1, bins: [] },
+          latestSimulations: [],
+          linkDistanceDistribution: [],
+          siteDensitySummary: [],
         }),
       })),
     );
 
     render(<StatsPage />);
 
-    expect(await screen.findAllByText("No growth data yet.")).toHaveLength(4);
+    expect(await screen.findByText("Growth appears after dated community activity is available.")).toBeInTheDocument();
     expect(screen.getByText("Site density will appear after Sites with coordinates are created.")).toBeInTheDocument();
+    expect(screen.getByText("Latest non-empty Simulations will appear here.")).toBeInTheDocument();
   });
 });

--- a/src/components/StatsPage.tsx
+++ b/src/components/StatsPage.tsx
@@ -1,160 +1,139 @@
+import { Activity, ExternalLink, MapPinned, Network, Radio, Ruler, Sparkles, Users } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
+import type { CSSProperties, ReactNode } from "react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
 import { ActionButton } from "./ActionButton";
+import { AvatarBadge } from "./AvatarBadge";
+import { StatsDensityMap } from "./StatsDensityMap";
 import { fetchStats, type StatsGrowthBucket, type StatsPayload } from "../lib/stats";
 import { useThemeVariant } from "../hooks/useThemeVariant";
 
 type GrowthMode = "monthly" | "weekly";
-type MetricKey = "users" | "sites" | "simulations" | "links";
 
 const formatNumber = (value: number): string => new Intl.NumberFormat("en").format(value);
+const formatDecimal = (value: number): string => new Intl.NumberFormat("en", { maximumFractionDigits: 1 }).format(value);
+const chartColors = ["var(--accent)", "var(--success)", "var(--temporary)", "var(--warning)"];
 
-const metricLabel = (value: number, singular: string, plural = `${singular}s`): string =>
-  `${formatNumber(value)} ${value === 1 ? singular : plural}`;
-
-const metricConfig: Record<MetricKey, { label: string; detail: string; cumulativeKey: keyof StatsGrowthBucket }> = {
-  users: {
-    label: "Users",
-    detail: "Registered community members.",
-    cumulativeKey: "cumulativeUsers",
-  },
-  sites: {
-    label: "Sites",
-    detail: "Saved planning locations.",
-    cumulativeKey: "cumulativeSites",
-  },
-  simulations: {
-    label: "Simulations",
-    detail: "Saved Simulations.",
-    cumulativeKey: "cumulativeSimulations",
-  },
-  links: {
-    label: "Links",
-    detail: "Saved Paths inside Simulations.",
-    cumulativeKey: "cumulativeLinks",
-  },
+const growthLabels: Record<GrowthMode, string> = {
+  monthly: "All time",
+  weekly: "Last 30 days",
 };
 
-const EmptyPanel = ({ title, children }: { title: string; children: string }) => (
-  <article className="stats-placeholder panel-section">
-    <div className="section-heading">
-      <h2>{title}</h2>
-      <span className="stats-chip">planned</span>
+const CustomTooltip = ({ active, label, payload }: { active?: boolean; label?: string; payload?: Array<{ name?: string; value?: number; color?: string }> }) => {
+  if (!active || !payload?.length) return null;
+  return (
+    <div className="stats-chart-tooltip">
+      <strong>{label}</strong>
+      {payload.map((entry) => (
+        <span key={entry.name} style={{ "--series-color": entry.color } as CSSProperties}>
+          {entry.name}: {formatNumber(Number(entry.value ?? 0))}
+        </span>
+      ))}
     </div>
-    <p className="field-help">{children}</p>
+  );
+};
+
+const Panel = ({ title, children, className = "" }: { title: string; children: ReactNode; className?: string }) => (
+  <article className={`stats-atlas-panel panel-section ${className}`.trim()}>
+    <div className="section-heading stats-atlas-panel-heading">
+      <h2>{title}</h2>
+    </div>
+    {children}
   </article>
 );
 
-const MetricChart = ({ buckets, metric }: { buckets: StatsGrowthBucket[]; metric: MetricKey }) => {
-  const width = 320;
-  const height = 150;
-  const config = metricConfig[metric];
-  const maxValue = Math.max(1, ...buckets.map((bucket) => Number(bucket[config.cumulativeKey])));
-  const points = buckets.map((bucket, index) => {
-    const x = buckets.length <= 1 ? width - 28 : 26 + (index / (buckets.length - 1)) * (width - 54);
-    const value = Number(bucket[config.cumulativeKey]);
-    const y = height - 28 - (value / maxValue) * (height - 54);
-    return { x, y, value, bucket };
-  });
-  const path = points.map((point, index) => `${index === 0 ? "M" : "L"}${point.x.toFixed(1)},${point.y.toFixed(1)}`).join(" ");
-
-  if (!buckets.length) {
-    return <div className="stats-mini-empty">No growth data yet.</div>;
-  }
-
-  return (
-    <div className="stats-mini-chart-wrap">
-      <svg className="stats-growth-chart" role="img" viewBox={`0 0 ${width} ${height}`} aria-label={`${config.label} growth over time`}>
-        <text className="stats-axis-label stats-axis-label-y" x="2" y="18">Total</text>
-        <text className="stats-axis-label stats-axis-label-x" x={width - 60} y={height - 4}>Time</text>
-        <path className="stats-chart-grid" d={`M26 ${height - 28} H${width - 18}`} />
-        <path className="stats-chart-grid stats-chart-axis-y" d={`M26 16 V${height - 28}`} />
-        <path className="stats-chart-area" d={`${path} L${width - 18},${height - 28} L26,${height - 28} Z`} />
-        <path className="stats-chart-line" d={path} />
-        {points.map((point) => (
-          <g key={point.bucket.label}>
-            <circle className="stats-chart-dot" cx={point.x} cy={point.y} r="4" />
-            <title>
-              {point.bucket.label}: {metricLabel(point.value, config.label.slice(0, -1) || config.label)}
-            </title>
-          </g>
-        ))}
-      </svg>
-    </div>
-  );
-};
-
-const StatCard = ({
-  buckets,
-  metric,
+const MetricCard = ({
+  label,
   value,
+  delta,
+  icon: Icon,
 }: {
-  buckets: StatsGrowthBucket[];
-  metric: MetricKey;
+  label: string;
   value: number;
-}) => {
-  const config = metricConfig[metric];
+  delta: number;
+  icon: typeof Users;
+}) => (
+  <article className="stats-atlas-metric">
+    <div className="stats-atlas-metric-icon" aria-hidden="true">
+      <Icon size={18} />
+    </div>
+    <div>
+      <span className="stats-atlas-metric-value">{formatNumber(value)}</span>
+      <span className="stats-atlas-metric-label">{label}</span>
+    </div>
+    <span className="stats-atlas-delta">{delta > 0 ? `+${formatNumber(delta)}` : "No new"}</span>
+  </article>
+);
+
+const GrowthChart = ({ buckets }: { buckets: StatsGrowthBucket[] }) => {
+  if (!buckets.length) {
+    return <div className="stats-empty">Growth appears after dated community activity is available.</div>;
+  }
   return (
-    <article className="stats-counter">
-      <div className="stats-counter-copy">
-        <span className="stats-counter-value">{formatNumber(value)}</span>
-        <span className="stats-counter-label">{config.label}</span>
-        <span className="stats-counter-detail">{config.detail}</span>
-      </div>
-      <MetricChart buckets={buckets} metric={metric} />
-    </article>
+    <div className="stats-chart-shell">
+      <ResponsiveContainer height={280} width="100%">
+        <LineChart data={buckets} margin={{ top: 10, right: 18, bottom: 18, left: 4 }}>
+          <CartesianGrid stroke="var(--panel-shell-divider)" strokeDasharray="3 7" vertical={false} />
+          <XAxis dataKey="label" minTickGap={22} stroke="var(--muted)" tickLine={false} />
+          <YAxis stroke="var(--muted)" tickLine={false} width={42} />
+          <Tooltip content={<CustomTooltip />} />
+          <Legend iconType="circle" />
+          <Line dataKey="cumulativeUsers" dot={false} name="Users" stroke={chartColors[0]} strokeWidth={3} type="monotone" />
+          <Line dataKey="cumulativeSites" dot={false} name="Sites" stroke={chartColors[1]} strokeWidth={3} type="monotone" />
+          <Line dataKey="cumulativeSimulations" dot={false} name="Simulations" stroke={chartColors[2]} strokeWidth={3} type="monotone" />
+          <Line dataKey="cumulativeLinks" dot={false} name="Links" stroke={chartColors[3]} strokeWidth={3} type="monotone" />
+        </LineChart>
+      </ResponsiveContainer>
+      <p className="stats-chart-range">{buckets[0]?.label} to {buckets.at(-1)?.label}</p>
+    </div>
   );
 };
 
-const GeoDensity = ({ stats }: { stats: StatsPayload }) => {
-  const bins = stats.geography.bins.slice(0, 180);
-  const maxCount = Math.max(1, ...bins.map((bin) => bin.count));
-  const minLat = Math.min(...bins.map((bin) => bin.latBand));
-  const maxLat = Math.max(...bins.map((bin) => bin.latBand));
-  const minLon = Math.min(...bins.map((bin) => bin.lonBand));
-  const maxLon = Math.max(...bins.map((bin) => bin.lonBand));
-  const rawLatSpan = maxLat - minLat;
-  const rawLonSpan = maxLon - minLon;
-  const latSpan = Math.max(1, rawLatSpan);
-  const lonSpan = Math.max(1, rawLonSpan);
-
-  if (!bins.length) {
-    return <div className="stats-empty">Site density will appear after Sites with coordinates are created.</div>;
-  }
-
+const SizeBucketsChart = ({ buckets }: { buckets: StatsPayload["complexity"]["sizeBuckets"] }) => {
+  const data = Object.entries(buckets).map(([label, count]) => ({ label, count }));
   return (
-    <div className="stats-geo-wrap" aria-label="Binned Site geography">
-      <svg className="stats-geo-map" role="img" viewBox="0 0 720 360" aria-label="Binned density map of entered Site locations">
-        <rect className="stats-geo-frame" x="1" y="1" width="718" height="358" rx="18" />
-        <text className="stats-axis-label" x="24" y="28">North</text>
-        <text className="stats-axis-label" x="24" y="342">South</text>
-        <text className="stats-axis-label" x="650" y="342">East</text>
-        <path className="stats-geo-equator" d="M24 180 H696" />
-        <path className="stats-geo-meridian" d="M360 24 V336" />
-        {bins.map((bin) => {
-          const x = rawLonSpan === 0 ? 360 : ((bin.lonBand - minLon) / lonSpan) * 592 + 64;
-          const y = rawLatSpan === 0 ? 180 : ((maxLat - bin.latBand) / latSpan) * 252 + 54;
-          const radius = 3 + (bin.count / maxCount) * 18;
-          return (
-            <circle
-              className="stats-geo-bin"
-              cx={x}
-              cy={y}
-              key={`${bin.latBand}:${bin.lonBand}`}
-              r={radius}
-            >
-              <title>
-                {bin.count} Sites near {bin.latBand} degrees latitude, {bin.lonBand} degrees longitude
-              </title>
-            </circle>
-          );
-        })}
-      </svg>
-    </div>
+    <ResponsiveContainer height={180} width="100%">
+      <BarChart data={data} margin={{ top: 8, right: 8, bottom: 10, left: -18 }}>
+        <CartesianGrid stroke="var(--panel-shell-divider)" strokeDasharray="3 7" vertical={false} />
+        <XAxis dataKey="label" stroke="var(--muted)" tickLine={false} />
+        <YAxis allowDecimals={false} stroke="var(--muted)" tickLine={false} />
+        <Tooltip content={<CustomTooltip />} />
+        <Bar dataKey="count" fill="var(--temporary)" name="Simulations" radius={[6, 6, 0, 0]} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+};
+
+const DistanceChart = ({ buckets }: { buckets: StatsPayload["linkDistanceDistribution"] }) => {
+  if (!buckets.some((bucket) => bucket.count > 0)) {
+    return <div className="stats-empty is-compact">Link distances appear after saved Links have endpoints with coordinates.</div>;
+  }
+  return (
+    <ResponsiveContainer height={180} width="100%">
+      <BarChart data={buckets} margin={{ top: 8, right: 8, bottom: 10, left: -18 }}>
+        <CartesianGrid stroke="var(--panel-shell-divider)" strokeDasharray="3 7" vertical={false} />
+        <XAxis dataKey="label" stroke="var(--muted)" tickLine={false} />
+        <YAxis allowDecimals={false} stroke="var(--muted)" tickLine={false} />
+        <Tooltip content={<CustomTooltip />} />
+        <Bar dataKey="count" fill="var(--warning)" name="Links" radius={[6, 6, 0, 0]} />
+      </BarChart>
+    </ResponsiveContainer>
   );
 };
 
 export function StatsPage() {
-  const { theme, variant, activeHolidayTheme } = useThemeVariant();
+  const { theme, colorTheme, variant, activeHolidayTheme } = useThemeVariant();
   const [stats, setStats] = useState<StatsPayload | null>(null);
   const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
   const [errorMessage, setErrorMessage] = useState("");
@@ -193,74 +172,146 @@ export function StatsPage() {
   }, []);
 
   const activeGrowth = useMemo(() => stats?.growth[growthMode] ?? [], [growthMode, stats]);
+  const latestBucket = activeGrowth.at(-1);
 
   return (
-    <main className="stats-page">
-      <section className="stats-hero">
-        <div className="stats-hero-copy">
-          <span className="stats-kicker">LinkSim community telemetry</span>
-          <h1>Stats</h1>
-          <p>
-            Public aggregate signals from entered Sites, saved Simulations, and community growth.
-          </p>
-        </div>
-      </section>
-
-      {status === "error" ? (
-        <section className="stats-panel panel-section">
-          <div className="section-heading">
-            <h2>Stats unavailable</h2>
-          </div>
-          <p className="field-help field-help-error">{errorMessage}</p>
-        </section>
-      ) : null}
-
-      <section className="stats-growth-header">
+    <main className="stats-page stats-atlas-page">
+      <header className="stats-atlas-header">
         <div>
-          <h2>Growth</h2>
-          <p className="field-help">Each chart shows one cumulative metric over time.</p>
+          <h1>Stats</h1>
+          <p>Public aggregate signals from entered Sites, saved Simulations, and community growth.</p>
         </div>
-        <div className="chip-group">
+        <div className="chip-group" aria-label="Stats time range">
           <ActionButton aria-pressed={growthMode === "monthly"} onClick={() => setGrowthMode("monthly")} type="button">
             All time
           </ActionButton>
           <ActionButton aria-pressed={growthMode === "weekly"} onClick={() => setGrowthMode("weekly")} type="button">
-            Recent
+            Last 30 days
           </ActionButton>
         </div>
+      </header>
+
+      {status === "error" ? (
+        <section className="stats-panel panel-section">
+          <h2>Stats unavailable</h2>
+          <p className="field-help field-help-error">{errorMessage}</p>
+        </section>
+      ) : null}
+
+      <section className="stats-atlas-metrics" aria-label="Community totals">
+        <MetricCard delta={latestBucket?.users ?? 0} icon={Users} label="Users" value={stats?.totals.users ?? 0} />
+        <MetricCard delta={latestBucket?.sites ?? 0} icon={MapPinned} label="Sites" value={stats?.totals.sites ?? 0} />
+        <MetricCard delta={latestBucket?.simulations ?? 0} icon={Network} label="Simulations" value={stats?.totals.simulations ?? 0} />
+        <MetricCard delta={latestBucket?.links ?? 0} icon={Radio} label="Links" value={stats?.totals.links ?? 0} />
       </section>
 
-      <section className="stats-counter-grid" aria-label="Community totals and growth">
-        <StatCard buckets={activeGrowth} metric="users" value={stats?.totals.users ?? 0} />
-        <StatCard buckets={activeGrowth} metric="sites" value={stats?.totals.sites ?? 0} />
-        <StatCard buckets={activeGrowth} metric="simulations" value={stats?.totals.simulations ?? 0} />
-        <StatCard buckets={activeGrowth} metric="links" value={stats?.totals.links ?? 0} />
-      </section>
+      <section className="stats-atlas-grid">
+        <Panel className="stats-atlas-map-panel" title="Site Geography">
+          <p className="field-help">Binned density from user-entered Site coordinates. Exact coordinates stay out of the stats payload.</p>
+          {status === "loading" || !stats ? (
+            <div className="stats-map-skeleton">Loading Site density...</div>
+          ) : (
+            <StatsDensityMap
+              accentColor={variant.cssVars["--accent"] ?? ""}
+              bins={stats.geography.bins}
+              colorTheme={colorTheme}
+              surfaceColor={variant.cssVars["--surface"] ?? ""}
+              theme={theme}
+            />
+          )}
+        </Panel>
 
-      <section className="stats-grid">
-        <article className="stats-panel stats-panel-wide panel-section">
-          <div className="section-heading stats-section-heading">
-            <div>
-              <h2>Site Geography</h2>
-              <p className="field-help">Binned density from user-entered Site coordinates.</p>
-            </div>
-            <span className="stats-chip">{stats ? `${stats.geography.binSizeDegrees} degree bins` : "loading"}</span>
+        <Panel className="stats-atlas-side-panel" title="Contributor Highlights">
+          <div className="stats-person-list">
+            {(stats?.highlights.topContributors ?? []).map((user) => (
+              <button className="stats-person-row" key={user.userId} type="button">
+                <AvatarBadge avatarUrl={user.avatarUrl} imageClassName="profile-avatar" name={user.username} />
+                <span>{user.username}</span>
+                <strong>{formatNumber(user.contributions)}</strong>
+              </button>
+            ))}
+            {!stats?.highlights.topContributors.length ? <p className="field-help">Contributor highlights appear after community resources are saved.</p> : null}
           </div>
-          {status === "loading" || !stats ? <div className="stats-empty">Loading Site geography...</div> : <GeoDensity stats={stats} />}
-        </article>
+        </Panel>
 
-        <EmptyPanel title="Contributor Highlights">
-          Planned: top 5 contributors, newest 5 members, and recent community activity using normal profile-safe fields.
-        </EmptyPanel>
-        <EmptyPanel title="Simulation Complexity">
-          Planned: average and median Sites and Links per non-empty Simulation, plus size distribution buckets.
-        </EmptyPanel>
-        <EmptyPanel title="Radio And Network Flavor">
-          Planned: common frequencies, bands, link distance distribution, and common presets or Channels.
-        </EmptyPanel>
-        <EmptyPanel title="Geography Details">
-          Planned: densest regions, cardinal extent bins, and a future longest passing Path spotlight.
-        </EmptyPanel>
+        <Panel className="stats-atlas-wide-panel" title="Growth over time">
+          <GrowthChart buckets={activeGrowth} />
+          <span className="stats-chip">{growthLabels[growthMode]}</span>
+        </Panel>
+
+        <Panel title="Latest Simulations">
+          <div className="stats-simulation-list">
+            {(stats?.latestSimulations ?? []).map((simulation) => (
+              <a className="stats-simulation-row" href={simulation.href} key={simulation.id}>
+                <span>
+                  <strong>{simulation.name}</strong>
+                  <small>by {simulation.owner.username}</small>
+                </span>
+                <span>{simulation.siteCount} Sites</span>
+                <span>{simulation.linkCount} Links</span>
+                <ExternalLink aria-hidden="true" size={15} />
+              </a>
+            ))}
+            {!stats?.latestSimulations.length ? <p className="field-help">Latest non-empty Simulations will appear here.</p> : null}
+          </div>
+        </Panel>
+
+        <Panel title="Simulation Complexity">
+          <div className="stats-complexity-grid">
+            <span><strong>{formatDecimal(stats?.complexity.averageSitesPerSimulation ?? 0)}</strong>Avg. Sites</span>
+            <span><strong>{formatDecimal(stats?.complexity.medianSitesPerSimulation ?? 0)}</strong>Median Sites</span>
+            <span><strong>{formatDecimal(stats?.complexity.averageLinksPerSimulation ?? 0)}</strong>Avg. Links</span>
+            <span><strong>{formatDecimal(stats?.complexity.medianLinksPerSimulation ?? 0)}</strong>Median Links</span>
+          </div>
+          <p className="field-help">Excludes empty Simulations with no Sites.</p>
+        </Panel>
+
+        <Panel title="Simulations by Size">
+          <SizeBucketsChart buckets={stats?.complexity.sizeBuckets ?? { "1-2": 0, "3-5": 0, "6-10": 0, "11+": 0 }} />
+        </Panel>
+
+        <Panel title="Site Density">
+          <div className="stats-density-list">
+            {(stats?.siteDensitySummary ?? []).map((bin) => (
+              <div className="stats-density-row" key={bin.label}>
+                <span>{bin.label}</span>
+                <strong>{bin.count}</strong>
+              </div>
+            ))}
+            {!stats?.siteDensitySummary.length ? <p className="field-help">Site density appears after Sites with coordinates are created.</p> : null}
+          </div>
+        </Panel>
+
+        <Panel title="Link Distance Distribution">
+          <DistanceChart buckets={stats?.linkDistanceDistribution ?? []} />
+        </Panel>
+
+        <Panel title="Network Flavor">
+          <div className="stats-flavor-lockup">
+            <Activity aria-hidden="true" size={20} />
+            <p className="field-help">Frequency, band, and Channel analysis will use saved Link and Network fields in a later pass.</p>
+          </div>
+        </Panel>
+
+        <Panel title="Newest Members">
+          <div className="stats-person-list">
+            {(stats?.highlights.newestMembers ?? []).map((user) => (
+              <div className="stats-person-row" key={user.userId}>
+                <AvatarBadge avatarUrl={user.avatarUrl} imageClassName="profile-avatar" name={user.username} />
+                <span>{user.username}</span>
+                <Sparkles aria-hidden="true" size={14} />
+              </div>
+            ))}
+            {!stats?.highlights.newestMembers.length ? <p className="field-help">Newest members appear after users join.</p> : null}
+          </div>
+        </Panel>
+
+        <Panel title="Distance Notes">
+          <div className="stats-flavor-lockup">
+            <Ruler aria-hidden="true" size={20} />
+            <p className="field-help">Distances are derived from saved Simulation endpoints and grouped into public aggregate buckets.</p>
+          </div>
+        </Panel>
       </section>
     </main>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -932,54 +932,38 @@ button {
 
 .stats-page {
   min-height: 100lvh;
-  padding: clamp(18px, 4vw, 48px);
+  padding: clamp(14px, 3vw, 34px);
   display: grid;
-  gap: 18px;
+  gap: 14px;
   align-content: start;
 }
 
-.stats-hero {
-  min-height: 260px;
+.stats-atlas-page {
+  background:
+    radial-gradient(circle at 16% 0%, color-mix(in srgb, var(--accent-soft) 72%, transparent), transparent 30%),
+    linear-gradient(180deg, color-mix(in srgb, var(--surface-2) 74%, transparent), transparent 260px);
+}
+
+.stats-atlas-header {
   display: flex;
-  align-items: flex-end;
   justify-content: space-between;
-  gap: 18px;
-  border-bottom: 1px solid color-mix(in srgb, var(--border) 74%, transparent);
-  padding-bottom: 22px;
+  align-items: flex-end;
+  gap: 16px;
+  padding: 4px 0 8px;
 }
 
-.stats-hero-copy {
-  max-width: 760px;
-  display: grid;
-  gap: 10px;
-}
-
-.stats-kicker {
-  color: var(--muted);
-  font-family: var(--font-mono);
-  font-size: 0.76rem;
-  text-transform: uppercase;
-}
-
-.stats-hero h1 {
+.stats-atlas-header h1 {
   margin: 0;
-  font-size: clamp(3rem, 9vw, 7.8rem);
-  line-height: 0.9;
+  font-size: clamp(2.2rem, 5vw, 4.8rem);
+  line-height: 0.92;
   letter-spacing: 0;
 }
 
-.stats-hero p {
-  margin: 0;
-  max-width: 620px;
+.stats-atlas-header p {
+  margin: 8px 0 0;
   color: var(--muted);
-  font-size: clamp(1rem, 2vw, 1.25rem);
-  line-height: 1.45;
-}
-
-.stats-section-heading {
-  display: flex;
-  align-items: center;
-  gap: 10px;
+  max-width: 680px;
+  line-height: 1.35;
 }
 
 .stats-chip {
@@ -995,159 +979,208 @@ button {
   white-space: nowrap;
 }
 
-.stats-counter-grid {
+.stats-atlas-metrics {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 10px;
 }
 
-.stats-counter {
-  min-height: 300px;
-  border: 1px solid color-mix(in srgb, var(--border) 76%, transparent);
+.stats-atlas-metric {
+  min-height: 116px;
+  border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
   border-radius: 8px;
   background: color-mix(in srgb, var(--surface) 88%, transparent);
   box-shadow: var(--shadow-elev-1);
-  padding: 16px;
+  padding: 14px;
   display: grid;
-  grid-template-rows: auto minmax(140px, 1fr);
-  align-items: stretch;
+  grid-template-columns: auto 1fr auto;
+  align-items: start;
+  gap: 12px;
+  overflow: hidden;
+}
+
+.stats-atlas-metric-icon {
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  display: grid;
+  place-items: center;
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.stats-atlas-metric-value {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: clamp(1.7rem, 3vw, 2.8rem);
+  line-height: 1;
+  animation: stats-rise-in 520ms ease-out both;
+}
+
+.stats-atlas-metric-label {
+  color: var(--muted);
+  font-size: 0.86rem;
+}
+
+.stats-atlas-delta {
+  color: var(--success);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+}
+
+.stats-atlas-grid {
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.stats-atlas-panel {
+  grid-column: span 4;
+  min-height: 230px;
+  border-radius: 8px;
+  display: grid;
+  align-content: start;
   gap: 10px;
   overflow: hidden;
 }
 
-.stats-counter-copy {
-  display: grid;
-  align-content: start;
-  gap: 4px;
+.stats-atlas-map-panel {
+  grid-column: span 8;
+  min-height: 540px;
 }
 
-.stats-counter-value {
-  font-family: var(--font-mono);
-  font-size: clamp(2rem, 5vw, 4rem);
-  line-height: 0.95;
-  animation: stats-rise-in 520ms ease-out both;
+.stats-atlas-side-panel {
+  grid-column: span 4;
+  min-height: 540px;
 }
 
-.stats-counter-label {
-  font-weight: 700;
+.stats-atlas-wide-panel {
+  grid-column: span 8;
 }
 
-.stats-counter-detail {
-  color: var(--muted);
-  font-size: 0.82rem;
-}
-
-.stats-growth-header {
-  display: flex;
-  justify-content: space-between;
-  gap: 14px;
-  align-items: flex-end;
-  border-bottom: 1px solid color-mix(in srgb, var(--border) 74%, transparent);
-  padding-bottom: 10px;
-}
-
-.stats-growth-header h2,
-.stats-growth-header .field-help {
+.stats-atlas-panel-heading h2 {
   margin: 0;
 }
 
-.stats-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
-}
-
-.stats-panel,
-.stats-placeholder {
+.stats-map-shell {
+  position: relative;
+  min-height: 430px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--border) 68%, transparent);
   border-radius: 8px;
+  background: color-mix(in srgb, var(--surface-2) 80%, transparent);
 }
 
-.stats-panel-wide {
-  grid-column: 1 / -1;
+.stats-map-shell .maplibregl-map {
+  min-height: 430px;
+  font-family: var(--font-ui);
 }
 
-.stats-section-heading {
-  justify-content: space-between;
-  align-items: flex-start;
+.stats-map-marker-layer {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
 }
 
-.stats-section-heading .field-help {
-  margin: 2px 0 0;
+.stats-map-marker-layer::before {
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(color-mix(in srgb, var(--border) 24%, transparent) 1px, transparent 1px),
+    linear-gradient(90deg, color-mix(in srgb, var(--border) 22%, transparent) 1px, transparent 1px),
+    radial-gradient(circle at 70% 34%, color-mix(in srgb, var(--accent-soft) 36%, transparent), transparent 34%);
+  background-size: 96px 96px, 96px 96px, 100% 100%;
+  content: "";
+  opacity: 0.5;
 }
 
-.stats-mini-chart-wrap,
-.stats-geo-wrap {
+.stats-map-marker {
+  position: absolute;
+  width: var(--marker-size);
+  height: var(--marker-size);
   display: grid;
   place-items: center;
+  border: 2px solid color-mix(in srgb, var(--surface) 84%, transparent);
+  border-radius: var(--radius-pill);
+  background:
+    radial-gradient(circle at 50% 50%, color-mix(in srgb, var(--warning) 86%, var(--accent) 14%) 0 35%, transparent 36%),
+    color-mix(in srgb, var(--warning) 30%, transparent);
+  box-shadow:
+    0 0 0 8px color-mix(in srgb, var(--warning) 18%, transparent),
+    0 14px 26px color-mix(in srgb, var(--text) 18%, transparent);
+  color: var(--text);
+  cursor: pointer;
+  font: 700 0.72rem/1 var(--font-ui);
+  pointer-events: auto;
+  transform: translate(-50%, -50%);
+  transition:
+    box-shadow 160ms ease,
+    transform 160ms ease;
 }
 
-.stats-mini-chart-wrap {
-  min-height: 150px;
+.stats-map-marker:hover,
+.stats-map-marker:focus-visible {
+  outline: 2px solid var(--focus-outline);
+  outline-offset: 3px;
+  transform: translate(-50%, -50%) scale(1.05);
 }
 
-.stats-geo-wrap {
-  min-height: 280px;
+.stats-map-reset,
+.stats-map-legend {
+  position: absolute;
+  z-index: 2;
 }
 
-.stats-growth-chart,
-.stats-geo-map {
-  width: 100%;
-  max-height: 360px;
+.stats-map-reset {
+  right: 12px;
+  top: 12px;
 }
 
-.stats-growth-chart {
-  height: 100%;
+.stats-map-legend {
+  right: 12px;
+  bottom: 28px;
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  padding: 7px 9px;
+  color: var(--muted);
+  font-size: 0.78rem;
 }
 
-.stats-axis-label {
-  fill: var(--muted);
-  font-family: var(--font-mono);
-  font-size: 0.65rem;
+.stats-map-legend i {
+  width: 64px;
+  height: 8px;
+  border-radius: var(--radius-pill);
+  background: linear-gradient(90deg, color-mix(in srgb, var(--accent) 14%, transparent), var(--accent));
 }
 
-.stats-chart-grid {
-  stroke: color-mix(in srgb, var(--border) 72%, transparent);
-  stroke-width: 1;
+.stats-map-popup {
+  position: absolute;
+  display: grid;
+  gap: 2px;
+  z-index: 3;
+  min-width: 132px;
+  border: 1px solid color-mix(in srgb, var(--border) 74%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--surface) 92%, transparent);
+  box-shadow: var(--shadow-elev-2);
+  padding: 8px 10px;
+  color: var(--text);
+  font-family: var(--font-ui);
+  pointer-events: none;
+  transform: translate(-50%, calc(-100% - 16px));
 }
 
-.stats-chart-area {
-  fill: color-mix(in srgb, var(--accent) 16%, transparent);
+.stats-map-popup span {
+  color: var(--muted);
+  font-size: 0.78rem;
 }
 
-.stats-chart-line {
-  fill: none;
-  stroke: var(--accent);
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  stroke-width: 4;
-  filter: drop-shadow(0 6px 18px color-mix(in srgb, var(--accent) 24%, transparent));
-}
-
-.stats-chart-dot {
-  fill: var(--surface);
-  stroke: var(--accent);
-  stroke-width: 3;
-}
-
-.stats-geo-frame {
-  fill: color-mix(in srgb, var(--surface-2) 72%, transparent);
-  stroke: color-mix(in srgb, var(--border) 72%, transparent);
-}
-
-.stats-geo-equator,
-.stats-geo-meridian {
-  fill: none;
-  stroke: color-mix(in srgb, var(--border) 44%, transparent);
-  stroke-dasharray: 6 8;
-}
-
-.stats-geo-bin {
-  fill: color-mix(in srgb, var(--los) 50%, transparent);
-  stroke: color-mix(in srgb, var(--surface) 90%, transparent);
-  stroke-width: 1.5;
-  animation: stats-pulse-in 620ms ease-out both;
-}
-
+.stats-map-skeleton,
 .stats-empty {
   min-height: 180px;
   display: grid;
@@ -1159,23 +1192,133 @@ button {
   padding: 16px;
 }
 
-.stats-mini-empty {
-  min-height: 150px;
-  display: grid;
-  place-items: center;
-  border: 1px dashed color-mix(in srgb, var(--border) 70%, transparent);
-  border-radius: 8px;
-  color: var(--muted);
-  text-align: center;
-  padding: 12px;
-  font-size: 0.82rem;
+.stats-map-skeleton {
+  min-height: 430px;
+  background: linear-gradient(90deg, transparent, color-mix(in srgb, var(--accent-soft) 60%, transparent), transparent);
+  background-size: 240% 100%;
+  animation: stats-shimmer 1.2s ease-in-out infinite;
 }
 
-.stats-placeholder {
-  min-height: 168px;
+.stats-empty.is-compact {
+  min-height: 150px;
+}
+
+.stats-chart-shell {
+  position: relative;
+  min-height: 310px;
+}
+
+.stats-chart-range {
+  margin: -6px 0 0;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+}
+
+.stats-chart-tooltip {
+  border: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--surface) 94%, transparent);
+  box-shadow: var(--shadow-elev-2);
+  padding: 9px 10px;
   display: grid;
-  align-content: start;
+  gap: 4px;
+  color: var(--text);
+}
+
+.stats-chart-tooltip span::before {
+  content: "";
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  margin-right: 6px;
+  border-radius: 50%;
+  background: var(--series-color, var(--accent));
+}
+
+.stats-person-list,
+.stats-simulation-list,
+.stats-density-list {
+  display: grid;
+  gap: 8px;
+}
+
+.stats-person-row,
+.stats-simulation-row,
+.stats-density-row {
+  min-height: 42px;
+  display: grid;
+  align-items: center;
+  gap: 9px;
+  border: 1px solid color-mix(in srgb, var(--border) 58%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--surface-2) 54%, transparent);
+  padding: 8px;
+  color: var(--text);
+}
+
+.stats-person-row {
+  grid-template-columns: auto 1fr auto;
+  width: 100%;
+  font: inherit;
+  text-align: left;
+}
+
+.stats-person-row strong,
+.stats-density-row strong {
+  font-family: var(--font-mono);
+}
+
+.stats-simulation-row {
+  grid-template-columns: minmax(0, 1fr) auto auto auto;
+  text-decoration: none;
+}
+
+.stats-simulation-row strong,
+.stats-simulation-row small {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.stats-simulation-row small,
+.stats-simulation-row > span:not(:first-child) {
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
+.stats-density-row {
+  grid-template-columns: 1fr auto;
+}
+
+.stats-complexity-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.stats-complexity-grid span {
+  border: 1px solid color-mix(in srgb, var(--border) 58%, transparent);
+  border-radius: 8px;
+  padding: 12px;
+  background: color-mix(in srgb, var(--surface-2) 54%, transparent);
+  color: var(--muted);
+}
+
+.stats-complexity-grid strong {
+  display: block;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 1.65rem;
+}
+
+.stats-flavor-lockup {
+  display: flex;
   gap: 10px;
+  align-items: flex-start;
+  color: var(--muted);
 }
 
 @keyframes stats-rise-in {
@@ -1189,27 +1332,31 @@ button {
   }
 }
 
-@keyframes stats-pulse-in {
+@keyframes stats-shimmer {
   from {
-    opacity: 0;
-    transform: scale(0.72);
+    background-position: 180% 0;
   }
   to {
-    opacity: 1;
-    transform: scale(1);
+    background-position: -80% 0;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .stats-counter-value,
-  .stats-geo-bin {
+  .stats-atlas-metric-value,
+  .stats-map-skeleton {
     animation: none;
   }
 }
 
 @media (max-width: 1180px) {
-  .stats-counter-grid {
+  .stats-atlas-metrics {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .stats-atlas-map-panel,
+  .stats-atlas-side-panel,
+  .stats-atlas-wide-panel {
+    grid-column: 1 / -1;
   }
 }
 
@@ -1218,30 +1365,36 @@ button {
     padding: 16px;
   }
 
-  .stats-hero {
-    min-height: 220px;
-    align-items: flex-start;
+  .stats-atlas-header {
     flex-direction: column;
-    justify-content: flex-end;
+    align-items: stretch;
   }
 
-  .stats-counter-grid,
-  .stats-grid {
+  .stats-atlas-metrics,
+  .stats-atlas-grid {
     grid-template-columns: 1fr;
   }
 
-  .stats-counter {
-    min-height: 300px;
+  .stats-atlas-panel,
+  .stats-atlas-map-panel,
+  .stats-atlas-side-panel,
+  .stats-atlas-wide-panel {
+    grid-column: 1;
+    min-height: 0;
   }
 
-  .stats-section-heading {
-    align-items: stretch;
-    flex-direction: column;
+  .stats-map-shell,
+  .stats-map-shell .maplibregl-map,
+  .stats-map-skeleton {
+    min-height: 320px;
   }
 
-  .stats-growth-header {
-    align-items: stretch;
-    flex-direction: column;
+  .stats-simulation-row {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .stats-simulation-row > span:nth-child(3) {
+    display: none;
   }
 }
 

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -31,6 +31,10 @@ export type StatsPayload = {
       count: number;
     }>;
   };
+  siteDensitySummary: Array<{
+    label: string;
+    count: number;
+  }>;
   complexity: {
     averageSitesPerSimulation: number;
     medianSitesPerSimulation: number;
@@ -38,6 +42,25 @@ export type StatsPayload = {
     medianLinksPerSimulation: number;
     sizeBuckets: Record<"1-2" | "3-5" | "6-10" | "11+", number>;
   };
+  latestSimulations: Array<{
+    id: string;
+    name: string;
+    href: string;
+    createdAt: string | null;
+    owner: {
+      userId: string;
+      username: string;
+      avatarUrl: string;
+    };
+    siteCount: number;
+    linkCount: number;
+  }>;
+  linkDistanceDistribution: Array<{
+    label: string;
+    minKm: number;
+    maxKm: number | null;
+    count: number;
+  }>;
   highlights: {
     topContributors: Array<{
       userId: string;


### PR DESCRIPTION
## Summary
- rebuild /stats as the Pulse-based Atlas grid with top metrics, Site geography, growth, latest Simulations, contributor/member highlights, complexity, size, density, and link distance panels
- extend /api/stats with aggregate-only latestSimulations, linkDistanceDistribution, and siteDensitySummary data
- allow public unlisted Simulation bundles to load with referenced Sites for clickable stats links
- add recharts for interactive animated charts and a lazy MapLibre stats density component

Follow-up: #888 tracks privacy-safe longest passing path stats.

## Verification
- npm test -- --run functions/api/stats.test.ts functions/api/public-simulation.test.ts functions/_lib/db.sharedSimulation.test.ts
- npm test -- --run src/components/StatsPage.test.tsx
- npm test
- npm run build
- Playwright fallback visual QA for /stats desktop/mobile, chart hover, map visibility, latest Simulation link, and console errors

Closes #853