### PR TITLE
Persist panorama settings

### DIFF
--- a/src/components/PanoramaChart.tsx
+++ b/src/components/PanoramaChart.tsx
@@ -25,6 +25,7 @@ import { resolveVisiblePanoramaLabels, type PanoramaLabelCandidate } from "../li
 import { loadPanoramaPeaks, type PanoramaPeakCandidate } from "../lib/panoramaPeaks";
 import { isPeakLosVisible, nearestSampleForDistance } from "../lib/panoramaLos";
 import { buildDepthBands, buildNearBiasedDepthFractions, resolveRenderedEndpoint } from "../lib/panoramaRender";
+import { persistPanoramaSettings, readPanoramaSettings } from "../lib/panoramaSettings";
 import { cardinalLabelForAzimuth, formatAzimuthTick, fovScaleToSpanDeg, FOV_SCALE_DEFAULT, FOV_SCALE_MAX, FOV_SCALE_MIN, mod360, normalizeFovScale, resolvePanoramaWindow, unwrapAzimuthForWindow } from "../lib/panoramaView";
 import { centerForScaledWindow } from "../lib/panoramaViewport";
 import { passFailStateLabel } from "../lib/passFailState";
@@ -138,10 +139,11 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
 
   const [chartSize, setChartSize] = useState<{ width: number; height: number } | null>(null);
   const [viewportCenterAzimuthDeg, setViewportCenterAzimuthDeg] = useState(180);
-  const [exaggeration, setExaggeration] = useState(4);
+  const [initialPanoramaSettings] = useState(readPanoramaSettings);
+  const [exaggeration, setExaggeration] = useState(initialPanoramaSettings.exaggeration);
   const [mapHoverZoomEnabled, setMapHoverZoomEnabled] = useState(false);
-  const [showLabels, setShowLabels] = useState(true);
-  const [terrainDistanceHeatmap, setTerrainDistanceHeatmap] = useState(false);
+  const [showLabels, setShowLabels] = useState(initialPanoramaSettings.showLabels);
+  const [terrainDistanceHeatmap, setTerrainDistanceHeatmap] = useState(initialPanoramaSettings.terrainDistanceHeatmap);
   const [fovScale, setFovScale] = useState(FOV_SCALE_DEFAULT);
   const [hoverTarget, setHoverTarget] = useState<HoverTarget | null>(null);
   const [pinnedTarget, setPinnedTarget] = useState<HoverTarget | null>(null);
@@ -181,6 +183,10 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
   const quality: PanoramaQuality = previewCount > 0 ? "drag" : "full";
   const normalizedFovScale = normalizeFovScale(fovScale);
   const viewportSpanDeg = fovScaleToSpanDeg(normalizedFovScale);
