### PR TITLE
release: promote 0.22.0 to production

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,195 +1,52 @@
 # LinkSim Agent Rules
 
-## Mandatory Startup (No Exceptions)
+## Start Here
+
 - Treat this file as the single handoff entrypoint.
-- Before any code changes, review open GitHub Issues for the repo and then read:
+- Before changing code, review the relevant open GitHub Issue(s), then read:
   1. `docs/release-flow.md`
   2. `docs/milestone-release-checklist.md`
-- If instructions conflict, precedence is:
-  1. explicit user instruction in current thread
+- If instructions conflict, use this precedence:
+  1. explicit user instruction in the current thread
   2. this `AGENTS.md`
-  3. GitHub Issues / GitHub Projects state for the repo
+  3. GitHub Issues / GitHub Projects state
   4. `docs/release-flow.md`
   5. `docs/milestone-release-checklist.md`
+- Present and agree on a plan before implementation. Do not start newly created or newly requested issues without explicit user confirmation in the current thread.
+- Update the relevant GitHub Issue(s) before and after each implementation batch; never leave issue status ambiguous.
 
-- Always update the relevant GitHub Issue(s) before and after implementation batches.
-- Default environment workflow:
-  - Unless the user explicitly says otherwise, work in local test environment.
-  - After local verification, deploy to live test/staging for verification.
-  - For every implementation batch by default: do both local verification and staging deployment verification in the same pass.
-  - Only promote to production after explicit user approval, using the same verified commit.
-- Branch workflow:
-  - Use per-issue branches: `issue/<id>-<slug>` (requires numeric ID).
-  - **Always branch from `origin/staging`**, not `origin/main`. Creating a branch from `main` will cause merge conflicts when opening a PR to `staging`.
-  - Merge issue branches into `staging` first.
-  - For normal releases, promote to production only via a direct PR from `staging` into `main` (no release branch needed — the branch policy allows `staging` → `main` directly).
-  - **Release branch naming** (when no issue ID exists):
-    - For staging PRs: use `chore/release-X-Y-Z` (no dots, no ID required; e.g., `chore/release-0-19-0`).
-    - For production PRs when `staging` → `main` shows conflicts: use `release/vX.Y.Z` from `main`, squash-merge `staging`, resolve conflicts keeping staging's version, then PR to `main`.
-  - Use `hotfix/<slug>` only for explicitly approved incidents.
-  - This staging-integration model is the default unless the user explicitly overrides it.
-- Worktree branch vs. issue branch:
-  - When working inside a Claude Code worktree, the session branch is named `claude/<name>` — this is the worktree's own bookkeeping branch, **not** your working branch.
-  - Always create a new `issue/<id>-<slug>` branch from `origin/staging` before making any changes: `git checkout -b issue/<id>-<slug> origin/staging`
-  - Never commit to the `claude/*` session branch. All work goes on the `issue/<id>-<slug>` branch.
-- Deploy policy:
-  - **Never run `npm run deploy:staging`, `npm run deploy:prod:main`, or any deploy script locally.** CI automatically deploys when code merges to `staging` or `main` — you do not need to trigger a deploy.
-  - Local deploy attempts will fail: Cloudflare credentials (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`) are only available in the CI environment.
-  - If you encounter a Cloudflare authentication error while running a deploy script, stop immediately — you are running a command that belongs in CI, not locally.
-- Branch/worktree cleanup routine (default after each completed pass):
-  - Keep only long-lived branches locally/remotely: `main`, `staging` (unless an active pass needs additional branches).
-  - After merge/deploy, prune refs: `git fetch --prune origin`.
-  - Delete merged local branches (except `main`/`staging`): `git branch --merged origin/staging | egrep -v '(^\\*|main|staging)' | xargs -n 1 git branch -d` (skip if no matches).
-  - Delete remote merged issue/chore/hotfix branches once no longer needed.
-  - Remove temporary worktrees for completed branches; keep only active worktrees.
-- Prefer stabilization work (consistency, hardening, tests, UX cleanup) over net-new features unless explicitly requested.
-- Ship in batches: implement, run `npm test` and `npm run build`, then commit and push.
-- Never commit or push directly to `main`; always create/use a separate branch for changes and push that branch.
-- Use TDD methodology for changes and new features: write/update failing tests first, implement the minimal fix to pass, then refactor with tests green.
-- Keep terminology consistent: use `Simulation`, `Site`, `Library`, `Path`, and `Channel` terms across UI and docs.
-- Do not introduce hardcoded UI colors in code; use existing theme variables/tokens. If a new semantic color is truly required, define it in the shared theme system first.
-- Do not introduce hardcoded UI fonts in code; use existing font variables/tokens. If a new semantic font category is truly required, discuss it first and define it in the shared theme/token system.
-- Icon accessibility rule: every UI icon must include accessible text. For icon-only controls, require an explicit `aria-label` on the interactive element (and matching `title` where applicable). Decorative inline icons should be `aria-hidden="true"`.
-- Any modal/popover that can open on top of another dialog must use `tier="raised"` in `ModalOverlay`.
-- When catching UI errors, use `getUiErrorMessage()` from `src/lib/uiError.ts` for consistent messaging.
-- Do not leave issue status in an ambiguous state.
-- Default closure policy: once work is verified on shared staging and the user confirms staging sign-off, close the issue (do not wait for production deploy).
-- Do not start newly created or newly requested issues without explicit user confirmation in the current thread.
-- Maintain GitHub Issues in close dialogue with the user: confirm wording/scope before starting newly added user items, and confirm completion criteria before closing them.
-- Batch size policy:
-  - Default to 3-4 backlog items per pass.
-  - If scope is stable and low risk, target larger passes (~10 items) to reduce deploy churn.
-- For user-added issues:
-  - Discuss scope before starting implementation.
-  - Do not move them to in-progress automatically.
-- After every merge to `staging` or `main`, CI auto-deploys via the `Deploy LinkSim Pages` GitHub Actions workflow. Monitor the workflow run in GitHub Actions and report the commit SHA and build label when the deploy job completes. Do not run `npm run deploy:staging` or `npm run deploy:prod:main` manually after a merge — CI handles it. Manual deploys via `workflow_dispatch` are reserved for overrides only.
-- Follow and maintain `docs/release-flow.md` as the source of truth for release promotion steps.
-- Follow `docs/release-flow.md` versioning policy (SemVer + explicit bump rules) for all releases.
-- Maintain a human-readable `CHANGELOG.md` for every release; do not use raw commit dumps as release notes.
-- Before each production release, verify whether any issues closed since the previous release are missing a milestone and report/fix that metadata drift.
-- Version/channel labeling rule:
-  - Local must display `vX.Y.Z-alpha+<commit>`.
-  - Staging must display `vX.Y.Z-beta+<commit>`.
-  - Production must display `vX.Y.Z`.
-  - Same commit must use the same base version `X.Y.Z` in all environments.
-- Require a SemVer bump before every production release.
-- Deploys must use guarded npm scripts only:
-  - `npm run deploy:staging` → https://staging.linksim.link
-  - `npm run deploy:staging:preview` → Preview URL
-  - `npm run deploy:prod:main` → https://linksim.link
-- Staging deploy default:
-  - Merge to `staging` and let CI deploy to https://staging.linksim.link.
-  - Do not run deploy scripts locally for normal verification.
-  - Do not use preview deploys for normal verification; default is always the shared staging URL.
-- Never run raw `wrangler pages deploy` for release operations.
-- If a guarded deploy fails, fix the script/preflight issue and re-run the guarded script. Do not bypass with manual Wrangler deploys.
-- Promotion gate:
-  - Promote the exact same verified release tree from local -> staging -> production. With squash merges, commit SHAs can differ; the production deploy gate must verify that `main` HEAD matches the `vX.Y.Z` tag tree.
-  - If code changes after staging verification, rerun local verification and redeploy staging before production.
-  - Normal production promotion PR must be `staging` -> `main`.
-  - Hotfix promotion PR may be `hotfix/<slug>` -> `main` only with explicit user approval in-thread.
-- Normal squash-merged `staging` -> `main` and `release/vX.Y.Z` -> `main` production releases are not staging drift; the release content already came from `staging`, even though the squash commit is not in staging ancestry.
-- **After any hotfix merges to main**: immediately create a `chore/sync-main-to-staging` branch from `origin/staging`, apply the main-only hotfix/reconcile content in commits that can be squash-merged, PR into `staging`, merge, and let CI redeploy staging. Do not start new feature work until staging is back in sync. The `detect-staging-drift` workflow will open a GitHub Issue as a reminder if this is missed.
-- **Release-reconcile fallback rule**: if production promotion cannot be completed via direct `staging` -> `main` and uses a `hotfix/*` snapshot/reconcile PR instead, the same pass is not complete until `main` is synced back into `staging`, staging is redeployed, and the drift issue is closed.
+## Delivery Guardrails
 
-## Release Branch Policy (Detailed)
-
-### Branch naming rules (enforced by PR Branch Policy workflow):
-- `issue/<id>-<slug>` — **must have numeric ID** (e.g., `issue/123-fix-button`). Cannot be used without an issue number.
-- `chore/<slug>` — **no dots allowed** (regex: `^[a-z0-9-]+$`). Use hyphens only (e.g., `chore/release-0-19-0`, not `chore/release-0.19.0`).
-- `release/vX.Y.Z` — **must include `v` prefix and dots** (regex: `^release/v[0-9]+\.[0-9]+\.[0-9]+$`). Example: `release/v0.19.0`.
-
-### Staging → main tree divergence (common trap):
-When `staging` → `main` PR shows conflicts despite squash-merge policy:
-1. This happens because previous releases were squash-merged to `main`, creating commits not in `staging`'s history.
-2. GitHub's conflict detection compares the full tree diff, which shows 100s of "conflicts" for files modified in both branches.
-3. **Solution**: Create `release/vX.Y.Z` branch from `main`, run `git merge origin/staging --squash`, resolve conflicts keeping staging's version (`git checkout --theirs <file>`), commit, tag, then PR to `main`.
-4. This is **not a legacy path** — it's the correct workaround when direct `staging` → `main` PR is blocked by tree conflicts.
-
-### Release workflow (correct path):
-1. **Staging prep**: `chore/release-X-Y-Z` from `staging` → bump version, update CHANGELOG, tag `vX.Y.Z`, PR to `staging`
-2. **Staging verification**: wait for CI deploy, verify `https://staging.linksim.link` shows `vX.Y.Z-beta+<commit>`
-3. **Production promotion**: 
-   - Try direct `staging` → `main` PR first (normal path)
-   - If conflicts: use `release/vX.Y.Z` branch method (see above)
-4. **Production verification**: wait for CI deploy, verify `https://linksim.link` shows `vX.Y.Z`
-- Local run reliability:
-  - Restart local server whenever runtime/config/env changes can affect behavior.
-  - Re-verify affected flows after restart before marking work as done.
-  - Do not leave local dev/watch servers running after a pass. Before handing back, run `npm run dev:check`; if it reports a LinkSim dev/watch server, run `npm run dev:stop` unless the user explicitly asked to keep it running.
-- Production preflight checklist (required before production promotion):
-  - `npm run test`
-  - `npm run build:bundle`
-  - Confirm build label matches intended SemVer channel rules
-  - Confirm the `vX.Y.Z` tag tree matches the production promotion tree
-  - Confirm no unresolved issue/project status drift for items in the current pass
-  - Confirm `CHANGELOG.md` is updated with user-readable highlights for the target release
-- Token-efficient execution:
-  - Lock scope for each pass before implementation.
-  - Define done criteria and no-touch areas at pass start.
-  - Avoid mid-pass feature pivots unless explicitly requested by the user.
-- GitHub Issue workflow:
-  - Treat GitHub Issues as the canonical backlog for open and completed work.
-  - Use issue titles as the default source of task naming.
-  - Prefer one issue per discrete task unless the user explicitly wants a grouped batch.
-  - Maintain explicit status labels: `in-progress` -> `in-staging` (while open) -> issue closed after staging sign-off -> `released` label applied during milestone production release sweep.
-  - After every staging merge/deploy, automatically update the related GitHub Issue(s) label from `in-progress` to `in-staging`. Do not wait for the user to ask.
-  - Milestone release policy: at production release time, apply `released` to the milestone's shipped issues (including already-closed staging-verified issues).
-  - **Milestone required before closing**: always assign a milestone to an issue before closing it as completed. Closing without a milestone triggers an automated workflow that reopens the issue with a warning. Exception: add label `no-milestone-close-ok` for approved exceptions (e.g., chore/housekeeping issues that don't belong to a release).
-  - If a historical `docs/BACKLOG.md` file still exists, treat it as legacy reference only unless the user explicitly asks to maintain it.
-
-## Staging-First Milestone Workflow (Single Source)
-- Deploy target policy:
-  - Always validate live on `https://staging.linksim.link`.
-  - Do not use preview URLs unless the user explicitly requests a one-off preview comparison in the current thread.
-- Per-issue branch policy:
-  - Start each issue branch from `origin/staging`.
-  - Branch name format: `issue/<id>-<slug>`.
-  - Keep PR scope to one issue; avoid mixed API/UI/deeplink batches in the same PR.
-  - Agent safety rails:
-    - Do not create normal-release `release/*` branches (except `release/vX.Y.Z` for blocked `staging` → `main` promotion).
-    - Do not open PRs to `main` from `issue/*` or `chore/*` branches.
-    - If local branch is behind its PR base branch, rebase/refresh before merging.
-- Drift check before coding (required):
-  - Run and report: `git log --oneline origin/staging -5`
-  - Run and report: `git log --oneline origin/main -5`
-  - Run and report: `git cherry -v origin/staging origin/main`
-  - If `git cherry` only reports the latest normal squash-merged `staging` -> `main` or `release/vX.Y.Z` -> `main` production release commit, treat it as expected ancestry-only drift and proceed.
-  - If new main-only hotfix/reconcile content appears, create a dedicated `chore/sync-main-to-staging` PR before feature work.
-- Verification gates for deep-link/API-affecting work:
+- Follow `docs/release-flow.md` as the source of truth for branching, deployment, promotion, drift handling, versioning, and releases.
+- Before coding, fetch/prune and report:
+  - `git log --oneline origin/staging -5`
+  - `git log --oneline origin/main -5`
+  - `git cherry -v origin/staging origin/main`
+- Create `issue/<id>-<slug>` from `origin/staging`; never commit or push directly to `main` or `staging`.
+- Default to local implementation and verification, then PR to `staging`. CI deploys merges to shared staging; do not run deploy scripts locally for normal verification. Production promotion requires explicit user approval.
+- Ship verified batches. Use TDD: write or update failing tests first, implement the minimal fix, then refactor with tests green. Run `npm test` and `npm run build` before committing and pushing.
+- For deep-link/API-affecting work, additionally run:
   - `npm run test -- --run src/lib/deepLink.test.ts`
   - `npm run test -- --run functions/api/v1/calculate.test.ts`
   - `npm run test -- --run src/store/appStore.test.ts`
-  - `npm run build`
-  - Manually verify deep-link matrix on staging:
-    - `/<simulation>`
-    - `/<simulation>/<site>`
-    - `/<simulation>/<site1>+<site2>`
-    - `/<simulation>/<site1>~<site2>`
-- Merge and staging deploy sequence per issue:
-  - Open PR into `staging` and merge. CI auto-deploys to https://staging.linksim.link — do NOT run `npm run deploy:staging` manually.
-  - After merge, monitor the `Deploy LinkSim Pages / deploy-staging` GitHub Actions job and report the commit SHA and build label from the workflow output when it completes.
-- Milestone promotion model:
-  - Complete and verify all milestone issues on `staging` first.
-  - Promote to production in one batch with a direct PR from `staging` to `main`.
-  - Use the exact verified release tree for production; no code changes between staging sign-off and production deploy.
-  - Freeze milestone scope at sign-off: no new feature work lands on `staging` until production deploy completes.
-  - After production deploy, continue new issue work from the updated `origin/staging` baseline.
+  - Manually verify `/<simulation>`, `/<simulation>/<site>`, `/<simulation>/<site1>+<site2>`, and `/<simulation>/<site1>~<site2>` on staging.
+- After a staging deploy, move related issues from `in-progress` to `in-staging`. Close only after shared-staging verification and user sign-off; assign a milestone first, or use `no-milestone-close-ok` for an approved exception. Apply `released` during the production milestone sweep.
+- After a completed pass, prune refs and remove merged issue/chore/hotfix branches and temporary worktrees; keep only active work and long-lived `main`/`staging` branches.
+- Restart the local server when runtime, configuration, or environment changes can affect behavior, then re-verify the affected flows.
+- Do not leave local dev/watch servers running. Before handoff, run `npm run dev:check`, then `npm run dev:stop` if LinkSim is still running unless the user asked to keep it running.
+- Roll out a new required status check in two phases: merge the workflow that produces it, then add it to branch protection.
 
-## Branch Protection Rollout Safety
-- When introducing a new required status check, roll it out in two phases to avoid PR deadlocks:
-  1. merge the workflow that produces the check
-  2. then add that check to branch protection required checks
+## Implementation Rules
 
-## Model Selection
-- **Codex 5.3** — use for full implementation passes where quality and breadth of change matter most. Expensive; reserve for when the work warrants it.
-- **Big Pickle / MiMo V2 Pro Free** — good for planning and moderate coding work. Use as the default for most passes.
-- **Plan mode always** — before any implementation pass, always present a plan first. Always recommend which model to use for the next implementation pass.
-- Also available but less experienced with this codebase: GPT-Nano, MiniMax M2.5 Free, Nemotron 3 Super Free.
-
-## AGENTS.md Feedback
-- If this file feels counterintuitive or is missing something, suggestions are welcome — but nothing changes without explicit approval.
+- Prefer stabilization (consistency, hardening, tests, and UX cleanup) over net-new features unless explicitly requested.
+- Reuse or adapt existing code and UI. Never add a new UI element without approval; flag opportunities to remove or consolidate overlapping code or UI.
+- Keep terminology consistent: `Simulation`, `Site`, `Library`, `Path`, and `Channel`.
+- Use existing theme variables/tokens; do not hardcode UI colors or fonts. Discuss and define a shared semantic token first when a new category is genuinely required.
+- Every UI icon needs accessible text. Icon-only controls require an explicit `aria-label` and matching `title` where applicable; decorative inline icons use `aria-hidden="true"`.
+- Any modal or popover that can open above another dialog must use `tier="raised"` in `ModalOverlay`.
+- Use `getUiErrorMessage()` from `src/lib/uiError.ts` when catching UI errors.
 
 ## Handoff Guarantee
-- A new agent should be able to continue by being pointed only to this file.
-- Do not rely on undocumented tribal knowledge; if a rule is repeated in chat, add it here (or in the linked source-of-truth docs) before ending the pass.
+
+- A new agent must be able to continue using this file and its required linked documents only.
+- Keep durable repo policy here or in the linked source of truth; do not rely on chat-only knowledge.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.22.0] - 2026-07-21
+
+### Added
+- Added the Mesh Extension candidate overlay to show where a new node can add the most terrain coverage while remaining bidirectionally connected to the existing mesh. Candidate scoring follows the selected Simulation Resolution and uses adaptive terrain-boundary refinement for responsive high-resolution analysis. (#910)
+
+### Fixed
+- Fixed newly created Simulations sometimes remaining read-only after account bootstrap, restoring the expected create-Site actions without requiring a page reload. (#909)
+
+### Internal
+- Streamlined the repository agent guidance and aligned its release-flow baseline with the shipped version. (#911)
+
 ## [0.21.0] - 2026-06-03
 
 ### Added

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -62,7 +62,7 @@
 
 ## Versioning Policy
 - SemVer is mandatory (`MAJOR.MINOR.PATCH`).
-- Current baseline: `0.17.0`.
+- Current baseline: `0.22.0`.
 - Bump level decision rules:
   - `PATCH` (`0.9.x`): bug fixes, polish, performance tuning, and non-breaking UX behavior fixes.
   - `MINOR` (`0.x.0`): new user-facing features or meaningful workflow additions that are backward-compatible.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linksim",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linksim",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "linksim",
   "private": true,
-  "version": "0.21.0",
+  "version": "0.22.0",
   "license": "GPL-3.0-only",
   "type": "module",
   "scripts": {

--- a/src/components/AppShell.copyFlow.test.tsx
+++ b/src/components/AppShell.copyFlow.test.tsx
@@ -237,4 +237,27 @@ describe("AppShell copy flow", () => {
       view.unmount();
     }
   });
+
+  it("keeps the workspace writable after creating and loading a blank simulation", async () => {
+    const view = render(<AppShell />);
+
+    try {
+      await waitFor(() => expect(sidebarCalls.length).toBeGreaterThan(0));
+
+      const createdId = useAppStore.getState().createBlankSimulationPreset("Blank Simulation", {
+        visibility: "private",
+        ownerUserId: "user-1",
+      });
+      expect(createdId).toBeTruthy();
+
+      await act(async () => {
+        useAppStore.getState().loadSimulationPreset(createdId as string);
+      });
+
+      await waitFor(() => expect(sidebarCalls[sidebarCalls.length - 1]?.readOnly).toBe(false));
+      expect(useAppStore.getState().selectedScenarioId).toBe(createdId);
+    } finally {
+      view.unmount();
+    }
+  });
 });

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -53,6 +53,7 @@ import { simulationAreaBoundsForSites } from "../lib/simulationArea";
 import { tilesForBounds } from "../lib/terrainTiles";
 import {
   buildCoverageOverlayPixelsAsync,
+  buildMeshExtensionOverlayPixelsAsync,
   buildRelayCandidateOverlayPixelsAsync,
   buildSourcePassFailOverlayPixelsAsync,
   buildTerrainShadeOverlayPixelsAsync,
@@ -61,6 +62,12 @@ import {
   type OverlayRasterPixels,
 } from "../lib/overlayRaster";
 import { overlayTaskBudgetForMode } from "../lib/overlayTaskBudget";
+import {
+  meshExtensionSiteDigest,
+  overlayGuideTitleForMode,
+  overlayModesForSelectionCount,
+  type MapOverlayMode,
+} from "../lib/mapOverlayMode";
 import {
   recordSimulationOverlayPerf,
   recordSimulationRunCancelled,
@@ -285,6 +292,10 @@ type CoverageSampleLite = { lat: number; lon: number; valueDbm: number; weakestD
 type OverlayRaster = {
   url: string;
   coordinates: [[number, number], [number, number], [number, number], [number, number]];
+  minDbm?: number;
+  maxDbm?: number;
+  minAreaKm2?: number;
+  maxAreaKm2?: number;
 };
 
 type OverlayMaskArea = {
@@ -981,6 +992,7 @@ export function MapView({
     () => selectedSiteIds.map((id) => sites.find((site) => site.id === id)).filter((site): site is Site => Boolean(site)),
     [selectedSiteIds, sites],
   );
+  const meshExtensionSites = selectedSites.length > 0 ? selectedSites : sites;
   const selectedSiteSet = useMemo(() => new Set(selectedSites.map((site) => site.id)), [selectedSites]);
   const selectionCount = selectedSites.length;
   const singleSelectedSite = selectionCount === 1 ? selectedSites[0] ?? null : null;
@@ -1542,6 +1554,9 @@ export function MapView({
     [propagationEnvironment],
   );
   const selectedSiteDigest = useMemo(() => selectedSiteIds.join(","), [selectedSiteIds]);
+  const selectedSiteRadioDigest = useMemo(() => meshExtensionSiteDigest(meshExtensionSites), [meshExtensionSites]);
+  const meshExtensionFrequencyMHz =
+    selectedNetwork?.frequencyOverrideMHz ?? selectedNetwork?.frequencyMHz ?? activeSelectionLink?.frequencyMHz ?? 869.618;
 
   useEffect(() => {
     const scheduler = coverageOverlaySchedulerRef.current!;
@@ -1570,6 +1585,10 @@ export function MapView({
       cancelCoveragePipeline(true);
       return;
     }
+    if (mode === "mesh-extension" && !meshExtensionSites.length) {
+      cancelCoveragePipeline(true);
+      return;
+    }
 
     const signature = [
       mode,
@@ -1593,6 +1612,8 @@ export function MapView({
       rxSensitivityTargetDbm,
       environmentLossDb,
       selectedSiteDigest,
+      selectedSiteRadioDigest,
+      meshExtensionFrequencyMHz,
     ].join("|");
     const cached = coverageOverlayCacheRef.current.get(signature);
     if (cached) {
@@ -1706,6 +1727,22 @@ export function MapView({
               overlayPointMask,
               context,
             );
+          } else if (mode === "mesh-extension") {
+            rasterPixels = await buildMeshExtensionOverlayPixelsAsync({
+              bounds: overlayBounds,
+              selectedSites: meshExtensionSites,
+              frequencyMHz: meshExtensionFrequencyMHz,
+              propagationEnvironment,
+              rxTargetDbm: rxSensitivityTargetDbm,
+              environmentLossDb,
+              terrainSampler,
+              dimensions: overlayDimensions,
+              candidateGridSize: effectiveGridSize,
+              coverageGridSize: effectiveGridSize,
+              terrainSamples: 20,
+              pointMask: overlayPointMask,
+              context,
+            });
           }
 
           const overlayBuildCompletedAt = performance.now();
@@ -1800,6 +1837,10 @@ export function MapView({
     effectiveGridSize,
     overlayRadiusKm,
     selectedSiteDigest,
+    selectedSiteRadioDigest,
+    meshExtensionFrequencyMHz,
+    meshExtensionSites,
+    selectedNetwork,
     showOverlayDiagnostics,
     beginOverlayJob,
     setOverlayPipelineProgress,
@@ -1849,18 +1890,17 @@ export function MapView({
     if (typeof coverageOverlay.minDbm !== "number" || typeof coverageOverlay.maxDbm !== "number") return null;
     return { min: coverageOverlay.minDbm, max: coverageOverlay.maxDbm };
   }, [coverageOverlay, coverageVizMode]);
-  const overlayGuideTitle =
-    coverageVizMode === "none"
-      ? "Hidden"
-      : coverageVizMode === "heatmap"
-      ? "Heatmap"
-      : coverageVizMode === "contours"
-        ? "Heatmap + Target Line"
-        : coverageVizMode === "weakest"
-          ? "Weakest Site"
-        : coverageVizMode === "passfail"
-          ? "Pass/Fail"
-          : "Relay";
+  const meshExtensionRange = useMemo(() => {
+    if (!coverageOverlay || coverageVizMode !== "mesh-extension") return null;
+    if (typeof coverageOverlay.maxAreaKm2 !== "number") return null;
+    return {
+      minAreaKm2: coverageOverlay.minAreaKm2 ?? 0,
+      maxAreaKm2: coverageOverlay.maxAreaKm2,
+      minDbm: coverageOverlay.minDbm,
+      maxDbm: coverageOverlay.maxDbm,
+    };
+  }, [coverageOverlay, coverageVizMode]);
+  const overlayGuideTitle = overlayGuideTitleForMode(coverageVizMode);
 
   useEffect(() => {
     const scheduler = terrainOverlaySchedulerRef.current!;
@@ -2658,14 +2698,12 @@ export function MapView({
     fitChromePadding.top,
     fitChromePadding.bottom,
   ]);
-  const allowedOverlayModes = useMemo<Array<"none" | "heatmap" | "contours" | "weakest" | "passfail" | "relay">>(() => {
-    if (selectionCount <= 0) return ["none", "heatmap", "weakest", "contours"];
-    if (selectionCount === 1) return ["none", "passfail", "heatmap", "weakest", "contours"];
-    if (selectionCount === 2) return ["none", "relay", "heatmap", "weakest", "contours"];
-    return ["none", "heatmap", "weakest", "contours"];
-  }, [selectionCount]);
+  const allowedOverlayModes = useMemo(
+    () => overlayModesForSelectionCount(selectionCount, sites.length),
+    [selectionCount, sites.length],
+  );
   useEffect(() => {
-    if (allowedOverlayModes.includes(coverageVizMode as "none" | "heatmap" | "contours" | "weakest" | "passfail" | "relay")) return;
+    if (allowedOverlayModes.includes(coverageVizMode)) return;
     setCoverageVizMode(selectionCount === 1 ? "passfail" : selectionCount === 2 ? "relay" : "heatmap");
   }, [allowedOverlayModes, coverageVizMode, selectionCount, setCoverageVizMode]);
   const simulationOverlaySelectValue = coverageVizMode;
@@ -3056,7 +3094,7 @@ export function MapView({
                 <select
                   className="locale-select"
                   onChange={(event) => {
-                    const mode = event.target.value as "none" | "heatmap" | "contours" | "weakest" | "passfail" | "relay";
+                    const mode = event.target.value as MapOverlayMode;
                     if (mode === "heatmap") {
                       setCoverageVizMode("heatmap");
                       return;
@@ -3075,6 +3113,7 @@ export function MapView({
                   {allowedOverlayModes.includes("contours") ? <option value="contours">Heatmap + Target Line</option> : null}
                   {allowedOverlayModes.includes("passfail") ? <option value="passfail">Pass/Fail</option> : null}
                   {allowedOverlayModes.includes("relay") ? <option value="relay">Relay</option> : null}
+                  {allowedOverlayModes.includes("mesh-extension") ? <option value="mesh-extension">Mesh Extension</option> : null}
                 </select>
               </label>
               {coverageVizMode !== "none" && (
@@ -3263,6 +3302,29 @@ export function MapView({
                   </div>
                 </div>
                 <p className="overlay-scale-help">Left side is worse relay quality. Right side is better relay quality.</p>
+              </>
+            ) : null}
+            {coverageVizMode === "mesh-extension" ? (
+              <>
+                <p>
+                  Shows where a representative new node can reach any selected Site, or any Simulation Site when none
+                  are selected, in both directions while adding terrain that those Sites do not currently cover.
+                </p>
+                <div className="overlay-scale">
+                  <div className="overlay-scale-bar" />
+                  <div className="overlay-scale-labels">
+                    <span>{(meshExtensionRange?.minAreaKm2 ?? 0).toFixed(1)} km² new</span>
+                    <span>{meshExtensionRange ? `${meshExtensionRange.maxAreaKm2.toFixed(1)} km² new` : "More new area"}</span>
+                  </div>
+                </div>
+                <p className="overlay-scale-help">
+                  Color shows newly covered area. Opacity shows bidirectional signal to the strongest applicable peer;
+                  locations below the RX target are hidden.
+                </p>
+                <p className="overlay-scale-help">
+                  Simulation Resolution controls both candidate placement and added-area precision. Higher resolutions
+                  refine coverage boundaries adaptively and can take longer.
+                </p>
               </>
             ) : null}
           </CompactDetails>

--- a/src/lib/coverage.ts
+++ b/src/lib/coverage.ts
@@ -34,6 +34,11 @@ export type CoverageGridDimensions = {
   targetSamples: number;
 };
 
+export type CoverageGridPoint = {
+  lat: number;
+  lon: number;
+};
+
 const COVERAGE_COMPUTE_CHUNK_SIZE = 48;
 const COVERAGE_COMPUTE_FRAME_BUDGET_MS = 12;
 
@@ -56,6 +61,25 @@ export const computeCoverageGridDimensions = (
     totalSamples: rows * cols,
     targetSamples,
   };
+};
+
+export const buildCoverageGridPoints = (
+  gridSize: number,
+  bounds: CoverageGridBounds,
+  sampleMultiplier = 1,
+): CoverageGridPoint[] => {
+  const { rows, cols } = computeCoverageGridDimensions(gridSize, bounds, sampleMultiplier);
+  const points: CoverageGridPoint[] = [];
+  for (let y = 0; y < rows; y += 1) {
+    const ty = rows <= 1 ? 0 : y / (rows - 1);
+    const lat = bounds.minLat + (bounds.maxLat - bounds.minLat) * ty;
+    for (let x = 0; x < cols; x += 1) {
+      const tx = cols <= 1 ? 0 : x / (cols - 1);
+      const lon = bounds.minLon + (bounds.maxLon - bounds.minLon) * tx;
+      points.push({ lat, lon });
+    }
+  }
+  return points;
 };
 
 const nUnitsToKFactor = (nUnits: number): number => {
@@ -198,24 +222,12 @@ export const buildCoverage = (
       ? effectiveMemberships
       : sites.map((site) => ({ siteId: site.id, systemId: fallbackSystemId }));
 
-  const samples: { lat: number; lon: number }[] = [];
   const bounds = simulationAreaBoundsForSites(sites, {
     overlayRadiusKm: options?.overlayRadiusKm,
     singleSiteRadiusKm: options?.singleSiteRadiusKm,
   });
   if (!bounds) return [];
-
-  const { rows, cols } = computeCoverageGridDimensions(gridSize, bounds, sampleMultiplier);
-
-  for (let y = 0; y < rows; y += 1) {
-    const ty = rows <= 1 ? 0 : y / (rows - 1);
-    const lat = bounds.minLat + (bounds.maxLat - bounds.minLat) * ty;
-    for (let x = 0; x < cols; x += 1) {
-      const tx = cols <= 1 ? 0 : x / (cols - 1);
-      const lon = bounds.minLon + (bounds.maxLon - bounds.minLon) * tx;
-      samples.push({ lat, lon });
-    }
-  }
+  const samples = buildCoverageGridPoints(gridSize, bounds, sampleMultiplier);
 
   onProgress?.(0);
   const total = Math.max(1, samples.length);
@@ -281,24 +293,12 @@ export const buildCoverageAsync = async (
       ? effectiveMemberships
       : sites.map((site) => ({ siteId: site.id, systemId: fallbackSystemId }));
 
-  const samples: { lat: number; lon: number }[] = [];
   const bounds = simulationAreaBoundsForSites(sites, {
     overlayRadiusKm: options?.overlayRadiusKm,
     singleSiteRadiusKm: options?.singleSiteRadiusKm,
   });
   if (!bounds) return [];
-
-  const { rows, cols } = computeCoverageGridDimensions(gridSize, bounds, sampleMultiplier);
-
-  for (let y = 0; y < rows; y += 1) {
-    const ty = rows <= 1 ? 0 : y / (rows - 1);
-    const lat = bounds.minLat + (bounds.maxLat - bounds.minLat) * ty;
-    for (let x = 0; x < cols; x += 1) {
-      const tx = cols <= 1 ? 0 : x / (cols - 1);
-      const lon = bounds.minLon + (bounds.maxLon - bounds.minLon) * tx;
-      samples.push({ lat, lon });
-    }
-  }
+  const samples = buildCoverageGridPoints(gridSize, bounds, sampleMultiplier);
 
   onProgress?.(0);
   const total = Math.max(1, samples.length);

--- a/src/lib/mapOverlayMode.test.ts
+++ b/src/lib/mapOverlayMode.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { meshExtensionSiteDigest, overlayGuideTitleForMode, overlayModesForSelectionCount } from "./mapOverlayMode";
+import type { Site } from "../types/radio";
+
+describe("map overlay modes", () => {
+  it("treats no selection as all Simulation Sites for Mesh Extension", () => {
+    expect(overlayModesForSelectionCount(0, 0)).not.toContain("mesh-extension");
+    expect(overlayModesForSelectionCount(0, 4)).toContain("mesh-extension");
+    expect(overlayModesForSelectionCount(1, 4)).toContain("mesh-extension");
+    expect(overlayModesForSelectionCount(2, 4)).toContain("mesh-extension");
+    expect(overlayModesForSelectionCount(3, 4)).toContain("mesh-extension");
+  });
+
+  it("keeps existing selection defaults separate from manual mode availability", () => {
+    expect(overlayModesForSelectionCount(1)).toContain("passfail");
+    expect(overlayModesForSelectionCount(2)).toContain("relay");
+  });
+
+  it("provides the Mesh Extension guide title", () => {
+    expect(overlayGuideTitleForMode("mesh-extension")).toBe("Mesh Extension");
+  });
+
+  it("invalidates mesh-extension identity when location, terrain, or radio values change", () => {
+    const site: Site = {
+      id: "a",
+      name: "A",
+      position: { lat: 60, lon: 10 },
+      groundElevationM: 100,
+      antennaHeightM: 5,
+      txPowerDbm: 22,
+      txGainDbi: 2,
+      rxGainDbi: 2,
+      cableLossDb: 1,
+    };
+    const baseline = meshExtensionSiteDigest([site]);
+
+    expect(meshExtensionSiteDigest([{ ...site, position: { ...site.position, lat: 60.1 } }])).not.toBe(baseline);
+    expect(meshExtensionSiteDigest([{ ...site, groundElevationM: 120 }])).not.toBe(baseline);
+    expect(meshExtensionSiteDigest([{ ...site, txPowerDbm: 24 }])).not.toBe(baseline);
+  });
+});

--- a/src/lib/mapOverlayMode.ts
+++ b/src/lib/mapOverlayMode.ts
@@ -1,0 +1,63 @@
+export type MapOverlayMode =
+  | "none"
+  | "heatmap"
+  | "contours"
+  | "weakest"
+  | "passfail"
+  | "relay"
+  | "mesh-extension";
+
+export const overlayModesForSelectionCount = (
+  selectionCount: number,
+  siteCount = selectionCount,
+): MapOverlayMode[] => {
+  if (selectionCount <= 0) {
+    return siteCount > 0
+      ? ["none", "mesh-extension", "heatmap", "weakest", "contours"]
+      : ["none", "heatmap", "weakest", "contours"];
+  }
+  if (selectionCount === 1) return ["none", "passfail", "mesh-extension", "heatmap", "weakest", "contours"];
+  if (selectionCount === 2) return ["none", "relay", "mesh-extension", "heatmap", "weakest", "contours"];
+  return ["none", "mesh-extension", "heatmap", "weakest", "contours"];
+};
+
+export const overlayGuideTitleForMode = (mode: MapOverlayMode): string => {
+  switch (mode) {
+    case "none": return "Hidden";
+    case "heatmap": return "Heatmap";
+    case "contours": return "Heatmap + Target Line";
+    case "weakest": return "Weakest Site";
+    case "passfail": return "Pass/Fail";
+    case "relay": return "Relay";
+    case "mesh-extension": return "Mesh Extension";
+  }
+};
+
+type MeshExtensionSiteDigestInput = Pick<
+  import("../types/radio").Site,
+  | "id"
+  | "position"
+  | "groundElevationM"
+  | "antennaHeightM"
+  | "txPowerDbm"
+  | "txGainDbi"
+  | "rxGainDbi"
+  | "cableLossDb"
+>;
+
+export const meshExtensionSiteDigest = (sites: MeshExtensionSiteDigestInput[]): string =>
+  sites
+    .map((site) =>
+      [
+        site.id,
+        site.position.lat,
+        site.position.lon,
+        site.groundElevationM,
+        site.antennaHeightM,
+        site.txPowerDbm,
+        site.txGainDbi,
+        site.rxGainDbi,
+        site.cableLossDb,
+      ].join(":"),
+    )
+    .join("|");

--- a/src/lib/overlayRaster.test.ts
+++ b/src/lib/overlayRaster.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
   buildCoverageOverlayPixelsAsync,
+  buildMeshExtensionOverlayPixelsAsync,
   computeCoverageRxTargetScale,
+  deriveMeshExtensionCandidateProfile,
+  meshExtensionAlphaForDbm,
+  meshExtensionColorForArea,
+  resolveMeshExtensionCandidateGridSize,
+  resolveMeshExtensionCoverageGridSize,
+  strongestBidirectionalPeerDbm,
   normalizeCoverageDbmForRxTarget,
   buildRelayCandidateOverlayPixelsAsync,
   buildSourcePassFailOverlayPixelsAsync,
@@ -70,6 +77,53 @@ const environment: PropagationEnvironment = {
 const terrainSampler = () => 135;
 
 describe("overlayRaster async builders", () => {
+  it("derives a representative mesh-extension profile from selected-site medians", () => {
+    const profile = deriveMeshExtensionCandidateProfile([
+      { ...fromSite, antennaHeightM: 4, txPowerDbm: 18, txGainDbi: 1, rxGainDbi: 2, cableLossDb: 0.5 },
+      { ...toSite, antennaHeightM: 12, txPowerDbm: 24, txGainDbi: 5, rxGainDbi: 6, cableLossDb: 1.5 },
+      { ...toSite, id: "c", antennaHeightM: 8, txPowerDbm: 22, txGainDbi: 3, rxGainDbi: 4, cableLossDb: 1 },
+    ]);
+
+    expect(profile).toEqual({
+      antennaHeightM: 8,
+      txPowerDbm: 22,
+      txGainDbi: 3,
+      rxGainDbi: 4,
+      cableLossDb: 1,
+    });
+  });
+
+  it("uses the strongest peer after taking each bidirectional bottleneck", () => {
+    expect(
+      strongestBidirectionalPeerDbm([
+        { selectedToCandidateDbm: -95, candidateToSelectedDbm: -130 },
+        { selectedToCandidateDbm: -108, candidateToSelectedDbm: -104 },
+      ]),
+    ).toBe(-108);
+  });
+
+  it("anchors mesh-extension opacity to established pass/fail and heatmap alpha levels", () => {
+    expect(meshExtensionAlphaForDbm(-121, -120, { min: -150, max: -90 })).toBe(0);
+    expect(meshExtensionAlphaForDbm(-120, -120, { min: -150, max: -90 })).toBe(162);
+    expect(meshExtensionAlphaForDbm(-90, -120, { min: -150, max: -90 })).toBe(180);
+  });
+
+  it("uses the selected resolution for both candidate and coverage scoring", () => {
+    expect(resolveMeshExtensionCandidateGridSize(24)).toBe(24);
+    expect(resolveMeshExtensionCandidateGridSize(42)).toBe(42);
+    expect(resolveMeshExtensionCandidateGridSize(168)).toBe(168);
+    expect(resolveMeshExtensionCoverageGridSize(24)).toBe(24);
+    expect(resolveMeshExtensionCoverageGridSize(84)).toBe(84);
+    expect(resolveMeshExtensionCoverageGridSize(168)).toBe(168);
+  });
+
+  it("changes extension hue with new area independently of signal alpha", () => {
+    expect(meshExtensionColorForArea(0, 20)).not.toEqual(meshExtensionColorForArea(20, 20));
+    expect(meshExtensionAlphaForDbm(-140, -120, { min: -150, max: -90 })).not.toBe(
+      meshExtensionAlphaForDbm(-100, -120, { min: -150, max: -90 }),
+    );
+  });
+
   it("samples raster rows in Web Mercator space so image overlays align with GeoJSON", () => {
     const minLat = 62.97069520171348;
     const maxLat = 63.869006376704505;
@@ -211,6 +265,167 @@ describe("overlayRaster async builders", () => {
     expect(terrain?.pixels.length).toBe(10 * 10 * 4);
     expect(relay?.minDbm).toEqual(expect.any(Number));
     expect(relay?.maxDbm).toEqual(expect.any(Number));
+  });
+
+  it("builds mesh-extension metadata and finds positive newly covered area", async () => {
+    const raster = await buildMeshExtensionOverlayPixelsAsync({
+      bounds: {
+        minLat: 59.89,
+        maxLat: 59.91,
+        minLon: 10.64,
+        maxLon: 10.68,
+      },
+      selectedSites: [fromSite],
+      frequencyMHz: 868,
+      propagationEnvironment: environment,
+      rxTargetDbm: -70,
+      environmentLossDb: 0,
+      terrainSampler: () => 100,
+      dimensions: { width: 8, height: 6 },
+      candidateGridSize: 6,
+      coverageGridSize: 6,
+      terrainSamples: 16,
+      context: { phase: "mesh-extension", signature: "mesh-extension-positive", frameBudgetMs: 2 },
+    });
+
+    expect(raster).not.toBeNull();
+    expect(raster?.pixels.length).toBe(8 * 6 * 4);
+    expect(raster?.minAreaKm2).toBe(0);
+    expect(raster?.maxAreaKm2).toBeGreaterThan(0);
+    expect(raster?.minDbm).toEqual(expect.any(Number));
+    expect(raster?.maxDbm).toEqual(expect.any(Number));
+  });
+
+  it("reports zero new area when the selected mesh already covers the comparison grid", async () => {
+    const raster = await buildMeshExtensionOverlayPixelsAsync({
+      bounds: { minLat: 59.899, maxLat: 59.901, minLon: 10.649, maxLon: 10.651 },
+      selectedSites: [fromSite],
+      frequencyMHz: 868,
+      propagationEnvironment: environment,
+      rxTargetDbm: -140,
+      environmentLossDb: 0,
+      terrainSampler: () => 100,
+      dimensions: { width: 6, height: 6 },
+      candidateGridSize: 6,
+      coverageGridSize: 6,
+      terrainSamples: 16,
+      context: { phase: "mesh-extension", signature: "mesh-extension-covered", frameBudgetMs: 2 },
+    });
+
+    expect(raster?.minAreaKm2).toBe(0);
+    expect(raster?.maxAreaKm2).toBe(0);
+  });
+
+  it("renders candidates below the bidirectional mesh target fully transparent", async () => {
+    const raster = await buildMeshExtensionOverlayPixelsAsync({
+      bounds,
+      selectedSites: [fromSite],
+      frequencyMHz: 868,
+      propagationEnvironment: environment,
+      rxTargetDbm: -20,
+      environmentLossDb: 0,
+      terrainSampler,
+      dimensions: { width: 8, height: 8 },
+      candidateGridSize: 8,
+      coverageGridSize: 8,
+      terrainSamples: 16,
+      context: { phase: "mesh-extension", signature: "mesh-extension-transparent-fail" },
+    });
+
+    expect(raster).not.toBeNull();
+    expect(Array.from(raster!.pixels).filter((_, index) => index % 4 === 3).every((alpha) => alpha === 0)).toBe(true);
+  });
+
+  it("skips quadratic high-resolution area work for candidates that cannot join the mesh", async () => {
+    let terrainReads = 0;
+    const raster = await buildMeshExtensionOverlayPixelsAsync({
+      bounds,
+      selectedSites: [fromSite],
+      frequencyMHz: 868,
+      propagationEnvironment: environment,
+      rxTargetDbm: -20,
+      environmentLossDb: 0,
+      terrainSampler: () => {
+        terrainReads += 1;
+        return 135;
+      },
+      dimensions: { width: 8, height: 8 },
+      candidateGridSize: 168,
+      coverageGridSize: 168,
+      terrainSamples: 16,
+      context: { phase: "mesh-extension", signature: "mesh-extension-high-resolution-pruning" },
+    });
+
+    expect(raster).not.toBeNull();
+    expect(terrainReads).toBeLessThan(70_000);
+    expect(Array.from(raster!.pixels).filter((_, index) => index % 4 === 3).every((alpha) => alpha === 0)).toBe(true);
+  });
+
+  it("returns no mesh-extension raster when terrain is unavailable", async () => {
+    const raster = await buildMeshExtensionOverlayPixelsAsync({
+      bounds,
+      selectedSites: [fromSite],
+      frequencyMHz: 868,
+      propagationEnvironment: environment,
+      rxTargetDbm: -118,
+      environmentLossDb: 0,
+      terrainSampler: () => null,
+      dimensions: { width: 6, height: 6 },
+      candidateGridSize: 6,
+      coverageGridSize: 6,
+      terrainSamples: 16,
+      context: { phase: "mesh-extension", signature: "mesh-extension-no-terrain", frameBudgetMs: 2 },
+    });
+
+    expect(raster).toBeNull();
+  });
+
+  it("cancels mesh-extension scoring before returning stale pixels", async () => {
+    await expect(
+      buildMeshExtensionOverlayPixelsAsync({
+        bounds,
+        selectedSites: [fromSite],
+        frequencyMHz: 868,
+        propagationEnvironment: environment,
+        rxTargetDbm: -118,
+        environmentLossDb: 0,
+        terrainSampler,
+        dimensions: { width: 12, height: 12 },
+        candidateGridSize: 12,
+        coverageGridSize: 12,
+        terrainSamples: 16,
+        context: {
+          phase: "mesh-extension",
+          signature: "mesh-extension-cancelled",
+          shouldCancel: () => true,
+        },
+      }),
+    ).rejects.toBeInstanceOf(OverlayTaskCancelledError);
+  });
+
+  it("reports monotonic aggregate progress across mesh-extension stages", async () => {
+    const progress: number[] = [];
+    await buildMeshExtensionOverlayPixelsAsync({
+      bounds: { minLat: 59.899, maxLat: 59.901, minLon: 10.649, maxLon: 10.651 },
+      selectedSites: [fromSite],
+      frequencyMHz: 868,
+      propagationEnvironment: environment,
+      rxTargetDbm: -120,
+      environmentLossDb: 0,
+      terrainSampler,
+      dimensions: { width: 6, height: 6 },
+      candidateGridSize: 6,
+      coverageGridSize: 6,
+      terrainSamples: 16,
+      context: {
+        phase: "mesh-extension",
+        signature: "mesh-extension-progress",
+        onProgress: ({ percent }) => progress.push(percent),
+      },
+    });
+
+    expect(progress.at(-1)).toBe(100);
+    expect(progress.every((value, index) => index === 0 || value >= progress[index - 1])).toBe(true);
   });
 
   it("cancels an in-flight overlay task without returning stale data", async () => {

--- a/src/lib/overlayRaster.ts
+++ b/src/lib/overlayRaster.ts
@@ -1,5 +1,8 @@
 import { classifyPassFailState, computeSourceCentricRxMetrics } from "./passFailState";
 import { STANDARD_SITE_RADIO } from "./linkRadio";
+import { buildCoverageGridPoints, computeCoverageGridDimensions } from "./coverage";
+import { haversineDistanceKm } from "./geo";
+import { getPathLossDb } from "./rfModels";
 import type { Link, PropagationEnvironment, Site } from "../types/radio";
 import { interpolateHeatmapColor } from "../themes/heatmapColors";
 
@@ -23,6 +26,8 @@ export type OverlayRasterPixels = {
   coordinates: [[number, number], [number, number], [number, number], [number, number]];
   minDbm?: number;
   maxDbm?: number;
+  minAreaKm2?: number;
+  maxAreaKm2?: number;
 };
 
 export type OverlayRasterDataUrl = {
@@ -30,6 +35,37 @@ export type OverlayRasterDataUrl = {
   coordinates: [[number, number], [number, number], [number, number], [number, number]];
   minDbm?: number;
   maxDbm?: number;
+  minAreaKm2?: number;
+  maxAreaKm2?: number;
+};
+
+export type MeshExtensionCandidateProfile = {
+  antennaHeightM: number;
+  txPowerDbm: number;
+  txGainDbi: number;
+  rxGainDbi: number;
+  cableLossDb: number;
+};
+
+export type MeshExtensionPeerSignals = {
+  selectedToCandidateDbm: number;
+  candidateToSelectedDbm: number;
+};
+
+export type MeshExtensionOverlayInput = {
+  bounds: TerrainBounds;
+  selectedSites: Site[];
+  frequencyMHz: number;
+  propagationEnvironment: PropagationEnvironment;
+  rxTargetDbm: number;
+  environmentLossDb: number;
+  terrainSampler: (lat: number, lon: number) => number | null;
+  dimensions: { width: number; height: number };
+  candidateGridSize: number;
+  coverageGridSize?: number;
+  terrainSamples: number;
+  pointMask?: (lat: number, lon: number) => boolean;
+  context?: OverlayTaskContext;
 };
 
 export type OverlayTaskContext = {
@@ -201,6 +237,47 @@ const percentile = (values: number[], ratio: number): number => {
   if (lower === upper) return values[lower];
   return lerp(values[lower], values[upper], index - lower);
 };
+
+const median = (values: number[], fallback: number): number => {
+  const finite = values.filter(Number.isFinite).sort((a, b) => a - b);
+  if (!finite.length) return fallback;
+  const midpoint = Math.floor(finite.length / 2);
+  return finite.length % 2 === 0 ? (finite[midpoint - 1] + finite[midpoint]) / 2 : finite[midpoint];
+};
+
+export const deriveMeshExtensionCandidateProfile = (selectedSites: Site[]): MeshExtensionCandidateProfile => ({
+  antennaHeightM: median(selectedSites.map((site) => site.antennaHeightM), 2),
+  txPowerDbm: median(selectedSites.map((site) => site.txPowerDbm), STANDARD_SITE_RADIO.txPowerDbm),
+  txGainDbi: median(selectedSites.map((site) => site.txGainDbi), STANDARD_SITE_RADIO.txGainDbi),
+  rxGainDbi: median(selectedSites.map((site) => site.rxGainDbi), STANDARD_SITE_RADIO.rxGainDbi),
+  cableLossDb: median(selectedSites.map((site) => site.cableLossDb), STANDARD_SITE_RADIO.cableLossDb),
+});
+
+export const strongestBidirectionalPeerDbm = (signals: MeshExtensionPeerSignals[]): number =>
+  signals.reduce(
+    (strongest, signal) =>
+      Math.max(strongest, Math.min(signal.selectedToCandidateDbm, signal.candidateToSelectedDbm)),
+    Number.NEGATIVE_INFINITY,
+  );
+
+export const meshExtensionAlphaForDbm = (
+  valueDbm: number,
+  rxTargetDbm: number,
+  scale: CoverageRxTargetScale,
+): number => {
+  if (!Number.isFinite(valueDbm) || valueDbm < rxTargetDbm) return 0;
+  const above = clamp((valueDbm - rxTargetDbm) / Math.max(1, scale.max - rxTargetDbm), 0, 1);
+  return Math.round(lerp(162, 180, above));
+};
+
+export const resolveMeshExtensionCandidateGridSize = (requestedGridSize: number): number =>
+  Math.max(6, Math.min(168, Math.round(requestedGridSize)));
+
+export const resolveMeshExtensionCoverageGridSize = (requestedGridSize: number): number =>
+  Math.max(6, Math.min(168, Math.round(requestedGridSize)));
+
+export const meshExtensionColorForArea = (areaKm2: number, maxAreaKm2: number): [number, number, number] =>
+  coverageColorForNormalized(maxAreaKm2 > 0 ? clamp(areaKm2 / maxAreaKm2, 0, 1) : 0);
 
 export const computeCoverageRxTargetScale = (
   samples: CoverageSampleLite[],
@@ -652,6 +729,462 @@ export const buildRelayCandidateOverlayPixelsAsync = async (
   };
 };
 
+const directionalBaseRxDbm = (
+  fromSite: Site,
+  toSite: Site,
+  frequencyMHz: number,
+  environment: PropagationEnvironment,
+): number => {
+  const distanceKm = Math.max(0.001, haversineDistanceKm(fromSite.position, toSite.position));
+  const loss = getPathLossDb(
+    distanceKm,
+    frequencyMHz,
+    fromSite.antennaHeightM,
+    toSite.antennaHeightM,
+    environment,
+  );
+  return fromSite.txPowerDbm + fromSite.txGainDbi - fromSite.cableLossDb + toSite.rxGainDbi - loss;
+};
+
+const directionalTerrainRxDbm = (
+  fromSite: Site,
+  toSite: Site,
+  frequencyMHz: number,
+  environment: PropagationEnvironment,
+  terrainSampler: (lat: number, lon: number) => number | null,
+  terrainSamples: number,
+): number =>
+  computeSourceCentricRxMetrics(
+    toSite.position.lat,
+    toSite.position.lon,
+    fromSite,
+    {
+      id: "__mesh_extension_link__",
+      fromSiteId: fromSite.id,
+      toSiteId: toSite.id,
+      frequencyMHz,
+    },
+    toSite.antennaHeightM,
+    toSite.rxGainDbi,
+    terrainSampler,
+    terrainSamples,
+    environment,
+  ).rxDbm;
+
+const bidirectionalBaseDbm = (
+  left: Site,
+  right: Site,
+  frequencyMHz: number,
+  environment: PropagationEnvironment,
+): number =>
+  Math.min(
+    directionalBaseRxDbm(left, right, frequencyMHz, environment),
+    directionalBaseRxDbm(right, left, frequencyMHz, environment),
+  );
+
+const bidirectionalTerrainDbm = (
+  left: Site,
+  right: Site,
+  frequencyMHz: number,
+  environment: PropagationEnvironment,
+  terrainSampler: (lat: number, lon: number) => number | null,
+  terrainSamples: number,
+): number =>
+  Math.min(
+    directionalTerrainRxDbm(left, right, frequencyMHz, environment, terrainSampler, terrainSamples),
+    directionalTerrainRxDbm(right, left, frequencyMHz, environment, terrainSampler, terrainSamples),
+  );
+
+const siteFromProfile = (
+  id: string,
+  lat: number,
+  lon: number,
+  groundElevationM: number,
+  profile: MeshExtensionCandidateProfile,
+): Site => ({
+  id,
+  name: id,
+  position: { lat, lon },
+  groundElevationM,
+  ...profile,
+});
+
+const cellAreaKm2 = (
+  index: number,
+  dimensions: { rows: number; cols: number },
+  bounds: TerrainBounds,
+  lat: number,
+): number => {
+  const row = Math.floor(index / dimensions.cols);
+  const col = index - row * dimensions.cols;
+  const latStep = (bounds.maxLat - bounds.minLat) / Math.max(1, dimensions.rows - 1);
+  const lonStep = (bounds.maxLon - bounds.minLon) / Math.max(1, dimensions.cols - 1);
+  const latShare = row === 0 || row === dimensions.rows - 1 ? 0.5 : 1;
+  const lonShare = col === 0 || col === dimensions.cols - 1 ? 0.5 : 1;
+  const heightKm = Math.abs(latStep) * 111.32 * latShare;
+  const widthKm = Math.abs(lonStep) * 111.32 * Math.max(0.1, Math.cos((lat * Math.PI) / 180)) * lonShare;
+  return heightKm * widthKm;
+};
+
+type MeshExtensionGridBlock = {
+  rowStart: number;
+  rowEnd: number;
+  colStart: number;
+  colEnd: number;
+};
+
+// Seed a small set of blocks, then recursively split only mixed pass/fail terrain boundaries.
+// This keeps 8x scoring responsive without reverting its finest cells to the 1x grid.
+const MESH_EXTENSION_ADAPTIVE_BASE_GRID_SIZE = 8;
+
+const partitionGridAxis = (length: number, targetPartitions: number): Array<[number, number]> => {
+  const partitions = Math.max(1, Math.min(length, targetPartitions));
+  return Array.from({ length: partitions }, (_, index) => [
+    Math.floor((index * length) / partitions),
+    Math.floor(((index + 1) * length) / partitions),
+  ]);
+};
+
+const buildAdaptiveGridBlocks = (
+  dimensions: { rows: number; cols: number },
+  baseGridSize = MESH_EXTENSION_ADAPTIVE_BASE_GRID_SIZE,
+): MeshExtensionGridBlock[] => {
+  const rowRanges = partitionGridAxis(dimensions.rows, baseGridSize);
+  const colRanges = partitionGridAxis(dimensions.cols, baseGridSize);
+  return rowRanges.flatMap(([rowStart, rowEnd]) =>
+    colRanges.map(([colStart, colEnd]) => ({ rowStart, rowEnd, colStart, colEnd })),
+  );
+};
+
+const splitAdaptiveGridBlock = (block: MeshExtensionGridBlock): MeshExtensionGridBlock[] => {
+  const rowMid = block.rowStart + Math.ceil((block.rowEnd - block.rowStart) / 2);
+  const colMid = block.colStart + Math.ceil((block.colEnd - block.colStart) / 2);
+  const rowRanges: Array<[number, number]> =
+    rowMid < block.rowEnd
+      ? [[block.rowStart, rowMid], [rowMid, block.rowEnd]]
+      : [[block.rowStart, block.rowEnd]];
+  const colRanges: Array<[number, number]> =
+    colMid < block.colEnd
+      ? [[block.colStart, colMid], [colMid, block.colEnd]]
+      : [[block.colStart, block.colEnd]];
+  return rowRanges.flatMap(([rowStart, rowEnd]) =>
+    colRanges.map(([colStart, colEnd]) => ({ rowStart, rowEnd, colStart, colEnd })),
+  );
+};
+
+const uniqueBlockSampleIndices = (
+  block: MeshExtensionGridBlock,
+  cols: number,
+): number[] => {
+  const rows = [
+    block.rowStart,
+    Math.floor((block.rowStart + block.rowEnd - 1) / 2),
+    block.rowEnd - 1,
+  ].filter((value, index, values) => values.indexOf(value) === index);
+  const columns = [
+    block.colStart,
+    Math.floor((block.colStart + block.colEnd - 1) / 2),
+    block.colEnd - 1,
+  ].filter((value, index, values) => values.indexOf(value) === index);
+  return rows.flatMap((row) => columns.map((col) => row * cols + col));
+};
+
+const buildAreaPrefixSum = (
+  values: Float64Array,
+  dimensions: { rows: number; cols: number },
+): Float64Array => {
+  const stride = dimensions.cols + 1;
+  const prefix = new Float64Array((dimensions.rows + 1) * stride);
+  for (let row = 0; row < dimensions.rows; row += 1) {
+    let rowSum = 0;
+    for (let col = 0; col < dimensions.cols; col += 1) {
+      rowSum += values[row * dimensions.cols + col];
+      prefix[(row + 1) * stride + col + 1] = prefix[row * stride + col + 1] + rowSum;
+    }
+  }
+  return prefix;
+};
+
+const areaForGridBlock = (
+  prefix: Float64Array,
+  dimensions: { rows: number; cols: number },
+  block: MeshExtensionGridBlock,
+): number => {
+  const stride = dimensions.cols + 1;
+  return (
+    prefix[block.rowEnd * stride + block.colEnd] -
+    prefix[block.rowStart * stride + block.colEnd] -
+    prefix[block.rowEnd * stride + block.colStart] +
+    prefix[block.rowStart * stride + block.colStart]
+  );
+};
+
+export const buildMeshExtensionOverlayPixelsAsync = async (
+  input: MeshExtensionOverlayInput,
+): Promise<OverlayRasterPixels | null> => {
+  if (!input.selectedSites.length) return null;
+  const candidateGridSize = resolveMeshExtensionCandidateGridSize(input.candidateGridSize);
+  const coverageGridSize = resolveMeshExtensionCoverageGridSize(input.coverageGridSize ?? candidateGridSize);
+  const candidatePoints = buildCoverageGridPoints(candidateGridSize, input.bounds);
+  const coveragePoints = buildCoverageGridPoints(coverageGridSize, input.bounds);
+  const coverageDimensions = computeCoverageGridDimensions(coverageGridSize, input.bounds);
+  const profile = deriveMeshExtensionCandidateProfile(input.selectedSites);
+  const terrainSamples = Math.max(16, Math.round(input.terrainSamples));
+  const thresholdBeforeEnvironmentDbm = input.rxTargetDbm + input.environmentLossDb;
+  const contextForProgressRange = (startPercent: number, endPercent: number): OverlayTaskContext | undefined => {
+    if (!input.context) return undefined;
+    return {
+      ...input.context,
+      onProgress: input.context.onProgress
+        ? (payload) =>
+            input.context?.onProgress?.({
+              ...payload,
+              percent: Math.round(lerp(startPercent, endPercent, payload.percent / 100)),
+            })
+        : undefined,
+    };
+  };
+
+  const targetSites: Array<Site | null> = coveragePoints.map((point, index) => {
+    if (input.pointMask && !input.pointMask(point.lat, point.lon)) return null;
+    const ground = input.terrainSampler(point.lat, point.lon);
+    return ground === null ? null : siteFromProfile(`__mesh_extension_target_${index}__`, point.lat, point.lon, ground, profile);
+  });
+  const targetAreaKm2 = coveragePoints.map((point, index) =>
+    targetSites[index] ? cellAreaKm2(index, coverageDimensions, input.bounds, point.lat) : 0,
+  );
+  const existingCovered = new Uint8Array(coveragePoints.length);
+
+  await runCooperativeLoop(
+    coveragePoints.length,
+    (targetIndex) => {
+      const target = targetSites[targetIndex];
+      if (!target) return;
+      for (const selectedSite of input.selectedSites) {
+        const optimistic = bidirectionalBaseDbm(
+          selectedSite,
+          target,
+          input.frequencyMHz,
+          input.propagationEnvironment,
+        );
+        if (optimistic < thresholdBeforeEnvironmentDbm) continue;
+        const actual = bidirectionalTerrainDbm(
+          selectedSite,
+          target,
+          input.frequencyMHz,
+          input.propagationEnvironment,
+          input.terrainSampler,
+          terrainSamples,
+        );
+        if (actual - input.environmentLossDb >= input.rxTargetDbm) {
+          existingCovered[targetIndex] = 1;
+          return;
+        }
+      }
+    },
+    contextForProgressRange(0, 15),
+  );
+
+  const uncoveredAreaByTarget = new Float64Array(coveragePoints.length);
+  for (let index = 0; index < coveragePoints.length; index += 1) {
+    if (!existingCovered[index] && targetSites[index]) uncoveredAreaByTarget[index] = targetAreaKm2[index];
+  }
+  const uncoveredAreaPrefix = buildAreaPrefixSum(uncoveredAreaByTarget, coverageDimensions);
+  const adaptiveBlocks = buildAdaptiveGridBlocks(coverageDimensions);
+
+  const candidateSites: Array<Site | null> = candidatePoints.map((point, index) => {
+    const ground = input.terrainSampler(point.lat, point.lon);
+    return ground === null ? null : siteFromProfile(`__mesh_extension_candidate_${index}__`, point.lat, point.lon, ground, profile);
+  });
+  const connectivityDbm = new Float64Array(candidatePoints.length).fill(Number.NEGATIVE_INFINITY);
+  const newlyCoveredAreaKm2 = new Float64Array(candidatePoints.length);
+
+  await runCooperativeLoop(
+    candidatePoints.length,
+    (candidateIndex) => {
+      const candidate = candidateSites[candidateIndex];
+      if (!candidate) return;
+      const peers = input.selectedSites.map((selectedSite) => {
+        const selectedToCandidateBase =
+          directionalBaseRxDbm(selectedSite, candidate, input.frequencyMHz, input.propagationEnvironment) -
+          input.environmentLossDb;
+        const candidateToSelectedBase =
+          directionalBaseRxDbm(candidate, selectedSite, input.frequencyMHz, input.propagationEnvironment) -
+          input.environmentLossDb;
+        if (Math.min(selectedToCandidateBase, candidateToSelectedBase) < input.rxTargetDbm) {
+          return {
+            selectedToCandidateDbm: selectedToCandidateBase,
+            candidateToSelectedDbm: candidateToSelectedBase,
+          };
+        }
+        return {
+          selectedToCandidateDbm:
+            directionalTerrainRxDbm(
+              selectedSite,
+              candidate,
+              input.frequencyMHz,
+              input.propagationEnvironment,
+              input.terrainSampler,
+              terrainSamples,
+            ) - input.environmentLossDb,
+          candidateToSelectedDbm:
+            directionalTerrainRxDbm(
+              candidate,
+              selectedSite,
+              input.frequencyMHz,
+              input.propagationEnvironment,
+              input.terrainSampler,
+              terrainSamples,
+            ) - input.environmentLossDb,
+        };
+      });
+      connectivityDbm[candidateIndex] = strongestBidirectionalPeerDbm(peers);
+    },
+    contextForProgressRange(15, 30),
+  );
+
+  const evaluationStamp = new Uint32Array(coveragePoints.length);
+  const evaluationPass = new Uint8Array(coveragePoints.length);
+  const areaContext = contextForProgressRange(30, 85);
+  const areaFrameBudgetMs = Math.max(1, input.context?.frameBudgetMs ?? DEFAULT_FRAME_BUDGET_MS);
+  const areaLongTaskMs = Math.max(areaFrameBudgetMs, input.context?.longTaskMs ?? DEFAULT_LONG_TASK_MS);
+  let areaLoopChunkStartedAt = nowMs();
+
+  for (let candidateIndex = 0; candidateIndex < candidatePoints.length; candidateIndex += 1) {
+    throwIfCancelled(input.context);
+    const candidate = candidateSites[candidateIndex];
+    if (candidate && connectivityDbm[candidateIndex] >= input.rxTargetDbm) {
+      const stamp = candidateIndex + 1;
+      const stack = adaptiveBlocks.slice();
+      let chunkStartedAt = nowMs();
+      const evaluateTarget = (targetIndex: number): number => {
+        if (existingCovered[targetIndex] || !targetSites[targetIndex]) return -1;
+        if (evaluationStamp[targetIndex] === stamp) return evaluationPass[targetIndex];
+        const target = targetSites[targetIndex]!;
+        const optimistic = directionalBaseRxDbm(
+          candidate,
+          target,
+          input.frequencyMHz,
+          input.propagationEnvironment,
+        );
+        let pass = false;
+        if (optimistic >= thresholdBeforeEnvironmentDbm) {
+          const actual = directionalTerrainRxDbm(
+            candidate,
+            target,
+            input.frequencyMHz,
+            input.propagationEnvironment,
+            input.terrainSampler,
+            terrainSamples,
+          );
+          pass = actual - input.environmentLossDb >= input.rxTargetDbm;
+        }
+        evaluationStamp[targetIndex] = stamp;
+        evaluationPass[targetIndex] = pass ? 1 : 0;
+        return evaluationPass[targetIndex];
+      };
+
+      while (stack.length) {
+        throwIfCancelled(input.context);
+        const block = stack.pop()!;
+        const blockArea = areaForGridBlock(uncoveredAreaPrefix, coverageDimensions, block);
+        if (blockArea <= 0) continue;
+        const states = uniqueBlockSampleIndices(block, coverageDimensions.cols)
+          .map(evaluateTarget)
+          .filter((state) => state >= 0);
+        const isLeaf = block.rowEnd - block.rowStart === 1 && block.colEnd - block.colStart === 1;
+        if (states.length && states.every((state) => state === states[0])) {
+          if (states[0] === 1) newlyCoveredAreaKm2[candidateIndex] += blockArea;
+        } else if (!isLeaf) {
+          stack.push(...splitAdaptiveGridBlock(block));
+        }
+
+        const chunkDuration = nowMs() - chunkStartedAt;
+        if (chunkDuration >= areaFrameBudgetMs && stack.length) {
+          if (chunkDuration >= areaLongTaskMs) {
+            input.context?.onLongTask?.({
+              phase: input.context.phase,
+              signature: input.context.signature,
+              durationMs: chunkDuration,
+              processed: candidateIndex,
+              total: candidatePoints.length,
+            });
+          }
+          await nextFrame();
+          chunkStartedAt = nowMs();
+        }
+      }
+    }
+
+    areaContext?.onProgress?.({
+      phase: areaContext.phase,
+      signature: areaContext.signature,
+      processed: candidateIndex + 1,
+      total: candidatePoints.length,
+      percent: Math.round(((candidateIndex + 1) / candidatePoints.length) * 100),
+    });
+    if (candidateIndex + 1 < candidatePoints.length && nowMs() - areaLoopChunkStartedAt >= areaFrameBudgetMs) {
+      await nextFrame();
+      areaLoopChunkStartedAt = nowMs();
+    }
+  }
+
+  const areaSamples: CoverageSampleLite[] = [];
+  const connectivitySamples: CoverageSampleLite[] = [];
+  for (let index = 0; index < candidatePoints.length; index += 1) {
+    if (!candidateSites[index] || !Number.isFinite(connectivityDbm[index])) continue;
+    const point = candidatePoints[index];
+    areaSamples.push({ ...point, valueDbm: newlyCoveredAreaKm2[index] });
+    connectivitySamples.push({ ...point, valueDbm: connectivityDbm[index] });
+  }
+  if (!areaSamples.length) return null;
+
+  const positiveAreas = areaSamples
+    .map((sample) => sample.valueDbm)
+    .filter((value) => value > 0)
+    .sort((a, b) => a - b);
+  const maxAreaKm2 = positiveAreas.length ? percentile(positiveAreas, 0.95) : 0;
+  const connectivityScale = computeCoverageRxTargetScale(connectivitySamples, input.rxTargetDbm);
+  const areaAt = makeGridInterpolator(areaSamples) ?? ((lat: number, lon: number) => interpolateCoverageDbm(areaSamples, lat, lon));
+  const connectivityAt = makeGridInterpolator(connectivitySamples) ??
+    ((lat: number, lon: number) => interpolateCoverageDbm(connectivitySamples, lat, lon));
+  const pixels = new Uint8ClampedArray(input.dimensions.width * input.dimensions.height * 4);
+  const { latByRow, lonByCol } = precomputeGridAxes(input.bounds, input.dimensions);
+
+  await runCooperativeLoop(
+    input.dimensions.width * input.dimensions.height,
+    (index) => {
+      const y = Math.floor(index / input.dimensions.width);
+      const x = index - y * input.dimensions.width;
+      const lat = latByRow[y];
+      const lon = lonByCol[x];
+      if (input.pointMask && !input.pointMask(lat, lon)) return;
+      if (input.terrainSampler(lat, lon) === null) return;
+      const area = areaAt(lat, lon);
+      const connectivity = connectivityAt(lat, lon);
+      if (area === null || connectivity === null) return;
+      const [r, g, b] = meshExtensionColorForArea(area, maxAreaKm2);
+      const px = index * 4;
+      pixels[px] = r;
+      pixels[px + 1] = g;
+      pixels[px + 2] = b;
+      pixels[px + 3] = meshExtensionAlphaForDbm(connectivity, input.rxTargetDbm, connectivityScale);
+    },
+    contextForProgressRange(85, 100),
+  );
+
+  return {
+    width: input.dimensions.width,
+    height: input.dimensions.height,
+    pixels,
+    coordinates: overlayCoordinates(input.bounds),
+    minDbm: connectivityScale.min,
+    maxDbm: connectivityScale.max,
+    minAreaKm2: 0,
+    maxAreaKm2,
+  };
+};
+
 export const buildTerrainShadeOverlayPixelsAsync = async (
   bounds: TerrainBounds,
   sampler: (lat: number, lon: number) => number | null,
@@ -795,5 +1328,7 @@ export const overlayPixelsToDataUrl = (raster: OverlayRasterPixels): OverlayRast
     coordinates: raster.coordinates,
     minDbm: raster.minDbm,
     maxDbm: raster.maxDbm,
+    minAreaKm2: raster.minAreaKm2,
+    maxAreaKm2: raster.maxAreaKm2,
   };
 };

--- a/src/lib/overlayTaskBudget.test.ts
+++ b/src/lib/overlayTaskBudget.test.ts
@@ -8,16 +8,18 @@ describe("overlayTaskBudgetForMode", () => {
     const terrain = overlayTaskBudgetForMode("terrain");
     const passFail = overlayTaskBudgetForMode("passfail");
     const relay = overlayTaskBudgetForMode("relay");
+    const meshExtension = overlayTaskBudgetForMode("mesh-extension");
 
     expect(passFail.frameBudgetMs).toBeGreaterThan(heatmap.frameBudgetMs);
     expect(passFail.frameBudgetMs).toBeGreaterThan(contours.frameBudgetMs);
     expect(passFail.frameBudgetMs).toBeGreaterThan(terrain.frameBudgetMs);
     expect(relay.frameBudgetMs).toBeGreaterThan(heatmap.frameBudgetMs);
     expect(relay.frameBudgetMs).toBeGreaterThan(terrain.frameBudgetMs);
+    expect(meshExtension.frameBudgetMs).toBeGreaterThanOrEqual(relay.frameBudgetMs);
   });
 
   it("always sets a long-task threshold not lower than frame budget", () => {
-    const modes = ["heatmap", "contours", "passfail", "relay", "terrain"] as const;
+    const modes = ["heatmap", "contours", "passfail", "relay", "mesh-extension", "terrain"] as const;
     for (const mode of modes) {
       const budget = overlayTaskBudgetForMode(mode);
       expect(budget.longTaskMs).toBeGreaterThanOrEqual(budget.frameBudgetMs);

--- a/src/lib/overlayTaskBudget.ts
+++ b/src/lib/overlayTaskBudget.ts
@@ -1,4 +1,4 @@
-export type OverlayTaskMode = "heatmap" | "contours" | "weakest" | "passfail" | "relay" | "terrain";
+export type OverlayTaskMode = "heatmap" | "contours" | "weakest" | "passfail" | "relay" | "mesh-extension" | "terrain";
 
 export type OverlayTaskBudget = {
   frameBudgetMs: number;
@@ -11,6 +11,7 @@ const BUDGET_BY_MODE: Record<OverlayTaskMode, OverlayTaskBudget> = {
   weakest: { frameBudgetMs: 9, longTaskMs: 30 },
   passfail: { frameBudgetMs: 14, longTaskMs: 42 },
   relay: { frameBudgetMs: 14, longTaskMs: 42 },
+  "mesh-extension": { frameBudgetMs: 16, longTaskMs: 48 },
   terrain: { frameBudgetMs: 8, longTaskMs: 28 },
 };
 

--- a/src/lib/propagation.ts
+++ b/src/lib/propagation.ts
@@ -7,7 +7,6 @@ import {
   isTerrainLineObstructed,
 } from "./terrainLoss";
 import type {
-  BestSiteCandidate,
   Coordinates,
   Link,
   LinkAnalysis,
@@ -207,55 +206,4 @@ export const analyzeLink = (
     worstFresnelClearancePercent,
     worstFresnelDistanceKm,
   };
-};
-
-export const computeBestSiteGrid = (
-  targetSites: Site[],
-  frequencyMHz: number,
-  txPowerDbm: number,
-  txGainDbi: number,
-  rxGainDbi: number,
-  cableLossDb: number,
-  center: Coordinates,
-  spanKm: number,
-  gridSize: number,
-  environment?: PropagationEnvironment,
-): BestSiteCandidate[] => {
-  const halfSpanDegLat = spanKm / 111.32;
-  const halfSpanDegLon = spanKm / (111.32 * Math.cos((center.lat * Math.PI) / 180));
-
-  const candidates: BestSiteCandidate[] = [];
-
-  for (let y = 0; y < gridSize; y += 1) {
-    const ty = y / (gridSize - 1);
-    const lat = center.lat - halfSpanDegLat + ty * halfSpanDegLat * 2;
-
-    for (let x = 0; x < gridSize; x += 1) {
-      const tx = x / (gridSize - 1);
-      const lon = center.lon - halfSpanDegLon + tx * halfSpanDegLon * 2;
-
-      const rxLevels = targetSites.map((site) => {
-        const distanceKm = Math.max(
-          0.001,
-          haversineDistanceKm({ lat, lon }, { lat: site.position.lat, lon: site.position.lon }),
-        );
-        const pathLoss = getPathLossDb(
-          distanceKm,
-          frequencyMHz,
-          2,
-          site.antennaHeightM,
-          environment,
-        );
-        const eirp = txPowerDbm + txGainDbi - cableLossDb;
-        return eirp + rxGainDbi - pathLoss;
-      });
-
-      const worstRxDbm = Math.min(...rxLevels);
-      const avgRxDbm = rxLevels.reduce((sum, value) => sum + value, 0) / rxLevels.length;
-
-      candidates.push({ lat, lon, worstRxDbm, avgRxDbm });
-    }
-  }
-
-  return candidates;
 };

--- a/src/lib/simulationPerf.ts
+++ b/src/lib/simulationPerf.ts
@@ -9,7 +9,7 @@ type CoveragePerfRecord = {
 
 type OverlayPerfRecord = {
   runId: string;
-  mode: "heatmap" | "contours" | "weakest" | "passfail" | "relay" | "terrain";
+  mode: "heatmap" | "contours" | "weakest" | "passfail" | "relay" | "mesh-extension" | "terrain";
   buildDurationMs: number;
   encodeDurationMs: number;
   width: number;

--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -510,6 +510,15 @@ describe("appStore blank simulation loading", () => {
     expect(raw).toBeTruthy();
     expect(raw).toContain(createdId as string);
   });
+
+  it("grants the owner edit access immediately when creating a blank simulation", () => {
+    const createdId = useAppStore
+      .getState()
+      .createBlankSimulationPreset("Writable Blank Session", { visibility: "private", ownerUserId: "owner-1" });
+
+    const created = useAppStore.getState().simulationPresets.find((entry) => entry.id === createdId);
+    expect(created?.effectiveRole).toBe("owner");
+  });
 });
 
 describe("appStore new simulation default frequency preset", () => {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -60,6 +60,7 @@ import type { UiColorTheme } from "../themes/types";
 import { getActiveHolidayTheme } from "../themes/holidayThemes";
 import type { CloudUser } from "../lib/cloudUser";
 import type { MeshmapNode } from "../lib/meshtasticMqtt";
+import type { MapOverlayMode as MapOverlayModeValue } from "../lib/mapOverlayMode";
 import type {
   CoverageResolution,
   Link,
@@ -257,7 +258,7 @@ const adoptOrphanedSimulations = (
   return fixed;
 };
 
-export type MapOverlayMode = "none" | "heatmap" | "contours" | "weakest" | "passfail" | "relay";
+export type MapOverlayMode = MapOverlayModeValue;
 export type AuthSessionState = "checking" | "signed_in" | "signed_out";
 
 type SiteLibraryEntry = {
@@ -2924,6 +2925,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         lastEditedByUserId: user.id,
         lastEditedByName: user.username,
         lastEditedByAvatarUrl: user.avatarUrl ?? "",
+        effectiveRole: "owner",
       };
       const next = [nextPreset, ...current.simulationPresets];
       writeStorage(SIM_PRESETS_KEY, next);

--- a/src/types/radio.ts
+++ b/src/types/radio.ts
@@ -125,13 +125,6 @@ export type ProfilePoint = {
   fresnelBottomM: number;
 };
 
-export type BestSiteCandidate = {
-  lat: number;
-  lon: number;
-  worstRxDbm: number;
-  avgRxDbm: number;
-};
-
 export type CoverageSample = {
   lat: number;
   lon: number;


### PR DESCRIPTION
## Summary

- promote verified LinkSim `0.22.0` to production through the documented release-branch fallback
- direct `staging` → `main` PR #918 was closed because GitHub reported squash-history conflicts
- fallback commit: `4e73ebb7`
- verified staging commit: `cc1af710813f5e5e6fe530f61ab3de77e76db5fd`
- verified staging build label: `v0.22.0-beta+cc1af710`
- release tag: `v0.22.0`

The fallback commit tree matches both `origin/staging` and tag `v0.22.0` exactly.

## Verification

- [x] `npm test` — 112 files, 573 tests passed
- [x] `npm run build`
- [x] `npm run build:verify`
- [x] `npm run dev:check` — no LinkSim dev/watch servers found
- [x] staging deployment succeeded: https://github.com/wilhel1812/LinkSim/actions/runs/29787362450
- [x] staging post-deploy verification passed for `cc1af710`
- [x] `git diff --quiet HEAD origin/staging`
- [x] `git diff --quiet HEAD v0.22.0`
- [x] `node scripts/validate-prod-promotion.mjs`
- [x] milestone issues #909, #910, and #911 are closed and labeled `released`

## Release checklist

- [x] Milestone release checklist completed: docs/milestone-release-checklist.md