### PR TITLE
fix: keep empty profile panel controls

### DIFF
--- a/src/components/LinkProfileChart.test.tsx
+++ b/src/components/LinkProfileChart.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { LinkProfileEmptyState } from "./LinkProfileChart";
+
+vi.hoisted(() => {
+  const data = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: (key: string) => data.get(key) ?? null,
+    setItem: (key: string, value: string) => data.set(key, String(value)),
+    removeItem: (key: string) => data.delete(key),
+    clear: () => data.clear(),
+    key: (index: number) => Array.from(data.keys())[index] ?? null,
+    get length() {
+      return data.size;
+    },
+  });
+});
+
+const noPathMessage =
+  "Select exactly two sites, or choose a saved link, to show path profile and LOS/Fresnel analysis.";
+const multiSiteMessage =
+  "Select exactly two sites, or choose a saved link, to show path profile analysis.";
+
+describe("LinkProfileEmptyState", () => {
+  it.each([noPathMessage, multiSiteMessage])(
+    "keeps the toolbar and supplied row controls for guidance text",
+    (message) => {
+      render(
+        <LinkProfileEmptyState
+          message={message}
+          rowControls={<button type="button">Hide Profile</button>}
+        />,
+      );
+
+      expect(screen.getByText("Path Profile")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Hide Profile" })).toBeInTheDocument();
+      expect(screen.getByText(message)).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Reverse path direction for this view" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Full screen" })).not.toBeInTheDocument();
+    },
+  );
+});

--- a/src/components/LinkProfileChart.tsx
+++ b/src/components/LinkProfileChart.tsx
@@ -59,6 +59,25 @@ type LinkProfileChartProps = {
   panelClassName?: string;
 };
 
+type LinkProfileEmptyStateProps = {
+  message: string;
+  rowControls?: ReactNode;
+  panelClassName?: string;
+};
+
+export function LinkProfileEmptyState({
+  message,
+  rowControls,
+  panelClassName,
+}: LinkProfileEmptyStateProps) {
+  return (
+    <section className={`chart-panel chart-panel-empty ${panelClassName ?? ""}`.trim()}>
+      <PanelToolbar title="Path Profile" actions={rowControls} />
+      <div className="chart-empty">{message}</div>
+    </section>
+  );
+}
+
 export function LinkProfileChart({
   isExpanded,
   onToggleExpanded,
@@ -771,21 +790,21 @@ export function LinkProfileChart({
 
   if (!hasMinimumTopology) {
     return (
-      <section className={`chart-panel chart-panel-empty ${panelClassName ?? ""}`.trim()}>
-        <div className="chart-empty">
-          Select exactly two sites, or choose a saved link, to show path profile and LOS/Fresnel analysis.
-        </div>
-      </section>
+      <LinkProfileEmptyState
+        message="Select exactly two sites, or choose a saved link, to show path profile and LOS/Fresnel analysis."
+        panelClassName={panelClassName}
+        rowControls={rowControls}
+      />
     );
   }
 
   if (tooManySelectedForProfile) {
     return (
-      <section className={`chart-panel chart-panel-empty ${panelClassName ?? ""}`.trim()}>
-        <div className="chart-empty">
-          Select exactly two sites, or choose a saved link, to show path profile analysis.
-        </div>
-      </section>
+      <LinkProfileEmptyState
+        message="Select exactly two sites, or choose a saved link, to show path profile analysis."
+        panelClassName={panelClassName}
+        rowControls={rowControls}
+      />
     );
   }
 


### PR DESCRIPTION
## Summary
- keep the empty Profile panel toolbar visible when no Path is analyzable
- reuse the same toolbar shell for 3+ selected Site guidance
- retain only existing hide/size row controls in empty states

## Verification
- npm test
- npm run build
- npm run dev:check

Closes #901