### PR TITLE
Clean up stats hover and cards

### DIFF
--- a/functions/api/stats.test.ts
+++ b/functions/api/stats.test.ts
@@ -75,6 +75,7 @@ beforeEach(() => {
             { id: "l1", name: "Short ridge", fromSiteId: "s1", toSiteId: "s2", frequencyMHz: 868 },
             { id: "l2", fromSiteId: "s2", toSiteId: "s3", frequencyMHz: 915 },
             { id: "auto-link", name: " Auto link ", fromSiteId: "s1", toSiteId: "s3", frequencyMHz: 868 },
+            { id: "__auto__", name: "Auto-Link", fromSiteId: "s1", toSiteId: "s3", frequencyMHz: 868 },
             { id: "bad-link", fromSiteId: "s1", toSiteId: "missing" },
           ],
         },
@@ -123,10 +124,10 @@ describe("api/stats", () => {
       sites: 3,
       simulations: 3,
       nonEmptySimulations: 2,
-      links: 6,
+      links: 7,
     });
     expect(body.complexity.averageSitesPerSimulation).toBe(2);
-    expect(body.complexity.averageLinksPerSimulation).toBe(3);
+    expect(body.complexity.averageLinksPerSimulation).toBe(3.5);
   });
 
   it("returns latest non-empty simulations and link distance buckets without leaking payloads", async () => {
@@ -160,11 +161,11 @@ describe("api/stats", () => {
         name: "Private sim",
         href: "/Ada/Private-sim",
         siteCount: 3,
-        linkCount: 4,
+        linkCount: 5,
       }),
     ]);
     expect(body.latestSimulations.some((entry) => entry.id === "sim-empty")).toBe(false);
-    expect(body.linkDistanceDistribution.reduce((sum, bucket) => sum + bucket.count, 0)).toBe(3);
+    expect(body.linkDistanceDistribution.reduce((sum, bucket) => sum + bucket.count, 0)).toBe(4);
     expect(body.longestLinks).toHaveLength(2);
     expect(body.longestLinks[0]).toMatchObject({
       label: "South ~ East",
@@ -172,7 +173,7 @@ describe("api/stats", () => {
       simulationName: "Private sim",
       owner: { username: "Ada" },
     });
-    expect(body.longestLinks.some((entry) => entry.label.trim().toLowerCase() === "auto link")).toBe(false);
+    expect(body.longestLinks.some((entry) => entry.label.toLowerCase().includes("auto"))).toBe(false);
     expect(body.longestLinks[0].distanceKm).toBeGreaterThan(body.longestLinks[1].distanceKm);
     expect(body.siteDensitySummary).toEqual([{ label: "60°N, 10°E", count: 2 }]);
     expect(raw).not.toContain("60.1");
@@ -201,8 +202,8 @@ describe("api/stats", () => {
     expect(body.growth.lastYear).toHaveLength(12);
     expect(body.growth.allTime).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ label: "2026-01", users: 1, sites: 1, simulations: 1, links: 4, cumulativeLinks: 4 }),
-        expect.objectContaining({ label: "2026-02", users: 1, sites: 2, simulations: 2, links: 2, cumulativeLinks: 6 }),
+        expect.objectContaining({ label: "2026-01", users: 1, sites: 1, simulations: 1, links: 5, cumulativeLinks: 5 }),
+        expect.objectContaining({ label: "2026-02", users: 1, sites: 2, simulations: 2, links: 2, cumulativeLinks: 7 }),
       ]),
     );
     expect(body.growth.monthly).toEqual(body.growth.allTime);

--- a/functions/api/stats.ts
+++ b/functions/api/stats.ts
@@ -281,8 +281,13 @@ const average = (values: number[]): number =>
   values.length ? values.reduce((sum, value) => sum + value, 0) / values.length : 0;
 
 const round1 = (value: number): number => Math.round(value * 10) / 10;
