### PR TITLE
Polish stats Atlas page

### DIFF
--- a/functions/api/stats.test.ts
+++ b/functions/api/stats.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { onRequestGet } from "./stats";
 
@@ -31,6 +31,8 @@ const mkCtx = (request = new Request("https://example.test/api/stats")) =>
   ({ request, env } as unknown as Parameters<typeof onRequestGet>[0]);
 
 beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-02-10T12:30:00.000Z"));
   tables.users = [
     { id: "u1", username: "Ada", avatar_url: "https://example.test/ada.png", created_at: "2026-01-03T00:00:00.000Z" },
     { id: "u2", username: "Grace", avatar_url: null, created_at: "2026-02-10T00:00:00.000Z" },
@@ -70,8 +72,9 @@ beforeEach(() => {
             { id: "s3", name: "East", position: { lat: 61, lon: 11 } },
           ],
           links: [
-            { id: "l1", fromSiteId: "s1", toSiteId: "s2", frequencyMHz: 868 },
+            { id: "l1", name: "Short ridge", fromSiteId: "s1", toSiteId: "s2", frequencyMHz: 868 },
             { id: "l2", fromSiteId: "s2", toSiteId: "s3", frequencyMHz: 915 },
+            { id: "bad-link", fromSiteId: "s1", toSiteId: "missing" },
           ],
         },
       }),
@@ -92,11 +95,15 @@ beforeEach(() => {
         slug: "Shared-sim",
         snapshot: {
           sites: [{ id: "s4", name: "Solo", position: { lat: 62, lon: 12 } }],
-          links: [{ id: "l3" }],
+          links: [{ id: "l3" }, { id: "malformed", fromSiteId: "s4", toSiteId: "missing" }],
         },
       }),
     },
   ];
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe("api/stats", () => {
@@ -107,7 +114,7 @@ describe("api/stats", () => {
 
     const body = await res.json() as {
       totals: { users: number; sites: number; simulations: number; nonEmptySimulations: number; links: number };
-      complexity: { averageSitesPerSimulation: number; medianSitesPerSimulation: number; averageLinksPerSimulation: number };
+      complexity: { averageSitesPerSimulation: number; averageLinksPerSimulation: number };
     };
 
     expect(body.totals).toMatchObject({
@@ -115,11 +122,10 @@ describe("api/stats", () => {
       sites: 3,
       simulations: 3,
       nonEmptySimulations: 2,
-      links: 3,
+      links: 5,
     });
     expect(body.complexity.averageSitesPerSimulation).toBe(2);
-    expect(body.complexity.medianSitesPerSimulation).toBe(2);
-    expect(body.complexity.averageLinksPerSimulation).toBe(1.5);
+    expect(body.complexity.averageLinksPerSimulation).toBe(2.5);
   });
 
   it("returns latest non-empty simulations and link distance buckets without leaking payloads", async () => {
@@ -135,6 +141,7 @@ describe("api/stats", () => {
       }>;
       linkDistanceDistribution: Array<{ label: string; minKm: number; maxKm: number | null; count: number }>;
       siteDensitySummary: Array<{ label: string; count: number }>;
+      longestLinks: Array<{ label: string; href: string; simulationName: string; distanceKm: number; owner: { username: string } }>;
     };
     const raw = JSON.stringify(body);
 
@@ -145,39 +152,58 @@ describe("api/stats", () => {
         href: "/Grace/Shared-sim",
         owner: { userId: "u2", username: "Grace", avatarUrl: "" },
         siteCount: 1,
-        linkCount: 1,
+        linkCount: 2,
       }),
       expect.objectContaining({
         id: "sim-1",
         name: "Private sim",
         href: "/Ada/Private-sim",
         siteCount: 3,
-        linkCount: 2,
+        linkCount: 3,
       }),
     ]);
     expect(body.latestSimulations.some((entry) => entry.id === "sim-empty")).toBe(false);
     expect(body.linkDistanceDistribution.reduce((sum, bucket) => sum + bucket.count, 0)).toBe(2);
+    expect(body.longestLinks).toHaveLength(2);
+    expect(body.longestLinks[0]).toMatchObject({
+      label: "South ~ East",
+      href: "/Ada/Private-sim/South~East",
+      simulationName: "Private sim",
+      owner: { username: "Ada" },
+    });
+    expect(body.longestLinks[0].distanceKm).toBeGreaterThan(body.longestLinks[1].distanceKm);
     expect(body.siteDensitySummary).toEqual([{ label: "60°N, 10°E", count: 2 }]);
-    expect(raw).not.toContain("North");
-    expect(raw).not.toContain("South");
+    expect(raw).not.toContain("60.1");
+    expect(raw).not.toContain("61");
     expect(raw).not.toContain("payload_json");
   });
 
-  it("returns monthly and weekly growth buckets", async () => {
+  it("returns UTC growth ranges including hourly today buckets", async () => {
     const res = await onRequestGet(mkCtx());
     const body = await res.json() as {
       growth: {
+        today: Array<{ label: string; users: number; sites: number; simulations: number; links: number }>;
+        last7Days: Array<{ label: string; users: number; sites: number; simulations: number; links: number }>;
+        last30Days: Array<{ label: string; users: number; sites: number; simulations: number; links: number }>;
+        lastYear: Array<{ label: string; users: number; sites: number; simulations: number; links: number }>;
+        allTime: Array<{ label: string; users: number; sites: number; simulations: number; links: number; cumulativeLinks: number }>;
         monthly: Array<{ label: string; users: number; sites: number; simulations: number; links: number; cumulativeLinks: number }>;
         weekly: Array<{ users: number; sites: number; simulations: number; links: number }>;
       };
     };
 
-    expect(body.growth.monthly).toEqual(
+    expect(body.growth.today).toHaveLength(24);
+    expect(body.growth.today[12]).toMatchObject({ label: "12:00", users: 0, sites: 0, simulations: 0, links: 0 });
+    expect(body.growth.last7Days).toHaveLength(7);
+    expect(body.growth.last30Days).toHaveLength(30);
+    expect(body.growth.lastYear).toHaveLength(12);
+    expect(body.growth.allTime).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ label: "2026-01", users: 1, sites: 1, simulations: 1, links: 2, cumulativeLinks: 2 }),
-        expect.objectContaining({ label: "2026-02", users: 1, sites: 2, simulations: 2, links: 1, cumulativeLinks: 3 }),
+        expect.objectContaining({ label: "2026-01", users: 1, sites: 1, simulations: 1, links: 3, cumulativeLinks: 3 }),
+        expect.objectContaining({ label: "2026-02", users: 1, sites: 2, simulations: 2, links: 2, cumulativeLinks: 5 }),
       ]),
     );
+    expect(body.growth.monthly).toEqual(body.growth.allTime);
     expect(body.growth.weekly.length).toBeGreaterThan(0);
   });
 

--- a/functions/api/stats.ts
+++ b/functions/api/stats.ts
@@ -28,6 +28,8 @@ type GrowthBucket = {
   cumulativeLinks: number;
 };
 
