### PR TITLE
Refine curated Site icons

### DIFF
--- a/src/components/map/MapEditorPanel.test.tsx
+++ b/src/components/map/MapEditorPanel.test.tsx
@@ -374,7 +374,8 @@ describe("MapEditorPanel", () => {
     expect(screen.queryByDisplayValue("Alpha Site")).not.toBeInTheDocument();
     expect(screen.getByText("60.1")).toBeInTheDocument();
     expect(screen.getByLabelText("Description")).toHaveTextContent("");
-    expect(screen.getByLabelText("Icon")).toHaveTextContent("Radio tower (Auto)");
+    expect(screen.getByRole("img", { name: "Radio Tower" })).toBeInTheDocument();
+    expect(screen.queryByText(/Radio tower|Auto/i)).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Save Site" }),
     ).not.toBeInTheDocument();
@@ -735,8 +736,15 @@ describe("MapEditorPanel", () => {
     render(<MapEditorPanel isMobile={false} />);
 
     await userEvent.type(await screen.findByLabelText("Name"), "Harbour node");
-    await userEvent.click(screen.getByRole("button", { name: /Auto · Radio tower/i }));
-    await userEvent.click(await screen.findByRole("button", { name: "Ship" }));
+    const trigger = screen.getByRole("button", { name: "Radio Tower" });
+    expect(trigger).toHaveTextContent("");
+    await userEvent.click(trigger);
+
+    const shipOption = await screen.findByRole("button", { name: "Ship" });
+    expect(shipOption).toHaveAttribute("title", "Ship");
+    expect(shipOption).toHaveClass("btn-icon");
+    expect(screen.queryByText("Ship")).not.toBeInTheDocument();
+    await userEvent.click(shipOption);
     await userEvent.click(screen.getByRole("button", { name: "Create Site" }));
 
     expect(addSiteLibraryEntry).toHaveBeenCalledWith(

--- a/src/components/map/MapEditorPanel.tsx
+++ b/src/components/map/MapEditorPanel.tsx
@@ -252,10 +252,12 @@ function SiteEditorCard({
           <StaticField label="Latitude" value={form.latDraft} />
           <StaticField label="Longitude" value={form.lonDraft} />
           <StaticField label="Ground elev (m)" value={form.groundDraft} />
-          <StaticField
-            label="Icon"
-            value={`${resolvedIconOption.label}${form.iconDraft === "auto" ? " (Auto)" : ""}`}
-          />
+          <div className="field-grid">
+            <span>Icon</span>
+            <span className="field-help static-field-value site-icon-static-value">
+              <ResolvedIcon aria-label={resolvedIconOption.label} role="img" size={16} strokeWidth={1.8} />
+            </span>
+          </div>
           <div className="beam-visualizer-field-group">
             <StaticField label="Antenna (m)" value={form.antennaDraft} />
             <StaticField label="Tx power (dBm)" value={form.txPowerDraft} />
@@ -295,6 +297,7 @@ function SiteEditorCard({
         <div className="field-grid">
           <span>Icon</span>
           <ActionButton
+            aria-label={resolvedIconOption.label}
             aria-expanded={iconPickerOpen}
             aria-haspopup="true"
             className="site-icon-picker-trigger"
@@ -303,7 +306,6 @@ function SiteEditorCard({
             type="button"
           >
             <ResolvedIcon aria-hidden="true" size={16} strokeWidth={1.8} />
-            <span>{form.iconDraft === "auto" ? `Auto · ${resolvedIconOption.label}` : resolvedIconOption.label}</span>
             <ChevronDown aria-hidden="true" size={14} />
           </ActionButton>
           <FloatingPopover
@@ -316,22 +318,25 @@ function SiteEditorCard({
           >
             <div aria-label="Site icon options" className="site-icon-picker-options" role="group">
               {[
-                { key: "auto" as const, label: `Auto · ${getSiteIconOption(suggestedIconKey).label}`, Icon: getSiteIconOption(suggestedIconKey).Icon },
+                { ...getSiteIconOption(suggestedIconKey), key: "auto" as const },
                 ...SITE_ICON_OPTIONS,
               ].map((option) => {
                 const OptionIcon = option.Icon;
                 return (
                   <ActionButton
+                    aria-label={option.label}
                     aria-pressed={form.iconDraft === option.key}
+                    className={form.iconDraft === option.key ? "is-selected" : undefined}
                     key={option.key}
                     onClick={() => {
                       form.setIconDraft(option.key);
                       setIconPickerOpen(false);
                     }}
+                    size="icon"
+                    title={option.label}
                     type="button"
                   >
                     <OptionIcon aria-hidden="true" size={16} strokeWidth={1.8} />
-                    <span>{option.label}</span>
                   </ActionButton>
                 );
               })}

--- a/src/index.css
+++ b/src/index.css
@@ -3102,35 +3102,32 @@ button {
 .site-icon-picker-trigger {
   display: inline-flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
   gap: 8px;
+  justify-self: start;
 }
 
-.site-icon-picker-trigger span {
-  flex: 1;
-  text-align: left;
+.site-icon-static-value {
+  display: inline-flex;
+  align-items: center;
 }
 
 .site-icon-picker-popover {
-  width: min(280px, calc(100vw - 24px));
+  width: min(236px, calc(100vw - 24px));
+  padding: 12px;
   z-index: 12050;
 }
 
 .site-icon-picker-options {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(5, 34px);
+  justify-content: center;
   gap: 6px;
 }
 
-.site-icon-picker-options .btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 7px;
-}
-
-.site-icon-picker-options .btn[aria-pressed="true"] {
-  border-color: var(--selection);
+.site-icon-picker-options .btn-icon.is-selected {
+  background: var(--selection-soft);
+  color: var(--text);
   box-shadow: 0 0 0 2px var(--selection-soft);
 }
 

--- a/src/lib/siteIcons.test.ts
+++ b/src/lib/siteIcons.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  getSiteIconOption,
   isSiteIconKey,
   resolveSiteIconKey,
   suggestSiteIconKey,
@@ -19,9 +20,34 @@ describe("siteIcons", () => {
     ["Forest node", "tree"],
     ["Harbour vessel", "ship"],
     ["Mobile truck", "vehicle"],
-    ["Plain gateway", "antenna"],
+    ["Solar gateway", "solar-panel"],
+    ["Laptop gateway", "radio-receiver"],
+    ["Pocket gateway", "smartphone"],
+    ["Temperature sensor", "thermometer"],
+    ["Leaf node", "leaf"],
+    ["Plain gateway", "radio"],
   ] as const)("suggests %s as %s", (name, expected) => {
     expect(suggestSiteIconKey({ name, antennaHeightM: 2 })).toBe(expected);
+  });
+
+  it.each([
+    ["antenna", "Antenna"],
+    ["radio-tower", "Radio Tower"],
+    ["house", "House"],
+    ["building", "Building 2"],
+    ["mountain", "Mountain"],
+    ["tree", "Tree Pine"],
+    ["ship", "Ship"],
+    ["vehicle", "Car"],
+    ["solar-panel", "Solar Panel"],
+    ["radio-receiver", "Radio Receiver"],
+    ["radio", "Radio"],
+    ["smartphone", "Smartphone"],
+    ["thermometer", "Thermometer"],
+    ["leaf", "Leaf"],
+  ] as const)("registers %s with the official Lucide name", (key, label) => {
+    expect(getSiteIconOption(key).label).toBe(label);
+    expect(isSiteIconKey(key)).toBe(true);
   });
 
   it("keeps a valid explicit choice and falls back to Auto for invalid persisted values", () => {
@@ -32,6 +58,6 @@ describe("siteIcons", () => {
   });
 
   it("matches name keywords as words rather than substrings", () => {
-    expect(suggestSiteIconKey({ name: "Carpenter Hill", antennaHeightM: 2 })).toBe("antenna");
+    expect(suggestSiteIconKey({ name: "Carpenter Hill", antennaHeightM: 2 })).toBe("radio");
   });
 });

--- a/src/lib/siteIcons.ts
+++ b/src/lib/siteIcons.ts
@@ -3,9 +3,15 @@ import {
   Building2,
   Car,
   House,
+  Leaf,
   Mountain,
+  Radio,
+  RadioReceiver,
   RadioTower,
   Ship,
+  Smartphone,
+  SolarPanel,
+  Thermometer,
   TreePine,
   type LucideIcon,
 } from "lucide-react";
@@ -19,6 +25,12 @@ export const SITE_ICON_KEYS = [
   "tree",
   "ship",
   "vehicle",
+  "solar-panel",
+  "radio-receiver",
+  "radio",
+  "smartphone",
+  "thermometer",
+  "leaf",
 ] as const;
 
 export type SiteIconKey = (typeof SITE_ICON_KEYS)[number];
@@ -29,13 +41,19 @@ export const SITE_ICON_OPTIONS: ReadonlyArray<{
   Icon: LucideIcon;
 }> = [
   { key: "antenna", label: "Antenna", Icon: Antenna },
-  { key: "radio-tower", label: "Radio tower", Icon: RadioTower },
+  { key: "radio-tower", label: "Radio Tower", Icon: RadioTower },
   { key: "house", label: "House", Icon: House },
-  { key: "building", label: "Building", Icon: Building2 },
+  { key: "building", label: "Building 2", Icon: Building2 },
   { key: "mountain", label: "Mountain", Icon: Mountain },
-  { key: "tree", label: "Tree", Icon: TreePine },
+  { key: "tree", label: "Tree Pine", Icon: TreePine },
   { key: "ship", label: "Ship", Icon: Ship },
-  { key: "vehicle", label: "Vehicle", Icon: Car },
+  { key: "vehicle", label: "Car", Icon: Car },
+  { key: "solar-panel", label: "Solar Panel", Icon: SolarPanel },
+  { key: "radio-receiver", label: "Radio Receiver", Icon: RadioReceiver },
+  { key: "radio", label: "Radio", Icon: Radio },
+  { key: "smartphone", label: "Smartphone", Icon: Smartphone },
+  { key: "thermometer", label: "Thermometer", Icon: Thermometer },
+  { key: "leaf", label: "Leaf", Icon: Leaf },
 ];
 
 const SITE_ICON_KEY_SET = new Set<string>(SITE_ICON_KEYS);
@@ -61,13 +79,18 @@ export const suggestSiteIconKey = ({ name, antennaHeightM }: SiteIconInput): Sit
   const normalizedName = name.trim().toLocaleLowerCase();
   const tokens = new Set(normalizedName.split(/[^\p{L}\p{N}]+/u).filter(Boolean));
   if (includesKeyword(tokens, ["tower", "mast", "repeater", "relay"])) return "radio-tower";
+  if (includesKeyword(tokens, ["solar", "photovoltaic", "pv"])) return "solar-panel";
+  if (includesKeyword(tokens, ["computer", "desktop", "laptop", "pc"])) return "radio-receiver";
+  if (includesKeyword(tokens, ["pocket", "phone", "smartphone", "handheld"])) return "smartphone";
+  if (includesKeyword(tokens, ["sensor", "temperature", "weather", "thermometer"])) return "thermometer";
+  if (includesKeyword(tokens, ["leaf"])) return "leaf";
   if (includesKeyword(tokens, ["house", "home", "cabin", "hytte"])) return "house";
   if (includesKeyword(tokens, ["office", "building", "hotel", "school", "roof"])) return "building";
   if (includesKeyword(tokens, ["mount", "mountain", "peak", "summit", "fjell"])) return "mountain";
   if (includesKeyword(tokens, ["tree", "forest", "woods", "woodland"])) return "tree";
   if (includesKeyword(tokens, ["boat", "ship", "vessel", "ferry"])) return "ship";
   if (includesKeyword(tokens, ["car", "truck", "vehicle", "mobile", "van"])) return "vehicle";
-  return "antenna";
+  return "radio";
 };
 
 export const resolveSiteIconKey = (site: SiteIconInput): SiteIconKey =>


### PR DESCRIPTION
## Summary

- add Solar Panel, Radio Receiver, Radio, Smartphone, Thermometer, and Leaf Site icons
- use Radio as the Auto fallback and add deterministic name suggestions
- remove visible icon names from the editor and read-only display
- render the picker as padded, circular icon-only controls with official Lucide accessibility names

Tracks #775.

## Validation

- focused icon/map/panorama suites: 63 passed
- deep-link suite: 35 passed
- calculate API suite: 6 passed
- app-store suite: 21 passed
- `npm test`: 113 files / 605 tests passed
- `npm run build`: passed
- focused ESLint: passed
- live browser testing omitted per explicit instruction

## Delivery note

A direct push to `staging` was explicitly requested but rejected by branch protection (`GH006`); this PR is the repository-required delivery path for the exact same commit.