### PR TITLE
fix: align raster overlays with Web Mercator

### DIFF
--- a/src/lib/overlayRaster.test.ts
+++ b/src/lib/overlayRaster.test.ts
@@ -6,6 +6,7 @@ import {
   buildRelayCandidateOverlayPixelsAsync,
   buildSourcePassFailOverlayPixelsAsync,
   buildTerrainShadeOverlayPixelsAsync,
+  latitudeForRasterRow,
   OverlayTaskCancelledError,
   type CoverageSampleLite,
   type TerrainBounds,
@@ -69,6 +70,16 @@ const environment: PropagationEnvironment = {
 const terrainSampler = () => 135;
 
 describe("overlayRaster async builders", () => {
+  it("samples raster rows in Web Mercator space so image overlays align with GeoJSON", () => {
+    const minLat = 62.97069520171348;
+    const maxLat = 63.869006376704505;
+
+    expect(latitudeForRasterRow(0, 3, minLat, maxLat)).toBeCloseTo(maxLat, 12);
+    expect(latitudeForRasterRow(2, 3, minLat, maxLat)).toBeCloseTo(minLat, 12);
+    expect(latitudeForRasterRow(1, 3, minLat, maxLat)).toBeCloseTo(63.42336981712888, 12);
+    expect(latitudeForRasterRow(1, 3, minLat, maxLat)).not.toBeCloseTo((minLat + maxLat) / 2, 4);
+  });
+
   it("normalizes coverage colors against the RX target instead of sample min/max", () => {
     const scale = { min: -150, max: -90 };
     expect(normalizeCoverageDbmForRxTarget(-150, -120, scale)).toBe(0);

--- a/src/lib/overlayRaster.ts
+++ b/src/lib/overlayRaster.ts
@@ -74,6 +74,25 @@ const clamp = (value: number, min: number, max: number): number => Math.max(min,
 
 const lerp = (a: number, b: number, t: number): number => a + (b - a) * t;
 
+const MAX_MERCATOR_LAT = 85.05112878;
+const mercatorYForLatitude = (lat: number): number => {
+  const radians = (clamp(lat, -MAX_MERCATOR_LAT, MAX_MERCATOR_LAT) * Math.PI) / 180;
+  return Math.log(Math.tan(Math.PI / 4 + radians / 2));
+};
+const latitudeForMercatorY = (mercatorY: number): number =>
+  ((2 * Math.atan(Math.exp(mercatorY)) - Math.PI / 2) * 180) / Math.PI;
+
+export const latitudeForRasterRow = (
+  row: number,
+  height: number,
+  minLat: number,
+  maxLat: number,
+): number => {
+  const divisor = Math.max(1, height - 1);
+  const fraction = clamp(row / divisor, 0, 1);
+  return latitudeForMercatorY(lerp(mercatorYForLatitude(maxLat), mercatorYForLatitude(minLat), fraction));
+};
+
 const overlayCoordinates = (bounds: TerrainBounds): OverlayRasterPixels["coordinates"] => [
   [bounds.minLon, bounds.maxLat],
   [bounds.maxLon, bounds.maxLat],
@@ -159,13 +178,11 @@ const precomputeGridAxes = (
   const height = dimensions.height;
   const latByRow = new Float64Array(height);
   const lonByCol = new Float64Array(width);
-  const latSpan = bounds.maxLat - bounds.minLat;
   const lonSpan = bounds.maxLon - bounds.minLon;
-  const heightDivisor = Math.max(1, height - 1);
   const widthDivisor = Math.max(1, width - 1);
 
   for (let y = 0; y < height; y += 1) {
-    latByRow[y] = bounds.maxLat - latSpan * (y / heightDivisor);
+    latByRow[y] = latitudeForRasterRow(y, height, bounds.minLat, bounds.maxLat);
   }
   for (let x = 0; x < width; x += 1) {
     lonByCol[x] = bounds.minLon + lonSpan * (x / widthDivisor);


### PR DESCRIPTION
## Summary
- sample raster overlay rows in Web Mercator space so MapLibre image overlays align with GeoJSON contours
- apply the shared correction to heatmap, target line background, pass/fail, relay, and terrain raster overlays
- add regression coverage for projected midpoint latitude sampling

Closes #902

## Verification
- npm test -- --run src/lib/overlayRaster.test.ts
- npm test
- npm run build
- git diff --check
- npm run dev:check