### PR TITLE
fix: allow selected paths in leaderboard

### DIFF
--- a/src/components/StatsPage.test.tsx
+++ b/src/components/StatsPage.test.tsx
@@ -165,6 +165,7 @@ describe("StatsPage", () => {
     expect(screen.getByText("Simulations by Size")).toBeInTheDocument();
     expect(screen.getByText("Link Distance Distribution")).toBeInTheDocument();
     expect(screen.getByText("Top Passing Paths")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /A Path appears here after a logged-in user calculates/i })).toBeInTheDocument();
     expect(screen.getByText("Top 5 Longest Links")).toBeInTheDocument();
     expect(screen.queryByText("Network Flavor")).not.toBeInTheDocument();
     expect(screen.queryByText("Distance Notes")).not.toBeInTheDocument();
@@ -237,6 +238,6 @@ describe("StatsPage", () => {
     expect(await screen.findByText("Growth appears after dated community activity is available.")).toBeInTheDocument();
     expect(screen.getByText("Site density will appear after Sites with coordinates are created.")).toBeInTheDocument();
     expect(screen.getByText("Latest non-empty Simulations will appear here.")).toBeInTheDocument();
-    expect(screen.getByText("Passing Paths appear after terrain-backed saved Paths are calculated.")).toBeInTheDocument();
+    expect(screen.getByText("Passing Paths appear after terrain-backed public/shared Simulation Paths are calculated.")).toBeInTheDocument();
   });
 });

--- a/src/components/StatsPage.tsx
+++ b/src/components/StatsPage.tsx
@@ -15,6 +15,7 @@ import {
 } from "recharts";
 import { ActionButton } from "./ActionButton";
 import { AvatarBadge } from "./AvatarBadge";
+import { InfoTip } from "./InfoTip";
 import { StatsDensityMap } from "./StatsDensityMap";
 import { UserProfileModal } from "./UserProfileModal";
 import { fetchUserById, type CloudUser } from "../lib/cloudUser";
@@ -75,10 +76,24 @@ const CustomTooltip = ({ active, label, payload }: { active?: boolean; label?: s
   );
 };
 
-const Panel = ({ title, children, className = "" }: { title: string; children: ReactNode; className?: string }) => (
+const passingPathLeaderboardInfo =
+  "A Path appears here after a logged-in user calculates a public/shared saved Simulation Path or selected two-site Path with no drag preview, terrain loading complete for the whole Simulation, real terrain for every profile sample, and RX after environment loss meeting the signal target. Only the global top five unique endpoint pairs are shown.";
+
+const Panel = ({
+  title,
+  children,
+  className = "",
+  actions,
+}: {
+  title: string;
+  children: ReactNode;
+  className?: string;
+  actions?: ReactNode;
+}) => (
   <article className={`stats-atlas-panel panel-section ${className}`.trim()}>
     <div className="section-heading stats-atlas-panel-heading">
       <h2>{title}</h2>
+      {actions}
     </div>
     {children}
   </article>
@@ -348,7 +363,7 @@ export function StatsPage() {
           <DistanceChart buckets={stats?.linkDistanceDistribution ?? []} />
         </Panel>
 
-        <Panel title="Top Passing Paths">
+        <Panel title="Top Passing Paths" actions={<InfoTip text={passingPathLeaderboardInfo} />}>
           <div className="stats-simulation-list">
             {(stats?.longestPassingPaths ?? []).map((path) => (
               <a className="stats-simulation-row" href={path.href || path.simulationHref} key={path.id}>
@@ -361,7 +376,7 @@ export function StatsPage() {
                 <ExternalLink aria-hidden="true" size={15} />
               </a>
             ))}
-            {!stats?.longestPassingPaths.length ? <p className="field-help">Passing Paths appear after terrain-backed saved Paths are calculated.</p> : null}
+            {!stats?.longestPassingPaths.length ? <p className="field-help">Passing Paths appear after terrain-backed public/shared Simulation Paths are calculated.</p> : null}
           </div>
         </Panel>
 

--- a/src/lib/pathLeaderboard.test.ts
+++ b/src/lib/pathLeaderboard.test.ts
@@ -101,6 +101,19 @@ describe("path leaderboard candidate gate", () => {
     expect(result.candidate.terrainTileSignature).toBeTruthy();
   });
 
+  it("allows unsaved selected site pairs by omitting the synthetic link id", () => {
+    const result = buildPathLeaderboardCandidate({
+      ...baseInput(),
+      link: {
+        ...link,
+        id: "__selection__",
+      },
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.candidate.linkId).toBeNull();
+  });
+
   it("waits while terrain is still loading", () => {
     expect(buildPathLeaderboardCandidate({ ...baseInput(), isTerrainFetching: true })).toEqual({
       ok: false,

--- a/src/lib/pathLeaderboard.ts
+++ b/src/lib/pathLeaderboard.ts
@@ -40,6 +40,7 @@ export type BuildPathLeaderboardCandidateResult =
   | { ok: false; reason: string };
 
 const FNV_OFFSET_BASIS = 2166136261;
+const SELECTION_LINK_ID = "__selection__";
 
 const updateFnvHash = (hash: number, input: string): number => {
   let next = hash;
@@ -121,7 +122,7 @@ export const buildPathLeaderboardCandidate = (
     simulationUpdatedAt,
     fromSiteId,
     toSiteId,
-    linkId: link.id,
+    linkId: link.id === SELECTION_LINK_ID ? null : link.id,
     distanceKm: analysis.distanceKm,
     rxAfterEnvLossDbm,
     rxMarginDb,


### PR DESCRIPTION
## Summary
- allow unsaved selected two-site Paths to submit leaderboard candidates by omitting the synthetic selection link id
- add the existing InfoTip next to the Top Passing Paths Stats leaderboard with valid-score conditions
- update empty-state copy and tests

## Verification
- npm test -- --run src/lib/pathLeaderboard.test.ts src/components/StatsPage.test.tsx
- npm test
- npm run build
- npm run dev:check

Refs #888