### PR TITLE
chore: release 0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.23.0] - 2026-07-22
+
+### Added
+- Added curated Lucide icons for Sites, including automatic suggestions based on Site names and antenna height, with consistent map and panorama rendering. (#775)
+- Added session-based automatic calculation controls with manual Start and Stop actions for deliberate simulation runs. (#923)
+
+### Changed
+- Automatically disables continuous calculation for expensive 100 km+ radius or 4x+ resolution settings, while preserving one-shot manual calculation and completed overlays. (#923)
+
 ## [0.22.0] - 2026-07-21
 
 ### Added

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -62,7 +62,7 @@
 
 ## Versioning Policy
 - SemVer is mandatory (`MAJOR.MINOR.PATCH`).
-- Current baseline: `0.22.0`.
+- Current baseline: `0.23.0`.
 - Bump level decision rules:
   - `PATCH` (`0.9.x`): bug fixes, polish, performance tuning, and non-breaking UX behavior fixes.
   - `MINOR` (`0.x.0`): new user-facing features or meaningful workflow additions that are backward-compatible.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linksim",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linksim",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "linksim",
   "private": true,
-  "version": "0.22.0",
+  "version": "0.23.0",
   "license": "GPL-3.0-only",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- bump LinkSim from 0.22.0 to 0.23.0
- add human-readable release notes for Site icons and calculation controls
- update the documented release-flow baseline

## Scope

- milestone #17
- issues #775 and #923

## Verification

- [x] Version consistency check (`package.json` and `package-lock.json`)
- [x] `git diff --check`
- [ ] Required GitHub checks

The local test suite and build were intentionally skipped by explicit release approval because the milestone implementation was already verified on shared staging. GitHub checks remain the merge gate.
