### PR TITLE
Add curated Site icons

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -19,6 +19,7 @@ import { buildCoverageTargetContourFeatures } from "../lib/coverageContour";
 import { STANDARD_SITE_RADIO } from "../lib/linkRadio";
 import { sampleSrtmElevation } from "../lib/srtm";
 import { getUiErrorMessage } from "../lib/uiError";
+import { getSiteIconOption, resolveSiteIconKey } from "../lib/siteIcons";
 import { useThemeVariant } from "../hooks/useThemeVariant";
 import {
   BASEMAP_CATEGORIES,
@@ -569,6 +570,11 @@ function MarkerActionButton({
       {children}
     </Surface>
   );
+}
+
+function SiteMarkerIcon({ site }: { site: Pick<Site, "name" | "antennaHeightM" | "iconKey"> }) {
+  const { Icon } = getSiteIconOption(resolveSiteIconKey(site));
+  return <Icon aria-hidden="true" className="map-site-icon" size={15} strokeWidth={1.8} />;
 }
 
 type PendingNewSiteDraft = {
@@ -3623,6 +3629,7 @@ export function MapView({
                   onSiteClick(site.id, isMultiSelectMode || Boolean(nativeEvent.ctrlKey || nativeEvent.metaKey));
                 }}
               >
+                <SiteMarkerIcon site={site} />
                 <span>{site.name}</span>
               </MarkerActionButton>
             </Marker>
@@ -3656,6 +3663,7 @@ export function MapView({
                     setSelectedDiscoveryLibraryEntryId(entry.id);
                   }}
                 >
+                  <SiteMarkerIcon site={entry} />
                   <span>{entry.name}</span>
                 </MarkerActionButton>
               </Marker>

--- a/src/components/MapView.userLocation.test.tsx
+++ b/src/components/MapView.userLocation.test.tsx
@@ -168,6 +168,32 @@ describe("MapView user location flow", () => {
     expect(screen.queryByRole("button", { name: /User location/i })).not.toBeInTheDocument();
   });
 
+  it("renders the resolved Site icon inside the accessible map marker", () => {
+    useAppStore.setState({
+      mapOverlayMode: "none",
+      sites: [
+        {
+          id: "site-ship",
+          name: "Harbour node",
+          position: { lat: 59.9, lon: 10.75 },
+          groundElevationM: 2,
+          antennaHeightM: 2,
+          txPowerDbm: 22,
+          txGainDbi: 2,
+          rxGainDbi: 2,
+          cableLossDb: 1,
+          iconKey: "ship",
+        },
+      ],
+    });
+
+    renderMapView();
+
+    const marker = screen.getByRole("button", { name: "Harbour node" });
+    expect(marker.querySelector(".lucide-ship")).toBeInTheDocument();
+    expect(marker.querySelector(".lucide-ship")).toHaveAttribute("aria-hidden", "true");
+  });
+
   it("centers on the first location update and stops following after user pan", () => {
     renderMapView();
     fireEvent.click(screen.getByRole("button", { name: "Use my location" }));

--- a/src/components/PanoramaChart.tsx
+++ b/src/components/PanoramaChart.tsx
@@ -3,7 +3,7 @@ import { FloatingPopover } from "./ui/FloatingPopover";
 import { MapControlButton } from "./ui/MapControlButton";
 import { PanelToolbar } from "./ui/PanelToolbar";
 import { StateDot } from "./StateDot";
-import { Info, MapPinned, Paintbrush, PanelBottomClose, PanelBottomOpen, Mountain, MountainSnow, RadioTower, Settings, Tags } from "lucide-react";
+import { Info, MapPinned, Paintbrush, PanelBottomClose, PanelBottomOpen, Mountain, MountainSnow, Settings, Tags } from "lucide-react";
 import type { CSSProperties, MouseEvent as ReactMouseEvent, ReactNode } from "react";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { STANDARD_SITE_RADIO } from "../lib/linkRadio";
@@ -34,6 +34,7 @@ import { useAppStore } from "../store/appStore";
 import { useThemeVariant } from "../hooks/useThemeVariant";
 import { UiSlider } from "./UiSlider";
 import { interpolateHeatmapColor } from "../themes/heatmapColors";
+import { getSiteIconOption, resolveSiteIconKey } from "../lib/siteIcons";
 
 const M = { t: 22, r: 20, b: 32, l: 46 };
 const LABEL_RAIL_HEIGHT = 34;
@@ -280,6 +281,7 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
         groundElevationM: site.groundElevationM,
         antennaHeightM: site.antennaHeightM,
         rxGainDbi: site.rxGainDbi,
+        iconKey: resolveSiteIconKey(site),
       }));
 
     const libraryById = new Set(simulation.map((entry) => entry.id.replace("sim:", "")));
@@ -294,6 +296,7 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
             groundElevationM: entry.groundElevationM,
             antennaHeightM: entry.antennaHeightM,
             rxGainDbi: entry.rxGainDbi,
+            iconKey: resolveSiteIconKey(entry),
           }))
       : [];
 