-const isAutoLinkName = (value: unknown): boolean =>
-  typeof value === "string" && value.trim().toLowerCase() === "auto link";
+const normalizeAutoLinkText = (value: unknown): string =>
+  typeof value === "string" ? value.trim().toLowerCase().replace(/[^a-z0-9]+/g, "") : "";
+const isAutoLink = (link: SnapshotLink): boolean => {
+  const normalizedName = normalizeAutoLinkText(link.name);
+  const normalizedId = normalizeAutoLinkText(link.id);
+  return normalizedName === "autolink" || normalizedId === "auto" || normalizedId === "autolink";
+};
 
 const bucketSimulationSize = (siteCount: number): "1-2" | "3-5" | "6-10" | "11+" => {
   if (siteCount <= 2) return "1-2";
@@ -480,7 +485,7 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
         const fromName = typeof from?.name === "string" && from.name.trim() ? from.name.trim() : "Site A";
         const toName = typeof to?.name === "string" && to.name.trim() ? to.name.trim() : "Site B";
         const linkName = typeof link.name === "string" && link.name.trim() ? link.name.trim() : `${fromName} ~ ${toName}`;
-        if (isAutoLinkName(link.name)) return;
+        if (isAutoLink(link)) return;
         longestLinks.push({
           id: `${simulation.id}:${typeof link.id === "string" ? link.id : `${link.fromSiteId}-${link.toSiteId}`}`,
           label: linkName,

--- a/src/components/StatsDensityMap.test.tsx
+++ b/src/components/StatsDensityMap.test.tsx
@@ -19,6 +19,7 @@ vi.mock("react-map-gl/maplibre", () => ({
     onMouseMove?: (event: unknown) => void;
   }) => {
     const event = {
+      point: { x: 120, y: 80 },
       features: [
         {
           geometry: { type: "Point", coordinates: [10.5, 60.5] },
@@ -28,7 +29,7 @@ vi.mock("react-map-gl/maplibre", () => ({
     };
     return (
       <div data-testid="mock-map">
-        <button onClick={() => onLoad?.({ target: { fitBounds: mockFitBounds } })} type="button">Load map</button>
+        <button onClick={() => onLoad?.({ target: { fitBounds: mockFitBounds, project: () => ({ x: 120, y: 80 }) } })} type="button">Load map</button>
         <button onClick={() => onMouseMove?.(event)} type="button">Hover bin</button>
         <button onClick={() => onClick?.(event)} type="button">Click bin</button>
         {children}
@@ -36,11 +37,6 @@ vi.mock("react-map-gl/maplibre", () => ({
     );
   },
   Layer: () => <div data-testid="mock-layer" />,
-  Popup: ({ children, className, latitude, longitude }: { children: ReactNode; className?: string; latitude: number; longitude: number }) => (
-    <div className={className} data-latitude={latitude} data-longitude={longitude} data-testid="mock-popup">
-      {children}
-    </div>
-  ),
   Source: ({ children }: { children: ReactNode }) => <div data-testid="mock-source">{children}</div>,
 }));
 
@@ -58,14 +54,16 @@ describe("StatsDensityMap", () => {
     );
 
     expect(screen.getByLabelText("Zoom out Site density map").closest(".stats-map-controls")).toHaveClass("map-controls");
-    expect(screen.getByText("CARTO").closest(".stats-map-attribution")).toHaveClass("floating-attribution-pill");
+    const attribution = screen.getByText("CARTO").closest(".stats-map-attribution");
+    expect(attribution).toHaveClass("floating-attribution-pill");
+    expect(attribution).toHaveTextContent("MapLibre");
 
     await userEvent.click(screen.getByRole("button", { name: "Hover bin" }));
 
-    const popup = screen.getByTestId("mock-popup");
+    const popup = screen.getByText("5 Sites").closest(".stats-map-popup-shell");
     expect(popup).toHaveClass("stats-map-popup-shell");
-    expect(popup).toHaveAttribute("data-longitude", "10.5");
-    expect(popup).toHaveAttribute("data-latitude", "60.5");
-    expect(screen.getByText("5 Sites").closest(".stats-map-popup")).toHaveClass("ui-surface-pill", "has-pointer-tail");
+    expect(popup).toHaveStyle({ left: "120px", top: "80px" });
+    expect(screen.getByText("5 Sites").closest(".stats-map-popup")).toHaveClass("ui-surface-pill");
+    expect(screen.getByText("5 Sites").closest(".stats-map-popup")).not.toHaveClass("has-pointer-tail");
   });
 });

--- a/src/components/StatsDensityMap.tsx
+++ b/src/components/StatsDensityMap.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useRef, useState } from "react";
 import { Fullscreen, ZoomIn, ZoomOut } from "lucide-react";
-import Map, { Layer, Popup, Source, type MapLayerMouseEvent, type MapRef } from "react-map-gl/maplibre";
+import Map, { Layer, Source, type MapLayerMouseEvent, type MapRef } from "react-map-gl/maplibre";
 import type { FeatureCollection, Point } from "geojson";
 import { getCartoFallbackStyle } from "../lib/basemaps";
 import type { StatsPayload } from "../lib/stats";
@@ -25,6 +25,8 @@ type HoveredBin = {
   label: string;
   longitude: number;
   latitude: number;
+  x: number;
+  y: number;
 };
 
 const colorVar = (name: string): string =>
@@ -98,10 +100,13 @@ export function StatsDensityMap({ bins, theme, colorTheme = "blue", accentColor,
     }
     const count = properties.count;
     const [longitude, latitude] = feature.geometry.coordinates;
+    const point = mapRef.current?.project([longitude, latitude]);
     setHovered((current) => {
       const next = {
         longitude,
         latitude,
+        x: point?.x ?? event.point.x,
+        y: point?.y ?? event.point.y,
         count,
         label: String(properties.label ?? "Site density bin"),
       };
@@ -109,6 +114,8 @@ export function StatsDensityMap({ bins, theme, colorTheme = "blue", accentColor,
         current &&
         current.longitude === next.longitude &&
         current.latitude === next.latitude &&
+        current.x === next.x &&
+        current.y === next.y &&
         current.count === next.count &&
         current.label === next.label
       ) {
@@ -124,7 +131,7 @@ export function StatsDensityMap({ bins, theme, colorTheme = "blue", accentColor,
         ref={mapRef}
         initialViewState={{ ...initialCenter, zoom: bins.length === 1 ? 5 : 3 }}
         mapStyle={getCartoFallbackStyle(theme, colorTheme)}
-        attributionControl={{ compact: true }}
+        attributionControl={false}
         dragPan={!window.matchMedia("(pointer: coarse)").matches}
         scrollZoom={false}
         touchZoomRotate={false}
@@ -158,15 +165,18 @@ export function StatsDensityMap({ bins, theme, colorTheme = "blue", accentColor,
             }}
           />
         </Source>
-        {hovered ? (
-          <Popup className="stats-map-popup-shell" closeButton={false} closeOnClick={false} latitude={hovered.latitude} longitude={hovered.longitude} offset={14}>
-            <div className="ui-surface-pill has-pointer-tail stats-map-popup">
-              <strong>{hovered.count} Sites</strong>
-              <span>{hovered.label}</span>
-            </div>
-          </Popup>
-        ) : null}
       </Map>
+      {hovered ? (
+        <div
+          className="stats-map-popup-shell"
+          style={{ left: hovered.x, top: hovered.y }}
+        >
+          <div className="ui-surface-pill stats-map-popup">
+            <strong>{hovered.count} Sites</strong>
+            <span>{hovered.label}</span>
+          </div>
+        </div>
+      ) : null}
       <div className="map-controls map-controls-unified map-controls-icon-only stats-map-controls">
         <div className="map-controls-group map-controls-group-utility map-controls-utility-pill ui-surface-pill">
           <MapControlButton aria-label="Zoom out Site density map" onClick={() => mapRef.current?.zoomOut()} title="Zoom out">

--- a/src/components/StatsPage.test.tsx
+++ b/src/components/StatsPage.test.tsx
@@ -151,6 +151,8 @@ describe("StatsPage", () => {
     expect(screen.getByText("Simulations by Size")).toBeInTheDocument();
     expect(screen.getByText("Link Distance Distribution")).toBeInTheDocument();
     expect(screen.getByText("Top 5 Longest Links")).toBeInTheDocument();
+    expect(screen.queryByText("Network Flavor")).not.toBeInTheDocument();
+    expect(screen.queryByText("Distance Notes")).not.toBeInTheDocument();
     expect(screen.getByTestId("stats-density-map")).toHaveTextContent("Map bins: 1");
     const backLink = screen.getByRole("link", { name: /Back to app/i });
     expect(backLink).toHaveAttribute("href", "/");

--- a/src/components/StatsPage.tsx
+++ b/src/components/StatsPage.tsx
@@ -1,4 +1,4 @@
-import { Activity, ArrowLeft, ExternalLink, MapPinned, Network, Radio, Ruler, Users } from "lucide-react";
+import { ArrowLeft, ExternalLink, MapPinned, Network, Radio, Users } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import type { CSSProperties, ReactNode } from "react";
 import {
@@ -64,7 +64,7 @@ const formatRelativeTime = (value: string): string => {
 const CustomTooltip = ({ active, label, payload }: { active?: boolean; label?: string; payload?: Array<{ name?: string; value?: number; color?: string }> }) => {
   if (!active || !payload?.length) return null;
   return (
-    <div className="ui-surface-pill has-pointer-tail stats-chart-tooltip">
+    <div className="ui-surface-pill stats-chart-tooltip">
       <strong>{label}</strong>
       {payload.map((entry) => (
         <span key={entry.name} style={{ "--series-color": entry.color } as CSSProperties}>
@@ -374,20 +374,6 @@ export function StatsPage() {
               </button>
             ))}
             {!stats?.highlights.newestMembers.length ? <p className="field-help">Newest members appear after users join.</p> : null}
-          </div>
-        </Panel>
-
-        <Panel className="stats-atlas-placeholder-panel" title="Network Flavor">
-          <div className="stats-flavor-lockup">
-            <Activity aria-hidden="true" size={20} />
-            <p className="field-help">Future analysis from saved Link and Channel fields.</p>
-          </div>
-        </Panel>
-
-        <Panel className="stats-atlas-placeholder-panel" title="Distance Notes">
-          <div className="stats-flavor-lockup">
-            <Ruler aria-hidden="true" size={20} />
-            <p className="field-help">Distances are derived from saved Simulation endpoints and grouped into public aggregate buckets.</p>
           </div>
         </Panel>
       </section>

--- a/src/index.css
+++ b/src/index.css
@@ -1149,24 +1149,16 @@ button {
   text-align: center;
 }
 
-.stats-map-popup span {
-  color: var(--muted);
-  font-size: 0.78rem;
-}
-
-.stats-map-shell .maplibregl-popup {
+.stats-map-popup-shell {
+  position: absolute;
+  z-index: 3;
+  transform: translate(-50%, calc(-100% - 12px));
   pointer-events: none;
 }
 
-.stats-map-shell .maplibregl-popup-content {
-  padding: 0;
-  border: 0;
-  background: transparent;
-  box-shadow: none;
-}
-
-.stats-map-shell .maplibregl-popup-tip {
-  display: none;
+.stats-map-popup span {
+  color: var(--muted);
+  font-size: 0.78rem;
 }
 
 .stats-map-skeleton,


### PR DESCRIPTION
## Summary
- remove Network Flavor and Distance Notes cards from `/stats`
- remove tooltip arrows from Stats chart/map hover surfaces
- replace MapLibre Popup hover with a passive absolute overlay to avoid map hover flicker
- disable built-in MapLibre attribution because Stats already renders its own attribution pill
- filter Auto Link variants from Top 5 Longest Links (`Auto Link`, `Auto-Link`, `__auto__`)

## Verification
- `npm test -- --run functions/api/stats.test.ts src/components/StatsPage.test.tsx src/components/StatsDensityMap.test.tsx`
- `npm test`
- `npm run build`
- Playwright fallback QA on `/stats` desktop/mobile for removed Auto Link text, removed placeholder cards, no tooltip arrow classes, no built-in MapLibre attribution, and mobile scroll

Refs #853