### PR TITLE
Polish automatic calculation controls

### DIFF
--- a/src/components/MapView.calculationControlsCss.test.ts
+++ b/src/components/MapView.calculationControlsCss.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("MapView calculation control styling", () => {
+  it("keeps the labeled calculation controls shadow-free", () => {
+    const stylesheet = readFileSync(resolve(process.cwd(), "src/index.css"), "utf8");
+    const controlRule = stylesheet.match(/\.map-calculation-control\.btn-ghost\s*\{([^}]*)\}/)?.[1];
+
+    expect(controlRule).toMatch(/box-shadow:\s*none;/);
+  });
+});

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -737,7 +737,9 @@ export function MapView({
   const simulationRunToken = useCoverageStore((state) => state.simulationRunToken);
   const completedCoverageRunToken = useCoverageStore((state) => state.completedCoverageRunToken);
   const autoCalculateEnabled = useCoverageStore((state) => state.autoCalculateEnabled);
+  const automaticLockNoticeShown = useCoverageStore((state) => state.automaticLockNoticeShown);
   const calculationCycleSource = useCoverageStore((state) => state.calculationCycleSource);
+  const markAutomaticLockNoticeShown = useCoverageStore((state) => state.markAutomaticLockNoticeShown);
   const setAutoCalculateEnabled = useCoverageStore((state) => state.setAutoCalculateEnabled);
   const startManualCalculation = useCoverageStore((state) => state.startManualCalculation);
   const stopCalculation = useCoverageStore((state) => state.stopCalculation);
@@ -1165,13 +1167,30 @@ export function MapView({
     selectedCoverageResolution,
     normalizedOverlayRadiusOption,
   );
+  const previousAutomaticCalculationLockedRef = useRef(automaticCalculationLocked);
   const calculationWorkAllowed =
     (autoCalculateEnabled && !automaticCalculationLocked) || calculationCycleSource === "manual";
   useEffect(() => {
-    if (automaticCalculationLocked && autoCalculateEnabled) {
-      setAutoCalculateEnabled(false);
-    }
-  }, [automaticCalculationLocked, autoCalculateEnabled, setAutoCalculateEnabled]);
+    const becameLocked = automaticCalculationLocked && !previousAutomaticCalculationLockedRef.current;
+    previousAutomaticCalculationLockedRef.current = automaticCalculationLocked;
+    if (!automaticCalculationLocked) return;
+    if (autoCalculateEnabled) setAutoCalculateEnabled(false);
+    if (!becameLocked || automaticLockNoticeShown) return;
+    markAutomaticLockNoticeShown();
+    onPublishNotice?.({
+      id: "automatic-calculation-locked",
+      message: "Auto calculate was turned off for 100 km or 4x and above. Press Start to calculate.",
+      tone: "info",
+      persistent: false,
+    });
+  }, [
+    automaticCalculationLocked,
+    automaticLockNoticeShown,
+    autoCalculateEnabled,
+    markAutomaticLockNoticeShown,
+    onPublishNotice,
+    setAutoCalculateEnabled,
+  ]);
   const targetRadiusKm = useMemo(
     () => resolveTargetOverlayRadiusKm(selectionCount, normalizedOverlayRadiusOption),
     [selectionCount, normalizedOverlayRadiusOption],

--- a/src/components/MapView.userLocation.test.tsx
+++ b/src/components/MapView.userLocation.test.tsx
@@ -158,6 +158,7 @@ describe("MapView user location flow", () => {
       simulationRunToken: "",
       completedCoverageRunToken: "",
       autoCalculateEnabled: true,
+      automaticLockNoticeShown: false,
       calculationCycleSource: null,
     });
   });
@@ -191,8 +192,10 @@ describe("MapView user location flow", () => {
   });
 
   it("locks automatic calculation at 4x while preserving manual Start", async () => {
-    useAppStore.setState({ selectedCoverageResolution: "84" });
-    renderMapView({ showInspector: true });
+    const onPublishNotice = vi.fn();
+    renderMapView({ showInspector: true, onPublishNotice });
+
+    act(() => useAppStore.setState({ selectedCoverageResolution: "84" }));
 
     const lockedToggle = await screen.findByRole("button", {
       name: "Automatic calculation unavailable at 100 km or 4x and above",
@@ -200,6 +203,17 @@ describe("MapView user location flow", () => {
     expect(lockedToggle).toBeDisabled();
     expect(lockedToggle).toHaveClass("is-off");
     expect(screen.getByRole("button", { name: "Start calculation" })).toBeInTheDocument();
+    expect(onPublishNotice).toHaveBeenCalledWith({
+      id: "automatic-calculation-locked",
+      message: "Auto calculate was turned off for 100 km or 4x and above. Press Start to calculate.",
+      tone: "info",
+      persistent: false,
+    });
+
+    act(() => useAppStore.setState({ selectedCoverageResolution: "24" }));
+    act(() => useAppStore.setState({ selectedOverlayRadiusOption: "100" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Start calculation" })).toBeInTheDocument());
+    expect(onPublishNotice).toHaveBeenCalledTimes(1);
   });
 
   it("starts and stops live geolocation from the map control", () => {

--- a/src/index.css
+++ b/src/index.css
@@ -2369,6 +2369,7 @@ button {
   height: 28px;
   padding: 0 7px;
   font-size: 0.72rem;
+  box-shadow: none;
 }
 
 .map-calculation-toggle.is-on,

--- a/src/store/coverageStore.ts
+++ b/src/store/coverageStore.ts
@@ -85,8 +85,10 @@ export type CoverageState = {
   simulationRunToken: string;
   completedCoverageRunToken: string;
   autoCalculateEnabled: boolean;
+  automaticLockNoticeShown: boolean;
   calculationCycleSource: "auto" | "manual" | null;
   recomputeCoverage: () => void;
+  markAutomaticLockNoticeShown: () => void;
   setAutoCalculateEnabled: (enabled: boolean) => void;
   startManualCalculation: () => void;
   stopCalculation: () => void;
@@ -558,6 +560,7 @@ export const useCoverageStore = create<CoverageState>((set, get) => ({
   simulationRunToken: "",
   completedCoverageRunToken: "",
   autoCalculateEnabled: true,
+  automaticLockNoticeShown: false,
   calculationCycleSource: null,
   recomputeCoverage: () => {
     if (!appStoreBridge) return;
@@ -586,6 +589,7 @@ export const useCoverageStore = create<CoverageState>((set, get) => ({
       simulationSamplesTotal: 0,
     });
   },
+  markAutomaticLockNoticeShown: () => set({ automaticLockNoticeShown: true }),
   setAutoCalculateEnabled: (enabled) => {
     if (!enabled) {
       const hadPendingRun = coverageRecomputeTimer !== null;


### PR DESCRIPTION
## Summary
- remove the box shadow from the labeled Auto calculate and Start/Stop controls
- notify the user when selecting 100 km+/4x+ first forces Auto calculate off
- show that guidance only once per app session using non-persisted scheduler state
- add focused regression coverage

## Verification
- `npm run test -- --run src/components/MapView.userLocation.test.tsx src/store/coverageStore.test.ts src/components/MapView.calculationControlsCss.test.ts`
- `npm test` (614 passed)
- `npm run build`
- `npm run dev:check`

No browser control or live UI testing was performed, per request.

Final polish for #923.