+type GrowthRangeKey = "today" | "last7Days" | "last30Days" | "lastYear" | "allTime";
+
 type SitePayload = {
   position?: {
     lat?: unknown;
@@ -56,6 +58,7 @@ type SnapshotSite = {
 
 type SnapshotLink = {
   id?: unknown;
+  name?: unknown;
   fromSiteId?: unknown;
   toSiteId?: unknown;
 };
@@ -79,6 +82,10 @@ const parseDate = (value: string | null): Date | null => {
 
 const monthLabel = (date: Date): string =>
   `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}`;
+
+const dayLabel = (date: Date): string => date.toISOString().slice(0, 10);
+
+const hourLabel = (date: Date): string => `${String(date.getUTCHours()).padStart(2, "0")}:00`;
 
 const weekLabel = (date: Date): string => {
   const start = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
@@ -149,6 +156,120 @@ const buildGrowth = (
     });
 };
 
+type GrowthEvent = {
+  date: Date;
+  key: GrowthCountKey;
+  amount: number;
+};
+
+const collectGrowthEvents = (users: UserRow[], sites: ResourceRow[], simulations: ResourceRow[]): GrowthEvent[] => {
+  const events: GrowthEvent[] = [];
+  users.forEach((row) => {
+    const date = parseDate(row.created_at);
+    if (date) events.push({ date, key: "users", amount: 1 });
+  });
+  sites.forEach((row) => {
+    const date = parseDate(row.created_at);
+    if (date) events.push({ date, key: "sites", amount: 1 });
+  });
+  simulations.forEach((row) => {
+    const date = parseDate(row.created_at);
+    if (!date) return;
+    events.push({ date, key: "simulations", amount: 1 });
+    events.push({ date, key: "links", amount: simulationLinkCount(row) });
+  });
+  return events;
+};
+
+const startOfUtcDay = (date: Date): Date =>
+  new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+
+const addUtcDays = (date: Date, days: number): Date => {
+  const next = new Date(date);
+  next.setUTCDate(next.getUTCDate() + days);
+  return next;
+};
+
+const addUtcMonths = (date: Date, months: number): Date => {
+  const next = new Date(date);
+  next.setUTCMonth(next.getUTCMonth() + months);
+  return next;
+};
+
+const buildFixedRangeGrowth = (
+  events: GrowthEvent[],
+  labels: string[],
+  eventLabel: (date: Date) => string | null,
+): GrowthBucket[] => {
+  const buckets = new Map(labels.map((label) => [label, emptyGrowthCounts()] as const));
+  events.forEach((event) => {
+    const label = eventLabel(event.date);
+    if (!label || !buckets.has(label)) return;
+    increment(buckets, label, event.key, event.amount);
+  });
+
+  let cumulativeUsers = 0;
+  let cumulativeSites = 0;
+  let cumulativeSimulations = 0;
+  let cumulativeLinks = 0;
+  return labels.map((label) => {
+    const counts = buckets.get(label) ?? emptyGrowthCounts();
+    cumulativeUsers += counts.users;
+    cumulativeSites += counts.sites;
+    cumulativeSimulations += counts.simulations;
+    cumulativeLinks += counts.links;
+    return {
+      label,
+      ...counts,
+      cumulativeUsers,
+      cumulativeSites,
+      cumulativeSimulations,
+      cumulativeLinks,
+    };
+  });
+};
+
+const buildGrowthRanges = (
+  users: UserRow[],
+  sites: ResourceRow[],
+  simulations: ResourceRow[],
+  now = new Date(),
+): Record<GrowthRangeKey, GrowthBucket[]> => {
+  const events = collectGrowthEvents(users, sites, simulations);
+  const todayStart = startOfUtcDay(now);
+  const todayLabels = Array.from({ length: 24 }, (_, hour) => `${String(hour).padStart(2, "0")}:00`);
+  const last7Start = addUtcDays(todayStart, -6);
+  const last30Start = addUtcDays(todayStart, -29);
+  const yearStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 11, 1));
+  const last7Labels = Array.from({ length: 7 }, (_, index) => dayLabel(addUtcDays(last7Start, index)));
+  const last30Labels = Array.from({ length: 30 }, (_, index) => dayLabel(addUtcDays(last30Start, index)));
+  const lastYearLabels = Array.from({ length: 12 }, (_, index) => monthLabel(addUtcMonths(yearStart, index)));
+
+  return {
+    today: buildFixedRangeGrowth(
+      events,
+      todayLabels,
+      (date) => date >= todayStart && date < addUtcDays(todayStart, 1) ? hourLabel(date) : null,
+    ),
+    last7Days: buildFixedRangeGrowth(
+      events,
+      last7Labels,
+      (date) => date >= last7Start && date < addUtcDays(todayStart, 1) ? dayLabel(date) : null,
+    ),
+    last30Days: buildFixedRangeGrowth(
+      events,
+      last30Labels,
+      (date) => date >= last30Start && date < addUtcDays(todayStart, 1) ? dayLabel(date) : null,
+    ),
+    lastYear: buildFixedRangeGrowth(
+      events,
+      lastYearLabels,
+      (date) => date >= yearStart && date < addUtcMonths(yearStart, 12) ? monthLabel(date) : null,
+    ),
+    allTime: buildGrowth(users, sites, simulations, monthLabel),
+  };
+};
+
 const median = (values: number[]): number => {
   if (!values.length) return 0;
   const sorted = [...values].sort((a, b) => a - b);
@@ -190,6 +311,20 @@ const hrefForSimulation = (owner: UserRow | undefined, simulation: ResourceRow, 
   const simulationSlug = slugifySegment(name);
   if (username && simulationSlug) return `/${username}/${simulationSlug}`;
   return `/?sim=${encodeURIComponent(simulation.id)}`;
+};
+
+const hrefForLink = (
+  owner: UserRow | undefined,
+  simulation: ResourceRow,
+  payload: SimulationPayload | null,
+  fromSite: SnapshotSite,
+  toSite: SnapshotSite,
+): string => {
+  const simulationHref = hrefForSimulation(owner, simulation, payload);
+  const fromName = typeof fromSite.name === "string" ? slugifySegment(fromSite.name) : "";
+  const toName = typeof toSite.name === "string" ? slugifySegment(toSite.name) : "";
+  if (!fromName || !toName || simulationHref.startsWith("/?")) return simulationHref;
+  return `${simulationHref}/${fromName}~${toName}`;
 };
 
 const formatGeoLabel = (latBand: number, lonBand: number): string => {
@@ -283,6 +418,15 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
       siteCount: number;
       linkCount: number;
     }> = [];
+    const longestLinks: Array<{
+      id: string;
+      label: string;
+      href: string;
+      simulationHref: string;
+      simulationName: string;
+      distanceKm: number;
+      owner: { userId: string; username: string; avatarUrl: string };
+    }> = [];
     const linkDistanceCounts = DISTANCE_BUCKETS.map((bucket) => ({ ...bucket, count: 0 }));
 
     simulations.forEach((simulation) => {
@@ -327,8 +471,26 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
         const toLat = to?.position?.lat;
         const toLon = to?.position?.lon;
         if (!isFiniteNumber(fromLat) || !isFiniteNumber(fromLon) || !isFiniteNumber(toLat) || !isFiniteNumber(toLon)) return;
-        const bucket = bucketForDistance(haversineKm({ lat: fromLat, lon: fromLon }, { lat: toLat, lon: toLon }));
+        const distanceKm = haversineKm({ lat: fromLat, lon: fromLon }, { lat: toLat, lon: toLon });
+        const bucket = bucketForDistance(distanceKm);
         if (bucket) linkDistanceCounts.find((entry) => entry.label === bucket.label)!.count += 1;
+        const owner = userById.get(simulation.owner_user_id);
+        const fromName = typeof from?.name === "string" && from.name.trim() ? from.name.trim() : "Site A";
+        const toName = typeof to?.name === "string" && to.name.trim() ? to.name.trim() : "Site B";
+        const linkName = typeof link.name === "string" && link.name.trim() ? link.name.trim() : `${fromName} ~ ${toName}`;
+        longestLinks.push({
+          id: `${simulation.id}:${typeof link.id === "string" ? link.id : `${link.fromSiteId}-${link.toSiteId}`}`,
+          label: linkName,
+          href: hrefForLink(owner, simulation, payload, from, to),
+          simulationHref: hrefForSimulation(owner, simulation, payload),
+          simulationName: typeof payload?.name === "string" && payload.name.trim() ? payload.name.trim() : simulation.name?.trim() || "Untitled Simulation",
+          distanceKm: round1(distanceKm),
+          owner: {
+            userId: simulation.owner_user_id,
+            username: owner?.username?.trim() || "Unknown user",
+            avatarUrl: owner?.avatar_url ?? "",
+          },
+        });
       });
     });
 
