### PR TITLE
docs: update release-flow baseline

### DIFF
--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -62,7 +62,7 @@
 
 ## Versioning Policy
 - SemVer is mandatory (`MAJOR.MINOR.PATCH`).
-- Current baseline: `0.17.0`.
+- Current baseline: `0.21.0`.
 - Bump level decision rules:
   - `PATCH` (`0.9.x`): bug fixes, polish, performance tuning, and non-breaking UX behavior fixes.
   - `MINOR` (`0.x.0`): new user-facing features or meaningful workflow additions that are backward-compatible.


### PR DESCRIPTION
## Summary

- update the stale current release baseline in `docs/release-flow.md` from `0.17.0` to `0.21.0`
- align the release source of truth with `package.json` and the latest shipped release
- leave all release policy wording unchanged

Follow-up to #911.

## Validation

- `git diff --check`
- `npm test` — 111 files, 555 tests passed
- `npm run build` — passed
- `npm run dev:check` — no LinkSim dev/watch servers found