@@ -306,6 +309,7 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
           groundElevationM: node.altitudeM ?? 0,
           antennaHeightM: 2,
           rxGainDbi: STANDARD_SITE_RADIO.rxGainDbi,
+          iconKey: "antenna" as const,
         }))
       : [];
 
@@ -746,6 +750,7 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
       distanceKm: entry.node.distanceKm,
       priorityBucket: 0,
       state: entry.node.state,
+      iconKey: entry.node.iconKey,
     }));
     const visibleLabels = showLabels
       ? resolveVisiblePanoramaLabels({
@@ -1530,7 +1535,7 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
                 const isPoi = label.source === "poi";
                 const elevM = label.elevationM ?? null;
                 const IconEl = isPoi
-                  ? RadioTower
+                  ? getSiteIconOption(label.iconKey ?? "antenna").Icon
                   : elevM !== null && elevM >= 1000
                     ? MountainSnow
                     : Mountain;

--- a/src/components/map/MapEditorPanel.test.tsx
+++ b/src/components/map/MapEditorPanel.test.tsx
@@ -374,6 +374,7 @@ describe("MapEditorPanel", () => {
     expect(screen.queryByDisplayValue("Alpha Site")).not.toBeInTheDocument();
     expect(screen.getByText("60.1")).toBeInTheDocument();
     expect(screen.getByLabelText("Description")).toHaveTextContent("");
+    expect(screen.getByLabelText("Icon")).toHaveTextContent("Radio tower (Auto)");
     expect(
       screen.queryByRole("button", { name: "Save Site" }),
     ).not.toBeInTheDocument();
@@ -717,6 +718,44 @@ describe("MapEditorPanel", () => {
     expect(useAppStore.getState().mapEditor).not.toBeNull();
   });
 
+  it("persists a manually selected Site icon", async () => {
+    const addSiteLibraryEntry = vi.fn(() => "site-created");
+    useAppStore.setState({
+      addSiteLibraryEntry,
+      mapEditor: {
+        kind: "site",
+        resourceId: null,
+        isNew: true,
+        label: "New Site",
+        anchorRect,
+        siteSeed: { lat: 60.3, lon: 10.4, insertIntoSimulation: false },
+      },
+    });
+
+    render(<MapEditorPanel isMobile={false} />);
+
+    await userEvent.type(await screen.findByLabelText("Name"), "Harbour node");
+    await userEvent.click(screen.getByRole("button", { name: /Auto · Radio tower/i }));
+    await userEvent.click(await screen.findByRole("button", { name: "Ship" }));
+    await userEvent.click(screen.getByRole("button", { name: "Create Site" }));
+
+    expect(addSiteLibraryEntry).toHaveBeenCalledWith(
+      "Harbour node",
+      60.3,
+      10.4,
+      0,
+      10,
+      22,
+      2,
+      2,
+      1,
+      undefined,
+      "private",
+      undefined,
+      "ship",
+    );
+  });
+
   it("rejects pasted latitude outside the valid range without moving the site draft", async () => {
     const addSiteLibraryEntry = vi.fn(() => "site-created");
     const loadTerrainForCoordinate = vi.fn(async () => undefined);
@@ -830,6 +869,7 @@ describe("MapEditorPanel", () => {
       1,
       undefined,
       "private",
+      undefined,
       undefined,
     );
     expect(useAppStore.getState().mapEditor).toBeNull();

--- a/src/components/map/MapEditorPanel.tsx
+++ b/src/components/map/MapEditorPanel.tsx
@@ -1,6 +1,6 @@
 import { createPortal } from "react-dom";
 import { useEffect, useRef, useState } from "react";
-import { History, Loader2, Pencil, RefreshCw, Search } from "lucide-react";
+import { ChevronDown, History, Loader2, Pencil, RefreshCw, Search } from "lucide-react";
 import {
   fetchResourceChanges,
   fetchUserById,
@@ -20,6 +20,13 @@ import { InlineCloseIconButton } from "../InlineCloseIconButton";
 import { SiteBeamVisualizer } from "../SiteBeamVisualizer";
 import { AvatarBadge } from "../AvatarBadge";
 import { ModalOverlay } from "../ModalOverlay";
+import { FloatingPopover } from "../ui/FloatingPopover";
+import {
+  getSiteIconOption,
+  resolveSiteIconKey,
+  SITE_ICON_OPTIONS,
+  suggestSiteIconKey,
+} from "../../lib/siteIcons";
 
 // ─── Positioning ─────────────────────────────────────────────────────────────
 
@@ -215,6 +222,16 @@ function SiteEditorCard({
   const mapEditor = useAppStore((state) => state.mapEditor);
   const isReadOnly = Boolean(mapEditor?.readOnly && !isNew) || (!form.canWrite && !isNew);
   const title = isNew ? "New Site" : (mapEditor?.label ?? form.nameDraft);
+  const [iconPickerOpen, setIconPickerOpen] = useState(false);
+  const iconPickerTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const suggestedIconKey = suggestSiteIconKey({ name: form.nameDraft, antennaHeightM: form.antennaDraft });
+  const resolvedIconKey = resolveSiteIconKey({
+    name: form.nameDraft,
+    antennaHeightM: form.antennaDraft,
+    iconKey: form.iconDraft === "auto" ? undefined : form.iconDraft,
+  });
+  const resolvedIconOption = getSiteIconOption(resolvedIconKey);
+  const ResolvedIcon = resolvedIconOption.Icon;
 
   return (
     <>
@@ -235,6 +252,10 @@ function SiteEditorCard({
           <StaticField label="Latitude" value={form.latDraft} />
           <StaticField label="Longitude" value={form.lonDraft} />
           <StaticField label="Ground elev (m)" value={form.groundDraft} />
+          <StaticField
+            label="Icon"
+            value={`${resolvedIconOption.label}${form.iconDraft === "auto" ? " (Auto)" : ""}`}
+          />
           <div className="beam-visualizer-field-group">
             <StaticField label="Antenna (m)" value={form.antennaDraft} />
             <StaticField label="Tx power (dBm)" value={form.txPowerDraft} />
@@ -270,6 +291,53 @@ function SiteEditorCard({
             value={form.nameDraft}
           />
         </label>
+
+        <div className="field-grid">
+          <span>Icon</span>
+          <ActionButton
+            aria-expanded={iconPickerOpen}
+            aria-haspopup="true"
+            className="site-icon-picker-trigger"
+            onClick={() => setIconPickerOpen((open) => !open)}
+            ref={iconPickerTriggerRef}
+            type="button"
+          >
+            <ResolvedIcon aria-hidden="true" size={16} strokeWidth={1.8} />
+            <span>{form.iconDraft === "auto" ? `Auto · ${resolvedIconOption.label}` : resolvedIconOption.label}</span>
+            <ChevronDown aria-hidden="true" size={14} />
+          </ActionButton>
+          <FloatingPopover
+            className="site-icon-picker-popover"
+            estimatedHeight={250}
+            estimatedWidth={280}
+            onClose={() => setIconPickerOpen(false)}
+            open={iconPickerOpen}
+            triggerRef={iconPickerTriggerRef}
+          >
+            <div aria-label="Site icon options" className="site-icon-picker-options" role="group">
+              {[
+                { key: "auto" as const, label: `Auto · ${getSiteIconOption(suggestedIconKey).label}`, Icon: getSiteIconOption(suggestedIconKey).Icon },
+                ...SITE_ICON_OPTIONS,
+              ].map((option) => {
+                const OptionIcon = option.Icon;
+                return (
+                  <ActionButton
+                    aria-pressed={form.iconDraft === option.key}
+                    key={option.key}
+                    onClick={() => {
+                      form.setIconDraft(option.key);
+                      setIconPickerOpen(false);
+                    }}
+                    type="button"
+                  >
+                    <OptionIcon aria-hidden="true" size={16} strokeWidth={1.8} />
+                    <span>{option.label}</span>
+                  </ActionButton>
+                );
+              })}
+            </div>
+          </FloatingPopover>
+        </div>
 
         <label className="field-grid">
           <span>Description</span>

--- a/src/components/map/useMapEditorFormState.ts
+++ b/src/components/map/useMapEditorFormState.ts
@@ -9,6 +9,7 @@ import { searchLocations, type GeocodeResult } from "../../lib/geocode";
 import { sampleSrtmElevation } from "../../lib/srtm";
 import { getUiErrorMessage } from "../../lib/uiError";
 import { hasDuplicateSimulationNameForOwner } from "../../lib/simulationNameValidation";
+import { isSiteIconKey, type SiteIconKey } from "../../lib/siteIcons";
 import { useAppStore } from "../../store/appStore";
 import type { CollaboratorDirectoryUser } from "../../lib/cloudUser";
 import type { AccessRole, AccessVisibility } from "../AccessSettingsEditor";
@@ -87,6 +88,7 @@ export function useMapEditorFormState() {
   const [lonError, setLonError] = useState<string | null>(null);
   const [groundDraft, setGroundDraft] = useState(0);
   const [antennaDraft, setAntennaDraft] = useState(2);
+  const [iconDraft, setIconDraft] = useState<"auto" | SiteIconKey>("auto");
   const [txPowerDraft, setTxPowerDraft] = useState(STANDARD_SITE_RADIO.txPowerDbm);
   const [txGainDraft, setTxGainDraft] = useState(STANDARD_SITE_RADIO.txGainDbi);
   const [rxGainDraft, setRxGainDraft] = useState(STANDARD_SITE_RADIO.rxGainDbi);
@@ -154,6 +156,7 @@ export function useMapEditorFormState() {
         setLonDraft(seededLon);
         setGroundDraft(0);
         setAntennaDraft(10);
+        setIconDraft("auto");
         setTxPowerDraft(STANDARD_SITE_RADIO.txPowerDbm);
         setTxGainDraft(STANDARD_SITE_RADIO.txGainDbi);
         setRxGainDraft(STANDARD_SITE_RADIO.rxGainDbi);
@@ -180,6 +183,7 @@ export function useMapEditorFormState() {
         setLonDraft(entryLon);
         setGroundDraft(entryGround);
         setAntennaDraft(entry?.antennaHeightM ?? 2);
+        setIconDraft(isSiteIconKey(entry?.iconKey) ? entry.iconKey : "auto");
         setTxPowerDraft(entry?.txPowerDbm ?? STANDARD_SITE_RADIO.txPowerDbm);
         const nextTxGain = entry?.txGainDbi ?? STANDARD_SITE_RADIO.txGainDbi;
         const nextRxGain = entry?.rxGainDbi ?? STANDARD_SITE_RADIO.rxGainDbi;
@@ -641,6 +645,7 @@ export function useMapEditorFormState() {
           siteSourceMeta,
           normalizedVisibility,
           descriptionDraft.trim() || undefined,
+          iconDraft === "auto" ? undefined : iconDraft,
         );
         if (!createdId) {
           setStatus("Failed creating site. Check the name and try again.");
@@ -663,6 +668,7 @@ export function useMapEditorFormState() {
           txGainDbi: txGainDraft,
           rxGainDbi: rxGainDraft,
           cableLossDb: cableLossDraft,
+          iconKey: iconDraft === "auto" ? undefined : iconDraft,
           visibility: normalizedVisibility,
           sharedWith,
         });
@@ -921,6 +927,7 @@ export function useMapEditorFormState() {
       setIsElevationUserSet(true);
     },
     antennaDraft, setAntennaDraft: (v: number | string) => setAntennaDraft(parseNumber(String(v))),
+    iconDraft, setIconDraft,
     txPowerDraft, setTxPowerDraft: (v: number | string) => setTxPowerDraft(parseNumber(String(v))),
     txGainDraft, setTxGainDraft: (v: number | string) => setTxGainDraft(parseNumber(String(v))),
     rxGainDraft, setRxGainDraft: (v: number | string) => setRxGainDraft(parseNumber(String(v))),

--- a/src/index.css
+++ b/src/index.css
@@ -2664,6 +2664,10 @@ button {
   isolation: isolate;
 }
 
+.map-site-icon {
+  flex: 0 0 auto;
+}
+
 .map-site-surface:not(.is-muted) {
   z-index: 1;
 }
@@ -3093,6 +3097,41 @@ button {
 
 .ui-settings-popover-row + .ui-settings-popover-row {
   border-top: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
+}
+
+.site-icon-picker-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.site-icon-picker-trigger span {
+  flex: 1;
+  text-align: left;
+}
+
+.site-icon-picker-popover {
+  width: min(280px, calc(100vw - 24px));
+  z-index: 12050;
+}
+
+.site-icon-picker-options {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.site-icon-picker-options .btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 7px;
+}
+
+.site-icon-picker-options .btn[aria-pressed="true"] {
+  border-color: var(--selection);
+  box-shadow: 0 0 0 2px var(--selection-soft);
 }
 
 .beam-visualizer-popover {

--- a/src/lib/panorama.test.ts
+++ b/src/lib/panorama.test.ts
@@ -67,6 +67,7 @@ describe("panorama", () => {
         {
           id: "n1",
           name: "N1",
+          iconKey: "mountain",
           lat: 59.95,
           lon: 10.8,
           groundElevationM: 140,
@@ -80,6 +81,7 @@ describe("panorama", () => {
     expect(result.rays.length).toBe(72);
     expect(result.radiusPolicyKm).toBe(50);
     expect(result.nodes.length).toBe(1);
+    expect(result.nodes[0].iconKey).toBe("mountain");
     expect(result.nodes[0].state).toMatch(/pass_|fail_/);
     expect(result.maxAngleDeg).toBeGreaterThan(result.minAngleDeg);
   });

--- a/src/lib/panorama.ts
+++ b/src/lib/panorama.ts
@@ -2,6 +2,7 @@ import { computeSourceCentricRxMetrics, classifyPassFailState, type PassFailStat
 import { haversineDistanceKm } from "./geo";
 import { normalizeFovScale, FOV_SCALE_DEFAULT } from "./panoramaView";
 import type { Link, PropagationEnvironment, Site } from "../types/radio";
+import type { SiteIconKey } from "./siteIcons";
 
 const EARTH_RADIUS_M = 6_371_000;
 
@@ -15,6 +16,7 @@ export type PanoramaNodeCandidate = {
   groundElevationM: number;
   antennaHeightM: number;
   rxGainDbi: number;
+  iconKey?: SiteIconKey;
 };
 
 export type PanoramaNodeProjection = {
@@ -33,6 +35,7 @@ export type PanoramaNodeProjection = {
   clearanceMarginM: number;
   visible: boolean;
   state: PassFailState;
+  iconKey?: SiteIconKey;
 };
 
 export type PanoramaRaySample = {
@@ -346,6 +349,7 @@ export const buildPanorama = (params: {
         clearanceMarginM,
         visible,
         state,
+        iconKey: candidate.iconKey,
       };
     });
 

--- a/src/lib/panoramaLabels.ts
+++ b/src/lib/panoramaLabels.ts
@@ -10,6 +10,7 @@ export type PanoramaLabelCandidate = {
   priorityBucket: 0 | 1;
   elevationM?: number | null;
   state?: string | null;
+  iconKey?: import("./siteIcons").SiteIconKey;
 };
 
 export type PanoramaLabelLayout = PanoramaLabelCandidate & {

--- a/src/lib/siteIcons.test.ts
+++ b/src/lib/siteIcons.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  isSiteIconKey,
+  resolveSiteIconKey,
+  suggestSiteIconKey,
+} from "./siteIcons";
+
+describe("siteIcons", () => {
+  it("suggests a radio tower for antennas at least 10 m high", () => {
+    expect(suggestSiteIconKey({ name: "Cabin", antennaHeightM: 10 })).toBe("radio-tower");
+    expect(suggestSiteIconKey({ name: "Cabin", antennaHeightM: 9.99 })).toBe("house");
+  });
+
+  it.each([
+    ["Repeater mast", "radio-tower"],
+    ["Family cabin", "house"],
+    ["Office roof", "building"],
+    ["Summit gateway", "mountain"],
+    ["Forest node", "tree"],
+    ["Harbour vessel", "ship"],
+    ["Mobile truck", "vehicle"],
+    ["Plain gateway", "antenna"],
+  ] as const)("suggests %s as %s", (name, expected) => {
+    expect(suggestSiteIconKey({ name, antennaHeightM: 2 })).toBe(expected);
+  });
+
+  it("keeps a valid explicit choice and falls back to Auto for invalid persisted values", () => {
+    expect(resolveSiteIconKey({ name: "Tall tower", antennaHeightM: 20, iconKey: "ship" })).toBe("ship");
+    expect(resolveSiteIconKey({ name: "Tall tower", antennaHeightM: 20, iconKey: "invalid" })).toBe("radio-tower");
+    expect(isSiteIconKey("mountain")).toBe(true);
+    expect(isSiteIconKey("invalid")).toBe(false);
+  });
+
+  it("matches name keywords as words rather than substrings", () => {
+    expect(suggestSiteIconKey({ name: "Carpenter Hill", antennaHeightM: 2 })).toBe("antenna");
+  });
+});

--- a/src/lib/siteIcons.ts
+++ b/src/lib/siteIcons.ts
@@ -1,0 +1,74 @@
+import {
+  Antenna,
+  Building2,
+  Car,
+  House,
+  Mountain,
+  RadioTower,
+  Ship,
+  TreePine,
+  type LucideIcon,
+} from "lucide-react";
+
+export const SITE_ICON_KEYS = [
+  "antenna",
+  "radio-tower",
+  "house",
+  "building",
+  "mountain",
+  "tree",
+  "ship",
+  "vehicle",
+] as const;
+
+export type SiteIconKey = (typeof SITE_ICON_KEYS)[number];
+
+export const SITE_ICON_OPTIONS: ReadonlyArray<{
+  key: SiteIconKey;
+  label: string;
+  Icon: LucideIcon;
+}> = [
+  { key: "antenna", label: "Antenna", Icon: Antenna },
+  { key: "radio-tower", label: "Radio tower", Icon: RadioTower },
+  { key: "house", label: "House", Icon: House },
+  { key: "building", label: "Building", Icon: Building2 },
+  { key: "mountain", label: "Mountain", Icon: Mountain },
+  { key: "tree", label: "Tree", Icon: TreePine },
+  { key: "ship", label: "Ship", Icon: Ship },
+  { key: "vehicle", label: "Vehicle", Icon: Car },
+];
+
+const SITE_ICON_KEY_SET = new Set<string>(SITE_ICON_KEYS);
+const SITE_ICON_BY_KEY = new Map(SITE_ICON_OPTIONS.map((option) => [option.key, option]));
+
+export const isSiteIconKey = (value: unknown): value is SiteIconKey =>
+  typeof value === "string" && SITE_ICON_KEY_SET.has(value);
+
+export const getSiteIconOption = (key: SiteIconKey) => SITE_ICON_BY_KEY.get(key)!;
+
+type SiteIconInput = {
+  name: string;
+  antennaHeightM: number;
+  iconKey?: unknown;
+};
+
+const includesKeyword = (tokens: ReadonlySet<string>, keywords: readonly string[]): boolean =>
+  keywords.some((keyword) => tokens.has(keyword));
+
+export const suggestSiteIconKey = ({ name, antennaHeightM }: SiteIconInput): SiteIconKey => {
+  if (Number.isFinite(antennaHeightM) && antennaHeightM >= 10) return "radio-tower";
+
+  const normalizedName = name.trim().toLocaleLowerCase();
+  const tokens = new Set(normalizedName.split(/[^\p{L}\p{N}]+/u).filter(Boolean));
+  if (includesKeyword(tokens, ["tower", "mast", "repeater", "relay"])) return "radio-tower";
+  if (includesKeyword(tokens, ["house", "home", "cabin", "hytte"])) return "house";
+  if (includesKeyword(tokens, ["office", "building", "hotel", "school", "roof"])) return "building";
+  if (includesKeyword(tokens, ["mount", "mountain", "peak", "summit", "fjell"])) return "mountain";
+  if (includesKeyword(tokens, ["tree", "forest", "woods", "woodland"])) return "tree";
+  if (includesKeyword(tokens, ["boat", "ship", "vessel", "ferry"])) return "ship";
+  if (includesKeyword(tokens, ["car", "truck", "vehicle", "mobile", "van"])) return "vehicle";
+  return "antenna";
+};
+
+export const resolveSiteIconKey = (site: SiteIconInput): SiteIconKey =>
+  isSiteIconKey(site.iconKey) ? site.iconKey : suggestSiteIconKey(site);

--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -659,6 +659,7 @@ describe("appStore simulation copy", () => {
           txGainDbi: 3,
           rxGainDbi: 3,
           cableLossDb: 1,
+          iconKey: "ship",
         },
       ],
       links: [
@@ -692,6 +693,7 @@ describe("appStore simulation copy", () => {
     });
     expect(created?.snapshot.sites).toHaveLength(2);
     expect(created?.snapshot.sites.map((site) => site.name)).toEqual(["Site Alpha", "Site Beta"]);
+    expect(created?.snapshot.sites[1]?.iconKey).toBe("ship");
     expect(created?.snapshot.links).toHaveLength(1);
     expect(created?.snapshot.links[0]).toMatchObject({
       fromSiteId: "site-alpha",
@@ -700,6 +702,7 @@ describe("appStore simulation copy", () => {
     });
     expect(useAppStore.getState().siteLibrary).toHaveLength(2);
     expect(useAppStore.getState().siteLibrary.map((entry) => entry.name)).toEqual(["Site Beta", "Site Alpha"]);
+    expect(useAppStore.getState().siteLibrary.find((entry) => entry.name === "Site Beta")?.iconKey).toBe("ship");
 
     useAppStore.getState().loadSimulationPreset(createdId as string);
     expect(useAppStore.getState().selectedScenarioId).toBe(createdId);

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -61,6 +61,7 @@ import { getActiveHolidayTheme } from "../themes/holidayThemes";
 import type { CloudUser } from "../lib/cloudUser";
 import type { MeshmapNode } from "../lib/meshtasticMqtt";
 import type { MapOverlayMode as MapOverlayModeValue } from "../lib/mapOverlayMode";
+import { isSiteIconKey, type SiteIconKey } from "../lib/siteIcons";
 import type {
   CoverageResolution,
   Link,
@@ -282,6 +283,7 @@ type SiteLibraryEntry = {
   txGainDbi: number;
   rxGainDbi: number;
   cableLossDb: number;
+  iconKey?: SiteIconKey;
   createdAt: string;
   sourceMeta?: {
     sourceType: string;
@@ -559,6 +561,7 @@ type AppState = {
     sourceMeta?: SiteLibraryEntry["sourceMeta"],
     visibility?: "private" | "public" | "shared",
     description?: string,
+    iconKey?: SiteIconKey,
     createdBy?: {
       userId: string;
       name: string;
@@ -581,6 +584,7 @@ type AppState = {
         | "txGainDbi"
         | "rxGainDbi"
         | "cableLossDb"
+        | "iconKey"
         | "visibility"
         | "sharedWith"
       >
@@ -833,6 +837,7 @@ const normalizeSiteLibrary = (entries: SiteLibraryEntry[]): SiteLibraryEntry[] =
           typeof entry.cableLossDb === "number" && Number.isFinite(entry.cableLossDb)
             ? entry.cableLossDb
             : STANDARD_SITE_RADIO.cableLossDb,
+        iconKey: isSiteIconKey(entry.iconKey) ? entry.iconKey : undefined,
       })),
   );
 
@@ -959,6 +964,7 @@ const syncLibraryLinkedSiteValues = (sites: Site[], library: SiteLibraryEntry[])
       txGainDbi: entry.txGainDbi,
       rxGainDbi: entry.rxGainDbi,
       cableLossDb: entry.cableLossDb,
+      iconKey: entry.iconKey,
       libraryEntryId: entry.id,
     };
   });
@@ -1001,6 +1007,7 @@ const ensureSitesBackedByLibrary = (
         txGainDbi: normalizedSite.txGainDbi,
         rxGainDbi: normalizedSite.rxGainDbi,
         cableLossDb: normalizedSite.cableLossDb,
+        iconKey: normalizedSite.iconKey,
         createdAt: new Date().toISOString(),
       };
       nextLibrary.unshift(entry);
@@ -1021,6 +1028,7 @@ const ensureSitesBackedByLibrary = (
       txGainDbi: entry.txGainDbi,
       rxGainDbi: entry.rxGainDbi,
       cableLossDb: entry.cableLossDb,
+      iconKey: entry.iconKey,
       libraryEntryId: entry.id,
     };
   });
@@ -2434,6 +2442,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     sourceMeta,
     visibility = "private",
     description,
+    iconKey,
   ) => {
     const { currentUser } = get();
     if (!currentUser?.id) {
@@ -2466,6 +2475,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       txGainDbi,
       rxGainDbi,
       cableLossDb,
+      iconKey,
       createdAt: nowIso,
       sourceMeta: normalizedMeta,
       ownerUserId: currentUser.id,
@@ -2581,6 +2591,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         txGainDbi: entry.txGainDbi,
         rxGainDbi: entry.rxGainDbi,
         cableLossDb: entry.cableLossDb,
+        iconKey: entry.iconKey,
         libraryEntryId: entry.id,
       };
     });
@@ -3515,6 +3526,7 @@ export const useAppStore = create<AppState>((set, get) => ({
               txGainDbi: updatedSite.txGainDbi,
               rxGainDbi: updatedSite.rxGainDbi,
               cableLossDb: updatedSite.cableLossDb,
+              iconKey: updatedSite.iconKey,
             }
           : entry,
       );

--- a/src/types/radio.ts
+++ b/src/types/radio.ts
@@ -13,6 +13,7 @@ export type Site = {
   txGainDbi: number;
   rxGainDbi: number;
   cableLossDb: number;
+  iconKey?: import("../lib/siteIcons").SiteIconKey;
   libraryEntryId?: string;
 };
 


### PR DESCRIPTION
## Summary

- add persistent curated Lucide icons for Sites with an Auto mode
- suggest icons deterministically from antenna height and Site-name keywords
- render resolved icons on map Site markers and panorama Site labels
- preserve existing Site records without a migration and keep invalid values on the safe Auto path

Tracks #775. The issue remains open until shared-staging verification and user sign-off.

## Validation

- `npm test` — 586 tests passed
- `npm run build` — passed
- focused ESLint on the Issue 775 files — passed
- local UI verification — map icons, accessible marker labels, and read-only Auto value passed

## Notes

Repository-wide `npm run lint` remains blocked by pre-existing lint failures, including tracked `.claude` worktrees and unchanged files. No unrelated lint cleanup is included.