### PR TITLE
Add mesh extension candidate overlay (#910)

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -53,6 +53,7 @@ import { simulationAreaBoundsForSites } from "../lib/simulationArea";
 import { tilesForBounds } from "../lib/terrainTiles";
 import {
   buildCoverageOverlayPixelsAsync,
+  buildMeshExtensionOverlayPixelsAsync,
   buildRelayCandidateOverlayPixelsAsync,
   buildSourcePassFailOverlayPixelsAsync,
   buildTerrainShadeOverlayPixelsAsync,
@@ -61,6 +62,12 @@ import {
   type OverlayRasterPixels,
 } from "../lib/overlayRaster";
 import { overlayTaskBudgetForMode } from "../lib/overlayTaskBudget";
+import {
+  meshExtensionSiteDigest,
+  overlayGuideTitleForMode,
+  overlayModesForSelectionCount,
+  type MapOverlayMode,
+} from "../lib/mapOverlayMode";
 import {
   recordSimulationOverlayPerf,
   recordSimulationRunCancelled,
@@ -285,6 +292,10 @@ type CoverageSampleLite = { lat: number; lon: number; valueDbm: number; weakestD
 type OverlayRaster = {
   url: string;
   coordinates: [[number, number], [number, number], [number, number], [number, number]];
+  minDbm?: number;
+  maxDbm?: number;
+  minAreaKm2?: number;
+  maxAreaKm2?: number;
 };
 
 type OverlayMaskArea = {
@@ -981,6 +992,7 @@ export function MapView({
     () => selectedSiteIds.map((id) => sites.find((site) => site.id === id)).filter((site): site is Site => Boolean(site)),
     [selectedSiteIds, sites],
   );
+  const meshExtensionSites = selectedSites.length > 0 ? selectedSites : sites;
   const selectedSiteSet = useMemo(() => new Set(selectedSites.map((site) => site.id)), [selectedSites]);
   const selectionCount = selectedSites.length;
   const singleSelectedSite = selectionCount === 1 ? selectedSites[0] ?? null : null;
@@ -1542,6 +1554,9 @@ export function MapView({
     [propagationEnvironment],
   );
   const selectedSiteDigest = useMemo(() => selectedSiteIds.join(","), [selectedSiteIds]);
+  const selectedSiteRadioDigest = useMemo(() => meshExtensionSiteDigest(meshExtensionSites), [meshExtensionSites]);
+  const meshExtensionFrequencyMHz =
+    selectedNetwork?.frequencyOverrideMHz ?? selectedNetwork?.frequencyMHz ?? activeSelectionLink?.frequencyMHz ?? 869.618;
 
   useEffect(() => {
     const scheduler = coverageOverlaySchedulerRef.current!;
@@ -1570,6 +1585,10 @@ export function MapView({
       cancelCoveragePipeline(true);
       return;
     }
+    if (mode === "mesh-extension" && !meshExtensionSites.length) {
+      cancelCoveragePipeline(true);
+      return;
+    }
 
     const signature = [
       mode,
@@ -1593,6 +1612,8 @@ export function MapView({
       rxSensitivityTargetDbm,
       environmentLossDb,
       selectedSiteDigest,
+      selectedSiteRadioDigest,
+      meshExtensionFrequencyMHz,
     ].join("|");
     const cached = coverageOverlayCacheRef.current.get(signature);
     if (cached) {
@@ -1706,6 +1727,22 @@ export function MapView({
               overlayPointMask,
               context,
             );
+          } else if (mode === "mesh-extension") {
+            rasterPixels = await buildMeshExtensionOverlayPixelsAsync({
+              bounds: overlayBounds,
+              selectedSites: meshExtensionSites,
+              frequencyMHz: meshExtensionFrequencyMHz,
+              propagationEnvironment,
+              rxTargetDbm: rxSensitivityTargetDbm,
+              environmentLossDb,
+              terrainSampler,
+              dimensions: overlayDimensions,
+              candidateGridSize: Math.min(effectiveGridSize, 42),
+              coverageGridSize: 24,
+              terrainSamples: 20,
+              pointMask: overlayPointMask,
+              context,
+            });
           }
 
           const overlayBuildCompletedAt = performance.now();
@@ -1800,6 +1837,10 @@ export function MapView({
     effectiveGridSize,
     overlayRadiusKm,
     selectedSiteDigest,
+    selectedSiteRadioDigest,
+    meshExtensionFrequencyMHz,
+    meshExtensionSites,
+    selectedNetwork,
     showOverlayDiagnostics,
     beginOverlayJob,
     setOverlayPipelineProgress,
@@ -1849,18 +1890,17 @@ export function MapView({
     if (typeof coverageOverlay.minDbm !== "number" || typeof coverageOverlay.maxDbm !== "number") return null;
     return { min: coverageOverlay.minDbm, max: coverageOverlay.maxDbm };
   }, [coverageOverlay, coverageVizMode]);
-  const overlayGuideTitle =
-    coverageVizMode === "none"
-      ? "Hidden"
-      : coverageVizMode === "heatmap"
-      ? "Heatmap"
-      : coverageVizMode === "contours"
-        ? "Heatmap + Target Line"
-        : coverageVizMode === "weakest"
-          ? "Weakest Site"
-        : coverageVizMode === "passfail"
-          ? "Pass/Fail"
-          : "Relay";
+  const meshExtensionRange = useMemo(() => {
+    if (!coverageOverlay || coverageVizMode !== "mesh-extension") return null;
+    if (typeof coverageOverlay.maxAreaKm2 !== "number") return null;
+    return {
+      minAreaKm2: coverageOverlay.minAreaKm2 ?? 0,
+      maxAreaKm2: coverageOverlay.maxAreaKm2,
+      minDbm: coverageOverlay.minDbm,
+      maxDbm: coverageOverlay.maxDbm,
+    };
+  }, [coverageOverlay, coverageVizMode]);
+  const overlayGuideTitle = overlayGuideTitleForMode(coverageVizMode);
 
   useEffect(() => {
     const scheduler = terrainOverlaySchedulerRef.current!;
@@ -2658,14 +2698,12 @@ export function MapView({
     fitChromePadding.top,
     fitChromePadding.bottom,
   ]);
-  const allowedOverlayModes = useMemo<Array<"none" | "heatmap" | "contours" | "weakest" | "passfail" | "relay">>(() => {
-    if (selectionCount <= 0) return ["none", "heatmap", "weakest", "contours"];
-    if (selectionCount === 1) return ["none", "passfail", "heatmap", "weakest", "contours"];
-    if (selectionCount === 2) return ["none", "relay", "heatmap", "weakest", "contours"];
-    return ["none", "heatmap", "weakest", "contours"];
-  }, [selectionCount]);
+  const allowedOverlayModes = useMemo(
+    () => overlayModesForSelectionCount(selectionCount, sites.length),
+    [selectionCount, sites.length],
+  );
   useEffect(() => {
-    if (allowedOverlayModes.includes(coverageVizMode as "none" | "heatmap" | "contours" | "weakest" | "passfail" | "relay")) return;
+    if (allowedOverlayModes.includes(coverageVizMode)) return;
     setCoverageVizMode(selectionCount === 1 ? "passfail" : selectionCount === 2 ? "relay" : "heatmap");
   }, [allowedOverlayModes, coverageVizMode, selectionCount, setCoverageVizMode]);
   const simulationOverlaySelectValue = coverageVizMode;
@@ -3056,7 +3094,7 @@ export function MapView({
                 <select
                   className="locale-select"
                   onChange={(event) => {
-                    const mode = event.target.value as "none" | "heatmap" | "contours" | "weakest" | "passfail" | "relay";
+                    const mode = event.target.value as MapOverlayMode;
                     if (mode === "heatmap") {
                       setCoverageVizMode("heatmap");
                       return;
@@ -3075,6 +3113,7 @@ export function MapView({
                   {allowedOverlayModes.includes("contours") ? <option value="contours">Heatmap + Target Line</option> : null}
                   {allowedOverlayModes.includes("passfail") ? <option value="passfail">Pass/Fail</option> : null}
                   {allowedOverlayModes.includes("relay") ? <option value="relay">Relay</option> : null}
+                  {allowedOverlayModes.includes("mesh-extension") ? <option value="mesh-extension">Mesh Extension</option> : null}
                 </select>
               </label>
               {coverageVizMode !== "none" && (
@@ -3263,6 +3302,29 @@ export function MapView({
                   </div>
                 </div>
                 <p className="overlay-scale-help">Left side is worse relay quality. Right side is better relay quality.</p>
+              </>
+            ) : null}
+            {coverageVizMode === "mesh-extension" ? (
+              <>
+                <p>
+                  Shows where a representative new node can reach any selected Site, or any Simulation Site when none
+                  are selected, in both directions while adding terrain that those Sites do not currently cover.
+                </p>
+                <div className="overlay-scale">
+                  <div className="overlay-scale-bar" />
+                  <div className="overlay-scale-labels">
+                    <span>{(meshExtensionRange?.minAreaKm2 ?? 0).toFixed(1)} km² new</span>
+                    <span>{meshExtensionRange ? `${meshExtensionRange.maxAreaKm2.toFixed(1)} km² new` : "More new area"}</span>
+                  </div>
+                </div>
+                <p className="overlay-scale-help">
+                  Color shows newly covered area. Opacity shows bidirectional signal to the strongest applicable peer;
+                  faint locations are below the RX target.
+                </p>
+                <p className="overlay-scale-help">
+                  Candidate scoring is terrain-aware and capped at the 2x grid; the Simulation Resolution still controls
+                  rendered smoothness above that cap.
+                </p>
               </>
             ) : null}
           </CompactDetails>

--- a/src/lib/coverage.ts
+++ b/src/lib/coverage.ts
@@ -34,6 +34,11 @@ export type CoverageGridDimensions = {
   targetSamples: number;
 };
 
+export type CoverageGridPoint = {
+  lat: number;
+  lon: number;
+};
+
 const COVERAGE_COMPUTE_CHUNK_SIZE = 48;
 const COVERAGE_COMPUTE_FRAME_BUDGET_MS = 12;
 
@@ -56,6 +61,25 @@ export const computeCoverageGridDimensions = (
     totalSamples: rows * cols,
     targetSamples,
   };
+};
+
+export const buildCoverageGridPoints = (
+  gridSize: number,
+  bounds: CoverageGridBounds,
+  sampleMultiplier = 1,
+): CoverageGridPoint[] => {
+  const { rows, cols } = computeCoverageGridDimensions(gridSize, bounds, sampleMultiplier);
+  const points: CoverageGridPoint[] = [];
+  for (let y = 0; y < rows; y += 1) {
+    const ty = rows <= 1 ? 0 : y / (rows - 1);
+    const lat = bounds.minLat + (bounds.maxLat - bounds.minLat) * ty;
+    for (let x = 0; x < cols; x += 1) {
+      const tx = cols <= 1 ? 0 : x / (cols - 1);
+      const lon = bounds.minLon + (bounds.maxLon - bounds.minLon) * tx;
+      points.push({ lat, lon });
+    }
+  }
+  return points;
 };
 
 const nUnitsToKFactor = (nUnits: number): number => {
@@ -198,24 +222,12 @@ export const buildCoverage = (
       ? effectiveMemberships
       : sites.map((site) => ({ siteId: site.id, systemId: fallbackSystemId }));
 
-  const samples: { lat: number; lon: number }[] = [];
   const bounds = simulationAreaBoundsForSites(sites, {
     overlayRadiusKm: options?.overlayRadiusKm,
     singleSiteRadiusKm: options?.singleSiteRadiusKm,
   });
   if (!bounds) return [];
-
-  const { rows, cols } = computeCoverageGridDimensions(gridSize, bounds, sampleMultiplier);
-
-  for (let y = 0; y < rows; y += 1) {
-    const ty = rows <= 1 ? 0 : y / (rows - 1);
-    const lat = bounds.minLat + (bounds.maxLat - bounds.minLat) * ty;
-    for (let x = 0; x < cols; x += 1) {
-      const tx = cols <= 1 ? 0 : x / (cols - 1);
-      const lon = bounds.minLon + (bounds.maxLon - bounds.minLon) * tx;
-      samples.push({ lat, lon });
-    }
-  }
+  const samples = buildCoverageGridPoints(gridSize, bounds, sampleMultiplier);
 
   onProgress?.(0);
   const total = Math.max(1, samples.length);
@@ -281,24 +293,12 @@ export const buildCoverageAsync = async (
       ? effectiveMemberships
       : sites.map((site) => ({ siteId: site.id, systemId: fallbackSystemId }));
 
-  const samples: { lat: number; lon: number }[] = [];
   const bounds = simulationAreaBoundsForSites(sites, {
     overlayRadiusKm: options?.overlayRadiusKm,
     singleSiteRadiusKm: options?.singleSiteRadiusKm,
   });
   if (!bounds) return [];
-
-  const { rows, cols } = computeCoverageGridDimensions(gridSize, bounds, sampleMultiplier);
-
-  for (let y = 0; y < rows; y += 1) {
-    const ty = rows <= 1 ? 0 : y / (rows - 1);
-    const lat = bounds.minLat + (bounds.maxLat - bounds.minLat) * ty;
-    for (let x = 0; x < cols; x += 1) {
-      const tx = cols <= 1 ? 0 : x / (cols - 1);
-      const lon = bounds.minLon + (bounds.maxLon - bounds.minLon) * tx;
-      samples.push({ lat, lon });
-    }
-  }
+  const samples = buildCoverageGridPoints(gridSize, bounds, sampleMultiplier);
 
   onProgress?.(0);
   const total = Math.max(1, samples.length);

--- a/src/lib/mapOverlayMode.test.ts
+++ b/src/lib/mapOverlayMode.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { meshExtensionSiteDigest, overlayGuideTitleForMode, overlayModesForSelectionCount } from "./mapOverlayMode";
+import type { Site } from "../types/radio";
+
+describe("map overlay modes", () => {
+  it("treats no selection as all Simulation Sites for Mesh Extension", () => {
+    expect(overlayModesForSelectionCount(0, 0)).not.toContain("mesh-extension");
+    expect(overlayModesForSelectionCount(0, 4)).toContain("mesh-extension");
+    expect(overlayModesForSelectionCount(1, 4)).toContain("mesh-extension");
+    expect(overlayModesForSelectionCount(2, 4)).toContain("mesh-extension");
+    expect(overlayModesForSelectionCount(3, 4)).toContain("mesh-extension");
+  });
+
+  it("keeps existing selection defaults separate from manual mode availability", () => {
+    expect(overlayModesForSelectionCount(1)).toContain("passfail");
+    expect(overlayModesForSelectionCount(2)).toContain("relay");
+  });
+
+  it("provides the Mesh Extension guide title", () => {
+    expect(overlayGuideTitleForMode("mesh-extension")).toBe("Mesh Extension");
+  });
+
+  it("invalidates mesh-extension identity when location, terrain, or radio values change", () => {
+    const site: Site = {
+      id: "a",
+      name: "A",
+      position: { lat: 60, lon: 10 },
+      groundElevationM: 100,
+      antennaHeightM: 5,
+      txPowerDbm: 22,
+      txGainDbi: 2,
+      rxGainDbi: 2,
+      cableLossDb: 1,
+    };
+    const baseline = meshExtensionSiteDigest([site]);
+
+    expect(meshExtensionSiteDigest([{ ...site, position: { ...site.position, lat: 60.1 } }])).not.toBe(baseline);
+    expect(meshExtensionSiteDigest([{ ...site, groundElevationM: 120 }])).not.toBe(baseline);
+    expect(meshExtensionSiteDigest([{ ...site, txPowerDbm: 24 }])).not.toBe(baseline);
+  });
+});

--- a/src/lib/mapOverlayMode.ts
+++ b/src/lib/mapOverlayMode.ts
@@ -1,0 +1,63 @@
+export type MapOverlayMode =
+  | "none"
+  | "heatmap"
+  | "contours"
+  | "weakest"
+  | "passfail"
+  | "relay"
+  | "mesh-extension";
+
+export const overlayModesForSelectionCount = (
+  selectionCount: number,
+  siteCount = selectionCount,
+): MapOverlayMode[] => {
+  if (selectionCount <= 0) {
+    return siteCount > 0
+      ? ["none", "mesh-extension", "heatmap", "weakest", "contours"]
+      : ["none", "heatmap", "weakest", "contours"];
+  }
+  if (selectionCount === 1) return ["none", "passfail", "mesh-extension", "heatmap", "weakest", "contours"];
+  if (selectionCount === 2) return ["none", "relay", "mesh-extension", "heatmap", "weakest", "contours"];
+  return ["none", "mesh-extension", "heatmap", "weakest", "contours"];
+};
+
+export const overlayGuideTitleForMode = (mode: MapOverlayMode): string => {
+  switch (mode) {
+    case "none": return "Hidden";
+    case "heatmap": return "Heatmap";
+    case "contours": return "Heatmap + Target Line";
+    case "weakest": return "Weakest Site";
+    case "passfail": return "Pass/Fail";
+    case "relay": return "Relay";
+    case "mesh-extension": return "Mesh Extension";
+  }
+};
+
+type MeshExtensionSiteDigestInput = Pick<
+  import("../types/radio").Site,
+  | "id"
+  | "position"
+  | "groundElevationM"
+  | "antennaHeightM"
+  | "txPowerDbm"
+  | "txGainDbi"
+  | "rxGainDbi"
+  | "cableLossDb"
+>;
+
+export const meshExtensionSiteDigest = (sites: MeshExtensionSiteDigestInput[]): string =>
+  sites
+    .map((site) =>
+      [
+        site.id,
+        site.position.lat,
+        site.position.lon,
+        site.groundElevationM,
+        site.antennaHeightM,
+        site.txPowerDbm,
+        site.txGainDbi,
+        site.rxGainDbi,
+        site.cableLossDb,
+      ].join(":"),
+    )
+    .join("|");

--- a/src/lib/overlayRaster.test.ts
+++ b/src/lib/overlayRaster.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
   buildCoverageOverlayPixelsAsync,
+  buildMeshExtensionOverlayPixelsAsync,
   computeCoverageRxTargetScale,
+  deriveMeshExtensionCandidateProfile,
+  meshExtensionAlphaForDbm,
+  meshExtensionColorForArea,
+  resolveMeshExtensionCandidateGridSize,
+  strongestBidirectionalPeerDbm,
   normalizeCoverageDbmForRxTarget,
   buildRelayCandidateOverlayPixelsAsync,
   buildSourcePassFailOverlayPixelsAsync,
@@ -70,6 +76,50 @@ const environment: PropagationEnvironment = {
 const terrainSampler = () => 135;
 
 describe("overlayRaster async builders", () => {
+  it("derives a representative mesh-extension profile from selected-site medians", () => {
+    const profile = deriveMeshExtensionCandidateProfile([
+      { ...fromSite, antennaHeightM: 4, txPowerDbm: 18, txGainDbi: 1, rxGainDbi: 2, cableLossDb: 0.5 },
+      { ...toSite, antennaHeightM: 12, txPowerDbm: 24, txGainDbi: 5, rxGainDbi: 6, cableLossDb: 1.5 },
+      { ...toSite, id: "c", antennaHeightM: 8, txPowerDbm: 22, txGainDbi: 3, rxGainDbi: 4, cableLossDb: 1 },
+    ]);
+
+    expect(profile).toEqual({
+      antennaHeightM: 8,
+      txPowerDbm: 22,
+      txGainDbi: 3,
+      rxGainDbi: 4,
+      cableLossDb: 1,
+    });
+  });
+
+  it("uses the strongest peer after taking each bidirectional bottleneck", () => {
+    expect(
+      strongestBidirectionalPeerDbm([
+        { selectedToCandidateDbm: -95, candidateToSelectedDbm: -130 },
+        { selectedToCandidateDbm: -108, candidateToSelectedDbm: -104 },
+      ]),
+    ).toBe(-108);
+  });
+
+  it("anchors mesh-extension opacity to established pass/fail and heatmap alpha levels", () => {
+    expect(meshExtensionAlphaForDbm(-120, -120, { min: -150, max: -90 })).toBe(162);
+    expect(meshExtensionAlphaForDbm(-90, -120, { min: -150, max: -90 })).toBe(180);
+    expect(meshExtensionAlphaForDbm(-150, -120, { min: -150, max: -90 })).toBe(36);
+  });
+
+  it("caps mesh-extension candidate scoring at the 2x grid", () => {
+    expect(resolveMeshExtensionCandidateGridSize(24)).toBe(24);
+    expect(resolveMeshExtensionCandidateGridSize(42)).toBe(42);
+    expect(resolveMeshExtensionCandidateGridSize(168)).toBe(42);
+  });
+
+  it("changes extension hue with new area independently of signal alpha", () => {
+    expect(meshExtensionColorForArea(0, 20)).not.toEqual(meshExtensionColorForArea(20, 20));
+    expect(meshExtensionAlphaForDbm(-140, -120, { min: -150, max: -90 })).not.toBe(
+      meshExtensionAlphaForDbm(-100, -120, { min: -150, max: -90 }),
+    );
+  });
+
   it("samples raster rows in Web Mercator space so image overlays align with GeoJSON", () => {
     const minLat = 62.97069520171348;
     const maxLat = 63.869006376704505;
@@ -211,6 +261,122 @@ describe("overlayRaster async builders", () => {
     expect(terrain?.pixels.length).toBe(10 * 10 * 4);
     expect(relay?.minDbm).toEqual(expect.any(Number));
     expect(relay?.maxDbm).toEqual(expect.any(Number));
+  });
+
+  it("builds mesh-extension metadata and finds positive newly covered area", async () => {
+    const raster = await buildMeshExtensionOverlayPixelsAsync({
+      bounds: {
+        minLat: 59.89,
+        maxLat: 59.91,
+        minLon: 10.64,
+        maxLon: 10.68,
+      },
+      selectedSites: [fromSite],
+      frequencyMHz: 868,
+      propagationEnvironment: environment,
+      rxTargetDbm: -70,
+      environmentLossDb: 0,
+      terrainSampler: () => 100,
+      dimensions: { width: 8, height: 6 },
+      candidateGridSize: 6,
+      coverageGridSize: 6,
+      terrainSamples: 16,
+      context: { phase: "mesh-extension", signature: "mesh-extension-positive", frameBudgetMs: 2 },
+    });
+
+    expect(raster).not.toBeNull();
+    expect(raster?.pixels.length).toBe(8 * 6 * 4);
+    expect(raster?.minAreaKm2).toBe(0);
+    expect(raster?.maxAreaKm2).toBeGreaterThan(0);
+    expect(raster?.minDbm).toEqual(expect.any(Number));
+    expect(raster?.maxDbm).toEqual(expect.any(Number));
+  });
+
+  it("reports zero new area when the selected mesh already covers the comparison grid", async () => {
+    const raster = await buildMeshExtensionOverlayPixelsAsync({
+      bounds: { minLat: 59.899, maxLat: 59.901, minLon: 10.649, maxLon: 10.651 },
+      selectedSites: [fromSite],
+      frequencyMHz: 868,
+      propagationEnvironment: environment,
+      rxTargetDbm: -140,
+      environmentLossDb: 0,
+      terrainSampler: () => 100,
+      dimensions: { width: 6, height: 6 },
+      candidateGridSize: 6,
+      coverageGridSize: 6,
+      terrainSamples: 16,
+      context: { phase: "mesh-extension", signature: "mesh-extension-covered", frameBudgetMs: 2 },
+    });
+
+    expect(raster?.minAreaKm2).toBe(0);
+    expect(raster?.maxAreaKm2).toBe(0);
+  });
+
+  it("returns no mesh-extension raster when terrain is unavailable", async () => {
+    const raster = await buildMeshExtensionOverlayPixelsAsync({
+      bounds,
+      selectedSites: [fromSite],
+      frequencyMHz: 868,
+      propagationEnvironment: environment,
+      rxTargetDbm: -118,
+      environmentLossDb: 0,
+      terrainSampler: () => null,
+      dimensions: { width: 6, height: 6 },
+      candidateGridSize: 6,
+      coverageGridSize: 6,
+      terrainSamples: 16,
+      context: { phase: "mesh-extension", signature: "mesh-extension-no-terrain", frameBudgetMs: 2 },
+    });
+
+    expect(raster).toBeNull();
+  });
+
+  it("cancels mesh-extension scoring before returning stale pixels", async () => {
+    await expect(
+      buildMeshExtensionOverlayPixelsAsync({
+        bounds,
+        selectedSites: [fromSite],
+        frequencyMHz: 868,
+        propagationEnvironment: environment,
+        rxTargetDbm: -118,
+        environmentLossDb: 0,
+        terrainSampler,
+        dimensions: { width: 12, height: 12 },
+        candidateGridSize: 12,
+        coverageGridSize: 12,
+        terrainSamples: 16,
+        context: {
+          phase: "mesh-extension",
+          signature: "mesh-extension-cancelled",
+          shouldCancel: () => true,
+        },
+      }),
+    ).rejects.toBeInstanceOf(OverlayTaskCancelledError);
+  });
+
+  it("reports monotonic aggregate progress across mesh-extension stages", async () => {
+    const progress: number[] = [];
+    await buildMeshExtensionOverlayPixelsAsync({
+      bounds: { minLat: 59.899, maxLat: 59.901, minLon: 10.649, maxLon: 10.651 },
+      selectedSites: [fromSite],
+      frequencyMHz: 868,
+      propagationEnvironment: environment,
+      rxTargetDbm: -120,
+      environmentLossDb: 0,
+      terrainSampler,
+      dimensions: { width: 6, height: 6 },
+      candidateGridSize: 6,
+      coverageGridSize: 6,
+      terrainSamples: 16,
+      context: {
+        phase: "mesh-extension",
+        signature: "mesh-extension-progress",
+        onProgress: ({ percent }) => progress.push(percent),
+      },
+    });
+
+    expect(progress.at(-1)).toBe(100);
+    expect(progress.every((value, index) => index === 0 || value >= progress[index - 1])).toBe(true);
   });
 
   it("cancels an in-flight overlay task without returning stale data", async () => {

--- a/src/lib/overlayRaster.ts
+++ b/src/lib/overlayRaster.ts
@@ -1,5 +1,8 @@
 import { classifyPassFailState, computeSourceCentricRxMetrics } from "./passFailState";
 import { STANDARD_SITE_RADIO } from "./linkRadio";
+import { buildCoverageGridPoints, computeCoverageGridDimensions } from "./coverage";
+import { haversineDistanceKm } from "./geo";
+import { getPathLossDb } from "./rfModels";
 import type { Link, PropagationEnvironment, Site } from "../types/radio";
 import { interpolateHeatmapColor } from "../themes/heatmapColors";
 
@@ -23,6 +26,8 @@ export type OverlayRasterPixels = {
   coordinates: [[number, number], [number, number], [number, number], [number, number]];
   minDbm?: number;
   maxDbm?: number;
+  minAreaKm2?: number;
+  maxAreaKm2?: number;
 };
 
 export type OverlayRasterDataUrl = {
@@ -30,6 +35,37 @@ export type OverlayRasterDataUrl = {
   coordinates: [[number, number], [number, number], [number, number], [number, number]];
   minDbm?: number;
   maxDbm?: number;
+  minAreaKm2?: number;
+  maxAreaKm2?: number;
+};
+
+export type MeshExtensionCandidateProfile = {
+  antennaHeightM: number;
+  txPowerDbm: number;
+  txGainDbi: number;
+  rxGainDbi: number;
+  cableLossDb: number;
+};
+
+export type MeshExtensionPeerSignals = {
+  selectedToCandidateDbm: number;
+  candidateToSelectedDbm: number;
+};
+
+export type MeshExtensionOverlayInput = {
+  bounds: TerrainBounds;
+  selectedSites: Site[];
+  frequencyMHz: number;
+  propagationEnvironment: PropagationEnvironment;
+  rxTargetDbm: number;
+  environmentLossDb: number;
+  terrainSampler: (lat: number, lon: number) => number | null;
+  dimensions: { width: number; height: number };
+  candidateGridSize: number;
+  coverageGridSize?: number;
+  terrainSamples: number;
+  pointMask?: (lat: number, lon: number) => boolean;
+  context?: OverlayTaskContext;
 };
 
 export type OverlayTaskContext = {
@@ -201,6 +237,47 @@ const percentile = (values: number[], ratio: number): number => {
   if (lower === upper) return values[lower];
   return lerp(values[lower], values[upper], index - lower);
 };
+
+const median = (values: number[], fallback: number): number => {
+  const finite = values.filter(Number.isFinite).sort((a, b) => a - b);
+  if (!finite.length) return fallback;
+  const midpoint = Math.floor(finite.length / 2);
+  return finite.length % 2 === 0 ? (finite[midpoint - 1] + finite[midpoint]) / 2 : finite[midpoint];
+};
+
+export const deriveMeshExtensionCandidateProfile = (selectedSites: Site[]): MeshExtensionCandidateProfile => ({
+  antennaHeightM: median(selectedSites.map((site) => site.antennaHeightM), 2),
+  txPowerDbm: median(selectedSites.map((site) => site.txPowerDbm), STANDARD_SITE_RADIO.txPowerDbm),
+  txGainDbi: median(selectedSites.map((site) => site.txGainDbi), STANDARD_SITE_RADIO.txGainDbi),
+  rxGainDbi: median(selectedSites.map((site) => site.rxGainDbi), STANDARD_SITE_RADIO.rxGainDbi),
+  cableLossDb: median(selectedSites.map((site) => site.cableLossDb), STANDARD_SITE_RADIO.cableLossDb),
+});
+
+export const strongestBidirectionalPeerDbm = (signals: MeshExtensionPeerSignals[]): number =>
+  signals.reduce(
+    (strongest, signal) =>
+      Math.max(strongest, Math.min(signal.selectedToCandidateDbm, signal.candidateToSelectedDbm)),
+    Number.NEGATIVE_INFINITY,
+  );
+
+export const meshExtensionAlphaForDbm = (
+  valueDbm: number,
+  rxTargetDbm: number,
+  scale: CoverageRxTargetScale,
+): number => {
+  if (valueDbm <= rxTargetDbm) {
+    const below = clamp((valueDbm - scale.min) / Math.max(1, rxTargetDbm - scale.min), 0, 1);
+    return Math.round(lerp(36, 162, below));
+  }
+  const above = clamp((valueDbm - rxTargetDbm) / Math.max(1, scale.max - rxTargetDbm), 0, 1);
+  return Math.round(lerp(162, 180, above));
+};
+
+export const resolveMeshExtensionCandidateGridSize = (requestedGridSize: number): number =>
+  Math.max(6, Math.min(42, Math.round(requestedGridSize)));
+
+export const meshExtensionColorForArea = (areaKm2: number, maxAreaKm2: number): [number, number, number] =>
+  coverageColorForNormalized(maxAreaKm2 > 0 ? clamp(areaKm2 / maxAreaKm2, 0, 1) : 0);
 
 export const computeCoverageRxTargetScale = (
   samples: CoverageSampleLite[],
@@ -652,6 +729,307 @@ export const buildRelayCandidateOverlayPixelsAsync = async (
   };
 };
 
+const directionalBaseRxDbm = (
+  fromSite: Site,
+  toSite: Site,
+  frequencyMHz: number,
+  environment: PropagationEnvironment,
+): number => {
+  const distanceKm = Math.max(0.001, haversineDistanceKm(fromSite.position, toSite.position));
+  const loss = getPathLossDb(
+    distanceKm,
+    frequencyMHz,
+    fromSite.antennaHeightM,
+    toSite.antennaHeightM,
+    environment,
+  );
+  return fromSite.txPowerDbm + fromSite.txGainDbi - fromSite.cableLossDb + toSite.rxGainDbi - loss;
+};
+
+const directionalTerrainRxDbm = (
+  fromSite: Site,
+  toSite: Site,
+  frequencyMHz: number,
+  environment: PropagationEnvironment,
+  terrainSampler: (lat: number, lon: number) => number | null,
+  terrainSamples: number,
+): number =>
+  computeSourceCentricRxMetrics(
+    toSite.position.lat,
+    toSite.position.lon,
+    fromSite,
+    {
+      id: "__mesh_extension_link__",
+      fromSiteId: fromSite.id,
+      toSiteId: toSite.id,
+      frequencyMHz,
+    },
+    toSite.antennaHeightM,
+    toSite.rxGainDbi,
+    terrainSampler,
+    terrainSamples,
+    environment,
+  ).rxDbm;
+
+const bidirectionalBaseDbm = (
+  left: Site,
+  right: Site,
+  frequencyMHz: number,
+  environment: PropagationEnvironment,
+): number =>
+  Math.min(
+    directionalBaseRxDbm(left, right, frequencyMHz, environment),
+    directionalBaseRxDbm(right, left, frequencyMHz, environment),
+  );
+
+const bidirectionalTerrainDbm = (
+  left: Site,
+  right: Site,
+  frequencyMHz: number,
+  environment: PropagationEnvironment,
+  terrainSampler: (lat: number, lon: number) => number | null,
+  terrainSamples: number,
+): number =>
+  Math.min(
+    directionalTerrainRxDbm(left, right, frequencyMHz, environment, terrainSampler, terrainSamples),
+    directionalTerrainRxDbm(right, left, frequencyMHz, environment, terrainSampler, terrainSamples),
+  );
+
+const siteFromProfile = (
+  id: string,
+  lat: number,
+  lon: number,
+  groundElevationM: number,
+  profile: MeshExtensionCandidateProfile,
+): Site => ({
+  id,
+  name: id,
+  position: { lat, lon },
+  groundElevationM,
+  ...profile,
+});
+
+const cellAreaKm2 = (
+  index: number,
+  dimensions: { rows: number; cols: number },
+  bounds: TerrainBounds,
+  lat: number,
+): number => {
+  const row = Math.floor(index / dimensions.cols);
+  const col = index - row * dimensions.cols;
+  const latStep = (bounds.maxLat - bounds.minLat) / Math.max(1, dimensions.rows - 1);
+  const lonStep = (bounds.maxLon - bounds.minLon) / Math.max(1, dimensions.cols - 1);
+  const latShare = row === 0 || row === dimensions.rows - 1 ? 0.5 : 1;
+  const lonShare = col === 0 || col === dimensions.cols - 1 ? 0.5 : 1;
+  const heightKm = Math.abs(latStep) * 111.32 * latShare;
+  const widthKm = Math.abs(lonStep) * 111.32 * Math.max(0.1, Math.cos((lat * Math.PI) / 180)) * lonShare;
+  return heightKm * widthKm;
+};
+
+export const buildMeshExtensionOverlayPixelsAsync = async (
+  input: MeshExtensionOverlayInput,
+): Promise<OverlayRasterPixels | null> => {
+  if (!input.selectedSites.length) return null;
+  const candidateGridSize = resolveMeshExtensionCandidateGridSize(input.candidateGridSize);
+  const coverageGridSize = Math.max(6, Math.min(24, Math.round(input.coverageGridSize ?? 24)));
+  const candidatePoints = buildCoverageGridPoints(candidateGridSize, input.bounds);
+  const coveragePoints = buildCoverageGridPoints(coverageGridSize, input.bounds);
+  const coverageDimensions = computeCoverageGridDimensions(coverageGridSize, input.bounds);
+  const profile = deriveMeshExtensionCandidateProfile(input.selectedSites);
+  const terrainSamples = Math.max(16, Math.round(input.terrainSamples));
+  const thresholdBeforeEnvironmentDbm = input.rxTargetDbm + input.environmentLossDb;
+  const contextForProgressRange = (startPercent: number, endPercent: number): OverlayTaskContext | undefined => {
+    if (!input.context) return undefined;
+    return {
+      ...input.context,
+      onProgress: input.context.onProgress
+        ? (payload) =>
+            input.context?.onProgress?.({
+              ...payload,
+              percent: Math.round(lerp(startPercent, endPercent, payload.percent / 100)),
+            })
+        : undefined,
+    };
+  };
+
+  const targetSites: Array<Site | null> = coveragePoints.map((point, index) => {
+    if (input.pointMask && !input.pointMask(point.lat, point.lon)) return null;
+    const ground = input.terrainSampler(point.lat, point.lon);
+    return ground === null ? null : siteFromProfile(`__mesh_extension_target_${index}__`, point.lat, point.lon, ground, profile);
+  });
+  const targetAreaKm2 = coveragePoints.map((point, index) =>
+    targetSites[index] ? cellAreaKm2(index, coverageDimensions, input.bounds, point.lat) : 0,
+  );
+  const existingCovered = new Uint8Array(coveragePoints.length);
+
+  await runCooperativeLoop(
+    coveragePoints.length,
+    (targetIndex) => {
+      const target = targetSites[targetIndex];
+      if (!target) return;
+      for (const selectedSite of input.selectedSites) {
+        const optimistic = bidirectionalBaseDbm(
+          selectedSite,
+          target,
+          input.frequencyMHz,
+          input.propagationEnvironment,
+        );
+        if (optimistic < thresholdBeforeEnvironmentDbm) continue;
+        const actual = bidirectionalTerrainDbm(
+          selectedSite,
+          target,
+          input.frequencyMHz,
+          input.propagationEnvironment,
+          input.terrainSampler,
+          terrainSamples,
+        );
+        if (actual - input.environmentLossDb >= input.rxTargetDbm) {
+          existingCovered[targetIndex] = 1;
+          return;
+        }
+      }
+    },
+    contextForProgressRange(0, 15),
+  );
+
+  const candidateSites: Array<Site | null> = candidatePoints.map((point, index) => {
+    const ground = input.terrainSampler(point.lat, point.lon);
+    return ground === null ? null : siteFromProfile(`__mesh_extension_candidate_${index}__`, point.lat, point.lon, ground, profile);
+  });
+  const connectivityDbm = new Float64Array(candidatePoints.length).fill(Number.NEGATIVE_INFINITY);
+  const newlyCoveredAreaKm2 = new Float64Array(candidatePoints.length);
+
+  await runCooperativeLoop(
+    candidatePoints.length,
+    (candidateIndex) => {
+      const candidate = candidateSites[candidateIndex];
+      if (!candidate) return;
+      const peers = input.selectedSites.map((selectedSite) => {
+        const selectedToCandidateBase =
+          directionalBaseRxDbm(selectedSite, candidate, input.frequencyMHz, input.propagationEnvironment) -
+          input.environmentLossDb;
+        const candidateToSelectedBase =
+          directionalBaseRxDbm(candidate, selectedSite, input.frequencyMHz, input.propagationEnvironment) -
+          input.environmentLossDb;
+        if (Math.min(selectedToCandidateBase, candidateToSelectedBase) < input.rxTargetDbm) {
+          return {
+            selectedToCandidateDbm: selectedToCandidateBase,
+            candidateToSelectedDbm: candidateToSelectedBase,
+          };
+        }
+        return {
+          selectedToCandidateDbm:
+            directionalTerrainRxDbm(
+              selectedSite,
+              candidate,
+              input.frequencyMHz,
+              input.propagationEnvironment,
+              input.terrainSampler,
+              terrainSamples,
+            ) - input.environmentLossDb,
+          candidateToSelectedDbm:
+            directionalTerrainRxDbm(
+              candidate,
+              selectedSite,
+              input.frequencyMHz,
+              input.propagationEnvironment,
+              input.terrainSampler,
+              terrainSamples,
+            ) - input.environmentLossDb,
+        };
+      });
+      connectivityDbm[candidateIndex] = strongestBidirectionalPeerDbm(peers);
+    },
+    contextForProgressRange(15, 30),
+  );
+
+  await runCooperativeLoop(
+    candidatePoints.length * coveragePoints.length,
+    (pairIndex) => {
+      const candidateIndex = Math.floor(pairIndex / coveragePoints.length);
+      const targetIndex = pairIndex - candidateIndex * coveragePoints.length;
+      if (existingCovered[targetIndex]) return;
+      const candidate = candidateSites[candidateIndex];
+      const target = targetSites[targetIndex];
+      if (!candidate || !target) return;
+      const optimistic = bidirectionalBaseDbm(
+        candidate,
+        target,
+        input.frequencyMHz,
+        input.propagationEnvironment,
+      );
+      if (optimistic < thresholdBeforeEnvironmentDbm) return;
+      const actual = bidirectionalTerrainDbm(
+        candidate,
+        target,
+        input.frequencyMHz,
+        input.propagationEnvironment,
+        input.terrainSampler,
+        terrainSamples,
+      );
+      if (actual - input.environmentLossDb >= input.rxTargetDbm) {
+        newlyCoveredAreaKm2[candidateIndex] += targetAreaKm2[targetIndex];
+      }
+    },
+    contextForProgressRange(30, 85),
+  );
+
+  const areaSamples: CoverageSampleLite[] = [];
+  const connectivitySamples: CoverageSampleLite[] = [];
+  for (let index = 0; index < candidatePoints.length; index += 1) {
+    if (!candidateSites[index] || !Number.isFinite(connectivityDbm[index])) continue;
+    const point = candidatePoints[index];
+    areaSamples.push({ ...point, valueDbm: newlyCoveredAreaKm2[index] });
+    connectivitySamples.push({ ...point, valueDbm: connectivityDbm[index] });
+  }
+  if (!areaSamples.length) return null;
+
+  const positiveAreas = areaSamples
+    .map((sample) => sample.valueDbm)
+    .filter((value) => value > 0)
+    .sort((a, b) => a - b);
+  const maxAreaKm2 = positiveAreas.length ? percentile(positiveAreas, 0.95) : 0;
+  const connectivityScale = computeCoverageRxTargetScale(connectivitySamples, input.rxTargetDbm);
+  const areaAt = makeGridInterpolator(areaSamples) ?? ((lat: number, lon: number) => interpolateCoverageDbm(areaSamples, lat, lon));
+  const connectivityAt = makeGridInterpolator(connectivitySamples) ??
+    ((lat: number, lon: number) => interpolateCoverageDbm(connectivitySamples, lat, lon));
+  const pixels = new Uint8ClampedArray(input.dimensions.width * input.dimensions.height * 4);
+  const { latByRow, lonByCol } = precomputeGridAxes(input.bounds, input.dimensions);
+
+  await runCooperativeLoop(
+    input.dimensions.width * input.dimensions.height,
+    (index) => {
+      const y = Math.floor(index / input.dimensions.width);
+      const x = index - y * input.dimensions.width;
+      const lat = latByRow[y];
+      const lon = lonByCol[x];
+      if (input.pointMask && !input.pointMask(lat, lon)) return;
+      if (input.terrainSampler(lat, lon) === null) return;
+      const area = areaAt(lat, lon);
+      const connectivity = connectivityAt(lat, lon);
+      if (area === null || connectivity === null) return;
+      const [r, g, b] = meshExtensionColorForArea(area, maxAreaKm2);
+      const px = index * 4;
+      pixels[px] = r;
+      pixels[px + 1] = g;
+      pixels[px + 2] = b;
+      pixels[px + 3] = meshExtensionAlphaForDbm(connectivity, input.rxTargetDbm, connectivityScale);
+    },
+    contextForProgressRange(85, 100),
+  );
+
+  return {
+    width: input.dimensions.width,
+    height: input.dimensions.height,
+    pixels,
+    coordinates: overlayCoordinates(input.bounds),
+    minDbm: connectivityScale.min,
+    maxDbm: connectivityScale.max,
+    minAreaKm2: 0,
+    maxAreaKm2,
+  };
+};
+
 export const buildTerrainShadeOverlayPixelsAsync = async (
   bounds: TerrainBounds,
   sampler: (lat: number, lon: number) => number | null,
@@ -795,5 +1173,7 @@ export const overlayPixelsToDataUrl = (raster: OverlayRasterPixels): OverlayRast
     coordinates: raster.coordinates,
     minDbm: raster.minDbm,
     maxDbm: raster.maxDbm,
+    minAreaKm2: raster.minAreaKm2,
+    maxAreaKm2: raster.maxAreaKm2,
   };
 };

--- a/src/lib/overlayTaskBudget.test.ts
+++ b/src/lib/overlayTaskBudget.test.ts
@@ -8,16 +8,18 @@ describe("overlayTaskBudgetForMode", () => {
     const terrain = overlayTaskBudgetForMode("terrain");
     const passFail = overlayTaskBudgetForMode("passfail");
     const relay = overlayTaskBudgetForMode("relay");
+    const meshExtension = overlayTaskBudgetForMode("mesh-extension");
 
     expect(passFail.frameBudgetMs).toBeGreaterThan(heatmap.frameBudgetMs);
     expect(passFail.frameBudgetMs).toBeGreaterThan(contours.frameBudgetMs);
     expect(passFail.frameBudgetMs).toBeGreaterThan(terrain.frameBudgetMs);
     expect(relay.frameBudgetMs).toBeGreaterThan(heatmap.frameBudgetMs);
     expect(relay.frameBudgetMs).toBeGreaterThan(terrain.frameBudgetMs);
+    expect(meshExtension.frameBudgetMs).toBeGreaterThanOrEqual(relay.frameBudgetMs);
   });
 
   it("always sets a long-task threshold not lower than frame budget", () => {
-    const modes = ["heatmap", "contours", "passfail", "relay", "terrain"] as const;
+    const modes = ["heatmap", "contours", "passfail", "relay", "mesh-extension", "terrain"] as const;
     for (const mode of modes) {
       const budget = overlayTaskBudgetForMode(mode);
       expect(budget.longTaskMs).toBeGreaterThanOrEqual(budget.frameBudgetMs);

--- a/src/lib/overlayTaskBudget.ts
+++ b/src/lib/overlayTaskBudget.ts
@@ -1,4 +1,4 @@
-export type OverlayTaskMode = "heatmap" | "contours" | "weakest" | "passfail" | "relay" | "terrain";
+export type OverlayTaskMode = "heatmap" | "contours" | "weakest" | "passfail" | "relay" | "mesh-extension" | "terrain";
 
 export type OverlayTaskBudget = {
   frameBudgetMs: number;
@@ -11,6 +11,7 @@ const BUDGET_BY_MODE: Record<OverlayTaskMode, OverlayTaskBudget> = {
   weakest: { frameBudgetMs: 9, longTaskMs: 30 },
   passfail: { frameBudgetMs: 14, longTaskMs: 42 },
   relay: { frameBudgetMs: 14, longTaskMs: 42 },
+  "mesh-extension": { frameBudgetMs: 16, longTaskMs: 48 },
   terrain: { frameBudgetMs: 8, longTaskMs: 28 },
 };
 

--- a/src/lib/propagation.ts
+++ b/src/lib/propagation.ts
@@ -7,7 +7,6 @@ import {
   isTerrainLineObstructed,
 } from "./terrainLoss";
 import type {
-  BestSiteCandidate,
   Coordinates,
   Link,
   LinkAnalysis,
@@ -207,55 +206,4 @@ export const analyzeLink = (
     worstFresnelClearancePercent,
     worstFresnelDistanceKm,
   };
-};
-
-export const computeBestSiteGrid = (
-  targetSites: Site[],
-  frequencyMHz: number,
-  txPowerDbm: number,
-  txGainDbi: number,
-  rxGainDbi: number,
-  cableLossDb: number,
-  center: Coordinates,
-  spanKm: number,
-  gridSize: number,
-  environment?: PropagationEnvironment,
-): BestSiteCandidate[] => {
-  const halfSpanDegLat = spanKm / 111.32;
-  const halfSpanDegLon = spanKm / (111.32 * Math.cos((center.lat * Math.PI) / 180));
-
-  const candidates: BestSiteCandidate[] = [];
-
-  for (let y = 0; y < gridSize; y += 1) {
-    const ty = y / (gridSize - 1);
-    const lat = center.lat - halfSpanDegLat + ty * halfSpanDegLat * 2;
-
-    for (let x = 0; x < gridSize; x += 1) {
-      const tx = x / (gridSize - 1);
-      const lon = center.lon - halfSpanDegLon + tx * halfSpanDegLon * 2;
-
-      const rxLevels = targetSites.map((site) => {
-        const distanceKm = Math.max(
-          0.001,
-          haversineDistanceKm({ lat, lon }, { lat: site.position.lat, lon: site.position.lon }),
-        );
-        const pathLoss = getPathLossDb(
-          distanceKm,
-          frequencyMHz,
-          2,
-          site.antennaHeightM,
-          environment,
-        );
-        const eirp = txPowerDbm + txGainDbi - cableLossDb;
-        return eirp + rxGainDbi - pathLoss;
-      });
-
-      const worstRxDbm = Math.min(...rxLevels);
-      const avgRxDbm = rxLevels.reduce((sum, value) => sum + value, 0) / rxLevels.length;
-
-      candidates.push({ lat, lon, worstRxDbm, avgRxDbm });
-    }
-  }
-
-  return candidates;
 };

--- a/src/lib/simulationPerf.ts
+++ b/src/lib/simulationPerf.ts
@@ -9,7 +9,7 @@ type CoveragePerfRecord = {
 
 type OverlayPerfRecord = {
   runId: string;
-  mode: "heatmap" | "contours" | "weakest" | "passfail" | "relay" | "terrain";
+  mode: "heatmap" | "contours" | "weakest" | "passfail" | "relay" | "mesh-extension" | "terrain";
   buildDurationMs: number;
   encodeDurationMs: number;
   width: number;

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -60,6 +60,7 @@ import type { UiColorTheme } from "../themes/types";
 import { getActiveHolidayTheme } from "../themes/holidayThemes";
 import type { CloudUser } from "../lib/cloudUser";
 import type { MeshmapNode } from "../lib/meshtasticMqtt";
+import type { MapOverlayMode as MapOverlayModeValue } from "../lib/mapOverlayMode";
 import type {
   CoverageResolution,
   Link,
@@ -257,7 +258,7 @@ const adoptOrphanedSimulations = (
   return fixed;
 };
 
-export type MapOverlayMode = "none" | "heatmap" | "contours" | "weakest" | "passfail" | "relay";
+export type MapOverlayMode = MapOverlayModeValue;
 export type AuthSessionState = "checking" | "signed_in" | "signed_out";
 
 type SiteLibraryEntry = {

--- a/src/types/radio.ts
+++ b/src/types/radio.ts
@@ -125,13 +125,6 @@ export type ProfilePoint = {
   fresnelBottomM: number;
 };
 
-export type BestSiteCandidate = {
-  lat: number;
-  lon: number;
-  worstRxDbm: number;
-  avgRxDbm: number;
-};
-
 export type CoverageSample = {
   lat: number;
   lon: number;


### PR DESCRIPTION
## Summary

- add a manually selected Mesh Extension simulation overlay
- score newly covered terrain area while encoding bidirectional strongest-peer connectivity in opacity
- reuse the existing raster pipeline, palette, guide/scale UI, scheduling, cancellation, progress, diagnostics, and LRU cache
- consolidate coverage grid generation and remove the unused competing best-site grid implementation
- treat no Site selection as all Simulation Sites, consistent with the rest of the app

Closes #910 after staging verification and approval.

## Verification

- `npm test` — 112 files, 571 tests passed
- `npm run build` — passed
- manual local checks with zero, one, two, and three selected Sites; 20–200 km radii; all resolution choices; rapid selection changes; terrain toggle; and optional terrain shading
- zero-selection check confirms Mesh Extension is available while Heatmap remains the automatic default
- `npm run dev:check` — no LinkSim dev/watch servers running

The local demo had no terrain tiles available, so deterministic terrain behavior is covered by unit tests rather than a live terrain-pixel visual check.