### PR TITLE
Label calculation controls

### DIFF
--- a/src/components/ActionButton.tsx
+++ b/src/components/ActionButton.tsx
@@ -4,7 +4,7 @@ import { Button } from "./ui/Button";
 
 type ActionButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   children: ReactNode;
-  variant?: "default" | "danger";
+  variant?: "default" | "ghost" | "danger";
   size?: "default" | "icon";
 };
 

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -2977,7 +2977,6 @@ export function MapView({
                 className={`map-calculation-control map-calculation-toggle ${autoCalculateEnabled ? "is-on" : "is-off"}`}
                 disabled={automaticCalculationLocked}
                 onClick={() => setAutoCalculateEnabled(!autoCalculateEnabled)}
-                size="icon"
                 title={
                   automaticCalculationLocked
                     ? "Automatic calculation unavailable at 100 km or 4x and above"
@@ -2985,26 +2984,29 @@ export function MapView({
                       ? "Turn off automatic calculation"
                       : "Turn on automatic calculation"
                 }
+                variant="ghost"
               >
                 {autoCalculateEnabled ? (
                   <ToggleRight aria-hidden="true" size={20} strokeWidth={1.8} />
                 ) : (
                   <ToggleLeft aria-hidden="true" size={20} strokeWidth={1.8} />
                 )}
+                <span>Auto calculate</span>
               </ActionButton>
               {!autoCalculateEnabled ? (
                 <ActionButton
                   aria-label={calculationControlRunning ? "Stop calculation" : "Start calculation"}
                   className={`map-calculation-control map-calculation-action ${calculationControlRunning ? "is-stop" : "is-start"}`}
                   onClick={calculationControlRunning ? handleStopCalculation : startManualCalculation}
-                  size="icon"
                   title={calculationControlRunning ? "Stop calculation" : "Start calculation"}
+                  variant="ghost"
                 >
                   {calculationControlRunning ? (
                     <Square aria-hidden="true" size={15} strokeWidth={2} />
                   ) : (
                     <Play aria-hidden="true" size={17} strokeWidth={2} />
                   )}
+                  <span>{calculationControlRunning ? "Stop" : "Start"}</span>
                 </ActionButton>
               ) : null}
             </div>

--- a/src/components/MapView.userLocation.test.tsx
+++ b/src/components/MapView.userLocation.test.tsx
@@ -167,6 +167,7 @@ describe("MapView user location flow", () => {
 
     const autoToggle = screen.getByRole("button", { name: "Turn off automatic calculation" });
     expect(autoToggle).toHaveClass("is-on");
+    expect(within(autoToggle).getByText("Auto calculate")).toBeInTheDocument();
     expect(autoToggle.querySelector(".lucide-toggle-right")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Start calculation" })).not.toBeInTheDocument();
 
@@ -174,12 +175,14 @@ describe("MapView user location flow", () => {
 
     const startButton = screen.getByRole("button", { name: "Start calculation" });
     expect(startButton).toHaveClass("is-start");
+    expect(within(startButton).getByText("Start")).toBeInTheDocument();
     expect(startButton.querySelector(".lucide-play")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Turn on automatic calculation" }).querySelector(".lucide-toggle-left")).toBeInTheDocument();
 
     fireEvent.click(startButton);
     const stopButton = screen.getByRole("button", { name: "Stop calculation" });
     expect(stopButton).toHaveClass("is-stop");
+    expect(within(stopButton).getByText("Stop")).toBeInTheDocument();
     expect(stopButton.querySelector(".lucide-square")).toBeInTheDocument();
 
     fireEvent.click(stopButton);

--- a/src/index.css
+++ b/src/index.css
@@ -2362,9 +2362,13 @@ button {
   min-height: 28px;
 }
 
-.map-calculation-control.btn-icon {
-  width: 28px;
+.map-calculation-control.btn-ghost {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
   height: 28px;
+  padding: 0 7px;
+  font-size: 0.72rem;
 }
 
 .map-calculation-toggle.is-on,


### PR DESCRIPTION
## Summary
- show `Auto calculate` beside the existing toggle icon
- show contextual `Start` / `Stop` text beside the manual action icon
- preserve existing calculation behavior, colors, titles, and accessible names

## Verification
- `npm run test -- --run src/components/MapView.userLocation.test.tsx`
- `npm test` (613 passed)
- `npm run build`
- `npm run dev:check`

No browser control or live UI testing was performed, per request.

Follow-up for #923.