### PR TITLE
fix: keep collaborator popover on screen on mobile

### DIFF
--- a/src/components/ui/FloatingPopover.test.tsx
+++ b/src/components/ui/FloatingPopover.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useRef, useState } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { FloatingPopover } from "./FloatingPopover";
+
+const setViewportWidth = (width: number) => {
+  Object.defineProperty(window, "innerWidth", { configurable: true, value: width });
+};
+
+function Harness({ estimatedWidth }: { estimatedWidth: number }) {
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+
+  return (
+    <>
+      <button ref={triggerRef} onClick={() => setOpen(true)} type="button">
+        Open
+      </button>
+      <FloatingPopover
+        estimatedWidth={estimatedWidth}
+        onClose={() => setOpen(false)}
+        open={open}
+        triggerRef={triggerRef}
+      >
+        <div>Popover content</div>
+      </FloatingPopover>
+    </>
+  );
+}
+
+describe("FloatingPopover", () => {
+  afterEach(() => {
+    setViewportWidth(1024);
+  });
+
+  it("keeps a wide trigger popover within the viewport near the right edge", async () => {
+    setViewportWidth(500);
+    render(<Harness estimatedWidth={420} />);
+    const trigger = screen.getByRole("button", { name: "Open" });
+    trigger.getBoundingClientRect = () => new DOMRect(460, 200, 32, 32);
+
+    await userEvent.click(trigger);
+
+    await waitFor(() => {
+      expect(document.querySelector(".ui-action-popover")).toHaveStyle({ left: "282px" });
+    });
+  });
+
+  it("centers the anchor when the viewport is narrower than the requested width", async () => {
+    setViewportWidth(360);
+    render(<Harness estimatedWidth={420} />);
+    const trigger = screen.getByRole("button", { name: "Open" });
+    trigger.getBoundingClientRect = () => new DOMRect(320, 200, 32, 32);
+
+    await userEvent.click(trigger);
+
+    await waitFor(() => {
+      expect(document.querySelector(".ui-action-popover")).toHaveStyle({ left: "180px" });
+    });
+  });
+});

--- a/src/components/ui/FloatingPopover.tsx
+++ b/src/components/ui/FloatingPopover.tsx
@@ -11,6 +11,20 @@ type FloatingPopoverPosition = {
   direction: "up" | "down";
 };
 
+const POPOVER_VIEWPORT_MARGIN = 8;
+
+const clampHorizontalAnchor = (anchor: number, estimatedWidth: number): number => {
+  const viewportMargin = Math.min(POPOVER_VIEWPORT_MARGIN, window.innerWidth / 2);
+  const availableWidth = Math.max(window.innerWidth - viewportMargin * 2, 0);
+  const effectiveWidth = Math.min(estimatedWidth, availableWidth);
+  const halfWidth = effectiveWidth / 2;
+
+  return Math.min(
+    Math.max(anchor, halfWidth + viewportMargin),
+    window.innerWidth - halfWidth - viewportMargin,
+  );
+};
+
 type FloatingPopoverProps = {
   open: boolean;
   onClose: () => void;
@@ -60,10 +74,7 @@ export function FloatingPopover({
         const containerWidth = rect.width;
         const containerLeft = rect.left;
         const containerTop = rect.top;
-        const left = Math.min(
-          Math.max(containerLeft + containerWidth / 2, estimatedWidth / 2 + 8),
-          window.innerWidth - estimatedWidth / 2 - 8,
-        );
+        const left = clampHorizontalAnchor(containerLeft + containerWidth / 2, estimatedWidth);
         const spaceAbove = containerTop;
         const spaceBelow = window.innerHeight - rect.bottom;
         const direction: "up" | "down" =
@@ -84,10 +95,7 @@ export function FloatingPopover({
       const spaceBelow = window.innerHeight - rect.bottom;
       const direction: "up" | "down" =
         spaceAbove >= estimatedHeight + 12 || spaceAbove >= spaceBelow ? "up" : "down";
-      const left = Math.min(
-        Math.max(rect.left + rect.width / 2, 84),
-        window.innerWidth - 84,
-      );
+      const left = clampHorizontalAnchor(rect.left + rect.width / 2, estimatedWidth);
       setPosition({
         left,
         top: direction === "up" ? rect.top - 8 : rect.bottom + 8,


### PR DESCRIPTION
## Summary
- clamp shared FloatingPopover anchors using their estimated width
- cap effective width to the usable viewport so narrow screens stay centered
- reuse the horizontal clamp for trigger and centered placement
- add regression coverage for right-edge and narrower-than-requested mobile viewports

Relates to #885

## Verification
- npm test (553 tests)
- npm run build
- authenticated local edge browser check at 390px viewport: collaborator popover bounds left=12px, right=378px, width=366px
- npm run dev:check (no LinkSim dev/watch servers found)