### PR TITLE
Fix new simulations becoming read-only (#909)

### DIFF
--- a/src/components/AppShell.copyFlow.test.tsx
+++ b/src/components/AppShell.copyFlow.test.tsx
@@ -237,4 +237,27 @@ describe("AppShell copy flow", () => {
       view.unmount();
     }
   });
+
+  it("keeps the workspace writable after creating and loading a blank simulation", async () => {
+    const view = render(<AppShell />);
+
+    try {
+      await waitFor(() => expect(sidebarCalls.length).toBeGreaterThan(0));
+
+      const createdId = useAppStore.getState().createBlankSimulationPreset("Blank Simulation", {
+        visibility: "private",
+        ownerUserId: "user-1",
+      });
+      expect(createdId).toBeTruthy();
+
+      await act(async () => {
+        useAppStore.getState().loadSimulationPreset(createdId as string);
+      });
+
+      await waitFor(() => expect(sidebarCalls[sidebarCalls.length - 1]?.readOnly).toBe(false));
+      expect(useAppStore.getState().selectedScenarioId).toBe(createdId);
+    } finally {
+      view.unmount();
+    }
+  });
 });

--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -510,6 +510,15 @@ describe("appStore blank simulation loading", () => {
     expect(raw).toBeTruthy();
     expect(raw).toContain(createdId as string);
   });
+
+  it("grants the owner edit access immediately when creating a blank simulation", () => {
+    const createdId = useAppStore
+      .getState()
+      .createBlankSimulationPreset("Writable Blank Session", { visibility: "private", ownerUserId: "owner-1" });
+
+    const created = useAppStore.getState().simulationPresets.find((entry) => entry.id === createdId);
+    expect(created?.effectiveRole).toBe("owner");
+  });
 });
 
 describe("appStore new simulation default frequency preset", () => {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -2924,6 +2924,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         lastEditedByUserId: user.id,
         lastEditedByName: user.username,
         lastEditedByAvatarUrl: user.avatarUrl ?? "",
+        effectiveRole: "owner",
       };
       const next = [nextPreset, ...current.simulationPresets];
       writeStorage(SIM_PRESETS_KEY, next);


### PR DESCRIPTION
## Summary

- assign the locally created blank simulation an immediate owner role
- keep the new simulation writable without requiring a page reload
- add store and AppShell regressions for the creation/load sequence

## Root cause

`createBlankSimulationPreset` omitted `effectiveRole`, while `AppShell` requires an active simulation role of owner, admin, or editor before enabling persistence. Cloud reload derived the owner role, which is why the missing `Save To Library` action returned after refresh.

## User impact

After creating a new simulation, users can immediately mark a map location and use `Save To Library` without reloading LinkSim.

## Verification

- [x] Focused regression suite: 23 tests passed
- [x] `npm test`: 111 files / 557 tests passed
- [x] `npm run build`
- [x] Authenticated local edge QA: create blank simulation, place map marker, confirm `Save To Library` appears immediately
- [x] `npm run dev:check`: no LinkSim dev/watch servers left running

Closes #909 after shared-staging verification and user sign-off.