### PR TITLE
Add manual simulation calculation controls

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent, type ReactNode } from "react";
-import { Egg, Fullscreen, Layers, Locate, LocateFixed, Maximize2, Minimize2, Rabbit, RefreshCw, SquareStack, ZoomIn, ZoomOut } from "lucide-react";
+import { Egg, Fullscreen, Layers, Locate, LocateFixed, Maximize2, Minimize2, Play, Rabbit, RefreshCw, Square, SquareStack, ToggleLeft, ToggleRight, ZoomIn, ZoomOut } from "lucide-react";
 import { CompactDetails, CompactDetailsSummary } from "./ui/CompactDetails";
 import { FloatingPopover } from "./ui/FloatingPopover";
 import { MapControlButton } from "./ui/MapControlButton";
@@ -37,7 +37,7 @@ import {
 } from "../lib/profileDraftEvent";
 import { subscribePanoramaInteraction, type PanoramaFocusPoint, type PanoramaInteractionEvent } from "../lib/panoramaEvents";
 import { useAppStore } from "../store/appStore";
-import { useCoverageStore } from "../store/coverageStore";
+import { isAutomaticCalculationLocked, useCoverageStore } from "../store/coverageStore";
 import { TERRAIN_DATASET_LABEL } from "../lib/terrainDataset";
 import type { Link, Site } from "../types/radio";
 import { fetchMeshmapNodes, type MeshmapNode } from "../lib/meshtasticMqtt";
