### PR TITLE
chore: release 0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.22.0] - 2026-07-21
+
+### Added
+- Added the Mesh Extension candidate overlay to show where a new node can add the most terrain coverage while remaining bidirectionally connected to the existing mesh. Candidate scoring follows the selected Simulation Resolution and uses adaptive terrain-boundary refinement for responsive high-resolution analysis. (#910)
+
+### Fixed
+- Fixed newly created Simulations sometimes remaining read-only after account bootstrap, restoring the expected create-Site actions without requiring a page reload. (#909)
+
+### Internal
+- Streamlined the repository agent guidance and aligned its release-flow baseline with the shipped version. (#911)
+
 ## [0.21.0] - 2026-06-03
 
 ### Added

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -62,7 +62,7 @@
 
 ## Versioning Policy
 - SemVer is mandatory (`MAJOR.MINOR.PATCH`).
-- Current baseline: `0.21.0`.
+- Current baseline: `0.22.0`.
 - Bump level decision rules:
   - `PATCH` (`0.9.x`): bug fixes, polish, performance tuning, and non-breaking UX behavior fixes.
   - `MINOR` (`0.x.0`): new user-facing features or meaningful workflow additions that are backward-compatible.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linksim",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linksim",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "linksim",
   "private": true,
-  "version": "0.21.0",
+  "version": "0.22.0",
   "license": "GPL-3.0-only",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- bump LinkSim from `0.21.0` to `0.22.0`
- add human-readable release notes for milestone issues #909, #910, and #911
- update the documented current release baseline to `0.22.0`

This batch contains release metadata only. Application behavior is unchanged from the staging tree already verified at `79e211d133b402bcbcfc84b939decc361f5e960d`.

## Verification

- [x] `git diff --check`
- [x] `npm test` — 112 files, 573 tests passed
- [x] `npm run build`
- [x] `npm run build:verify`
- [x] `npm run dev:check` — no LinkSim dev/watch servers found
- [x] staging deployment for pre-release tree `79e211d1` succeeded

## Release checklist

- [x] Milestone release checklist completed: docs/milestone-release-checklist.md