### PR TITLE
fix: refine empty bottom panel guidance

### DIFF
--- a/src/components/LinkProfileChart.test.tsx
+++ b/src/components/LinkProfileChart.test.tsx
@@ -17,27 +17,20 @@ vi.hoisted(() => {
   });
 });
 
-const noPathMessage =
-  "Select exactly two sites, or choose a saved link, to show path profile and LOS/Fresnel analysis.";
-const multiSiteMessage =
-  "Select exactly two sites, or choose a saved link, to show path profile analysis.";
+const guidance =
+  "Select one Site for Panorama, or select exactly two Sites or choose a saved Path for Path Profile and LOS/Fresnel analysis.";
 
 describe("LinkProfileEmptyState", () => {
-  it.each([noPathMessage, multiSiteMessage])(
-    "keeps the toolbar and supplied row controls for guidance text",
-    (message) => {
-      render(
-        <LinkProfileEmptyState
-          message={message}
-          rowControls={<button type="button">Hide Profile</button>}
-        />,
-      );
+  it("keeps a titleless toolbar at the top and supplies guidance for Panorama and Path Profile modes", () => {
+    const { container } = render(
+      <LinkProfileEmptyState rowControls={<button type="button">Hide Profile</button>} />,
+    );
 
-      expect(screen.getByText("Path Profile")).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "Hide Profile" })).toBeInTheDocument();
-      expect(screen.getByText(message)).toBeInTheDocument();
-      expect(screen.queryByRole("button", { name: "Reverse path direction for this view" })).not.toBeInTheDocument();
-      expect(screen.queryByRole("button", { name: "Full screen" })).not.toBeInTheDocument();
-    },
-  );
+    expect(screen.queryByText("Path Profile")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Hide Profile" })).toBeInTheDocument();
+    expect(screen.getByText(guidance)).toHaveClass("chart-panel-empty-message");
+    expect(container.querySelector(".chart-panel")).not.toHaveClass("chart-panel-empty");
+    expect(screen.queryByRole("button", { name: "Reverse path direction for this view" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Full screen" })).not.toBeInTheDocument();
+  });
 });

--- a/src/components/LinkProfileChart.tsx
+++ b/src/components/LinkProfileChart.tsx
@@ -60,20 +60,20 @@ type LinkProfileChartProps = {
 };
 
 type LinkProfileEmptyStateProps = {
-  message: string;
   rowControls?: ReactNode;
   panelClassName?: string;
 };
 
 export function LinkProfileEmptyState({
-  message,
   rowControls,
   panelClassName,
 }: LinkProfileEmptyStateProps) {
   return (
-    <section className={`chart-panel chart-panel-empty ${panelClassName ?? ""}`.trim()}>
-      <PanelToolbar title="Path Profile" actions={rowControls} />
-      <div className="chart-empty">{message}</div>
+    <section className={`chart-panel ${panelClassName ?? ""}`.trim()}>
+      <PanelToolbar actions={rowControls} />
+      <div className="chart-empty chart-panel-empty-message">
+        Select one Site for Panorama, or select exactly two Sites or choose a saved Path for Path Profile and LOS/Fresnel analysis.
+      </div>
     </section>
   );
 }
@@ -791,7 +791,6 @@ export function LinkProfileChart({
   if (!hasMinimumTopology) {
     return (
       <LinkProfileEmptyState
-        message="Select exactly two sites, or choose a saved link, to show path profile and LOS/Fresnel analysis."
         panelClassName={panelClassName}
         rowControls={rowControls}
       />
@@ -801,7 +800,6 @@ export function LinkProfileChart({
   if (tooManySelectedForProfile) {
     return (
       <LinkProfileEmptyState
-        message="Select exactly two sites, or choose a saved link, to show path profile analysis."
         panelClassName={panelClassName}
         rowControls={rowControls}
       />

--- a/src/index.css
+++ b/src/index.css
@@ -2765,6 +2765,10 @@ button {
   justify-content: center;
 }
 
+.chart-panel-empty-message {
+  flex: 1;
+}
+
 .chart-svg-wrap {
   flex: 1;
   min-height: 90px;


### PR DESCRIPTION
## Summary
- keep the empty bottom-panel toolbar titleless because the panel supports multiple modes
- align the toolbar at the top like Path Profile and Panorama modes
- update guidance to mention one-Site Panorama and two-Site or saved-Path analysis

## Verification
- npm test
- npm run build
- npm run dev:check

Follow-up for #901