@@ -735,6 +735,13 @@ export function MapView({
   const simulationProgressMode = useCoverageStore((state) => state.simulationProgressMode);
   const simulationStepLabel = useCoverageStore((state) => state.simulationStepLabel);
   const simulationRunToken = useCoverageStore((state) => state.simulationRunToken);
+  const completedCoverageRunToken = useCoverageStore((state) => state.completedCoverageRunToken);
+  const autoCalculateEnabled = useCoverageStore((state) => state.autoCalculateEnabled);
+  const calculationCycleSource = useCoverageStore((state) => state.calculationCycleSource);
+  const setAutoCalculateEnabled = useCoverageStore((state) => state.setAutoCalculateEnabled);
+  const startManualCalculation = useCoverageStore((state) => state.startManualCalculation);
+  const stopCalculation = useCoverageStore((state) => state.stopCalculation);
+  const finishCalculationCycle = useCoverageStore((state) => state.finishCalculationCycle);
   const isTerrainFetching = useAppStore((state) => state.isTerrainFetching);
   const isTerrainRecommending = useAppStore((state) => state.isTerrainRecommending);
   const basemapStyleId = useAppStore((state) => state.basemapStyleId);
@@ -1154,6 +1161,17 @@ export function MapView({
     selectionCount,
     option: selectedOverlayRadiusOption,
   });
+  const automaticCalculationLocked = isAutomaticCalculationLocked(
+    selectedCoverageResolution,
+    normalizedOverlayRadiusOption,
+  );
+  const calculationWorkAllowed =
+    (autoCalculateEnabled && !automaticCalculationLocked) || calculationCycleSource === "manual";
+  useEffect(() => {
+    if (automaticCalculationLocked && autoCalculateEnabled) {
+      setAutoCalculateEnabled(false);
+    }
+  }, [automaticCalculationLocked, autoCalculateEnabled, setAutoCalculateEnabled]);
   const targetRadiusKm = useMemo(
     () => resolveTargetOverlayRadiusKm(selectionCount, normalizedOverlayRadiusOption),
     [selectionCount, normalizedOverlayRadiusOption],
@@ -1215,6 +1233,10 @@ export function MapView({
   const targetRadiusTerrainSignature = `${targetRadiusKm}|${requiredTargetRadiusTileKeys.join(",")}`;
   const targetRadiusFetchAttemptRef = useRef("");
   useEffect(() => {
+    if (!calculationWorkAllowed) {
+      targetRadiusFetchAttemptRef.current = "";
+      return;
+    }
     if (coverageVizMode === "none") {
       targetRadiusFetchAttemptRef.current = "";
       return;
@@ -1237,6 +1259,7 @@ export function MapView({
     targetRadiusTerrainSignature,
     recommendAndFetchTerrainForCurrentArea,
     targetRadiusKm,
+    calculationWorkAllowed,
   ]);
   const overlayMaskArea = useMemo(
     () => buildBufferedSelectionArea(analysisTargetSites, overlayRadiusKm),
@@ -1452,6 +1475,8 @@ export function MapView({
   const coverageOverlayRunCounterRef = useRef(0);
   const terrainOverlayRunCounterRef = useRef(0);
   const latestCoverageRunTokenRef = useRef("");
+  const lastCoverageOverlayCompletionRef = useRef("");
+  const lastTerrainOverlayCompletionRef = useRef("");
   const coverageOverlayCacheRef = useRef(
     createLruCache<OverlayRaster & { minDbm?: number; maxDbm?: number }>(4),
   );
@@ -1621,6 +1646,22 @@ export function MapView({
       selectedSiteRadioDigest,
       meshExtensionFrequencyMHz,
     ].join("|");
+    const hasFreshCoverageCompletion =
+      calculationCycleSource !== null &&
+      completedCoverageRunToken !== "" &&
+      lastCoverageOverlayCompletionRef.current !== completedCoverageRunToken;
+    if (!calculationWorkAllowed && !hasFreshCoverageCompletion) {
+      const snapshot = scheduler.snapshot();
+      scheduler.clearQueue();
+      if (snapshot.activeSignature && snapshot.activeSignature !== signature) {
+        scheduler.cancelActive();
+        setOverlayPipelineProgress("coverage", null);
+      }
+      return;
+    }
+    if (hasFreshCoverageCompletion) {
+      lastCoverageOverlayCompletionRef.current = completedCoverageRunToken;
+    }
     const cached = coverageOverlayCacheRef.current.get(signature);
     if (cached) {
       scheduler.clearQueue();
@@ -1851,6 +1892,9 @@ export function MapView({
     beginOverlayJob,
     setOverlayPipelineProgress,
     logOverlaySchedulerEvent,
+    calculationWorkAllowed,
+    calculationCycleSource,
+    completedCoverageRunToken,
   ]);
   const signalRange = useMemo(() => {
     if (!samplesForOverlay.length) return { min: -125, max: -62 };
@@ -1935,6 +1979,22 @@ export function MapView({
       selectedSiteDigest,
       overlayRadiusKm,
     ].join("|");
+    const hasFreshCoverageCompletion =
+      calculationCycleSource !== null &&
+      completedCoverageRunToken !== "" &&
+      lastTerrainOverlayCompletionRef.current !== completedCoverageRunToken;
+    if (!calculationWorkAllowed && !hasFreshCoverageCompletion) {
+      const snapshot = scheduler.snapshot();
+      scheduler.clearQueue();
+      if (snapshot.activeSignature && snapshot.activeSignature !== signature) {
+        scheduler.cancelActive();
+        setOverlayPipelineProgress("terrain", null);
+      }
+      return;
+    }
+    if (hasFreshCoverageCompletion) {
+      lastTerrainOverlayCompletionRef.current = completedCoverageRunToken;
+    }
     const cached = terrainOverlayCacheRef.current.get(signature);
     if (cached) {
       scheduler.clearQueue();
@@ -2079,6 +2139,9 @@ export function MapView({
     beginOverlayJob,
     setOverlayPipelineProgress,
     logOverlaySchedulerEvent,
+    calculationWorkAllowed,
+    calculationCycleSource,
+    completedCoverageRunToken,
   ]);
 
   const webglAvailable = useMemo(() => supportsWebgl(), []);
@@ -2157,6 +2220,45 @@ export function MapView({
       terrainProgressTilesTotal,
     ],
   );
+  const calculationControlRunning = calculationCycleSource !== null || isSimulationRecomputing;
+  const handleStopCalculation = useCallback(() => {
+    stopCalculation();
+    coverageOverlaySchedulerRef.current?.clearQueue();
+    coverageOverlaySchedulerRef.current?.cancelActive();
+    terrainOverlaySchedulerRef.current?.clearQueue();
+    terrainOverlaySchedulerRef.current?.cancelActive();
+    setOverlayPipelineProgress("coverage", null);
+    setOverlayPipelineProgress("terrain", null);
+  }, [setOverlayPipelineProgress, stopCalculation]);
+  useEffect(() => {
+    if (!calculationCycleSource || isSimulationRecomputing || overlayJobsInFlight > 0 || isTerrainFetching || isTerrainRecommending) {
+      return;
+    }
+    const timeoutId = window.setTimeout(() => {
+      const coverageState = useCoverageStore.getState();
+      const appState = useAppStore.getState();
+      const coverageScheduler = coverageOverlaySchedulerRef.current?.snapshot();
+      const terrainScheduler = terrainOverlaySchedulerRef.current?.snapshot();
+      if (
+        coverageState.isSimulationRecomputing ||
+        appState.isTerrainFetching ||
+        appState.isTerrainRecommending ||
+        coverageScheduler?.running ||
+        coverageScheduler?.queuedSignature ||
+        terrainScheduler?.running ||
+        terrainScheduler?.queuedSignature
+      ) return;
+      finishCalculationCycle();
+    }, 240);
+    return () => window.clearTimeout(timeoutId);
+  }, [
+    calculationCycleSource,
+    finishCalculationCycle,
+    isSimulationRecomputing,
+    isTerrainFetching,
+    isTerrainRecommending,
+    overlayJobsInFlight,
+  ]);
   const showLocalTerrainDiagnostics =
     import.meta.env.DEV || (typeof window !== "undefined" && window.location.hostname === "localhost");
   useEffect(() => {
@@ -2847,20 +2949,66 @@ export function MapView({
           {(inspectorPanelToggle != null || inspectorActions != null) ? (
             <PanelToolbar title={inspectorPanelToggle} actions={inspectorActions} />
           ) : null}
-          {simulationBusyIndicator ? (
-            <div className="map-inspector-section">
-              <p className="map-inspector-line">
-                {simulationBusyIndicator.label || "Working in background..."}
-              </p>
-              <div className="map-progress-track">
-                {simulationBusyIndicator.progressMode === "determinate" ? (
-                  <div className="map-progress-fill" style={{ width: `${simulationBusyIndicator.progressPercent ?? 0}%` }} />
+          <div className="map-inspector-section map-calculation-status">
+            {simulationBusyIndicator ? (
+              <>
+                <p className="map-inspector-line">
+                  {simulationBusyIndicator.label || "Working in background..."}
+                </p>
+                <div className="map-progress-track">
+                  {simulationBusyIndicator.progressMode === "determinate" ? (
+                    <div className="map-progress-fill" style={{ width: `${simulationBusyIndicator.progressPercent ?? 0}%` }} />
+                  ) : (
+                    <div className="map-progress-fill map-progress-fill-indeterminate" />
+                  )}
+                </div>
+              </>
+            ) : null}
+            <div className="map-calculation-controls">
+              <ActionButton
+                aria-label={
+                  automaticCalculationLocked
+                    ? "Automatic calculation unavailable at 100 km or 4x and above"
+                    : autoCalculateEnabled
+                      ? "Turn off automatic calculation"
+                      : "Turn on automatic calculation"
+                }
+                aria-pressed={autoCalculateEnabled}
+                className={`map-calculation-control map-calculation-toggle ${autoCalculateEnabled ? "is-on" : "is-off"}`}
+                disabled={automaticCalculationLocked}
+                onClick={() => setAutoCalculateEnabled(!autoCalculateEnabled)}
+                size="icon"
+                title={
+                  automaticCalculationLocked
+                    ? "Automatic calculation unavailable at 100 km or 4x and above"
+                    : autoCalculateEnabled
+                      ? "Turn off automatic calculation"
+                      : "Turn on automatic calculation"
+                }
+              >
+                {autoCalculateEnabled ? (
+                  <ToggleRight aria-hidden="true" size={20} strokeWidth={1.8} />
                 ) : (
-                  <div className="map-progress-fill map-progress-fill-indeterminate" />
+                  <ToggleLeft aria-hidden="true" size={20} strokeWidth={1.8} />
                 )}
-              </div>
+              </ActionButton>
+              {!autoCalculateEnabled ? (
+                <ActionButton
+                  aria-label={calculationControlRunning ? "Stop calculation" : "Start calculation"}
+                  className={`map-calculation-control map-calculation-action ${calculationControlRunning ? "is-stop" : "is-start"}`}
+                  onClick={calculationControlRunning ? handleStopCalculation : startManualCalculation}
+                  size="icon"
+                  title={calculationControlRunning ? "Stop calculation" : "Start calculation"}
+                >
+                  {calculationControlRunning ? (
+                    <Square aria-hidden="true" size={15} strokeWidth={2} />
+                  ) : (
+                    <Play aria-hidden="true" size={17} strokeWidth={2} />
+                  )}
+                </ActionButton>
+              ) : null}
             </div>
-          ) : null}
+          </div>
           {showHolidayThemeNotice && activeHolidayTheme ? (
             <div className="map-inspector-section map-holiday-note" role="status">
               <p className="map-inspector-primary map-holiday-note-title">

--- a/src/components/MapView.userLocation.test.tsx
+++ b/src/components/MapView.userLocation.test.tsx
@@ -111,6 +111,7 @@ const position = (latitude: number, longitude: number, accuracy: number, timesta
 });
 
 import { useAppStore } from "../store/appStore";
+import { useCoverageStore } from "../store/coverageStore";
 import { MapView } from "./MapView";
 
 const renderMapView = (props: Partial<React.ComponentProps<typeof MapView>> = {}) =>
@@ -146,8 +147,56 @@ describe("MapView user location flow", () => {
       selectedSiteId: "",
       selectedSiteIds: [],
       selectedLinkId: "",
+      selectedCoverageResolution: "24",
+      selectedOverlayRadiusOption: "20",
       mapViewport: { center: { lat: 59.9, lon: 10.75 }, zoom: 8 },
     });
+    useCoverageStore.setState({
+      coverageSamples: [],
+      isSimulationRecomputing: false,
+      simulationProgress: 0,
+      simulationRunToken: "",
+      completedCoverageRunToken: "",
+      autoCalculateEnabled: true,
+      calculationCycleSource: null,
+    });
+  });
+
+  it("switches between automatic, manual start, and manual stop controls", () => {
+    renderMapView({ showInspector: true });
+
+    const autoToggle = screen.getByRole("button", { name: "Turn off automatic calculation" });
+    expect(autoToggle).toHaveClass("is-on");
+    expect(autoToggle.querySelector(".lucide-toggle-right")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Start calculation" })).not.toBeInTheDocument();
+
+    fireEvent.click(autoToggle);
+
+    const startButton = screen.getByRole("button", { name: "Start calculation" });
+    expect(startButton).toHaveClass("is-start");
+    expect(startButton.querySelector(".lucide-play")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Turn on automatic calculation" }).querySelector(".lucide-toggle-left")).toBeInTheDocument();
+
+    fireEvent.click(startButton);
+    const stopButton = screen.getByRole("button", { name: "Stop calculation" });
+    expect(stopButton).toHaveClass("is-stop");
+    expect(stopButton.querySelector(".lucide-square")).toBeInTheDocument();
+
+    fireEvent.click(stopButton);
+    expect(screen.getByRole("button", { name: "Start calculation" })).toBeInTheDocument();
+    expect(useCoverageStore.getState().autoCalculateEnabled).toBe(false);
+  });
+
+  it("locks automatic calculation at 4x while preserving manual Start", async () => {
+    useAppStore.setState({ selectedCoverageResolution: "84" });
+    renderMapView({ showInspector: true });
+
+    const lockedToggle = await screen.findByRole("button", {
+      name: "Automatic calculation unavailable at 100 km or 4x and above",
+    });
+    expect(lockedToggle).toBeDisabled();
+    expect(lockedToggle).toHaveClass("is-off");
+    expect(screen.getByRole("button", { name: "Start calculation" })).toBeInTheDocument();
   });
 
   it("starts and stops live geolocation from the map control", () => {

--- a/src/index.css
+++ b/src/index.css
@@ -2350,6 +2350,36 @@ button {
   animation: map-progress-indeterminate 1.2s ease-in-out infinite;
 }
 
+.map-calculation-status {
+  display: grid;
+  gap: 7px;
+}
+
+.map-calculation-controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 28px;
+}
+
+.map-calculation-control.btn-icon {
+  width: 28px;
+  height: 28px;
+}
+
+.map-calculation-toggle.is-on,
+.map-calculation-action.is-start {
+  color: var(--success);
+}
+
+.map-calculation-toggle.is-off {
+  color: var(--muted);
+}
+
+.map-calculation-action.is-stop {
+  color: var(--danger);
+}
+
 @keyframes map-progress-indeterminate {
   0% {
     transform: translateX(-110%);

--- a/src/lib/coverage.test.ts
+++ b/src/lib/coverage.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { buildCoverage, buildCoverageAsync, computeCoverageGridDimensions } from "./coverage";
+import {
+  buildCoverage,
+  buildCoverageAsync,
+  computeCoverageGridDimensions,
+  CoverageBuildCancelledError,
+} from "./coverage";
 import { haversineDistanceKm } from "./geo";
 import { defaultPropagationEnvironment } from "./propagationEnvironment";
 import type { Network, RadioSystem, Site } from "../types/radio";
@@ -88,6 +93,18 @@ describe("buildCoverage", () => {
     const asyncResult = await buildCoverageAsync(NORMAL_GRID, network, sites, systems, defaultPropagationEnvironment());
     expect(asyncResult).toHaveLength(sync.length);
     expect(Math.abs(asyncResult[0].valueDbm - sync[0].valueDbm)).toBeLessThan(0.0001);
+  });
+
+  it("cooperatively cancels asynchronous coverage work", async () => {
+    let checks = 0;
+    await expect(
+      buildCoverageAsync(NORMAL_GRID, network, sites, systems, defaultPropagationEnvironment(), undefined, {
+        shouldCancel: () => {
+          checks += 1;
+          return checks > 8;
+        },
+      }),
+    ).rejects.toBeInstanceOf(CoverageBuildCancelledError);
   });
 
   it("uses single-site radius override for sampling bounds", () => {

--- a/src/lib/coverage.ts
+++ b/src/lib/coverage.ts
@@ -18,7 +18,15 @@ export type BuildCoverageOptions = {
   terrainCacheKey?: string;
   overlayRadiusKm?: number;
   singleSiteRadiusKm?: number;
+  shouldCancel?: () => boolean;
 };
+
+export class CoverageBuildCancelledError extends Error {
+  constructor() {
+    super("Coverage build cancelled");
+    this.name = "CoverageBuildCancelledError";
+  }
+}
 
 export type CoverageGridBounds = {
   minLat: number;
@@ -208,6 +216,7 @@ export const buildCoverage = (
   const sampleMultiplier = Math.max(1, options?.sampleMultiplier ?? 1);
   const terrainSamples = Math.max(16, Math.round(options?.terrainSamples ?? 20));
   const onProgress = options?.onProgress;
+  const shouldCancel = options?.shouldCancel;
   const fallbackSystemId = systems[0]?.id ?? "";
   const effectiveMemberships =
     network.memberships
@@ -234,6 +243,7 @@ export const buildCoverage = (
   const notifyEvery = Math.max(1, Math.floor(total / 40));
   const results: CoverageSample[] = [];
   for (let i = 0; i < samples.length; i += 1) {
+    if (shouldCancel?.()) throw new CoverageBuildCancelledError();
     const sample = samples[i];
     const rxLevels = membershipsToUse
       .map((m) => {
@@ -279,6 +289,7 @@ export const buildCoverageAsync = async (
   const sampleMultiplier = Math.max(1, options?.sampleMultiplier ?? 1);
   const terrainSamples = Math.max(16, Math.round(options?.terrainSamples ?? 20));
   const onProgress = options?.onProgress;
+  const shouldCancel = options?.shouldCancel;
   const fallbackSystemId = systems[0]?.id ?? "";
   const effectiveMemberships =
     network.memberships
@@ -308,6 +319,7 @@ export const buildCoverageAsync = async (
   let chunkStartedAt = performance.now();
 
   for (let i = 0; i < samples.length; i += 1) {
+    if (shouldCancel?.()) throw new CoverageBuildCancelledError();
     const sample = samples[i];
     const rxLevels = membershipsToUse
       .map((m) => {
@@ -343,6 +355,7 @@ export const buildCoverageAsync = async (
         }
         setTimeout(resolve, 0);
       });
+      if (shouldCancel?.()) throw new CoverageBuildCancelledError();
       chunkStartedAt = performance.now();
     }
   }

--- a/src/store/coverageStore.test.ts
+++ b/src/store/coverageStore.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { resetCoverageSchedulerForTests, setAppStoreBridge, useCoverageStore } from "./coverageStore";
+import {
+  isAutomaticCalculationLocked,
+  resetCoverageSchedulerForTests,
+  setAppStoreBridge,
+  useCoverageStore,
+} from "./coverageStore";
 import * as coverageLib from "../lib/coverage";
 import type { CoverageSample, Site } from "../types/radio";
 
@@ -71,6 +76,9 @@ describe("coverageStore simulation progress phases", () => {
       simulationSamplesDone: 0,
       simulationSamplesTotal: 0,
       simulationRunToken: "",
+      completedCoverageRunToken: "",
+      autoCalculateEnabled: true,
+      calculationCycleSource: null,
     });
     resetCoverageSchedulerForTests();
     setAppStoreBridge({
@@ -117,6 +125,67 @@ describe("coverageStore simulation progress phases", () => {
     expect(useCoverageStore.getState().coverageSamples).toHaveLength(1);
   });
 
+  it("suppresses automatic recomputes while Auto calculate is off", () => {
+    useCoverageStore.getState().setAutoCalculateEnabled(false);
+    useCoverageStore.getState().recomputeCoverage();
+    vi.advanceTimersByTime(220);
+
+    expect(useCoverageStore.getState().autoCalculateEnabled).toBe(false);
+    expect(useCoverageStore.getState().isSimulationRecomputing).toBe(false);
+  });
+
+  it("runs once manually without enabling Auto calculate", async () => {
+    const buildSpy = vi.spyOn(coverageLib, "buildCoverageAsync").mockResolvedValue([]);
+    useCoverageStore.getState().setAutoCalculateEnabled(false);
+    useCoverageStore.getState().startManualCalculation();
+
+    vi.advanceTimersByTime(220);
+    await flushAsyncTicks();
+    vi.advanceTimersByTime(700);
+    await flushAsyncTicks();
+
+    expect(buildSpy).toHaveBeenCalledTimes(1);
+    expect(useCoverageStore.getState().autoCalculateEnabled).toBe(false);
+    expect(useCoverageStore.getState().calculationCycleSource).toBe("manual");
+  });
+
+  it("locks automatic calculation for 100 km+ or 4x+ settings", () => {
+    expect(isAutomaticCalculationLocked("24", "50")).toBe(false);
+    expect(isAutomaticCalculationLocked("24", "100")).toBe(true);
+    expect(isAutomaticCalculationLocked("84", "20")).toBe(true);
+
+    bridgeState.selectedCoverageResolution = "84";
+    useCoverageStore.getState().recomputeCoverage();
+    vi.advanceTimersByTime(220);
+
+    expect(useCoverageStore.getState().autoCalculateEnabled).toBe(false);
+    expect(useCoverageStore.getState().isSimulationRecomputing).toBe(false);
+  });
+
+  it("stops active coverage work and clears queued reruns", async () => {
+    let observedCancellation = false;
+    vi.spyOn(coverageLib, "buildCoverageAsync").mockImplementation((...args) => {
+      const options = args[6];
+      return new Promise<CoverageSample[]>((resolve) => {
+        window.setTimeout(() => {
+          observedCancellation = options?.shouldCancel?.() ?? false;
+          resolve([]);
+        }, 20);
+      });
+    });
+
+    useCoverageStore.getState().recomputeCoverage();
+    vi.advanceTimersByTime(220);
+    await flushAsyncTicks();
+    useCoverageStore.getState().stopCalculation();
+    vi.advanceTimersByTime(30);
+    await flushAsyncTicks();
+
+    expect(observedCancellation).toBe(true);
+    expect(useCoverageStore.getState().isSimulationRecomputing).toBe(false);
+    expect(useCoverageStore.getState().calculationCycleSource).toBe(null);
+  });
+
   it("forces 1x simulation resolution while terrain is fetching", async () => {
     let capturedGridSize = 0;
     setAppStoreBridge({
@@ -133,7 +202,7 @@ describe("coverageStore simulation progress phases", () => {
       return Promise.resolve([]);
     });
 
-    useCoverageStore.getState().recomputeCoverage();
+    useCoverageStore.getState().startManualCalculation();
     vi.advanceTimersByTime(220);
     await flushAsyncTicks();
     vi.advanceTimersByTime(700);
@@ -232,5 +301,24 @@ describe("coverageStore simulation progress phases", () => {
     vi.advanceTimersByTime(760);
     await flushAsyncTicks();
     expect(useCoverageStore.getState().coverageSamples[0]?.valueDbm).toBe(-70);
+  });
+
+  it("discards a stale result without scheduling a rerun while automatic calculation is off", async () => {
+    let resolveBuild!: (value: CoverageSample[]) => void;
+    vi.spyOn(coverageLib, "buildCoverageAsync").mockImplementation(
+      () => new Promise<CoverageSample[]>((resolve) => { resolveBuild = resolve; }),
+    );
+
+    useCoverageStore.getState().recomputeCoverage();
+    vi.advanceTimersByTime(220);
+    await flushAsyncTicks();
+    useCoverageStore.getState().setAutoCalculateEnabled(false);
+    bridgeState.selectedCoverageResolution = "42";
+    useCoverageStore.getState().recomputeCoverage();
+    resolveBuild([{ lat: site.position.lat, lon: site.position.lon, valueDbm: -60 }]);
+    await flushAsyncTicks();
+
+    expect(useCoverageStore.getState().coverageSamples).toEqual([]);
+    expect(useCoverageStore.getState().isSimulationRecomputing).toBe(false);
   });
 });

--- a/src/store/coverageStore.ts
+++ b/src/store/coverageStore.ts
@@ -1,5 +1,9 @@
 import { create } from "zustand";
-import { buildCoverageAsync, computeCoverageGridDimensions } from "../lib/coverage";
+import {
+  buildCoverageAsync,
+  computeCoverageGridDimensions,
+  CoverageBuildCancelledError,
+} from "../lib/coverage";
 import { simulationAreaBoundsForSites } from "../lib/simulationArea";
 import {
   deriveDynamicPropagationEnvironment,
@@ -79,7 +83,23 @@ export type CoverageState = {
   simulationSamplesDone: number;
   simulationSamplesTotal: number;
   simulationRunToken: string;
+  completedCoverageRunToken: string;
+  autoCalculateEnabled: boolean;
+  calculationCycleSource: "auto" | "manual" | null;
   recomputeCoverage: () => void;
+  setAutoCalculateEnabled: (enabled: boolean) => void;
+  startManualCalculation: () => void;
+  stopCalculation: () => void;
+  finishCalculationCycle: () => void;
+};
+
+export const isAutomaticCalculationLocked = (
+  resolution: unknown,
+  radiusOption: unknown,
+): boolean => {
+  const gridSize = Number(resolution);
+  const radiusKm = Number(radiusOption);
+  return (Number.isFinite(gridSize) && gridSize >= 84) || (Number.isFinite(radiusKm) && radiusKm >= 100);
 };
 
 type NetworkLike = {
@@ -249,7 +269,7 @@ const queueCoverageRunFlush = (delay = COVERAGE_RECOMPUTE_DEBOUNCE_MS): void => 
 };
 
 const shouldSkipStaleCommit = (runSignature: string): boolean => {
-  if (!coverageRerunQueued || !appStoreBridge) return false;
+  if (!appStoreBridge) return false;
   const latestState = appStoreBridge.getState();
   const latestInputs = readCoverageInputs(latestState);
   const latestSignature = coverageInputSignature(latestInputs);
@@ -275,6 +295,7 @@ const finalizeRunComplete = (
     simulationStepLabel: "",
     simulationSamplesDone: 0,
     simulationSamplesTotal: 0,
+    completedCoverageRunToken: runId,
   });
   window.setTimeout(() => {
     if (get().simulationRunToken === runId) {
@@ -419,6 +440,7 @@ const runCoverageComputation = async (
             set({ simulationProgress: next });
           }
         },
+        shouldCancel: () => get().simulationRunToken !== runId,
         terrainCacheKey: `${inputs.effectiveCoverageResolution}|${inputs.selectedNetworkId}|${inputs.propagationModel}|${inputs.terrainLoadEpoch}`,
       },
     );
@@ -431,12 +453,15 @@ const runCoverageComputation = async (
     }
 
     if (shouldSkipStaleCommit(runSignature)) {
+      const hasQueuedRerun = coverageRerunQueued;
       set({
+        isSimulationRecomputing: hasQueuedRerun,
         simulationProgress: 0,
         simulationProgressMode: "indeterminate",
-        simulationStepLabel: "Preparing simulation bounds...",
+        simulationStepLabel: hasQueuedRerun ? "Preparing simulation bounds..." : "",
         simulationSamplesDone: 0,
         simulationSamplesTotal: 0,
+        simulationRunToken: hasQueuedRerun ? runId : "",
       });
       markCancelled("stale-signature-superseded");
       return;
@@ -467,6 +492,10 @@ const runCoverageComputation = async (
     lastAppliedCoverageSignature = runSignature;
     warnLongTask("coverage-total-run", runSignature, nowMs() - startedAt);
   } catch (error) {
+    if (error instanceof CoverageBuildCancelledError) {
+      markCancelled("coverage-build-cancelled");
+      return;
+    }
     console.error("Coverage recompute failed", error);
     if (get().simulationRunToken === runId) {
       set({
@@ -497,6 +526,15 @@ const flushCoverageRunQueue = async (): Promise<void> => {
 
   if (runSignature === lastAppliedCoverageSignature) {
     coverageRerunQueued = false;
+    useCoverageStore.setState({
+      isSimulationRecomputing: false,
+      simulationProgress: 0,
+      simulationProgressMode: "indeterminate",
+      simulationStepLabel: "",
+      simulationSamplesDone: 0,
+      simulationSamplesTotal: 0,
+      simulationRunToken: "",
+    });
     return;
   }
 
@@ -518,12 +556,71 @@ export const useCoverageStore = create<CoverageState>((set, get) => ({
   simulationSamplesDone: 0,
   simulationSamplesTotal: 0,
   simulationRunToken: "",
+  completedCoverageRunToken: "",
+  autoCalculateEnabled: true,
+  calculationCycleSource: null,
   recomputeCoverage: () => {
     if (!appStoreBridge) return;
+    const appState = appStoreBridge.getState();
+    const locked = isAutomaticCalculationLocked(
+      appState.selectedCoverageResolution,
+      appState.selectedOverlayRadiusOption,
+    );
+    const state = get();
+    if (locked && state.autoCalculateEnabled) {
+      set({ autoCalculateEnabled: false });
+    }
+    const manualRun = state.calculationCycleSource === "manual";
+    if (!manualRun && (!state.autoCalculateEnabled || locked)) return;
     coverageRerunQueued = true;
     queueCoverageRunFlush(COVERAGE_RECOMPUTE_DEBOUNCE_MS);
     if (coverageRunInFlight) return;
     if (get().isSimulationRecomputing) return;
+    set({
+      calculationCycleSource: manualRun ? "manual" : "auto",
+      isSimulationRecomputing: true,
+      simulationProgress: 0,
+      simulationProgressMode: "indeterminate",
+      simulationStepLabel: "Preparing simulation bounds...",
+      simulationSamplesDone: 0,
+      simulationSamplesTotal: 0,
+    });
+  },
+  setAutoCalculateEnabled: (enabled) => {
+    if (!enabled) {
+      const hadPendingRun = coverageRecomputeTimer !== null;
+      if (coverageRecomputeTimer !== null) {
+        window.clearTimeout(coverageRecomputeTimer);
+        coverageRecomputeTimer = null;
+      }
+      coverageRerunQueued = false;
+      set({
+        autoCalculateEnabled: false,
+        ...(hadPendingRun && !coverageRunInFlight
+          ? {
+              calculationCycleSource: null,
+              isSimulationRecomputing: false,
+              simulationProgress: 0,
+              simulationStepLabel: "",
+            }
+          : {}),
+      });
+      return;
+    }
+    if (!appStoreBridge) return;
+    const appState = appStoreBridge.getState();
+    if (isAutomaticCalculationLocked(appState.selectedCoverageResolution, appState.selectedOverlayRadiusOption)) {
+      set({ autoCalculateEnabled: false });
+      return;
+    }
+    set({ autoCalculateEnabled: true, calculationCycleSource: "auto" });
+    get().recomputeCoverage();
+  },
+  startManualCalculation: () => {
+    set({ calculationCycleSource: "manual" });
+    coverageRerunQueued = true;
+    queueCoverageRunFlush(COVERAGE_RECOMPUTE_DEBOUNCE_MS);
+    if (coverageRunInFlight || get().isSimulationRecomputing) return;
     set({
       isSimulationRecomputing: true,
       simulationProgress: 0,
@@ -533,4 +630,22 @@ export const useCoverageStore = create<CoverageState>((set, get) => ({
       simulationSamplesTotal: 0,
     });
   },
+  stopCalculation: () => {
+    if (coverageRecomputeTimer !== null) {
+      window.clearTimeout(coverageRecomputeTimer);
+      coverageRecomputeTimer = null;
+    }
+    coverageRerunQueued = false;
+    set({
+      calculationCycleSource: null,
+      isSimulationRecomputing: false,
+      simulationProgress: 0,
+      simulationProgressMode: "indeterminate",
+      simulationStepLabel: "",
+      simulationSamplesDone: 0,
+      simulationSamplesTotal: 0,
+      simulationRunToken: "",
+    });
+  },
+  finishCalculationCycle: () => set({ calculationCycleSource: null }),
 }));


### PR DESCRIPTION
Closes #923

## What changed
- adds the session-only Auto calculate toggle beneath the simulation progress bar
- adds manual one-shot Start and cooperative Stop controls while automatic calculation is off
- locks automatic calculation at 100 km+ radius or 4x+ resolution while retaining deliberate manual runs
- gates terrain acquisition and overlay rendering, preserves completed overlays, and rejects stale results
- adds focused scheduler, cancellation, threshold, accessibility, and UI transition coverage

## Validation
- `npm test` — 613 tests passed across 113 files
- `npm run build` — passed
- `npm run dev:check` — no LinkSim dev/watch servers running
- focused #923 tests — 34 passed

Browser control and live testing were intentionally omitted; final behavior will be verified by the user on shared staging.