@@ -342,6 +504,7 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
         createdAt: user.created_at,
       }));
 
+    const growthRanges = buildGrowthRanges(users, sites, simulations);
     const body = {
       generatedAt: new Date().toISOString(),
       totals: {
@@ -352,7 +515,8 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
         links: totalLinks,
       },
       growth: {
-        monthly: buildGrowth(users, sites, simulations, monthLabel),
+        ...growthRanges,
+        monthly: growthRanges.allTime,
         weekly: buildGrowth(users, sites, simulations, weekLabel).slice(-52),
       },
       geography: {
@@ -372,6 +536,9 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
       },
       latestSimulations: latestSimulations
         .sort((a, b) => (parseDate(b.createdAt)?.getTime() ?? 0) - (parseDate(a.createdAt)?.getTime() ?? 0))
+        .slice(0, 5),
+      longestLinks: longestLinks
+        .sort((a, b) => b.distanceKm - a.distanceKm || a.label.localeCompare(b.label))
         .slice(0, 5),
       linkDistanceDistribution: linkDistanceCounts,
       highlights: {

--- a/src/components/StatsDensityMap.tsx
+++ b/src/components/StatsDensityMap.tsx
@@ -1,9 +1,11 @@
-import { useMemo, useRef, useState, type CSSProperties } from "react";
-import Map, { Layer, NavigationControl, Source, type MapRef } from "react-map-gl/maplibre";
+import { useMemo, useRef, useState } from "react";
+import { Fullscreen, ZoomIn, ZoomOut } from "lucide-react";
+import Map, { Layer, Popup, Source, type MapLayerMouseEvent, type MapRef } from "react-map-gl/maplibre";
 import type { FeatureCollection, Point } from "geojson";
 import { getCartoFallbackStyle } from "../lib/basemaps";
 import type { StatsPayload } from "../lib/stats";
 import type { UiColorTheme } from "../themes/types";
+import { MapControlButton } from "./ui/MapControlButton";
 
 type StatsDensityMapProps = {
   bins: StatsPayload["geography"]["bins"];
@@ -21,8 +23,8 @@ type DensityProperties = {
 type HoveredBin = {
   count: number;
   label: string;
-  xPercent: number;
-  yPercent: number;
+  longitude: number;
+  latitude: number;
 };
 
 const colorVar = (name: string): string =>
@@ -58,28 +60,6 @@ export function StatsDensityMap({ bins, theme, colorTheme = "blue", accentColor,
   const mapRef = useRef<MapRef | null>(null);
   const [hovered, setHovered] = useState<HoveredBin | null>(null);
   const maxCount = Math.max(1, ...bins.map((bin) => bin.count));
-  const overlayBins = useMemo(() => {
-    if (!bins.length) return [];
-    const points = bins.map((bin) => ({
-      count: bin.count,
-      label: binLabel(bin.latBand, bin.lonBand),
-      longitude: bin.lonBand + 0.5,
-      latitude: bin.latBand + 0.5,
-    }));
-    const lons = points.map((point) => point.longitude);
-    const lats = points.map((point) => point.latitude);
-    const minLon = Math.min(...lons);
-    const maxLon = Math.max(...lons);
-    const minLat = Math.min(...lats);
-    const maxLat = Math.max(...lats);
-    const lonSpan = Math.max(1, maxLon - minLon);
-    const latSpan = Math.max(1, maxLat - minLat);
-    return points.map((point) => ({
-      ...point,
-      xPercent: 8 + ((point.longitude - minLon) / lonSpan) * 76,
-      yPercent: 84 - ((point.latitude - minLat) / latSpan) * 66,
-    }));
-  }, [bins]);
   const featureCollection = useMemo<FeatureCollection<Point, DensityProperties>>(
     () => ({
       type: "FeatureCollection",
@@ -116,88 +96,88 @@ export function StatsDensityMap({ bins, theme, colorTheme = "blue", accentColor,
         initialViewState={{ ...initialCenter, zoom: bins.length === 1 ? 5 : 3 }}
         mapStyle={getCartoFallbackStyle(theme, colorTheme)}
         attributionControl={{ compact: true }}
-        cooperativeGestures
+        dragPan={!window.matchMedia("(pointer: coarse)").matches}
+        scrollZoom={false}
+        touchZoomRotate={false}
         onError={() => setHovered(null)}
         onLoad={(event) => fitBins(event.target as unknown as MapRef, bins)}
         onMouseLeave={() => setHovered(null)}
+        onMouseMove={(event: MapLayerMouseEvent) => {
+          const feature = event.features?.[0];
+          const properties = feature?.properties as Partial<DensityProperties> | undefined;
+          if (!feature || !properties || typeof properties.count !== "number") {
+            setHovered(null);
+            return;
+          }
+          setHovered({
+            longitude: event.lngLat.lng,
+            latitude: event.lngLat.lat,
+            count: properties.count,
+            label: String(properties.label ?? "Site density bin"),
+          });
+        }}
+        onClick={(event: MapLayerMouseEvent) => {
+          const feature = event.features?.[0];
+          const properties = feature?.properties as Partial<DensityProperties> | undefined;
+          if (!feature || !properties || typeof properties.count !== "number") return;
+          setHovered({
+            longitude: event.lngLat.lng,
+            latitude: event.lngLat.lat,
+            count: properties.count,
+            label: String(properties.label ?? "Site density bin"),
+          });
+        }}
         interactiveLayerIds={["stats-density-bins"]}
       >
-        <NavigationControl position="top-left" showCompass={false} />
         <Source data={featureCollection} id="stats-density" type="geojson">
           <Layer
             id="stats-density-bins"
             type="circle"
             paint={{
               "circle-color": accentColor || colorVar("--accent"),
-              "circle-opacity": 0.34,
+              "circle-blur": 0.18,
+              "circle-opacity": 0.64,
               "circle-stroke-color": surfaceColor || colorVar("--surface"),
-              "circle-stroke-opacity": 0.94,
-              "circle-stroke-width": 2,
+              "circle-stroke-opacity": 0.82,
+              "circle-stroke-width": 1.5,
               "circle-radius": [
                 "interpolate",
                 ["linear"],
                 ["get", "count"],
                 1,
-                9,
+                12,
                 maxCount,
-                30,
+                42,
               ],
             }}
           />
         </Source>
-      </Map>
-      <div className="stats-map-marker-layer" aria-label="Binned Site density markers">
-        {overlayBins.map((bin) => {
-          const intensity = Math.max(0.35, bin.count / maxCount);
-          const size = 24 + intensity * 42;
-          return (
-            <button
-              aria-label={`${bin.count} Sites near ${bin.label}`}
-              className="stats-map-marker"
-              key={bin.label}
-              onBlur={() => setHovered(null)}
-              onClick={(event) => {
-                event.stopPropagation();
-                setHovered(bin);
-              }}
-              onFocus={() => setHovered(bin)}
-              onMouseEnter={() => setHovered(bin)}
-              onMouseLeave={() => setHovered(null)}
-              style={
-                {
-                  "--marker-size": `${size}px`,
-                  left: `${bin.xPercent}%`,
-                  top: `${bin.yPercent}%`,
-                } as CSSProperties
-              }
-              title={`${bin.count} Sites near ${bin.label}`}
-              type="button"
-            >
-              <span>{bin.count}</span>
-            </button>
-          );
-        })}
         {hovered ? (
-          <div
-            className="stats-map-popup"
-            style={{ left: `${hovered.xPercent}%`, top: `${hovered.yPercent}%` }}
-          >
-            <strong>{hovered.count} Sites</strong>
-            <span>{hovered.label}</span>
-          </div>
+          <Popup closeButton={false} closeOnClick={false} latitude={hovered.latitude} longitude={hovered.longitude} offset={14}>
+            <div className="stats-map-popup">
+              <strong>{hovered.count} Sites</strong>
+              <span>{hovered.label}</span>
+            </div>
+          </Popup>
         ) : null}
+      </Map>
+      <div className="map-controls map-controls-unified map-controls-icon-only stats-map-controls">
+        <div className="map-controls-group map-controls-group-utility map-controls-utility-pill ui-surface-pill">
+          <MapControlButton aria-label="Zoom out Site density map" onClick={() => mapRef.current?.zoomOut()} title="Zoom out">
+            <ZoomOut aria-hidden="true" strokeWidth={1.8} />
+          </MapControlButton>
+          <MapControlButton aria-label="Zoom in Site density map" onClick={() => mapRef.current?.zoomIn()} title="Zoom in">
+            <ZoomIn aria-hidden="true" strokeWidth={1.8} />
+          </MapControlButton>
+          <MapControlButton aria-label="Reset Site density map fit" onClick={() => fitBins(mapRef.current, bins)} title="Fit">
+            <Fullscreen aria-hidden="true" strokeWidth={1.8} />
+          </MapControlButton>
+        </div>
       </div>
-      <button
-        aria-label="Reset Site density map fit"
-        className="stats-map-reset btn-ghost"
-        onClick={() => fitBins(mapRef.current, bins)}
-        type="button"
-      >
-        Reset fit
-      </button>
-      <div className="stats-map-legend" aria-label="Site density legend">
-        <span>Site density</span>
-        <i />
+      <div className="floating-attribution-pill ui-surface-pill stats-map-attribution">
+        <a href="https://carto.com/attributions" rel="noreferrer" target="_blank">CARTO</a>
+        <span>·</span>
+        <a href="https://github.com/maplibre/maplibre-gl-js" rel="noreferrer" target="_blank">MapLibre</a>
       </div>
     </div>
   );

--- a/src/components/StatsPage.test.tsx
+++ b/src/components/StatsPage.test.tsx
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 vi.mock("../hooks/useThemeVariant", () => ({
-  useThemeVariant: () => ({ theme: "light", variant: { cssVars: {} }, activeHolidayTheme: null }),
+  useThemeVariant: () => ({ theme: "light", colorTheme: "blue", variant: { cssVars: {} }, activeHolidayTheme: null }),
 }));
 
 vi.mock("./StatsDensityMap", () => ({
@@ -26,6 +26,30 @@ const statsPayload = {
     links: 21,
   },
   growth: {
+    today: Array.from({ length: 24 }, (_, hour) => ({
+      label: `${String(hour).padStart(2, "0")}:00`,
+      users: hour === 10 ? 1 : 0,
+      sites: 0,
+      simulations: 0,
+      links: 0,
+      cumulativeUsers: hour >= 10 ? 1 : 0,
+      cumulativeSites: 0,
+      cumulativeSimulations: 0,
+      cumulativeLinks: 0,
+    })),
+    last7Days: [
+      { label: "2026-05-04", users: 1, sites: 2, simulations: 1, links: 3, cumulativeUsers: 1, cumulativeSites: 2, cumulativeSimulations: 1, cumulativeLinks: 3 },
+    ],
+    last30Days: [
+      { label: "2026-05-04", users: 1, sites: 2, simulations: 1, links: 3, cumulativeUsers: 1, cumulativeSites: 2, cumulativeSimulations: 1, cumulativeLinks: 3 },
+    ],
+    lastYear: [
+      { label: "2026-05", users: 3, sites: 6, simulations: 2, links: 7, cumulativeUsers: 3, cumulativeSites: 6, cumulativeSimulations: 2, cumulativeLinks: 7 },
+    ],
+    allTime: [
+      { label: "2026-01", users: 2, sites: 4, simulations: 1, links: 5, cumulativeUsers: 2, cumulativeSites: 4, cumulativeSimulations: 1, cumulativeLinks: 5 },
+      { label: "2026-02", users: 3, sites: 6, simulations: 2, links: 7, cumulativeUsers: 5, cumulativeSites: 10, cumulativeSimulations: 3, cumulativeLinks: 12 },
+    ],
     monthly: [
       { label: "2026-01", users: 2, sites: 4, simulations: 1, links: 5, cumulativeUsers: 2, cumulativeSites: 4, cumulativeSimulations: 1, cumulativeLinks: 5 },
       { label: "2026-02", users: 3, sites: 6, simulations: 2, links: 7, cumulativeUsers: 5, cumulativeSites: 10, cumulativeSimulations: 3, cumulativeLinks: 12 },
@@ -56,6 +80,17 @@ const statsPayload = {
       linkCount: 2,
     },
   ],
+  longestLinks: [
+    {
+      id: "sim-2:l1",
+      label: "Ridge to Valley",
+      href: "/Grace/Shared-Ridge/Ridge~Valley",
+      simulationHref: "/Grace/Shared-Ridge",
+      simulationName: "Shared Ridge",
+      distanceKm: 42.4,
+      owner: { userId: "u2", username: "Grace", avatarUrl: "" },
+    },
+  ],
   linkDistanceDistribution: [
     { label: "0-10 km", minKm: 0, maxKm: 10, count: 1 },
     { label: "10-25 km", minKm: 10, maxKm: 25, count: 2 },
@@ -69,12 +104,33 @@ const statsPayload = {
 
 beforeEach(() => {
   vi.restoreAllMocks();
+  vi.spyOn(Date, "now").mockReturnValue(new Date("2026-05-12T12:00:00.000Z").getTime());
   vi.stubGlobal(
     "fetch",
-    vi.fn(async () => ({
-      ok: true,
-      json: async () => statsPayload,
-    })),
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/users/u1")) {
+        return {
+          ok: true,
+          json: async () => ({
+            user: {
+              id: "u1",
+              username: "Ada",
+              bio: "Radio planner",
+              avatarUrl: "",
+              isAdmin: false,
+              isApproved: true,
+              createdAt: "2026-01-01T00:00:00.000Z",
+              updatedAt: null,
+            },
+          }),
+        };
+      }
+      return {
+        ok: true,
+        json: async () => statsPayload,
+      };
+    }),
   );
 });
 
@@ -93,10 +149,17 @@ describe("StatsPage", () => {
     expect(screen.getByText("Latest Simulations")).toBeInTheDocument();
     expect(screen.getByText("Simulation Complexity")).toBeInTheDocument();
     expect(screen.getByText("Simulations by Size")).toBeInTheDocument();
-    expect(screen.getByText("Site Density")).toBeInTheDocument();
     expect(screen.getByText("Link Distance Distribution")).toBeInTheDocument();
+    expect(screen.getByText("Top 5 Longest Links")).toBeInTheDocument();
     expect(screen.getByTestId("stats-density-map")).toHaveTextContent("Map bins: 1");
-    expect(screen.getByRole("link", { name: /Shared Ridge/i })).toHaveAttribute("href", "/Grace/Shared-Ridge");
+    expect(screen.getByRole("link", { name: /Back to app/i })).toHaveAttribute("href", "/");
+    expect(screen.getAllByRole("link", { name: /Shared Ridge/i })[0]).toHaveAttribute("href", "/Grace/Shared-Ridge");
+    expect(screen.getByRole("link", { name: /Ridge to Valley/i })).toHaveAttribute("href", "/Grace/Shared-Ridge/Ridge~Valley");
+    expect(screen.getByText("Sites + Simulations")).toBeInTheDocument();
+    expect(screen.getByText("11 days ago")).toBeInTheDocument();
+    expect(screen.queryByText("Median Sites")).not.toBeInTheDocument();
+    expect(screen.queryByText("Median Links")).not.toBeInTheDocument();
+    expect(screen.queryByText("Site Density")).not.toBeInTheDocument();
     expect(screen.queryByText("Moderator Snapshot")).not.toBeInTheDocument();
     expect(screen.queryByText(/Longest Passing Path/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/draft/i)).not.toBeInTheDocument();
@@ -104,16 +167,29 @@ describe("StatsPage", () => {
     expect(fetch).toHaveBeenCalledWith("/api/stats", { method: "GET" });
   });
 
-  it("switches the growth chart between all-time and recent buckets", async () => {
+  it("switches the growth chart across ranges with active state", async () => {
     render(<StatsPage />);
-    await screen.findByRole("button", { name: "All time" });
+    await screen.findByRole("button", { name: "Last 30 days" });
 
-    expect(screen.getByText(/2026-01 to 2026-02/)).toBeInTheDocument();
-    fireEvent.click(screen.getByText("Last 30 days"));
+    expect(screen.getByRole("button", { name: "Last 30 days" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByText(/Last 30 days · UTC/)).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Today"));
 
     await waitFor(() => {
-      expect(screen.getByText(/2026-05-04 to 2026-05-04/)).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Today" })).toHaveAttribute("aria-pressed", "true");
+      expect(screen.getByText(/Today · UTC/)).toBeInTheDocument();
     });
+  });
+
+  it("opens the profile modal from contributor rows", async () => {
+    render(<StatsPage />);
+    await screen.findByText("Contributor Highlights");
+
+    fireEvent.click(screen.getByRole("button", { name: /Ada/i }));
+
+    expect(await screen.findByRole("heading", { name: "User Profile" })).toBeInTheDocument();
+    expect(screen.getByText(/Radio planner/)).toBeInTheDocument();
+    expect(fetch).toHaveBeenCalledWith("/api/users/u1", expect.objectContaining({ method: "GET" }));
   });
 
   it("renders polished empty states", async () => {
@@ -123,11 +199,12 @@ describe("StatsPage", () => {
         ok: true,
         json: async () => ({
           ...statsPayload,
-          growth: { monthly: [], weekly: [] },
+          growth: { ...statsPayload.growth, today: [], last7Days: [], last30Days: [], lastYear: [], allTime: [], monthly: [], weekly: [] },
           geography: { binSizeDegrees: 1, bins: [] },
           latestSimulations: [],
           linkDistanceDistribution: [],
           siteDensitySummary: [],
+          longestLinks: [],
         }),
       })),
     );

--- a/src/components/StatsPage.tsx
+++ b/src/components/StatsPage.tsx
@@ -1,4 +1,4 @@
-import { Activity, ExternalLink, MapPinned, Network, Radio, Ruler, Sparkles, Users } from "lucide-react";
+import { Activity, ArrowLeft, ExternalLink, MapPinned, Network, Radio, Ruler, Users } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import type { CSSProperties, ReactNode } from "react";
 import {
@@ -16,18 +16,49 @@ import {
 import { ActionButton } from "./ActionButton";
 import { AvatarBadge } from "./AvatarBadge";
 import { StatsDensityMap } from "./StatsDensityMap";
+import { UserProfileModal } from "./UserProfileModal";
+import { fetchUserById, type CloudUser } from "../lib/cloudUser";
+import { getUiErrorMessage } from "../lib/uiError";
 import { fetchStats, type StatsGrowthBucket, type StatsPayload } from "../lib/stats";
 import { useThemeVariant } from "../hooks/useThemeVariant";
 
-type GrowthMode = "monthly" | "weekly";
+type GrowthMode = "today" | "last7Days" | "last30Days" | "lastYear" | "allTime";
 
 const formatNumber = (value: number): string => new Intl.NumberFormat("en").format(value);
 const formatDecimal = (value: number): string => new Intl.NumberFormat("en", { maximumFractionDigits: 1 }).format(value);
-const chartColors = ["var(--accent)", "var(--success)", "var(--temporary)", "var(--warning)"];
+const formatKm = (value: number): string => `${formatDecimal(value)} km`;
+
+const chartColors = {
+  users: "var(--stats-series-users)",
+  sites: "var(--stats-series-sites)",
+  simulations: "var(--stats-series-simulations)",
+  links: "var(--stats-series-links)",
+};
 
 const growthLabels: Record<GrowthMode, string> = {
-  monthly: "All time",
-  weekly: "Last 30 days",
+  today: "Today",
+  last7Days: "Last 7 days",
+  last30Days: "Last 30 days",
+  lastYear: "Last year",
+  allTime: "All time",
+};
+
+const rangeOptions = Object.entries(growthLabels) as Array<[GrowthMode, string]>;
+
+const formatRelativeTime = (value: string): string => {
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) return "Unknown signup time";
+  const diffMs = date.getTime() - Date.now();
+  const units: Array<[Intl.RelativeTimeFormatUnit, number]> = [
+    ["year", 1000 * 60 * 60 * 24 * 365],
+    ["month", 1000 * 60 * 60 * 24 * 30],
+    ["day", 1000 * 60 * 60 * 24],
+    ["hour", 1000 * 60 * 60],
+    ["minute", 1000 * 60],
+  ];
+  const formatter = new Intl.RelativeTimeFormat("en", { numeric: "always" });
+  const [unit, unitMs] = units.find(([, size]) => Math.abs(diffMs) >= size) ?? ["minute", 1000 * 60];
+  return formatter.format(Math.round(diffMs / unitMs), unit);
 };
 
 const CustomTooltip = ({ active, label, payload }: { active?: boolean; label?: string; payload?: Array<{ name?: string; value?: number; color?: string }> }) => {
@@ -76,7 +107,10 @@ const MetricCard = ({
   </article>
 );
 
-const GrowthChart = ({ buckets }: { buckets: StatsGrowthBucket[] }) => {
+const sumGrowth = (buckets: StatsGrowthBucket[], key: "users" | "sites" | "simulations" | "links") =>
+  buckets.reduce((sum, bucket) => sum + bucket[key], 0);
+
+const GrowthChart = ({ buckets, label }: { buckets: StatsGrowthBucket[]; label: string }) => {
   if (!buckets.length) {
     return <div className="stats-empty">Growth appears after dated community activity is available.</div>;
   }
@@ -89,29 +123,39 @@ const GrowthChart = ({ buckets }: { buckets: StatsGrowthBucket[] }) => {
           <YAxis stroke="var(--muted)" tickLine={false} width={42} />
           <Tooltip content={<CustomTooltip />} />
           <Legend iconType="circle" />
-          <Line dataKey="cumulativeUsers" dot={false} name="Users" stroke={chartColors[0]} strokeWidth={3} type="monotone" />
-          <Line dataKey="cumulativeSites" dot={false} name="Sites" stroke={chartColors[1]} strokeWidth={3} type="monotone" />
-          <Line dataKey="cumulativeSimulations" dot={false} name="Simulations" stroke={chartColors[2]} strokeWidth={3} type="monotone" />
-          <Line dataKey="cumulativeLinks" dot={false} name="Links" stroke={chartColors[3]} strokeWidth={3} type="monotone" />
+          <Line dataKey="cumulativeUsers" dot={false} name="Users" stroke={chartColors.users} strokeWidth={3} type="monotone" />
+          <Line dataKey="cumulativeSites" dot={false} name="Sites" stroke={chartColors.sites} strokeWidth={3} type="monotone" />
+          <Line dataKey="cumulativeSimulations" dot={false} name="Simulations" stroke={chartColors.simulations} strokeWidth={3} type="monotone" />
+          <Line dataKey="cumulativeLinks" dot={false} name="Links" stroke={chartColors.links} strokeWidth={3} type="monotone" />
         </LineChart>
       </ResponsiveContainer>
-      <p className="stats-chart-range">{buckets[0]?.label} to {buckets.at(-1)?.label}</p>
+      <p className="stats-chart-range">{label} · UTC · X: time · Y: cumulative count</p>
     </div>
   );
+};
+
+const activeBar = {
+  fillOpacity: 0.92,
+  stroke: "var(--text)",
+  strokeOpacity: 0.72,
+  strokeWidth: 2,
 };
 
 const SizeBucketsChart = ({ buckets }: { buckets: StatsPayload["complexity"]["sizeBuckets"] }) => {
   const data = Object.entries(buckets).map(([label, count]) => ({ label, count }));
   return (
-    <ResponsiveContainer height={180} width="100%">
-      <BarChart data={data} margin={{ top: 8, right: 8, bottom: 10, left: -18 }}>
-        <CartesianGrid stroke="var(--panel-shell-divider)" strokeDasharray="3 7" vertical={false} />
-        <XAxis dataKey="label" stroke="var(--muted)" tickLine={false} />
-        <YAxis allowDecimals={false} stroke="var(--muted)" tickLine={false} />
-        <Tooltip content={<CustomTooltip />} />
-        <Bar dataKey="count" fill="var(--temporary)" name="Simulations" radius={[6, 6, 0, 0]} />
-      </BarChart>
-    </ResponsiveContainer>
+    <>
+      <ResponsiveContainer height={180} width="100%">
+        <BarChart data={data} margin={{ top: 8, right: 8, bottom: 10, left: -18 }}>
+          <CartesianGrid stroke="var(--panel-shell-divider)" strokeDasharray="3 7" vertical={false} />
+          <XAxis dataKey="label" stroke="var(--muted)" tickLine={false} />
+          <YAxis allowDecimals={false} stroke="var(--muted)" tickLine={false} />
+          <Tooltip content={<CustomTooltip />} />
+          <Bar activeBar={activeBar} dataKey="count" fill={chartColors.simulations} name="Simulations" radius={[6, 6, 0, 0]} />
+        </BarChart>
+      </ResponsiveContainer>
+      <p className="stats-chart-range">X: Sites per Simulation · Y: Simulations</p>
+    </>
   );
 };
 
@@ -120,15 +164,18 @@ const DistanceChart = ({ buckets }: { buckets: StatsPayload["linkDistanceDistrib
     return <div className="stats-empty is-compact">Link distances appear after saved Links have endpoints with coordinates.</div>;
   }
   return (
-    <ResponsiveContainer height={180} width="100%">
-      <BarChart data={buckets} margin={{ top: 8, right: 8, bottom: 10, left: -18 }}>
-        <CartesianGrid stroke="var(--panel-shell-divider)" strokeDasharray="3 7" vertical={false} />
-        <XAxis dataKey="label" stroke="var(--muted)" tickLine={false} />
-        <YAxis allowDecimals={false} stroke="var(--muted)" tickLine={false} />
-        <Tooltip content={<CustomTooltip />} />
-        <Bar dataKey="count" fill="var(--warning)" name="Links" radius={[6, 6, 0, 0]} />
-      </BarChart>
-    </ResponsiveContainer>
+    <>
+      <ResponsiveContainer height={180} width="100%">
+        <BarChart data={buckets} margin={{ top: 8, right: 8, bottom: 10, left: -18 }}>
+          <CartesianGrid stroke="var(--panel-shell-divider)" strokeDasharray="3 7" vertical={false} />
+          <XAxis dataKey="label" stroke="var(--muted)" tickLine={false} />
+          <YAxis allowDecimals={false} stroke="var(--muted)" tickLine={false} />
+          <Tooltip content={<CustomTooltip />} />
+          <Bar activeBar={activeBar} dataKey="count" fill={chartColors.links} name="Links" radius={[6, 6, 0, 0]} />
+        </BarChart>
+      </ResponsiveContainer>
+      <p className="stats-chart-range">X: Link distance · Y: Links</p>
+    </>
   );
 };
 
@@ -137,7 +184,11 @@ export function StatsPage() {
   const [stats, setStats] = useState<StatsPayload | null>(null);
   const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
   const [errorMessage, setErrorMessage] = useState("");
-  const [growthMode, setGrowthMode] = useState<GrowthMode>("monthly");
+  const [growthMode, setGrowthMode] = useState<GrowthMode>("last30Days");
+  const [profileUser, setProfileUser] = useState<CloudUser | null>(null);
+  const [profileBusy, setProfileBusy] = useState(false);
+  const [profileStatus, setProfileStatus] = useState("");
+  const showProfileModal = profileBusy || profileStatus || profileUser;
 
   useEffect(() => {
     const root = document.documentElement;
@@ -171,23 +222,50 @@ export function StatsPage() {
     };
   }, []);
 
+  const openUserProfile = async (userId: string) => {
+    setProfileUser(null);
+    setProfileStatus("");
+    setProfileBusy(true);
+    try {
+      setProfileUser(await fetchUserById(userId));
+    } catch (error) {
+      setProfileStatus(`Failed loading user: ${getUiErrorMessage(error)}`);
+    } finally {
+      setProfileBusy(false);
+    }
+  };
+
+  const closeUserProfile = () => {
+    setProfileUser(null);
+    setProfileStatus("");
+    setProfileBusy(false);
+  };
+
   const activeGrowth = useMemo(() => stats?.growth[growthMode] ?? [], [growthMode, stats]);
-  const latestBucket = activeGrowth.at(-1);
 
   return (
     <main className="stats-page stats-atlas-page">
       <header className="stats-atlas-header">
-        <div>
+        <a className="btn-ghost stats-back-link" href="/">
+          <ArrowLeft aria-hidden="true" size={16} />
+          Back to app
+        </a>
+        <div className="stats-atlas-title">
           <h1>Stats</h1>
           <p>Public aggregate signals from entered Sites, saved Simulations, and community growth.</p>
         </div>
-        <div className="chip-group" aria-label="Stats time range">
-          <ActionButton aria-pressed={growthMode === "monthly"} onClick={() => setGrowthMode("monthly")} type="button">
-            All time
-          </ActionButton>
-          <ActionButton aria-pressed={growthMode === "weekly"} onClick={() => setGrowthMode("weekly")} type="button">
-            Last 30 days
-          </ActionButton>
+        <div className="chip-group stats-range-control" aria-label="Stats time range">
+          {rangeOptions.map(([mode, label]) => (
+            <ActionButton
+              aria-pressed={growthMode === mode}
+              className={growthMode === mode ? "is-selected" : ""}
+              key={mode}
+              onClick={() => setGrowthMode(mode)}
+              type="button"
+            >
+              {label}
+            </ActionButton>
+          ))}
         </div>
       </header>
 
@@ -199,15 +277,15 @@ export function StatsPage() {
       ) : null}
 
       <section className="stats-atlas-metrics" aria-label="Community totals">
-        <MetricCard delta={latestBucket?.users ?? 0} icon={Users} label="Users" value={stats?.totals.users ?? 0} />
-        <MetricCard delta={latestBucket?.sites ?? 0} icon={MapPinned} label="Sites" value={stats?.totals.sites ?? 0} />
-        <MetricCard delta={latestBucket?.simulations ?? 0} icon={Network} label="Simulations" value={stats?.totals.simulations ?? 0} />
-        <MetricCard delta={latestBucket?.links ?? 0} icon={Radio} label="Links" value={stats?.totals.links ?? 0} />
+        <MetricCard delta={sumGrowth(activeGrowth, "users")} icon={Users} label="Users" value={stats?.totals.users ?? 0} />
+        <MetricCard delta={sumGrowth(activeGrowth, "sites")} icon={MapPinned} label="Sites" value={stats?.totals.sites ?? 0} />
+        <MetricCard delta={sumGrowth(activeGrowth, "simulations")} icon={Network} label="Simulations" value={stats?.totals.simulations ?? 0} />
+        <MetricCard delta={sumGrowth(activeGrowth, "links")} icon={Radio} label="Links" value={stats?.totals.links ?? 0} />
       </section>
 
       <section className="stats-atlas-grid">
         <Panel className="stats-atlas-map-panel" title="Site Geography">
-          <p className="field-help">Binned density from user-entered Site coordinates. Exact coordinates stay out of the stats payload.</p>
+          <p className="field-help">Binned density from user-entered Site coordinates. Hover or tap a cluster for the coarse area count.</p>
           {status === "loading" || !stats ? (
             <div className="stats-map-skeleton">Loading Site density...</div>
           ) : (
@@ -224,10 +302,13 @@ export function StatsPage() {
         <Panel className="stats-atlas-side-panel" title="Contributor Highlights">
           <div className="stats-person-list">
             {(stats?.highlights.topContributors ?? []).map((user) => (
-              <button className="stats-person-row" key={user.userId} type="button">
+              <button className="stats-person-row" key={user.userId} onClick={() => void openUserProfile(user.userId)} type="button">
                 <AvatarBadge avatarUrl={user.avatarUrl} imageClassName="profile-avatar" name={user.username} />
                 <span>{user.username}</span>
-                <strong>{formatNumber(user.contributions)}</strong>
+                <span className="stats-contribution-count">
+                  <strong>{formatNumber(user.contributions)}</strong>
+                  <small>Sites + Simulations</small>
+                </span>
               </button>
             ))}
             {!stats?.highlights.topContributors.length ? <p className="field-help">Contributor highlights appear after community resources are saved.</p> : null}
@@ -235,8 +316,7 @@ export function StatsPage() {
         </Panel>
 
         <Panel className="stats-atlas-wide-panel" title="Growth over time">
-          <GrowthChart buckets={activeGrowth} />
-          <span className="stats-chip">{growthLabels[growthMode]}</span>
+          <GrowthChart buckets={activeGrowth} label={growthLabels[growthMode]} />
         </Panel>
 
         <Panel title="Latest Simulations">
@@ -259,9 +339,7 @@ export function StatsPage() {
         <Panel title="Simulation Complexity">
           <div className="stats-complexity-grid">
             <span><strong>{formatDecimal(stats?.complexity.averageSitesPerSimulation ?? 0)}</strong>Avg. Sites</span>
-            <span><strong>{formatDecimal(stats?.complexity.medianSitesPerSimulation ?? 0)}</strong>Median Sites</span>
             <span><strong>{formatDecimal(stats?.complexity.averageLinksPerSimulation ?? 0)}</strong>Avg. Links</span>
-            <span><strong>{formatDecimal(stats?.complexity.medianLinksPerSimulation ?? 0)}</strong>Median Links</span>
           </div>
           <p className="field-help">Excludes empty Simulations with no Sites.</p>
         </Panel>
@@ -270,49 +348,57 @@ export function StatsPage() {
           <SizeBucketsChart buckets={stats?.complexity.sizeBuckets ?? { "1-2": 0, "3-5": 0, "6-10": 0, "11+": 0 }} />
         </Panel>
 
-        <Panel title="Site Density">
-          <div className="stats-density-list">
-            {(stats?.siteDensitySummary ?? []).map((bin) => (
-              <div className="stats-density-row" key={bin.label}>
-                <span>{bin.label}</span>
-                <strong>{bin.count}</strong>
-              </div>
-            ))}
-            {!stats?.siteDensitySummary.length ? <p className="field-help">Site density appears after Sites with coordinates are created.</p> : null}
-          </div>
-        </Panel>
-
         <Panel title="Link Distance Distribution">
           <DistanceChart buckets={stats?.linkDistanceDistribution ?? []} />
         </Panel>
 
-        <Panel title="Network Flavor">
-          <div className="stats-flavor-lockup">
-            <Activity aria-hidden="true" size={20} />
-            <p className="field-help">Frequency, band, and Channel analysis will use saved Link and Network fields in a later pass.</p>
+        <Panel title="Top 5 Longest Links">
+          <div className="stats-simulation-list">
+            {(stats?.longestLinks ?? []).map((link) => (
+              <a className="stats-simulation-row" href={link.href || link.simulationHref} key={link.id}>
+                <span>
+                  <strong>{link.label}</strong>
+                  <small>{link.simulationName} · by {link.owner.username}</small>
+                </span>
+                <span>{formatKm(link.distanceKm)}</span>
+                <ExternalLink aria-hidden="true" size={15} />
+              </a>
+            ))}
+            {!stats?.longestLinks.length ? <p className="field-help">Longest Links appear after saved Links have endpoints with coordinates.</p> : null}
           </div>
         </Panel>
 
         <Panel title="Newest Members">
           <div className="stats-person-list">
             {(stats?.highlights.newestMembers ?? []).map((user) => (
-              <div className="stats-person-row" key={user.userId}>
+              <button className="stats-person-row" key={user.userId} onClick={() => void openUserProfile(user.userId)} type="button">
                 <AvatarBadge avatarUrl={user.avatarUrl} imageClassName="profile-avatar" name={user.username} />
                 <span>{user.username}</span>
-                <Sparkles aria-hidden="true" size={14} />
-              </div>
+                <span className="stats-person-meta">{formatRelativeTime(user.createdAt)}</span>
+              </button>
             ))}
             {!stats?.highlights.newestMembers.length ? <p className="field-help">Newest members appear after users join.</p> : null}
           </div>
         </Panel>
 
-        <Panel title="Distance Notes">
+        <Panel className="stats-atlas-placeholder-panel" title="Network Flavor">
+          <div className="stats-flavor-lockup">
+            <Activity aria-hidden="true" size={20} />
+            <p className="field-help">Future analysis from saved Link and Channel fields.</p>
+          </div>
+        </Panel>
+
+        <Panel className="stats-atlas-placeholder-panel" title="Distance Notes">
           <div className="stats-flavor-lockup">
             <Ruler aria-hidden="true" size={20} />
             <p className="field-help">Distances are derived from saved Simulation endpoints and grouped into public aggregate buckets.</p>
           </div>
         </Panel>
       </section>
+
+      {showProfileModal ? (
+        <UserProfileModal busy={profileBusy} onClose={closeUserProfile} status={profileStatus} user={profileUser} />
+      ) : null}
     </main>
   );
 }

--- a/src/components/UserProfileModal.tsx
+++ b/src/components/UserProfileModal.tsx
@@ -1,0 +1,46 @@
+import type { CloudUser } from "../lib/cloudUser";
+import { formatDate } from "../lib/locale";
+import { AvatarBadge } from "./AvatarBadge";
+import { InlineCloseIconButton } from "./InlineCloseIconButton";
+import { ModalOverlay } from "./ModalOverlay";
+
+type UserProfileModalProps = {
+  busy?: boolean;
+  onClose: () => void;
+  status?: string;
+  user: CloudUser | null;
+};
+
+const UserBadge = ({ name, avatarUrl }: { name: string; avatarUrl?: string | null }) => (
+  <span className="user-list-row">
+    <AvatarBadge avatarUrl={avatarUrl} imageClassName="profile-avatar" name={name} />
+    <span>{name}</span>
+  </span>
+);
+
+export function UserProfileModal({ busy = false, onClose, status = "", user }: UserProfileModalProps) {
+  return (
+    <ModalOverlay aria-label="User Profile" onClose={onClose} tier="raised">
+      <div className="library-manager-card user-profile-popup">
+        <div className="library-manager-header">
+          <h2>User Profile</h2>
+          <InlineCloseIconButton onClick={onClose} />
+        </div>
+        {busy ? <p className="field-help">Loading user...</p> : null}
+        {user ? (
+          <>
+            <p className="field-help">
+              <strong>
+                <UserBadge avatarUrl={user.avatarUrl} name={user.username} />
+              </strong>
+            </p>
+            {user.email ? <p className="field-help">Email: {user.email}</p> : null}
+            <p className="field-help">Bio: {user.bio || "-"}</p>
+            <p className="field-help">Created {formatDate(user.createdAt)}</p>
+          </>
+        ) : null}
+        {status ? <p className="field-help">{status}</p> : null}
+      </div>
+    </ModalOverlay>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -931,11 +931,18 @@ button {
 }
 
 .stats-page {
-  min-height: 100lvh;
+  height: 100dvh;
+  min-height: 100dvh;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
   padding: clamp(14px, 3vw, 34px);
   display: grid;
   gap: 14px;
   align-content: start;
+  --stats-series-users: var(--accent);
+  --stats-series-sites: var(--success);
+  --stats-series-simulations: var(--temporary);
+  --stats-series-links: var(--selection);
 }
 
 .stats-atlas-page {
@@ -945,11 +952,24 @@ button {
 }
 
 .stats-atlas-header {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: flex-end;
   gap: 16px;
   padding: 4px 0 8px;
+}
+
+.stats-atlas-title {
+  min-width: 0;
+}
+
+.stats-back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  align-self: end;
+  text-decoration: none;
+  white-space: nowrap;
 }
 
 .stats-atlas-header h1 {
@@ -977,6 +997,10 @@ button {
   color: var(--muted);
   font-size: 0.75rem;
   white-space: nowrap;
+}
+
+.stats-range-control {
+  justify-content: flex-end;
 }
 
 .stats-atlas-metrics {
@@ -1076,103 +1100,33 @@ button {
   font-family: var(--font-ui);
 }
 
-.stats-map-marker-layer {
-  position: absolute;
-  inset: 0;
-  z-index: 1;
-  pointer-events: none;
-}
-
-.stats-map-marker-layer::before {
-  position: absolute;
-  inset: 0;
-  background:
-    linear-gradient(color-mix(in srgb, var(--border) 24%, transparent) 1px, transparent 1px),
-    linear-gradient(90deg, color-mix(in srgb, var(--border) 22%, transparent) 1px, transparent 1px),
-    radial-gradient(circle at 70% 34%, color-mix(in srgb, var(--accent-soft) 36%, transparent), transparent 34%);
-  background-size: 96px 96px, 96px 96px, 100% 100%;
-  content: "";
-  opacity: 0.5;
-}
-
-.stats-map-marker {
-  position: absolute;
-  width: var(--marker-size);
-  height: var(--marker-size);
-  display: grid;
-  place-items: center;
-  border: 2px solid color-mix(in srgb, var(--surface) 84%, transparent);
-  border-radius: var(--radius-pill);
-  background:
-    radial-gradient(circle at 50% 50%, color-mix(in srgb, var(--warning) 86%, var(--accent) 14%) 0 35%, transparent 36%),
-    color-mix(in srgb, var(--warning) 30%, transparent);
-  box-shadow:
-    0 0 0 8px color-mix(in srgb, var(--warning) 18%, transparent),
-    0 14px 26px color-mix(in srgb, var(--text) 18%, transparent);
-  color: var(--text);
-  cursor: pointer;
-  font: 700 0.72rem/1 var(--font-ui);
-  pointer-events: auto;
-  transform: translate(-50%, -50%);
-  transition:
-    box-shadow 160ms ease,
-    transform 160ms ease;
-}
-
-.stats-map-marker:hover,
-.stats-map-marker:focus-visible {
-  outline: 2px solid var(--focus-outline);
-  outline-offset: 3px;
-  transform: translate(-50%, -50%) scale(1.05);
-}
-
-.stats-map-reset,
-.stats-map-legend {
+.stats-map-controls,
+.stats-map-attribution {
   position: absolute;
   z-index: 2;
 }
 
-.stats-map-reset {
-  right: 12px;
+.stats-map-controls.map-controls {
   top: 12px;
+  left: 12px;
+  right: auto;
+  padding: 0;
 }
 
-.stats-map-legend {
+.stats-map-attribution.floating-attribution-pill {
+  position: absolute;
   right: 12px;
-  bottom: 28px;
-  display: inline-flex;
-  align-items: center;
-  gap: 9px;
-  border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--surface) 88%, transparent);
-  padding: 7px 9px;
-  color: var(--muted);
-  font-size: 0.78rem;
-}
-
-.stats-map-legend i {
-  width: 64px;
-  height: 8px;
-  border-radius: var(--radius-pill);
-  background: linear-gradient(90deg, color-mix(in srgb, var(--accent) 14%, transparent), var(--accent));
+  bottom: 12px;
+  left: auto;
+  transform: none;
+  z-index: 2;
 }
 
 .stats-map-popup {
-  position: absolute;
   display: grid;
   gap: 2px;
-  z-index: 3;
-  min-width: 132px;
-  border: 1px solid color-mix(in srgb, var(--border) 74%, transparent);
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--surface) 92%, transparent);
-  box-shadow: var(--shadow-elev-2);
-  padding: 8px 10px;
   color: var(--text);
   font-family: var(--font-ui);
-  pointer-events: none;
-  transform: translate(-50%, calc(-100% - 16px));
 }
 
 .stats-map-popup span {
@@ -1267,6 +1221,30 @@ button {
 .stats-person-row strong,
 .stats-density-row strong {
   font-family: var(--font-mono);
+}
+
+.stats-person-meta {
+  color: var(--muted);
+  font-size: 0.78rem;
+  text-align: right;
+}
+
+.stats-contribution-count {
+  display: grid;
+  gap: 1px;
+  justify-items: end;
+  min-width: 86px;
+  text-align: right;
+}
+
+.stats-contribution-count strong {
+  font-family: var(--font-mono);
+}
+
+.stats-contribution-count small {
+  color: var(--muted);
+  font-size: 0.68rem;
+  line-height: 1.05;
 }
 
 .stats-simulation-row {
@@ -1366,8 +1344,12 @@ button {
   }
 
   .stats-atlas-header {
-    flex-direction: column;
+    grid-template-columns: 1fr;
     align-items: stretch;
+  }
+
+  .stats-range-control {
+    justify-content: flex-start;
   }
 
   .stats-atlas-metrics,

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -20,6 +20,11 @@ export type StatsPayload = {
     links: number;
   };
   growth: {
+    today: StatsGrowthBucket[];
+    last7Days: StatsGrowthBucket[];
+    last30Days: StatsGrowthBucket[];
+    lastYear: StatsGrowthBucket[];
+    allTime: StatsGrowthBucket[];
     monthly: StatsGrowthBucket[];
     weekly: StatsGrowthBucket[];
   };
@@ -54,6 +59,19 @@ export type StatsPayload = {
     };
     siteCount: number;
     linkCount: number;
+  }>;
+  longestLinks: Array<{
+    id: string;
+    label: string;
+    href: string;
+    simulationHref: string;
+    simulationName: string;
+    distanceKm: number;
+    owner: {
+      userId: string;
+      username: string;
+      avatarUrl: string;
+    };
   }>;
   linkDistanceDistribution: Array<{
     label: string;


### PR DESCRIPTION
## Summary
- polish the Stats Atlas layout with a back link, five-range control, distinct chart colors, labelled contributor counts, relative newest-member times, and longest-link rows
- simplify stats geography to one MapLibre density layer with existing map-style controls/attribution and mobile-safe touch behavior
- extend /api/stats with UTC growth ranges and top longest saved links while keeping aggregate/privacy-safe payloads

## Verification
- npm test -- --run functions/api/stats.test.ts src/components/StatsPage.test.tsx
- npm test
- npm run build
- Playwright visual QA on desktop/mobile for scroll, map controls/attribution, range toggle, chart hover, profile modal, and no console errors

Closes follow-up polish for #853