### PR TITLE
fix: remove legacy longest links stats

### DIFF
--- a/functions/api/stats.test.ts
+++ b/functions/api/stats.test.ts
@@ -165,7 +165,6 @@ describe("api/stats", () => {
       }>;
       linkDistanceDistribution: Array<{ label: string; minKm: number; maxKm: number | null; count: number }>;
       siteDensitySummary: Array<{ label: string; count: number }>;
-      longestLinks: Array<{ label: string; href: string; simulationName: string; distanceKm: number; owner: { username: string } }>;
       longestPassingPaths: Array<{ label: string; href: string; simulationName: string; distanceKm: number; rxMarginDb: number }>;
     };
     const raw = JSON.stringify(body);
@@ -189,15 +188,7 @@ describe("api/stats", () => {
     ]);
     expect(body.latestSimulations.some((entry) => entry.id === "sim-empty")).toBe(false);
     expect(body.linkDistanceDistribution.reduce((sum, bucket) => sum + bucket.count, 0)).toBe(4);
-    expect(body.longestLinks).toHaveLength(2);
-    expect(body.longestLinks[0]).toMatchObject({
-      label: "South ~ East",
-      href: "/Ada/Private-sim/South~East",
-      simulationName: "Private sim",
-      owner: { username: "Ada" },
-    });
-    expect(body.longestLinks.some((entry) => entry.label.toLowerCase().includes("auto"))).toBe(false);
-    expect(body.longestLinks[0].distanceKm).toBeGreaterThan(body.longestLinks[1].distanceKm);
+    expect(raw).not.toContain("longestLinks");
     expect(body.longestPassingPaths).toEqual([
       expect.objectContaining({
         label: "Ridge ~ Valley",

--- a/functions/api/stats.ts
+++ b/functions/api/stats.ts
@@ -282,13 +282,6 @@ const average = (values: number[]): number =>
   values.length ? values.reduce((sum, value) => sum + value, 0) / values.length : 0;
 
 const round1 = (value: number): number => Math.round(value * 10) / 10;
-const normalizeAutoLinkText = (value: unknown): string =>
-  typeof value === "string" ? value.trim().toLowerCase().replace(/[^a-z0-9]+/g, "") : "";
-const isAutoLink = (link: SnapshotLink): boolean => {
-  const normalizedName = normalizeAutoLinkText(link.name);
-  const normalizedId = normalizeAutoLinkText(link.id);
-  return normalizedName === "autolink" || normalizedId === "auto" || normalizedId === "autolink";
-};
 
 const bucketSimulationSize = (siteCount: number): "1-2" | "3-5" | "6-10" | "11+" => {
   if (siteCount <= 2) return "1-2";
@@ -319,20 +312,6 @@ const hrefForSimulation = (owner: UserRow | undefined, simulation: ResourceRow, 
   const simulationSlug = slugifySegment(name);
   if (username && simulationSlug) return `/${username}/${simulationSlug}`;
   return `/?sim=${encodeURIComponent(simulation.id)}`;
-};
-
-const hrefForLink = (
-  owner: UserRow | undefined,
-  simulation: ResourceRow,
-  payload: SimulationPayload | null,
-  fromSite: SnapshotSite,
-  toSite: SnapshotSite,
-): string => {
-  const simulationHref = hrefForSimulation(owner, simulation, payload);
-  const fromName = typeof fromSite.name === "string" ? slugifySegment(fromSite.name) : "";
-  const toName = typeof toSite.name === "string" ? slugifySegment(toSite.name) : "";
-  if (!fromName || !toName || simulationHref.startsWith("/?")) return simulationHref;
-  return `${simulationHref}/${fromName}~${toName}`;
 };
 
 const formatGeoLabel = (latBand: number, lonBand: number): string => {
@@ -427,15 +406,6 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
       siteCount: number;
       linkCount: number;
     }> = [];
-    const longestLinks: Array<{
-      id: string;
-      label: string;
-      href: string;
-      simulationHref: string;
-      simulationName: string;
-      distanceKm: number;
-      owner: { userId: string; username: string; avatarUrl: string };
-    }> = [];
     const linkDistanceCounts = DISTANCE_BUCKETS.map((bucket) => ({ ...bucket, count: 0 }));
 
     simulations.forEach((simulation) => {
@@ -483,24 +453,6 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
         const distanceKm = haversineKm({ lat: fromLat, lon: fromLon }, { lat: toLat, lon: toLon });
         const bucket = bucketForDistance(distanceKm);
         if (bucket) linkDistanceCounts.find((entry) => entry.label === bucket.label)!.count += 1;
-        const owner = userById.get(simulation.owner_user_id);
-        const fromName = typeof from?.name === "string" && from.name.trim() ? from.name.trim() : "Site A";
-        const toName = typeof to?.name === "string" && to.name.trim() ? to.name.trim() : "Site B";
-        const linkName = typeof link.name === "string" && link.name.trim() ? link.name.trim() : `${fromName} ~ ${toName}`;
-        if (isAutoLink(link)) return;
-        longestLinks.push({
-          id: `${simulation.id}:${typeof link.id === "string" ? link.id : `${link.fromSiteId}-${link.toSiteId}`}`,
-          label: linkName,
-          href: hrefForLink(owner, simulation, payload, from, to),
-          simulationHref: hrefForSimulation(owner, simulation, payload),
-          simulationName: typeof payload?.name === "string" && payload.name.trim() ? payload.name.trim() : simulation.name?.trim() || "Untitled Simulation",
-          distanceKm: round1(distanceKm),
-          owner: {
-            userId: simulation.owner_user_id,
-            username: owner?.username?.trim() || "Unknown user",
-            avatarUrl: owner?.avatar_url ?? "",
-          },
-        });
       });
     });
 
@@ -546,9 +498,6 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
       },
       latestSimulations: latestSimulations
         .sort((a, b) => (parseDate(b.createdAt)?.getTime() ?? 0) - (parseDate(a.createdAt)?.getTime() ?? 0))
-        .slice(0, 5),
-      longestLinks: longestLinks
-        .sort((a, b) => b.distanceKm - a.distanceKm || a.label.localeCompare(b.label))
         .slice(0, 5),
       longestPassingPaths,
       linkDistanceDistribution: linkDistanceCounts,

--- a/src/components/StatsPage.test.tsx
+++ b/src/components/StatsPage.test.tsx
@@ -80,17 +80,6 @@ const statsPayload = {
       linkCount: 2,
     },
   ],
-  longestLinks: [
-    {
-      id: "sim-2:l1",
-      label: "Ridge to Valley",
-      href: "/Grace/Shared-Ridge/Ridge~Valley",
-      simulationHref: "/Grace/Shared-Ridge",
-      simulationName: "Shared Ridge",
-      distanceKm: 42.4,
-      owner: { userId: "u2", username: "Grace", avatarUrl: "" },
-    },
-  ],
   longestPassingPaths: [
     {
       id: "sim-2:ridge~valley",
@@ -166,7 +155,7 @@ describe("StatsPage", () => {
     expect(screen.getByText("Link Distance Distribution")).toBeInTheDocument();
     expect(screen.getByText("Top Passing Paths")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /A Path appears here after a logged-in user calculates/i })).toBeInTheDocument();
-    expect(screen.getByText("Top 5 Longest Links")).toBeInTheDocument();
+    expect(screen.queryByText("Top 5 Longest Links")).not.toBeInTheDocument();
     expect(screen.queryByText("Network Flavor")).not.toBeInTheDocument();
     expect(screen.queryByText("Distance Notes")).not.toBeInTheDocument();
     expect(screen.getByTestId("stats-density-map")).toHaveTextContent("Map bins: 1");
@@ -176,7 +165,6 @@ describe("StatsPage", () => {
     expect(backLink).not.toHaveClass("btn-ghost");
     expect(screen.getAllByRole("link", { name: /Shared Ridge/i })[0]).toHaveAttribute("href", "/Grace/Shared-Ridge");
     expect(screen.getByRole("link", { name: /Ridge ~ Valley/i })).toHaveAttribute("href", "/Grace/Shared-Ridge/Ridge~Valley");
-    expect(screen.getByRole("link", { name: /Ridge to Valley/i })).toHaveAttribute("href", "/Grace/Shared-Ridge/Ridge~Valley");
     expect(screen.getByText("+18.8 dB")).toBeInTheDocument();
     expect(screen.getByText("Sites + Simulations")).toBeInTheDocument();
     expect(screen.getByText("11 days ago")).toBeInTheDocument();
@@ -227,7 +215,6 @@ describe("StatsPage", () => {
           latestSimulations: [],
           linkDistanceDistribution: [],
           siteDensitySummary: [],
-          longestLinks: [],
           longestPassingPaths: [],
         }),
       })),

--- a/src/components/StatsPage.tsx
+++ b/src/components/StatsPage.tsx
@@ -380,22 +380,6 @@ export function StatsPage() {
           </div>
         </Panel>
 
-        <Panel title="Top 5 Longest Links">
-          <div className="stats-simulation-list">
-            {(stats?.longestLinks ?? []).map((link) => (
-              <a className="stats-simulation-row" href={link.href || link.simulationHref} key={link.id}>
-                <span>
-                  <strong>{link.label}</strong>
-                  <small>{link.simulationName} · by {link.owner.username}</small>
-                </span>
-                <span>{formatKm(link.distanceKm)}</span>
-                <ExternalLink aria-hidden="true" size={15} />
-              </a>
-            ))}
-            {!stats?.longestLinks.length ? <p className="field-help">Longest Links appear after saved Links have endpoints with coordinates.</p> : null}
-          </div>
-        </Panel>
-
         <Panel title="Newest Members">
           <div className="stats-person-list">
             {(stats?.highlights.newestMembers ?? []).map((user) => (

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -60,19 +60,6 @@ export type StatsPayload = {
     siteCount: number;
     linkCount: number;
   }>;
-  longestLinks: Array<{
-    id: string;
-    label: string;
-    href: string;
-    simulationHref: string;
-    simulationName: string;
-    distanceKm: number;
-    owner: {
-      userId: string;
-      username: string;
-      avatarUrl: string;
-    };
-  }>;
   longestPassingPaths: Array<{
     id: string;
     label: string;


### PR DESCRIPTION
## Summary
- remove legacy longestLinks from /api/stats and StatsPayload
- remove the old Top 5 Longest Links panel from the Stats page
- keep Link Distance Distribution and terrain-backed Top Passing Paths

## Verification
- npm test -- --run functions/api/stats.test.ts src/components/StatsPage.test.tsx
- npm test
- npm run build
- npm run dev:check

Refs #888