### PR TITLE
Fix visible site source toggles

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent, type ReactNode } from "react";
-import { Egg, Fullscreen, Locate, LocateFixed, Maximize2, Minimize2, Rabbit, RefreshCw, SquareStack, ZoomIn, ZoomOut } from "lucide-react";
+import { Egg, Fullscreen, Layers, Locate, LocateFixed, Maximize2, Minimize2, Rabbit, RefreshCw, SquareStack, ZoomIn, ZoomOut } from "lucide-react";
 import { CompactDetails, CompactDetailsSummary } from "./ui/CompactDetails";
+import { FloatingPopover } from "./ui/FloatingPopover";
 import { MapControlButton } from "./ui/MapControlButton";
 import { Surface } from "./ui/Surface";
 import Map, {
@@ -772,6 +773,7 @@ export function MapView({
   const [siteDraftStatus, setSiteDraftStatus] = useState<string | null>(null);
   const [showDiscoverySites, setShowDiscoverySites] = useState(false);
   const [showDiscoveryMqtt, setShowDiscoveryMqtt] = useState(false);
+  const [visibleSiteSourcesOpen, setVisibleSiteSourcesOpen] = useState(false);
   const [mqttNodes, setMqttNodes] = useState<MeshmapNode[]>([]);
   const [mqttLoadStatus, setMqttLoadStatus] = useState<string | null>(null);
   const [overlayHoverInfo, setOverlayHoverInfo] = useState<MapInspectorHoverInfo | null>(null);
@@ -792,6 +794,7 @@ export function MapView({
     zoom: number;
   } | null>(null);
   const mapRef = useRef<MapRef | null>(null);
+  const visibleSiteSourcesTriggerRef = useRef<HTMLButtonElement | null>(null);
   const userLocationWatchIdRef = useRef<number | null>(null);
   const isUserLocationActiveRef = useRef(false);
   const isUserLocationFollowingRef = useRef(false);
@@ -909,6 +912,11 @@ export function MapView({
   useEffect(() => {
     setDiscoveryVisibility({ libraryVisible: showDiscoverySites, mqttVisible: showDiscoveryMqtt });
   }, [showDiscoverySites, showDiscoveryMqtt, setDiscoveryVisibility]);
+
+  useEffect(() => {
+    if (showDiscoveryMqtt) return;
+    setMqttDuplicatePrompt(null);
+  }, [showDiscoveryMqtt]);
 
   useEffect(() => {
     setMapDiscoveryMqttNodes(mqttNodes);
@@ -2661,8 +2669,21 @@ export function MapView({
     setCoverageVizMode(selectionCount === 1 ? "passfail" : selectionCount === 2 ? "relay" : "heatmap");
   }, [allowedOverlayModes, coverageVizMode, selectionCount, setCoverageVizMode]);
   const simulationOverlaySelectValue = coverageVizMode;
-  const siteVisibilityMode: "simulation" | "library" | "mqtt" =
-    showDiscoveryMqtt ? "mqtt" : showDiscoverySites ? "library" : "simulation";
+  const visibleSiteSourceSummary =
+    showDiscoverySites && showDiscoveryMqtt
+      ? "Simulation + Library + MQTT"
+      : showDiscoverySites
+        ? "Simulation + Library"
+        : showDiscoveryMqtt
+          ? "Simulation + MQTT"
+          : "Simulation only";
+  const setVisibleSiteSource = useCallback((source: "library" | "mqtt", visible: boolean) => {
+    if (source === "library") {
+      setShowDiscoverySites(visible);
+      return;
+    }
+    setShowDiscoveryMqtt(visible);
+  }, []);
   const selectedSite = selectedSites[0] ?? null;
   const selectedDiscoveryLibraryEntry =
     selectedDiscoveryLibraryEntryId
@@ -3089,32 +3110,53 @@ export function MapView({
                   </select>
                 </label>
               )}
-              <label className="map-inspector-map-setting">
+              <div className="map-inspector-map-setting">
                 <span>Visible Sites</span>
-                <select
-                  className="locale-select"
-                  onChange={(event) => {
-                    const mode = event.target.value as "simulation" | "library" | "mqtt";
-                    if (mode === "simulation") {
-                      setShowDiscoverySites(false);
-                      setShowDiscoveryMqtt(false);
-                      return;
-                    }
-                    if (mode === "library") {
-                      setShowDiscoverySites(true);
-                      setShowDiscoveryMqtt(false);
-                      return;
-                    }
-                    setShowDiscoverySites(false);
-                    setShowDiscoveryMqtt(true);
-                  }}
-                  value={siteVisibilityMode}
+                <div className="visible-site-sources-control">
+                  <ActionButton
+                    aria-expanded={visibleSiteSourcesOpen}
+                    aria-haspopup="dialog"
+                    className="visible-site-sources-trigger"
+                    onClick={() => setVisibleSiteSourcesOpen((open) => !open)}
+                    ref={visibleSiteSourcesTriggerRef}
+                    type="button"
+                  >
+                    <Layers aria-hidden="true" size={13} strokeWidth={1.8} />
+                    <span>{visibleSiteSourceSummary}</span>
+                  </ActionButton>
+                </div>
+                <FloatingPopover
+                  className="visible-site-sources-popover"
+                  estimatedHeight={120}
+                  estimatedWidth={240}
+                  onClose={() => setVisibleSiteSourcesOpen(false)}
+                  open={visibleSiteSourcesOpen}
+                  pointerTail
+                  triggerRef={visibleSiteSourcesTriggerRef}
                 >
-                  <option value="simulation">Only Simulation</option>
-                  <option value="library">Simulation + Library</option>
-                  <option value="mqtt">Simulation + MQTT</option>
-                </select>
-              </label>
+                  <div aria-label="Visible site sources" className="visible-site-sources-popover-content" role="dialog">
+                    <p className="visible-site-sources-summary">{visibleSiteSourceSummary}</p>
+                    <div className="visible-site-sources-options">
+                      <label className="checkbox-field visible-site-source-option">
+                        <input
+                          checked={showDiscoverySites}
+                          onChange={(event) => setVisibleSiteSource("library", event.currentTarget.checked)}
+                          type="checkbox"
+                        />
+                        <span>Library</span>
+                      </label>
+                      <label className="checkbox-field visible-site-source-option">
+                        <input
+                          checked={showDiscoveryMqtt}
+                          onChange={(event) => setVisibleSiteSource("mqtt", event.currentTarget.checked)}
+                          type="checkbox"
+                        />
+                        <span>MQTT</span>
+                      </label>
+                    </div>
+                  </div>
+                </FloatingPopover>
+              </div>
             </div>
             <p>
               Mode: <strong>{overlayGuideTitle}</strong>

--- a/src/components/MapView.userLocation.test.tsx
+++ b/src/components/MapView.userLocation.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import React from "react";
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mapMock = vi.hoisted(() => ({
@@ -64,6 +64,24 @@ vi.mock("react-map-gl/maplibre", async () => {
   };
 });
 
+vi.mock("../lib/meshtasticMqtt", () => ({
+  fetchMeshmapNodes: vi.fn(async () => ({
+    fromCache: false,
+    networkError: false,
+    nodes: [
+      {
+        nodeId: "mqtt-alpha",
+        shortName: "MQA",
+        longName: "MQTT Alpha",
+        hwModel: "T-Beam",
+        lat: 60.55,
+        lon: 11.55,
+        updatedAt: 1,
+      },
+    ],
+  })),
+}));
+
 const watchPosition = vi.fn();
 const clearWatch = vi.fn();
 
@@ -105,6 +123,11 @@ const renderMapView = (props: Partial<React.ComponentProps<typeof MapView>> = {}
       {...props}
     />,
   );
+
+const openVisibleSiteSources = async () => {
+  fireEvent.click(screen.getByRole("button", { name: /Simulation/ }));
+  return screen.findByRole("dialog", { name: "Visible site sources" });
+};
 
 describe("MapView user location flow", () => {
   beforeEach(() => {
@@ -230,7 +253,95 @@ describe("MapView user location flow", () => {
     expect(screen.queryByText("New Site")).not.toBeInTheDocument();
   });
 
-  it("explains why library sites cannot be added in read-only mode", () => {
+  it("opens visible site sources in the shared card popover", async () => {
+    renderMapView({ showInspector: true });
+
+    fireEvent.click(screen.getByText("Map"));
+    const popover = await openVisibleSiteSources();
+    const surface = popover.closest(".ui-surface-pill");
+
+    expect(surface).toHaveClass("is-card");
+    expect(surface).toHaveClass("has-pointer-tail");
+    expect(surface).toHaveClass("visible-site-sources-popover");
+    expect(within(popover).getByLabelText("Library")).not.toBeChecked();
+    expect(within(popover).getByLabelText("MQTT")).not.toBeChecked();
+  });
+
+  it("keeps Library visible when MQTT is also enabled", async () => {
+    useAppStore.setState({
+      siteLibrary: [
+        {
+          id: "lib-alpha",
+          name: "Library Alpha",
+          visibility: "shared",
+          sharedWith: [],
+          ownerUserId: "owner-1",
+          effectiveRole: "viewer",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          position: { lat: 60.5, lon: 11.5 },
+          groundElevationM: 120,
+          antennaHeightM: 2,
+          txPowerDbm: 20,
+          txGainDbi: 2,
+          rxGainDbi: 2,
+          cableLossDb: 1,
+        },
+      ],
+    });
+    renderMapView({ showInspector: true });
+
+    fireEvent.click(screen.getByText("Map"));
+    const popover = await openVisibleSiteSources();
+    fireEvent.click(within(popover).getByLabelText("Library"));
+    expect(screen.getByRole("button", { name: "Library Alpha" })).toBeInTheDocument();
+
+    fireEvent.click(within(popover).getByLabelText("MQTT"));
+
+    expect(screen.getByRole("button", { name: "Library Alpha" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Simulation + Library + MQTT" })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(useAppStore.getState().discoveryLibraryVisible).toBe(true);
+      expect(useAppStore.getState().discoveryMqttVisible).toBe(true);
+    });
+  });
+
+  it("clears selected library discovery actions when Library is disabled", async () => {
+    useAppStore.setState({
+      siteLibrary: [
+        {
+          id: "lib-alpha",
+          name: "Library Alpha",
+          visibility: "shared",
+          sharedWith: [],
+          ownerUserId: "owner-1",
+          effectiveRole: "viewer",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          position: { lat: 60.5, lon: 11.5 },
+          groundElevationM: 120,
+          antennaHeightM: 2,
+          txPowerDbm: 20,
+          txGainDbi: 2,
+          rxGainDbi: 2,
+          cableLossDb: 1,
+        },
+      ],
+    });
+    renderMapView({ showInspector: true });
+
+    fireEvent.click(screen.getByText("Map"));
+    const popover = await openVisibleSiteSources();
+    fireEvent.click(within(popover).getByLabelText("Library"));
+    fireEvent.click(screen.getByRole("button", { name: "Library Alpha" }));
+    expect(screen.getByRole("button", { name: "Add to Simulation" })).toBeInTheDocument();
+
+    fireEvent.click(within(popover).getByLabelText("Library"));
+
+    expect(screen.queryByRole("button", { name: "Library Alpha" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Add to Simulation" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Simulation only" })).toBeInTheDocument();
+  });
+
+  it("explains why library sites cannot be added in read-only mode", async () => {
     useAppStore.setState({
       siteLibrary: [
         {
@@ -254,14 +365,15 @@ describe("MapView user location flow", () => {
     renderMapView({ canPersist: false, readOnly: true, showInspector: true });
 
     fireEvent.click(screen.getByText("Map"));
-    fireEvent.change(screen.getByLabelText("Visible Sites"), { target: { value: "library" } });
+    const popover = await openVisibleSiteSources();
+    fireEvent.click(within(popover).getByLabelText("Library"));
     fireEvent.click(screen.getByRole("button", { name: "Library Alpha" }));
 
     expect(screen.queryByRole("button", { name: "Add to Simulation" })).not.toBeInTheDocument();
     expect(screen.getByText("Read-only: you need edit permission to add sites to this simulation.")).toBeInTheDocument();
   });
 
-  it("shows private library sites that are already accessible", () => {
+  it("shows private library sites that are already accessible", async () => {
     useAppStore.setState({
       siteLibrary: [
         {
@@ -285,7 +397,8 @@ describe("MapView user location flow", () => {
     renderMapView({ showInspector: true });
 
     fireEvent.click(screen.getByText("Map"));
-    fireEvent.change(screen.getByLabelText("Visible Sites"), { target: { value: "library" } });
+    const popover = await openVisibleSiteSources();
+    fireEvent.click(within(popover).getByLabelText("Library"));
 
     expect(screen.getByRole("button", { name: "Private Hill" })).toBeInTheDocument();
   });

--- a/src/components/ui/FloatingPopover.tsx
+++ b/src/components/ui/FloatingPopover.tsx
@@ -22,6 +22,8 @@ type FloatingPopoverProps = {
   style?: CSSProperties;
   estimatedHeight?: number;
   estimatedWidth?: number;
+  pointerTail?: boolean;
+  pointerTone?: "accent" | "selection" | "temporary";
 };
 
 export function FloatingPopover({
@@ -35,6 +37,8 @@ export function FloatingPopover({
   style,
   estimatedHeight = 200,
   estimatedWidth = 360,
+  pointerTail = false,
+  pointerTone = "accent",
 }: FloatingPopoverProps) {
   const popoverRef = useRef<HTMLDivElement | null>(null);
   const [position, setPosition] = useState<FloatingPopoverPosition | null>(null);
@@ -135,6 +139,8 @@ export function FloatingPopover({
       ref={popoverRef}
       variant="card"
       className={`ui-action-popover ${className ?? ""} ${position.direction === "down" ? "is-down" : ""}`}
+      pointerTail={pointerTail}
+      pointerTone={pointerTone}
       style={{
         left: position.left,
         top: position.top,

--- a/src/index.css
+++ b/src/index.css
@@ -2273,6 +2273,50 @@ button {
   padding: 2px 8px;
 }
 
+.visible-site-sources-control {
+  min-width: 0;
+}
+
+.visible-site-sources-trigger {
+  width: 100%;
+  min-width: 0;
+  justify-content: flex-start;
+}
+
+.visible-site-sources-trigger span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.visible-site-sources-popover {
+  width: min(240px, calc(100vw - 24px));
+  z-index: 12050;
+}
+
+.visible-site-sources-popover-content {
+  display: grid;
+  gap: 10px;
+  padding: 10px 12px;
+}
+
+.visible-site-sources-summary {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 600;
+}
+
+.visible-site-sources-options {
+  display: grid;
+  gap: 8px;
+}
+
+.visible-site-source-option {
+  min-width: 0;
+}
+
 .map-progress {
   width: 100%;
   padding: 0;
@@ -3026,6 +3070,13 @@ button {
 .ui-action-popover.is-down {
   transform: translate(-50%, 6px);
   animation: panorama-popover-drop 140ms ease-out;
+}
+
+.ui-action-popover.is-down.has-pointer-tail::after,
+.ui-action-popover.is-down.has-pointer-tail::before {
+  top: auto;
+  bottom: calc(100% + 1px);
+  clip-path: polygon(50% 0, 0 100%, 100% 100%);
 }
 
 .ui-settings-popover-list {


### PR DESCRIPTION
## Summary
- Replaces the Map inspector Visible Sites select with a card-style popover using independent Library and MQTT toggles.
- Keeps Simulation Sites as the always-visible baseline and shows the active source summary in the sidebar.
- Extends the shared FloatingPopover with optional pointer-tail support for the UI-gallery arrow style.

## Verification
- [x] `npm test -- --run src/components/MapView.userLocation.test.tsx src/components/ui/Surface.test.tsx`
- [x] `npm test`
- [x] `npm run build`
- [x] Local Playwright rendered QA on desktop and mobile with software WebGL

Closes #850