### PR TITLE
Polish stats Atlas interactions

### DIFF
--- a/functions/api/stats.test.ts
+++ b/functions/api/stats.test.ts
@@ -74,6 +74,7 @@ beforeEach(() => {
           links: [
             { id: "l1", name: "Short ridge", fromSiteId: "s1", toSiteId: "s2", frequencyMHz: 868 },
             { id: "l2", fromSiteId: "s2", toSiteId: "s3", frequencyMHz: 915 },
+            { id: "auto-link", name: " Auto link ", fromSiteId: "s1", toSiteId: "s3", frequencyMHz: 868 },
             { id: "bad-link", fromSiteId: "s1", toSiteId: "missing" },
           ],
         },
@@ -122,10 +123,10 @@ describe("api/stats", () => {
       sites: 3,
       simulations: 3,
       nonEmptySimulations: 2,
-      links: 5,
+      links: 6,
     });
     expect(body.complexity.averageSitesPerSimulation).toBe(2);
-    expect(body.complexity.averageLinksPerSimulation).toBe(2.5);
+    expect(body.complexity.averageLinksPerSimulation).toBe(3);
   });
 
   it("returns latest non-empty simulations and link distance buckets without leaking payloads", async () => {
@@ -159,11 +160,11 @@ describe("api/stats", () => {
         name: "Private sim",
         href: "/Ada/Private-sim",
         siteCount: 3,
-        linkCount: 3,
+        linkCount: 4,
       }),
     ]);
     expect(body.latestSimulations.some((entry) => entry.id === "sim-empty")).toBe(false);
-    expect(body.linkDistanceDistribution.reduce((sum, bucket) => sum + bucket.count, 0)).toBe(2);
+    expect(body.linkDistanceDistribution.reduce((sum, bucket) => sum + bucket.count, 0)).toBe(3);
     expect(body.longestLinks).toHaveLength(2);
     expect(body.longestLinks[0]).toMatchObject({
       label: "South ~ East",
@@ -171,6 +172,7 @@ describe("api/stats", () => {
       simulationName: "Private sim",
       owner: { username: "Ada" },
     });
+    expect(body.longestLinks.some((entry) => entry.label.trim().toLowerCase() === "auto link")).toBe(false);
     expect(body.longestLinks[0].distanceKm).toBeGreaterThan(body.longestLinks[1].distanceKm);
     expect(body.siteDensitySummary).toEqual([{ label: "60°N, 10°E", count: 2 }]);
     expect(raw).not.toContain("60.1");
@@ -199,8 +201,8 @@ describe("api/stats", () => {
     expect(body.growth.lastYear).toHaveLength(12);
     expect(body.growth.allTime).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ label: "2026-01", users: 1, sites: 1, simulations: 1, links: 3, cumulativeLinks: 3 }),
-        expect.objectContaining({ label: "2026-02", users: 1, sites: 2, simulations: 2, links: 2, cumulativeLinks: 5 }),
+        expect.objectContaining({ label: "2026-01", users: 1, sites: 1, simulations: 1, links: 4, cumulativeLinks: 4 }),
+        expect.objectContaining({ label: "2026-02", users: 1, sites: 2, simulations: 2, links: 2, cumulativeLinks: 6 }),
       ]),
     );
     expect(body.growth.monthly).toEqual(body.growth.allTime);

--- a/functions/api/stats.ts
+++ b/functions/api/stats.ts
@@ -281,6 +281,8 @@ const average = (values: number[]): number =>
   values.length ? values.reduce((sum, value) => sum + value, 0) / values.length : 0;
 
 const round1 = (value: number): number => Math.round(value * 10) / 10;