+
+  useEffect(() => {
+    persistPanoramaSettings({ exaggeration, showLabels, terrainDistanceHeatmap });
+  }, [exaggeration, showLabels, terrainDistanceHeatmap]);
 
   useLayoutEffect(() => {
     const element = chartHostRef.current;

--- a/src/lib/migrations.test.ts
+++ b/src/lib/migrations.test.ts
@@ -200,6 +200,7 @@ describe("migrations", () => {
     localStorage.setItem("rmw-storage-health-v1", JSON.stringify({ ok: true }));
     localStorage.setItem("linksim-copernicus-tilelist-v1", JSON.stringify({ copernicus30: {} }));
     localStorage.setItem("linksim-copernicus-tile-index-v1", JSON.stringify({ copernicus30: {} }));
+    localStorage.setItem("linksim-panorama-settings-v1", JSON.stringify({ exaggeration: 8 }));
 
     initializeMigrations();
     const result = await runMigrations();
@@ -209,6 +210,7 @@ describe("migrations", () => {
     expect(localStorage.getItem("rmw-storage-health-v1")).toBe(null);
     expect(localStorage.getItem("linksim-copernicus-tilelist-v1")).not.toBe(null);
     expect(localStorage.getItem("linksim-copernicus-tile-index-v1")).not.toBe(null);
+    expect(localStorage.getItem("linksim-panorama-settings-v1")).not.toBe(null);
   });
 
   it("initializeMigrations is idempotent", async () => {

--- a/src/lib/migrations.ts
+++ b/src/lib/migrations.ts
@@ -36,6 +36,7 @@ const CLIENT_STORAGE_RULES: ClientStorageRule[] = [
   { scope: "localStorage", policy: "preserve", key: "linksim-ui-color-theme-v1" },
   { scope: "localStorage", policy: "preserve", key: "linksim-basemap-provider-v1" },
   { scope: "localStorage", policy: "preserve", key: "linksim-basemap-style-preset-v1" },
+  { scope: "localStorage", policy: "preserve", key: "linksim-panorama-settings-v1" },
   { scope: "localStorage", policy: "resetOnVersionChange", key: "rmw-meshmap-cache-v1" },
   { scope: "localStorage", policy: "preserve", key: "rmw-meshmap-source-url-v1" },
   { scope: "localStorage", policy: "preserve", key: "linksim-copernicus-tilelist-v1" },

--- a/src/lib/panoramaSettings.test.ts
+++ b/src/lib/panoramaSettings.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_PANORAMA_SETTINGS,
+  PANORAMA_SETTINGS_STORAGE_KEY,
+  persistPanoramaSettings,
+  readPanoramaSettings,
+} from "./panoramaSettings";
+
+describe("panoramaSettings", () => {
+  it("returns defaults when no settings are stored", () => {
+    vi.stubGlobal("localStorage", { getItem: vi.fn().mockReturnValue(null) });
+
+    expect(readPanoramaSettings()).toEqual(DEFAULT_PANORAMA_SETTINGS);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("reads stored settings and normalizes invalid values", () => {
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn().mockReturnValue(JSON.stringify({
+        exaggeration: 50,
+        showLabels: false,
+        terrainDistanceHeatmap: true,
+      })),
+    });
+
+    expect(readPanoramaSettings()).toEqual({
+      exaggeration: 20,
+      showLabels: false,
+      terrainDistanceHeatmap: true,
+    });
+
+    vi.unstubAllGlobals();
+  });
+
+  it("falls back per field for malformed stored settings and storage errors", () => {
+    const getItem = vi.fn().mockReturnValue(JSON.stringify({
+      exaggeration: "large",
+      showLabels: "yes",
+      terrainDistanceHeatmap: null,
+    }));
+    vi.stubGlobal("localStorage", { getItem });
+
+    expect(readPanoramaSettings()).toEqual(DEFAULT_PANORAMA_SETTINGS);
+
+    getItem.mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    expect(readPanoramaSettings()).toEqual(DEFAULT_PANORAMA_SETTINGS);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("persists normalized settings with best-effort storage", () => {
+    const setItem = vi.fn();
+    vi.stubGlobal("localStorage", { setItem });
+
+    persistPanoramaSettings({
+      exaggeration: 0,
+      showLabels: false,
+      terrainDistanceHeatmap: true,
+    });
+    expect(setItem).toHaveBeenCalledWith(PANORAMA_SETTINGS_STORAGE_KEY, JSON.stringify({
+      exaggeration: 1,
+      showLabels: false,
+      terrainDistanceHeatmap: true,
+    }));
+
+    setItem.mockImplementation(() => {
+      throw new Error("quota");
+    });
+    expect(() => persistPanoramaSettings(DEFAULT_PANORAMA_SETTINGS)).not.toThrow();
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/src/lib/panoramaSettings.ts
+++ b/src/lib/panoramaSettings.ts
@@ -1,0 +1,47 @@
+export const PANORAMA_SETTINGS_STORAGE_KEY = "linksim-panorama-settings-v1";
+
+export type PanoramaSettings = {
+  exaggeration: number;
+  showLabels: boolean;
+  terrainDistanceHeatmap: boolean;
+};
+
+export const DEFAULT_PANORAMA_SETTINGS: PanoramaSettings = {
+  exaggeration: 4,
+  showLabels: true,
+  terrainDistanceHeatmap: false,
+};
+
+const clampExaggeration = (value: number): number => Math.max(1, Math.min(20, value));
+
+const normalizePanoramaSettings = (value: unknown): PanoramaSettings => {
+  const parsed = typeof value === "object" && value !== null ? value as Partial<PanoramaSettings> : {};
+  return {
+    exaggeration: typeof parsed.exaggeration === "number" && Number.isFinite(parsed.exaggeration)
+      ? clampExaggeration(parsed.exaggeration)
+      : DEFAULT_PANORAMA_SETTINGS.exaggeration,
+    showLabels: typeof parsed.showLabels === "boolean"
+      ? parsed.showLabels
+      : DEFAULT_PANORAMA_SETTINGS.showLabels,
+    terrainDistanceHeatmap: typeof parsed.terrainDistanceHeatmap === "boolean"
+      ? parsed.terrainDistanceHeatmap
+      : DEFAULT_PANORAMA_SETTINGS.terrainDistanceHeatmap,
+  };
+};
+
+export const readPanoramaSettings = (): PanoramaSettings => {
+  try {
+    const raw = localStorage.getItem(PANORAMA_SETTINGS_STORAGE_KEY);
+    return raw === null ? DEFAULT_PANORAMA_SETTINGS : normalizePanoramaSettings(JSON.parse(raw));
+  } catch {
+    return DEFAULT_PANORAMA_SETTINGS;
+  }
+};
+
+export const persistPanoramaSettings = (settings: PanoramaSettings): void => {
+  try {
+    localStorage.setItem(PANORAMA_SETTINGS_STORAGE_KEY, JSON.stringify(normalizePanoramaSettings(settings)));
+  } catch {
+    // Best effort only.
+  }
+};


### PR DESCRIPTION
Closes #857

## Summary
- persist Panorama vertical exaggeration, Labels, and Distance heatmap preferences in localStorage
- validate stored values and fall back to existing defaults
- preserve the settings key across client version migrations

## Verification
- [x] `npm test -- --run src/lib/panoramaSettings.test.ts src/lib/migrations.test.ts`
- [x] `npm test`
- [x] `npm run build`
- [x] `git diff --check`
- [x] `npm run dev:check`

## Notes
- `npm run lint` remains red from pre-existing unrelated findings, including files under `.claude/worktrees`. Touched-file lint reports only existing `PanoramaChart.tsx` findings outside this diff.