+const isAutoLinkName = (value: unknown): boolean =>
+  typeof value === "string" && value.trim().toLowerCase() === "auto link";
 
 const bucketSimulationSize = (siteCount: number): "1-2" | "3-5" | "6-10" | "11+" => {
   if (siteCount <= 2) return "1-2";
@@ -478,6 +480,7 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
         const fromName = typeof from?.name === "string" && from.name.trim() ? from.name.trim() : "Site A";
         const toName = typeof to?.name === "string" && to.name.trim() ? to.name.trim() : "Site B";
         const linkName = typeof link.name === "string" && link.name.trim() ? link.name.trim() : `${fromName} ~ ${toName}`;
+        if (isAutoLinkName(link.name)) return;
         longestLinks.push({
           id: `${simulation.id}:${typeof link.id === "string" ? link.id : `${link.fromSiteId}-${link.toSiteId}`}`,
           label: linkName,

--- a/src/components/StatsDensityMap.test.tsx
+++ b/src/components/StatsDensityMap.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+
+const mockFitBounds = vi.fn();
+
+vi.mock("react-map-gl/maplibre", () => ({
+  default: ({
+    children,
+    onClick,
+    onLoad,
+    onMouseMove,
+  }: {
+    children: ReactNode;
+    onClick?: (event: unknown) => void;
+    onLoad?: (event: unknown) => void;
+    onMouseMove?: (event: unknown) => void;
+  }) => {
+    const event = {
+      features: [
+        {
+          geometry: { type: "Point", coordinates: [10.5, 60.5] },
+          properties: { count: 5, label: "60 degrees N, 10 degrees E" },
+        },
+      ],
+    };
+    return (
+      <div data-testid="mock-map">
+        <button onClick={() => onLoad?.({ target: { fitBounds: mockFitBounds } })} type="button">Load map</button>
+        <button onClick={() => onMouseMove?.(event)} type="button">Hover bin</button>
+        <button onClick={() => onClick?.(event)} type="button">Click bin</button>
+        {children}
+      </div>
+    );
+  },
+  Layer: () => <div data-testid="mock-layer" />,
+  Popup: ({ children, className, latitude, longitude }: { children: ReactNode; className?: string; latitude: number; longitude: number }) => (
+    <div className={className} data-latitude={latitude} data-longitude={longitude} data-testid="mock-popup">
+      {children}
+    </div>
+  ),
+  Source: ({ children }: { children: ReactNode }) => <div data-testid="mock-source">{children}</div>,
+}));
+
+import { StatsDensityMap } from "./StatsDensityMap";
+
+describe("StatsDensityMap", () => {
+  it("uses centered controls and a shared surface hover popup anchored to the bin center", async () => {
+    render(
+      <StatsDensityMap
+        accentColor="var(--accent)"
+        bins={[{ latBand: 60, lonBand: 10, count: 5 }]}
+        surfaceColor="var(--surface)"
+        theme="light"
+      />,
+    );
+
+    expect(screen.getByLabelText("Zoom out Site density map").closest(".stats-map-controls")).toHaveClass("map-controls");
+    expect(screen.getByText("CARTO").closest(".stats-map-attribution")).toHaveClass("floating-attribution-pill");
+
+    await userEvent.click(screen.getByRole("button", { name: "Hover bin" }));
+
+    const popup = screen.getByTestId("mock-popup");
+    expect(popup).toHaveClass("stats-map-popup-shell");
+    expect(popup).toHaveAttribute("data-longitude", "10.5");
+    expect(popup).toHaveAttribute("data-latitude", "60.5");
+    expect(screen.getByText("5 Sites").closest(".stats-map-popup")).toHaveClass("ui-surface-pill", "has-pointer-tail");
+  });
+});

--- a/src/components/StatsDensityMap.tsx
+++ b/src/components/StatsDensityMap.tsx
@@ -89,6 +89,35 @@ export function StatsDensityMap({ bins, theme, colorTheme = "blue", accentColor,
     return <div className="stats-empty">Site density will appear after Sites with coordinates are created.</div>;
   }
 
+  const hoverFromFeature = (event: MapLayerMouseEvent) => {
+    const feature = event.features?.[0];
+    const properties = feature?.properties as Partial<DensityProperties> | undefined;
+    if (!feature || !properties || typeof properties.count !== "number" || feature.geometry.type !== "Point") {
+      setHovered(null);
+      return;
+    }
+    const count = properties.count;
+    const [longitude, latitude] = feature.geometry.coordinates;
+    setHovered((current) => {
+      const next = {
+        longitude,
+        latitude,
+        count,
+        label: String(properties.label ?? "Site density bin"),
+      };
+      if (
+        current &&
+        current.longitude === next.longitude &&
+        current.latitude === next.latitude &&
+        current.count === next.count &&
+        current.label === next.label
+      ) {
+        return current;
+      }
+      return next;
+    });
+  };
+
   return (
     <div className="stats-map-shell">
       <Map
@@ -102,31 +131,8 @@ export function StatsDensityMap({ bins, theme, colorTheme = "blue", accentColor,
         onError={() => setHovered(null)}
         onLoad={(event) => fitBins(event.target as unknown as MapRef, bins)}
         onMouseLeave={() => setHovered(null)}
-        onMouseMove={(event: MapLayerMouseEvent) => {
-          const feature = event.features?.[0];
-          const properties = feature?.properties as Partial<DensityProperties> | undefined;
-          if (!feature || !properties || typeof properties.count !== "number") {
-            setHovered(null);
-            return;
-          }
-          setHovered({
-            longitude: event.lngLat.lng,
-            latitude: event.lngLat.lat,
-            count: properties.count,
-            label: String(properties.label ?? "Site density bin"),
-          });
-        }}
-        onClick={(event: MapLayerMouseEvent) => {
-          const feature = event.features?.[0];
-          const properties = feature?.properties as Partial<DensityProperties> | undefined;
-          if (!feature || !properties || typeof properties.count !== "number") return;
-          setHovered({
-            longitude: event.lngLat.lng,
-            latitude: event.lngLat.lat,
-            count: properties.count,
-            label: String(properties.label ?? "Site density bin"),
-          });
-        }}
+        onMouseMove={hoverFromFeature}
+        onClick={hoverFromFeature}
         interactiveLayerIds={["stats-density-bins"]}
       >
         <Source data={featureCollection} id="stats-density" type="geojson">
@@ -153,8 +159,8 @@ export function StatsDensityMap({ bins, theme, colorTheme = "blue", accentColor,
           />
         </Source>
         {hovered ? (
-          <Popup closeButton={false} closeOnClick={false} latitude={hovered.latitude} longitude={hovered.longitude} offset={14}>
-            <div className="stats-map-popup">
+          <Popup className="stats-map-popup-shell" closeButton={false} closeOnClick={false} latitude={hovered.latitude} longitude={hovered.longitude} offset={14}>
+            <div className="ui-surface-pill has-pointer-tail stats-map-popup">
               <strong>{hovered.count} Sites</strong>
               <span>{hovered.label}</span>
             </div>

--- a/src/components/StatsPage.test.tsx
+++ b/src/components/StatsPage.test.tsx
@@ -152,7 +152,10 @@ describe("StatsPage", () => {
     expect(screen.getByText("Link Distance Distribution")).toBeInTheDocument();
     expect(screen.getByText("Top 5 Longest Links")).toBeInTheDocument();
     expect(screen.getByTestId("stats-density-map")).toHaveTextContent("Map bins: 1");
-    expect(screen.getByRole("link", { name: /Back to app/i })).toHaveAttribute("href", "/");
+    const backLink = screen.getByRole("link", { name: /Back to app/i });
+    expect(backLink).toHaveAttribute("href", "/");
+    expect(backLink).toHaveClass("btn");
+    expect(backLink).not.toHaveClass("btn-ghost");
     expect(screen.getAllByRole("link", { name: /Shared Ridge/i })[0]).toHaveAttribute("href", "/Grace/Shared-Ridge");
     expect(screen.getByRole("link", { name: /Ridge to Valley/i })).toHaveAttribute("href", "/Grace/Shared-Ridge/Ridge~Valley");
     expect(screen.getByText("Sites + Simulations")).toBeInTheDocument();
@@ -172,12 +175,12 @@ describe("StatsPage", () => {
     await screen.findByRole("button", { name: "Last 30 days" });
 
     expect(screen.getByRole("button", { name: "Last 30 days" })).toHaveAttribute("aria-pressed", "true");
-    expect(screen.getByText(/Last 30 days · UTC/)).toBeInTheDocument();
+    expect(screen.getByText("Showing: Last 30 days · UTC")).toBeInTheDocument();
     fireEvent.click(screen.getByText("Today"));
 
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Today" })).toHaveAttribute("aria-pressed", "true");
-      expect(screen.getByText(/Today · UTC/)).toBeInTheDocument();
+      expect(screen.getByText("Showing: Today · UTC")).toBeInTheDocument();
     });
   });
 

--- a/src/components/StatsPage.tsx
+++ b/src/components/StatsPage.tsx
@@ -64,7 +64,7 @@ const formatRelativeTime = (value: string): string => {
 const CustomTooltip = ({ active, label, payload }: { active?: boolean; label?: string; payload?: Array<{ name?: string; value?: number; color?: string }> }) => {
   if (!active || !payload?.length) return null;
   return (
-    <div className="stats-chart-tooltip">
+    <div className="ui-surface-pill has-pointer-tail stats-chart-tooltip">
       <strong>{label}</strong>
       {payload.map((entry) => (
         <span key={entry.name} style={{ "--series-color": entry.color } as CSSProperties}>
@@ -134,13 +134,6 @@ const GrowthChart = ({ buckets, label }: { buckets: StatsGrowthBucket[]; label: 
   );
 };
 
-const activeBar = {
-  fillOpacity: 0.92,
-  stroke: "var(--text)",
-  strokeOpacity: 0.72,
-  strokeWidth: 2,
-};
-
 const SizeBucketsChart = ({ buckets }: { buckets: StatsPayload["complexity"]["sizeBuckets"] }) => {
   const data = Object.entries(buckets).map(([label, count]) => ({ label, count }));
   return (
@@ -150,8 +143,8 @@ const SizeBucketsChart = ({ buckets }: { buckets: StatsPayload["complexity"]["si
           <CartesianGrid stroke="var(--panel-shell-divider)" strokeDasharray="3 7" vertical={false} />
           <XAxis dataKey="label" stroke="var(--muted)" tickLine={false} />
           <YAxis allowDecimals={false} stroke="var(--muted)" tickLine={false} />
-          <Tooltip content={<CustomTooltip />} />
-          <Bar activeBar={activeBar} dataKey="count" fill={chartColors.simulations} name="Simulations" radius={[6, 6, 0, 0]} />
+          <Tooltip content={<CustomTooltip />} cursor={false} />
+          <Bar dataKey="count" fill={chartColors.simulations} name="Simulations" radius={[6, 6, 0, 0]} />
         </BarChart>
       </ResponsiveContainer>
       <p className="stats-chart-range">X: Sites per Simulation · Y: Simulations</p>
@@ -170,8 +163,8 @@ const DistanceChart = ({ buckets }: { buckets: StatsPayload["linkDistanceDistrib
           <CartesianGrid stroke="var(--panel-shell-divider)" strokeDasharray="3 7" vertical={false} />
           <XAxis dataKey="label" stroke="var(--muted)" tickLine={false} />
           <YAxis allowDecimals={false} stroke="var(--muted)" tickLine={false} />
-          <Tooltip content={<CustomTooltip />} />
-          <Bar activeBar={activeBar} dataKey="count" fill={chartColors.links} name="Links" radius={[6, 6, 0, 0]} />
+          <Tooltip content={<CustomTooltip />} cursor={false} />
+          <Bar dataKey="count" fill={chartColors.links} name="Links" radius={[6, 6, 0, 0]} />
         </BarChart>
       </ResponsiveContainer>
       <p className="stats-chart-range">X: Link distance · Y: Links</p>
@@ -246,26 +239,29 @@ export function StatsPage() {
   return (
     <main className="stats-page stats-atlas-page">
       <header className="stats-atlas-header">
-        <a className="btn-ghost stats-back-link" href="/">
-          <ArrowLeft aria-hidden="true" size={16} />
-          Back to app
-        </a>
         <div className="stats-atlas-title">
+          <a className="btn stats-back-link" href="/">
+            <ArrowLeft aria-hidden="true" size={16} />
+            Back to app
+          </a>
           <h1>Stats</h1>
           <p>Public aggregate signals from entered Sites, saved Simulations, and community growth.</p>
         </div>
-        <div className="chip-group stats-range-control" aria-label="Stats time range">
-          {rangeOptions.map(([mode, label]) => (
-            <ActionButton
-              aria-pressed={growthMode === mode}
-              className={growthMode === mode ? "is-selected" : ""}
-              key={mode}
-              onClick={() => setGrowthMode(mode)}
-              type="button"
-            >
-              {label}
-            </ActionButton>
-          ))}
+        <div className="stats-range-stack">
+          <p className="stats-active-range">Showing: {growthLabels[growthMode]} · UTC</p>
+          <div className="chip-group stats-range-control" aria-label="Stats time range">
+            {rangeOptions.map(([mode, label]) => (
+              <ActionButton
+                aria-pressed={growthMode === mode}
+                className={growthMode === mode ? "is-selected" : ""}
+                key={mode}
+                onClick={() => setGrowthMode(mode)}
+                type="button"
+              >
+                {label}
+              </ActionButton>
+            ))}
+          </div>
         </div>
       </header>
 

--- a/src/components/UserAdminPanel.chip.test.tsx
+++ b/src/components/UserAdminPanel.chip.test.tsx
@@ -2,7 +2,7 @@
 // Tests for the UserAdminPanel chip's onOpenSettings integration.
 // Only covers the chip-row UI; the full modal and admin-inline mode are
 // better suited to Playwright given their network and canvas dependencies.
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { CloudUser } from "../lib/cloudUser";
@@ -104,6 +104,13 @@ describe("UserAdminPanel chip — onOpenSettings", () => {
     expect(buttons.length).toBeGreaterThanOrEqual(2);
     await userEvent.click(buttons[1]); // settings icon is second
     expect(onOpenSettings).toHaveBeenCalledOnce();
+  });
+
+  it("exposes a Stats link from the signed-in account actions", async () => {
+    render(<UserAdminPanel onOpenSettings={vi.fn()} />);
+
+    expect(screen.getByRole("link", { name: /open stats/i })).toHaveAttribute("href", "/stats");
+    await waitFor(() => expect(screen.getByRole("link", { name: /open stats/i })).toBeInTheDocument());
   });
 
   it("shows the sign-in button instead of the chip when signed out", () => {

--- a/src/components/UserAdminPanel.tsx
+++ b/src/components/UserAdminPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
-import { CircleAlert, CircleQuestionMark, CircleUserRound } from "lucide-react";
+import { BarChart3, CircleAlert, CircleQuestionMark, CircleUserRound } from "lucide-react";
 import {
   bulkReassignOwnership,
   fetchAdminAuditEvents,
@@ -973,6 +973,9 @@ export function UserAdminPanel({
                 <button aria-label="Open user settings" className="user-icon-button" onClick={() => onOpenSettings?.()} type="button">
                   <SettingsIcon title="Settings" />
                 </button>
+                <a aria-label="Open Stats" className="user-icon-button" href="/stats" title="Stats">
+                  <BarChart3 aria-hidden="true" strokeWidth={1.8} />
+                </a>
               </>
             ) : null}
             {onOpenHelp ? (

--- a/src/index.css
+++ b/src/index.css
@@ -953,7 +953,7 @@ button {
 
 .stats-atlas-header {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: flex-end;
   gap: 16px;
   padding: 4px 0 8px;
@@ -961,15 +961,19 @@ button {
 
 .stats-atlas-title {
   min-width: 0;
+  display: grid;
+  justify-items: start;
+  gap: 8px;
 }
 
 .stats-back-link {
   display: inline-flex;
   align-items: center;
   gap: 7px;
-  align-self: end;
   text-decoration: none;
   white-space: nowrap;
+  min-height: 30px;
+  padding: 6px 9px;
 }
 
 .stats-atlas-header h1 {
@@ -1001,6 +1005,19 @@ button {
 
 .stats-range-control {
   justify-content: flex-end;
+}
+
+.stats-range-stack {
+  display: grid;
+  gap: 6px;
+  justify-items: end;
+}
+
+.stats-active-range {
+  margin: 0;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
 }
 
 .stats-atlas-metrics {
@@ -1108,30 +1125,48 @@ button {
 
 .stats-map-controls.map-controls {
   top: 12px;
-  left: 12px;
+  left: 50%;
   right: auto;
+  transform: translateX(-50%);
   padding: 0;
 }
 
 .stats-map-attribution.floating-attribution-pill {
   position: absolute;
-  right: 12px;
+  right: auto;
   bottom: 12px;
-  left: auto;
-  transform: none;
+  left: 50%;
+  transform: translateX(-50%);
   z-index: 2;
 }
 
 .stats-map-popup {
   display: grid;
   gap: 2px;
-  color: var(--text);
   font-family: var(--font-ui);
+  pointer-events: none;
+  padding: 9px 11px;
+  text-align: center;
 }
 
 .stats-map-popup span {
   color: var(--muted);
   font-size: 0.78rem;
+}
+
+.stats-map-shell .maplibregl-popup {
+  pointer-events: none;
+}
+
+.stats-map-shell .maplibregl-popup-content {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.stats-map-shell .maplibregl-popup-tip {
+  display: none;
 }
 
 .stats-map-skeleton,
@@ -1170,14 +1205,11 @@ button {
 }
 
 .stats-chart-tooltip {
-  border: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--surface) 94%, transparent);
-  box-shadow: var(--shadow-elev-2);
   padding: 9px 10px;
   display: grid;
   gap: 4px;
-  color: var(--text);
+  min-width: 138px;
+  pointer-events: none;
 }
 
 .stats-chart-tooltip span::before {
@@ -1350,6 +1382,10 @@ button {
 
   .stats-range-control {
     justify-content: flex-start;
+  }
+
+  .stats-range-stack {
+    justify-items: start;
   }
 
   .stats-atlas-metrics,


### PR DESCRIPTION
## Summary
- compact the Stats back action and add a Stats entry point to the signed-in account header actions
- make the active Stats range explicit, remove the Recharts grey bar-hover cursor, and move Stats hover surfaces onto shared surface/pointer-tail styling
- stabilize Site Geography hover by anchoring popups to bin centers, center map controls/attribution, and exclude `Auto link` from Top 5 Longest Links

## Follow-up
- Created #891 for a shared user profile popover to replace duplicate implementations.

## Verification
- `npm test -- --run src/components/StatsDensityMap.test.tsx src/components/StatsPage.test.tsx src/components/UserAdminPanel.chip.test.tsx functions/api/stats.test.ts`
- `npm test`
- `npm run build`
- Playwright fallback QA on `/stats` desktop/mobile for header layout, active range, chart hover, map controls/attribution, mobile scroll, and console health

Refs #853