### PR TITLE
Fix private Simulation visibility and Stats disclosure

### DIFF
--- a/functions/_lib/db.sharedSimulation.test.ts
+++ b/functions/_lib/db.sharedSimulation.test.ts
@@ -129,6 +129,7 @@ class FakeStatement {
 class FakeDb {
   readonly sites = new Map<string, AnyRow>();
   readonly simulations = new Map<string, AnyRow>();
+  readonly simulationRoles = new Map<string, string>();
   readonly resourceChanges: AnyRow[] = [];
 
   prepare(sql: string): FakeStatement {
@@ -169,12 +170,15 @@ class FakeDb {
       if (!row) return null;
       return { id: row.id, visibility: row.visibility };
     }
-    if (sql.includes("SELECT id, payload_json, visibility FROM simulations WHERE id = ?")) {
+    if (sql.includes("FROM simulations WHERE id = ?") && sql.includes("payload_json")) {
       const id = String(bound[0] ?? "");
       return this.simulations.get(id) ?? null;
     }
     if (sql.includes("SELECT role FROM simulation_roles")) {
-      return null;
+      const simulationId = String(bound[0] ?? "");
+      const userId = String(bound[1] ?? "");
+      const role = this.simulationRoles.get(`${simulationId}:${userId}`);
+      return role ? { role } : null;
     }
     return null;
   }
@@ -336,15 +340,17 @@ describe("upsertLibrarySnapshot shared simulations", () => {
     expect(payload.snapshot?.sites?.[0]?.libraryEntryId).toBe("site-private");
   });
 
-  it("loads unlisted private simulation bundles with referenced private sites", async () => {
+  const createPrivateBundleDb = () => {
     const db = new FakeDb();
     db.sites.set("site-private", {
       id: "site-private",
+      owner_user_id: "owner-1",
       visibility: "private",
       payload_json: JSON.stringify({ id: "site-private", name: "Private Site" }),
     });
     db.simulations.set("sim-private", {
       id: "sim-private",
+      owner_user_id: "owner-1",
       visibility: "private",
       payload_json: JSON.stringify({
         id: "sim-private",
@@ -352,10 +358,55 @@ describe("upsertLibrarySnapshot shared simulations", () => {
         snapshot: { sites: [{ id: "site-a", libraryEntryId: "site-private" }], links: [] },
       }),
     });
+    return db;
+  };
+
+  it("rejects anonymous and unrelated access to private simulation bundles", async () => {
+    const db = createPrivateBundleDb();
+    const env = { DB: db } as unknown as Parameters<typeof fetchPublicSimulationBundle>[0];
+
+    await expect(fetchPublicSimulationBundle(env, { simulationId: "sim-private", actor: null }))
+      .resolves.toEqual({ status: "forbidden" });
+    await expect(fetchPublicSimulationBundle(env, {
+      simulationId: "sim-private",
+      actor: { id: "other-1", isAdmin: false, isModerator: false },
+    })).resolves.toEqual({ status: "forbidden" });
+  });
+
+  it("loads private simulation bundles for owners, collaborators, and admins", async () => {
+    const db = createPrivateBundleDb();
+    db.simulationRoles.set("sim-private:collab-1", "viewer");
+    const env = { DB: db } as unknown as Parameters<typeof fetchPublicSimulationBundle>[0];
+
+    for (const actor of [
+      { id: "owner-1", isAdmin: false, isModerator: false },
+      { id: "collab-1", isAdmin: false, isModerator: false },
+      { id: "admin-1", isAdmin: true, isModerator: false },
+    ]) {
+      const result = await fetchPublicSimulationBundle(env, { simulationId: "sim-private", actor });
+      expect(result.status).toBe("ok");
+      if (result.status !== "ok") continue;
+      expect(result.sites).toEqual([expect.objectContaining({ id: "site-private", visibility: "private" })]);
+    }
+  });
+
+  it("loads referenced private sites through an anonymous shared simulation bundle", async () => {
+    const db = createPrivateBundleDb();
+    const simulation = db.simulations.get("sim-private");
+    db.simulations.set("sim-shared", {
+      ...simulation,
+      id: "sim-shared",
+      visibility: "public_write",
+      payload_json: JSON.stringify({
+        id: "sim-shared",
+        visibility: "shared",
+        snapshot: { sites: [{ id: "site-a", libraryEntryId: "site-private" }], links: [] },
+      }),
+    });
 
     const result = await fetchPublicSimulationBundle(
       { DB: db } as unknown as Parameters<typeof fetchPublicSimulationBundle>[0],
-      { simulationId: "sim-private", actorId: null, allowUnlisted: true },
+      { simulationId: "sim-shared", actor: null },
     );
 
     expect(result.status).toBe("ok");

--- a/functions/_lib/db.ts
+++ b/functions/_lib/db.ts
@@ -2121,7 +2121,12 @@ export const resolveSimulationIdByOwnerSlug = async (
 
 export const fetchPublicSimulationBundle = async (
   env: Env,
-  options: { simulationId?: string; username?: string; simulationSlug?: string; actorId?: string | null; allowUnlisted?: boolean },
+  options: {
+    simulationId?: string;
+    username?: string;
+    simulationSlug?: string;
+    actor: ActorPolicy | null;
+  },
 ): Promise<
   | { status: "missing" | "forbidden" }
   | {
@@ -2140,24 +2145,23 @@ export const fetchPublicSimulationBundle = async (
   if (!resolvedId) return { status: "missing" };
 
   const simulationRow = await env.DB
-    .prepare("SELECT id, payload_json, visibility FROM simulations WHERE id = ? LIMIT 1")
+    .prepare("SELECT id, owner_user_id, payload_json, visibility FROM simulations WHERE id = ? LIMIT 1")
     .bind(resolvedId)
-    .first<{ id: string; payload_json: string; visibility: DbVisibility }>();
+    .first<{ id: string; owner_user_id: string; payload_json: string; visibility: DbVisibility }>();
   if (!simulationRow) return { status: "missing" };
   const visibility = visibilityFromDbVisibility(simulationRow.visibility);
-  const allowUnlisted = options.allowUnlisted === true;
 
   let actorSimulationRole: string | null = null;
-  if (visibility === "private") {
-    if (!options.actorId && !allowUnlisted) return { status: "forbidden" };
-    if (options.actorId) {
-      const roleRow = await env.DB
-        .prepare("SELECT role FROM simulation_roles WHERE simulation_id = ? AND user_id = ? LIMIT 1")
-        .bind(resolvedId, options.actorId)
-        .first<{ role: string }>();
-      if (roleRow) actorSimulationRole = roleRow.role;
-      else if (!allowUnlisted) return { status: "forbidden" };
-    }
+  if (options.actor) {
+    const roleRow = await env.DB
+      .prepare("SELECT role FROM simulation_roles WHERE simulation_id = ? AND user_id = ? LIMIT 1")
+      .bind(resolvedId, options.actor.id)
+      .first<{ role: string }>();
+    if (roleRow) actorSimulationRole = roleRow.role;
+  }
+  const actor = options.actor ?? { id: "", isAdmin: false, isModerator: false };
+  if (!canReadResource(actor, simulationRow.owner_user_id, visibility, actorSimulationRole)) {
+    return { status: "forbidden" };
   }
 
   let simulation: CloudResourceRecord;
@@ -2168,7 +2172,12 @@ export const fetchPublicSimulationBundle = async (
   }
   simulation.id = simulationRow.id;
   simulation.visibility = visibility;
-  simulation.effectiveRole = actorSimulationRole ?? "viewer";
+  simulation.effectiveRole =
+    options.actor?.isAdmin
+      ? "admin"
+      : options.actor?.id === simulationRow.owner_user_id
+        ? "owner"
+        : actorSimulationRole ?? "viewer";
 
   const referencedSiteIds = referencedLibrarySiteIdsFromSimulation(simulation);
   if (!referencedSiteIds.length) {
@@ -2187,8 +2196,7 @@ export const fetchPublicSimulationBundle = async (
     .all<{ id: string; payload_json: string; visibility: DbVisibility }>();
   const sites: CloudResourceRecord[] = [];
   for (const row of rows.results) {
-    // Unlisted Simulation access includes the referenced Sites needed to render that Simulation.
-    if (actorSimulationRole === null && !allowUnlisted && visibilityFromDbVisibility(row.visibility) === "private") continue;
+    // Authorization to the parent Simulation includes the referenced Sites needed to render it.
     try {
       const site = JSON.parse(row.payload_json) as CloudResourceRecord;
       site.id = row.id;

--- a/functions/api/public-simulation.test.ts
+++ b/functions/api/public-simulation.test.ts
@@ -1,12 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { fetchPublicSimulationBundleMock, verifyAuthMock } = vi.hoisted(() => ({
+const { ensureUserMock, fetchPublicSimulationBundleMock, fetchUserProfileMock, verifyAuthMock } = vi.hoisted(() => ({
+  ensureUserMock: vi.fn(),
   fetchPublicSimulationBundleMock: vi.fn(),
+  fetchUserProfileMock: vi.fn(),
   verifyAuthMock: vi.fn(),
 }));
 
 vi.mock("../_lib/db", () => ({
+  ensureUser: ensureUserMock,
   fetchPublicSimulationBundle: fetchPublicSimulationBundleMock,
+  fetchUserProfile: fetchUserProfileMock,
 }));
 
 vi.mock("../_lib/auth", () => ({
@@ -21,6 +25,7 @@ const mkCtx = (request: Request) => ({ request, env } as unknown as Parameters<t
 beforeEach(() => {
   vi.clearAllMocks();
   verifyAuthMock.mockResolvedValue(null);
+  fetchUserProfileMock.mockResolvedValue(null);
   fetchPublicSimulationBundleMock.mockResolvedValue({
     status: "ok",
     simulationId: "sim-1",
@@ -42,21 +47,30 @@ describe("api/public-simulation", () => {
     expect(res.headers.get("cache-control")).toBe("no-store");
   });
 
-  it("passes actorId null when request is unauthenticated", async () => {
+  it("passes an anonymous actor when request is unauthenticated", async () => {
     verifyAuthMock.mockResolvedValue(null);
     await onRequestGet(mkCtx(new Request("https://example.test/api/public-simulation?sim=sim-1")));
     expect(fetchPublicSimulationBundleMock).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ actorId: null, allowUnlisted: true }),
+      expect.objectContaining({ actor: null }),
     );
   });
 
-  it("passes actorId from auth when request is authenticated", async () => {
-    verifyAuthMock.mockResolvedValue({ userId: "user-42" });
+  it("passes the resolved actor policy when request is authenticated", async () => {
+    verifyAuthMock.mockResolvedValue({ userId: "user-42", tokenPayload: {} });
+    fetchUserProfileMock.mockResolvedValue({
+      id: "user-42",
+      isAdmin: true,
+      isModerator: false,
+      accountState: "approved",
+    });
     await onRequestGet(mkCtx(new Request("https://example.test/api/public-simulation?sim=sim-1")));
+    expect(ensureUserMock).toHaveBeenCalledWith(expect.anything(), "user-42", {});
     expect(fetchPublicSimulationBundleMock).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ actorId: "user-42" }),
+      expect.objectContaining({
+        actor: { id: "user-42", isAdmin: true, isModerator: false },
+      }),
     );
   });
 
@@ -64,7 +78,7 @@ describe("api/public-simulation", () => {
     await onRequestGet(mkCtx(new Request("https://example.test/api/public-simulation?username=Owner&slug=my-sim")));
     expect(fetchPublicSimulationBundleMock).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ username: "Owner", simulationSlug: "my-sim", allowUnlisted: true }),
+      expect.objectContaining({ username: "Owner", simulationSlug: "my-sim", actor: null }),
     );
   });
 

--- a/functions/api/public-simulation.ts
+++ b/functions/api/public-simulation.ts
@@ -1,5 +1,5 @@
 import { verifyAuth } from "../_lib/auth";
-import { fetchPublicSimulationBundle } from "../_lib/db";
+import { ensureUser, fetchPublicSimulationBundle, fetchUserProfile } from "../_lib/db";
 import { errorResponse, handleOptions, json, withCors } from "../_lib/http";
 import type { Env } from "../_lib/types";
 
@@ -18,14 +18,24 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
     }
 
     const auth = await verifyAuth(request, env).catch(() => null);
-    const actorId = auth?.userId ?? null;
+    let actor: { id: string; isAdmin: boolean; isModerator: boolean } | null = null;
+    if (auth) {
+      await ensureUser(env, auth.userId, auth.tokenPayload);
+      const profile = await fetchUserProfile(env, auth.userId);
+      if (profile?.accountState !== "revoked") {
+        actor = {
+          id: profile?.id ?? auth.userId,
+          isAdmin: Boolean(profile?.isAdmin),
+          isModerator: Boolean(profile?.isModerator),
+        };
+      }
+    }
 
     const bundle = await fetchPublicSimulationBundle(env, {
       simulationId: simulationId || undefined,
       username: username || undefined,
       simulationSlug: simulationSlug || undefined,
-      actorId,
-      allowUnlisted: true,
+      actor,
     });
 
     if (bundle.status !== "ok") {

--- a/functions/api/stats.test.ts
+++ b/functions/api/stats.test.ts
@@ -12,8 +12,8 @@ import { onRequestGet } from "./stats";
 
 type MockTable = {
   users: Array<{ id: string; username: string | null; avatar_url: string | null; created_at: string }>;
-  sites: Array<{ id: string; owner_user_id: string; created_at: string | null; payload_json: string }>;
-  simulations: Array<{ id: string; owner_user_id: string; created_at: string | null; name?: string; payload_json: string }>;
+  sites: Array<{ id: string; owner_user_id: string; created_at: string | null; visibility: string; payload_json: string }>;
+  simulations: Array<{ id: string; owner_user_id: string; created_at: string | null; name?: string; visibility: string; payload_json: string }>;
 };
 
 const tables: MockTable = {
@@ -64,18 +64,21 @@ beforeEach(() => {
       id: "site-1",
       owner_user_id: "u1",
       created_at: "2026-01-05T00:00:00.000Z",
+      visibility: "private",
       payload_json: JSON.stringify({ id: "site-1", name: "Private peak", position: { lat: 60.123456, lon: 10.123456 } }),
     },
     {
       id: "site-2",
       owner_user_id: "u2",
       created_at: "2026-02-05T00:00:00.000Z",
+      visibility: "public_write",
       payload_json: JSON.stringify({ id: "site-2", name: "Valley", position: { lat: 60.987654, lon: 10.987654 } }),
     },
     {
       id: "bad-site",
       owner_user_id: "u2",
       created_at: "2026-02-06T00:00:00.000Z",
+      visibility: "private",
       payload_json: "{not json",
     },
   ];
@@ -84,6 +87,7 @@ beforeEach(() => {
       id: "sim-1",
       owner_user_id: "u1",
       created_at: "2026-01-07T00:00:00.000Z",
+      visibility: "private",
       payload_json: JSON.stringify({
         id: "sim-1",
         name: "Private sim",
@@ -107,12 +111,14 @@ beforeEach(() => {
       id: "sim-empty",
       owner_user_id: "u2",
       created_at: "2026-02-07T00:00:00.000Z",
+      visibility: "private",
       payload_json: JSON.stringify({ id: "sim-empty", name: "Draft", snapshot: { sites: [], links: [] } }),
     },
     {
       id: "sim-2",
       owner_user_id: "u2",
       created_at: "2026-02-08T00:00:00.000Z",
+      visibility: "public_write",
       payload_json: JSON.stringify({
         id: "sim-2",
         name: "Shared sim",
@@ -156,10 +162,11 @@ describe("api/stats", () => {
     const res = await onRequestGet(mkCtx());
     const body = await res.json() as {
       latestSimulations: Array<{
-        id: string;
-        name: string;
-        href: string;
-        owner: { userId: string; username: string; avatarUrl: string };
+        visibility: "private" | "shared";
+        id?: string;
+        name?: string;
+        href?: string;
+        owner?: { userId: string; username: string; avatarUrl: string };
         siteCount: number;
         linkCount: number;
       }>;
@@ -171,6 +178,7 @@ describe("api/stats", () => {
 
     expect(body.latestSimulations).toEqual([
       expect.objectContaining({
+        visibility: "shared",
         id: "sim-2",
         name: "Shared sim",
         href: "/Grace/Shared-sim",
@@ -179,13 +187,15 @@ describe("api/stats", () => {
         linkCount: 2,
       }),
       expect.objectContaining({
-        id: "sim-1",
-        name: "Private sim",
-        href: "/Ada/Private-sim",
+        visibility: "private",
         siteCount: 3,
         linkCount: 5,
       }),
     ]);
+    expect(body.latestSimulations[1]).not.toHaveProperty("id");
+    expect(body.latestSimulations[1]).not.toHaveProperty("name");
+    expect(body.latestSimulations[1]).not.toHaveProperty("href");
+    expect(body.latestSimulations[1]).not.toHaveProperty("owner");
     expect(body.latestSimulations.some((entry) => entry.id === "sim-empty")).toBe(false);
     expect(body.linkDistanceDistribution.reduce((sum, bucket) => sum + bucket.count, 0)).toBe(4);
     expect(raw).not.toContain("longestLinks");

--- a/functions/api/stats.ts
+++ b/functions/api/stats.ts
@@ -1,6 +1,6 @@
 import { errorResponse, handleOptions, json, withCors } from "../_lib/http";
 import { listStatsPathLeaderboardEntries } from "../_lib/pathLeaderboard";
-import type { Env } from "../_lib/types";
+import type { DbVisibility, Env } from "../_lib/types";
 
 type UserRow = {
   id: string;
@@ -14,6 +14,7 @@ type ResourceRow = {
   owner_user_id: string;
   created_at: string | null;
   name?: string | null;
+  visibility: DbVisibility;
   payload_json: string;
 };
 
@@ -353,8 +354,8 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
   try {
     const [usersResult, sitesResult, simulationsResult, longestPassingPaths] = await Promise.all([
       env.DB.prepare("SELECT id, username, avatar_url, created_at FROM users").all<UserRow>(),
-      env.DB.prepare("SELECT id, owner_user_id, created_at, payload_json FROM sites").all<ResourceRow>(),
-      env.DB.prepare("SELECT id, owner_user_id, created_at, name, payload_json FROM simulations").all<ResourceRow>(),
+      env.DB.prepare("SELECT id, owner_user_id, created_at, visibility, payload_json FROM sites").all<ResourceRow>(),
+      env.DB.prepare("SELECT id, owner_user_id, created_at, name, visibility, payload_json FROM simulations").all<ResourceRow>(),
       listStatsPathLeaderboardEntries(env),
     ]);
 
@@ -398,6 +399,7 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
     const sizeBuckets = { "1-2": 0, "3-5": 0, "6-10": 0, "11+": 0 };
 
     const latestSimulations: Array<{
+      visibility: DbVisibility;
       id: string;
       name: string;
       href: string;
@@ -423,6 +425,7 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
 
       const owner = userById.get(simulation.owner_user_id);
       latestSimulations.push({
+        visibility: simulation.visibility,
         id: simulation.id,
         name: typeof payload?.name === "string" && payload.name.trim() ? payload.name.trim() : simulation.name?.trim() || "Untitled Simulation",
         href: hrefForSimulation(owner, simulation, payload),
@@ -498,7 +501,25 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
       },
       latestSimulations: latestSimulations
         .sort((a, b) => (parseDate(b.createdAt)?.getTime() ?? 0) - (parseDate(a.createdAt)?.getTime() ?? 0))
-        .slice(0, 5),
+        .slice(0, 5)
+        .map((simulation) =>
+          simulation.visibility === "private"
+            ? {
+                visibility: "private" as const,
+                siteCount: simulation.siteCount,
+                linkCount: simulation.linkCount,
+              }
+            : {
+                visibility: "shared" as const,
+                id: simulation.id,
+                name: simulation.name,
+                href: simulation.href,
+                createdAt: simulation.createdAt,
+                owner: simulation.owner,
+                siteCount: simulation.siteCount,
+                linkCount: simulation.linkCount,
+              },
+        ),
       longestPassingPaths,
       linkDistanceDistribution: linkDistanceCounts,
       highlights: {

--- a/src/components/AppShell.copyFlow.test.tsx
+++ b/src/components/AppShell.copyFlow.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import React from "react";
-import { act, render, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useAppStore } from "../store/appStore";
 
@@ -22,6 +23,9 @@ vi.hoisted(() => {
   };
   vi.stubGlobal("localStorage", localStorageMock);
 });
+const { pushCloudLibraryMock } = vi.hoisted(() => ({
+  pushCloudLibraryMock: vi.fn(async () => {}),
+}));
 
 const sidebarCalls: Array<{ readOnly?: boolean; panelToggleControl?: unknown }> = [];
 
@@ -46,20 +50,24 @@ vi.mock("../lib/cloudUser", () => ({
 vi.mock("../lib/cloudLibrary", () => ({
   fetchCloudLibrary: vi.fn(async () => ({ siteLibrary: [], simulationPresets: [] })),
   fetchPublicSimulationLibrary: vi.fn(async () => ({ simulationId: null, siteLibrary: [], simulationPresets: [] })),
-  pushCloudLibrary: vi.fn(async () => {}),
+  pushCloudLibrary: pushCloudLibraryMock,
 }));
 
 vi.mock("../lib/environment", () => ({ getCurrentRuntimeEnvironment: () => "production" }));
 vi.mock("../hooks/useThemeVariant", () => ({ useThemeVariant: () => ({ theme: "light", colorTheme: "green", variant: { cssVars: {} } }) }));
 vi.mock("../lib/migrations", () => ({ initializeMigrations: vi.fn(), runMigrations: vi.fn(async () => {}) }));
-vi.mock("./MapView", () => ({ MapView: () => null }));
+vi.mock("./MapView", () => ({
+  MapView: ({ inspectorActions }: { inspectorActions?: React.ReactNode }) => <div>{inspectorActions}</div>,
+}));
 vi.mock("./UserAdminPanel", () => ({ UserAdminPanel: () => null }));
 vi.mock("./SimulationLibraryPanel", () => ({ default: () => null }));
 vi.mock("./WelcomeModal", () => ({ default: () => null }));
 vi.mock("./OnboardingTutorialModal", () => ({ default: () => null }));
 vi.mock("./LinkProfileChart", () => ({ LinkProfileChart: () => null }));
 vi.mock("./PanoramaChart", () => ({ PanoramaChart: () => null }));
-vi.mock("./ActionButton", () => ({ ActionButton: ({ children }: { children?: React.ReactNode }) => <>{children}</> }));
+vi.mock("./ActionButton", () => ({
+  ActionButton: (props: React.ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props} />,
+}));
 vi.mock("./InlineCloseIconButton", () => ({ InlineCloseIconButton: () => null }));
 vi.mock("./ModalOverlay", () => ({ ModalOverlay: ({ children }: { children?: React.ReactNode }) => <>{children}</> }));
 vi.mock("./app-shell/MobileWorkspaceTabs", () => ({ MobileWorkspaceTabs: () => null }));
@@ -91,6 +99,11 @@ describe("AppShell copy flow", () => {
     sidebarCalls.length = 0;
     window.history.replaceState(null, "", "/");
     localStorage.clear();
+    pushCloudLibraryMock.mockClear();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn(async () => {}) },
+    });
     vi.stubGlobal("ResizeObserver", class {
       observe() {}
       disconnect() {}
@@ -256,6 +269,59 @@ describe("AppShell copy flow", () => {
 
       await waitFor(() => expect(sidebarCalls[sidebarCalls.length - 1]?.readOnly).toBe(false));
       expect(useAppStore.getState().selectedScenarioId).toBe(createdId);
+    } finally {
+      view.unmount();
+    }
+  });
+
+  it("shares a Simulation without changing referenced Private Site visibility", async () => {
+    const state = useAppStore.getState();
+    const privateSite = {
+      id: "private-site",
+      name: "Private Site",
+      visibility: "private" as const,
+      ownerUserId: "user-1",
+      effectiveRole: "owner" as const,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      position: { lat: 60.5, lon: 11.5 },
+      groundElevationM: 120,
+      antennaHeightM: 2,
+      txPowerDbm: 20,
+      txGainDbi: 2,
+      rxGainDbi: 2,
+      cableLossDb: 1,
+    };
+    useAppStore.setState({
+      siteLibrary: [privateSite],
+      sites: state.sites.map((site, index) =>
+        index === 0 ? { ...site, libraryEntryId: privateSite.id } : site,
+      ),
+      simulationPresets: state.simulationPresets.map((simulation) => ({
+        ...simulation,
+        ownerUserId: "user-1",
+        effectiveRole: "owner",
+        visibility: "private",
+        snapshot: {
+          ...simulation.snapshot,
+          sites: simulation.snapshot.sites.map((site, index) =>
+            index === 0 ? { ...site, libraryEntryId: privateSite.id } : site,
+          ),
+        },
+      })),
+    });
+
+    const view = render(<AppShell />);
+    try {
+      await userEvent.click(await screen.findByRole("button", { name: "Share" }));
+      await userEvent.click(await screen.findByRole("button", { name: "Make Shared & Copy Link" }));
+
+      await waitFor(() => expect(pushCloudLibraryMock).toHaveBeenCalledTimes(1));
+      expect(useAppStore.getState().simulationPresets[0]?.visibility).toBe("shared");
+      expect(useAppStore.getState().siteLibrary[0]?.visibility).toBe("private");
+      expect(pushCloudLibraryMock).toHaveBeenCalledWith(expect.objectContaining({
+        siteLibrary: [],
+        simulationPresets: [expect.objectContaining({ visibility: "shared" })],
+      }));
     } finally {
       view.unmount();
     }

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -5,7 +5,6 @@ import { fetchCloudLibrary, fetchPublicSimulationLibrary, pushCloudLibrary } fro
 import { buildDeepLinkPathname, buildDeepLinkUrl, buildSettingsPath, canonicalizeDeepLinkKey, matchSettingsPath, parseDeepLinkFromLocation, slugifyName, type SettingsSectionId } from "../lib/deepLink";
 import { canRunDeepLinkApply } from "../lib/deepLinkApplyGate";
 import {
-  formatPrivateSiteReferenceBlockMessage,
   type DeepLinkApplyOutcome,
   shouldRewritePathAfterDeepLinkApply,
   shouldUseReadonlyFallbackForAuthBootstrap,
@@ -163,7 +162,6 @@ export function AppShell() {
   const setMapOverlayMode = useAppStore((state) => state.setMapOverlayMode);
   const updateMapViewport = useAppStore((state) => state.updateMapViewport);
   const updateSimulationPresetEntry = useAppStore((state) => state.updateSimulationPresetEntry);
-  const updateSiteLibraryEntry = useAppStore((state) => state.updateSiteLibraryEntry);
   const selectedScenarioId = useAppStore((state) => state.selectedScenarioId);
   const selectedLinkId = useAppStore((state) => state.selectedLinkId);
   const links = useAppStore((state) => state.links);
@@ -1511,17 +1509,6 @@ export function AppShell() {
       });
       return;
     }
-    const blockedSites = referencedPrivateSites.filter((site) => !canEditResource(site));
-    if (blockedSites.length) {
-      publishAppNotice({
-        id: "share-no-edit-access-sites",
-        message: `Cannot upgrade ${blockedSites.length} private site(s) because you do not have edit access to them.`,
-        tone: "warning",
-        persistent: true,
-      });
-      return;
-    }
-
     setShareBusy(true);
 
     // Start clipboard write within gesture context; content resolves after save.
@@ -1531,26 +1518,20 @@ export function AppShell() {
     const upgradeClipboardDone = copyToClipboard(upgradeLinkPromise);
 
     try {
-      for (const site of referencedPrivateSites) {
-        updateSiteLibraryEntry(site.id, { visibility: "shared" });
-      }
       updateSimulationPresetEntry(activeSimulation.id, { visibility: "shared" });
 
       const latest = useAppStore.getState();
       const latestSimulation = latest.simulationPresets.find((preset) => preset.id === activeSimulation.id);
-      const latestSites = latest.siteLibrary.filter((site) =>
-        referencedPrivateSites.some((candidate) => candidate.id === site.id),
-      );
       if (!latestSimulation) throw new Error("Simulation missing after local update.");
 
       await pushCloudLibrary({
         simulationPresets: [latestSimulation],
-        siteLibrary: latestSites,
+        siteLibrary: [],
       });
 
       resolveUpgradeLink(currentShareLink);
       await upgradeClipboardDone;
-      publishTransientNotice("share-upgrade-complete", "Simulation and referenced sites are now Shared. Link copied.");
+      publishTransientNotice("share-upgrade-complete", "Simulation is now Shared. Link copied.");
     } catch (error) {
       rejectUpgradeLink(error);
       publishAppNotice({
@@ -1568,19 +1549,11 @@ export function AppShell() {
     currentUser,
     publishAppNotice,
     publishTransientNotice,
-    referencedPrivateSites,
     updateSimulationPresetEntry,
-    updateSiteLibraryEntry,
   ]);
 
   const runShareWithSpecificUsers = useCallback(async () => {
     if (!activeSimulation || !currentUser) return;
-    if (toVisibility(activeSimulation.visibility) !== "private" && referencedPrivateSites.length) {
-      setShareSpecificStatus(
-        formatPrivateSiteReferenceBlockMessage(referencedPrivateSites.map((site) => site.name)),
-      );
-      return;
-    }
     if (!shareSpecificUsers.length) {
       setShareSpecificStatus("Add at least one user first.");
       return;
@@ -1622,7 +1595,6 @@ export function AppShell() {
     activeSimulation,
     currentShareLink,
     currentUser,
-    referencedPrivateSites,
     shareSpecificRoles,
     shareSpecificUsers,
     updateSimulationPresetEntry,
@@ -2381,12 +2353,13 @@ export function AppShell() {
                         <Globe aria-hidden="true" size={22} strokeWidth={1.6} />
                         <strong>Make Broadly Accessible</strong>
                         <p className="field-help" style={{ flex: 1 }}>
-                          Anyone with the link can view. The simulation
-                          {referencedPrivateSites.length ? ` and ${referencedPrivateSites.length} referenced site(s)` : ""} will be set to Shared.
-                          {referencedPrivateSites.some((site) => !canEditResource(site)) ? " Some sites require owner access." : ""}
+                          Anyone with the link can view. The Simulation will be set to Shared.
+                          {referencedPrivateSites.length
+                            ? ` Its ${referencedPrivateSites.length} referenced Private Site(s) remain Private in the Library but are visible through this Simulation.`
+                            : ""}
                         </p>
                         <ActionButton disabled={shareBusy} onClick={() => void runUpgradeAndShare()} type="button">
-                          Upgrade &amp; Copy Link
+                          Make Shared &amp; Copy Link
                         </ActionButton>
                       </div>
                       {/* Option B: Specific users */}

--- a/src/components/Sidebar.readOnly.test.tsx
+++ b/src/components/Sidebar.readOnly.test.tsx
@@ -46,6 +46,7 @@ import { Sidebar } from "./Sidebar";
 describe("Sidebar read-only simulation site actions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
     useAppStore.setState({
       sites: [
         {
@@ -256,5 +257,71 @@ describe("Sidebar read-only simulation site actions", () => {
         "Read-only: you need edit permission to add or edit sites in this simulation.",
       ),
     ).toBeInTheDocument();
+  });
+
+  it("warns writable shared-simulation editors about every referenced private site", () => {
+    const state = useAppStore.getState();
+    const privateTooltip =
+      "This Site is Private in the Library, but is visible to anyone who can access this Shared Simulation.";
+    const warning =
+      "This Simulation is Shared and includes Private Sites. Those Sites are visible to anyone who can access this Simulation.";
+    useAppStore.setState({
+      sites: state.sites.map((site, index) => ({
+        ...site,
+        libraryEntryId: index === 0 ? "private-owned-elsewhere" : "shared-site",
+      })),
+      siteLibrary: [
+        {
+          id: "private-owned-elsewhere",
+          name: "Private Elsewhere",
+          visibility: "private",
+          ownerUserId: "another-owner",
+          effectiveRole: "viewer",
+          position: { lat: 60.5, lon: 11.5 },
+          groundElevationM: 120,
+          antennaHeightM: 2,
+          txPowerDbm: 20,
+          txGainDbi: 2,
+          rxGainDbi: 2,
+          cableLossDb: 1,
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+        {
+          id: "shared-site",
+          name: "Shared Site",
+          visibility: "shared",
+          ownerUserId: "another-owner",
+          effectiveRole: "viewer",
+          position: { lat: 60.6, lon: 11.6 },
+          groundElevationM: 130,
+          antennaHeightM: 4,
+          txPowerDbm: 21,
+          txGainDbi: 3,
+          rxGainDbi: 3,
+          cableLossDb: 1,
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+      simulationPresets: state.simulationPresets.map((simulation) => ({
+        ...simulation,
+        effectiveRole: "editor",
+        snapshot: {
+          ...simulation.snapshot,
+          sites: state.sites.map((site, index) => ({
+            ...site,
+            libraryEntryId: index === 0 ? "private-owned-elsewhere" : "shared-site",
+          })),
+        },
+      })),
+    });
+
+    const view = render(<Sidebar />);
+    expect(screen.getByText(warning)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: privateTooltip })).toBeInTheDocument();
+
+    view.unmount();
+    render(<Sidebar readOnly />);
+    expect(screen.queryByText(warning)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: privateTooltip })).not.toBeInTheDocument();
   });
 });

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import clsx from "clsx";
-import { CircleMinus, Funnel, Handshake, HatGlasses, Info, Pencil } from "lucide-react";
+import { CircleAlert, CircleMinus, Funnel, Handshake, HatGlasses, Info, Pencil } from "lucide-react";
 import { useThemeVariant } from "../hooks/useThemeVariant";
 import { t } from "../i18n/locales";
 import { getCurrentRuntimeEnvironment } from "../lib/environment";
@@ -50,6 +50,10 @@ const READ_ONLY_SIMULATION_SITE_HELP =
   "Read-only: you need edit permission to add or edit sites in this simulation.";
 const READ_ONLY_VIEW_DETAILS_HELP =
   "Read-only: you can view this item, but need edit permission to change it.";
+const PRIVATE_SITE_DISCLOSURE_NOTICE =
+  "This Simulation is Shared and includes Private Sites. Those Sites are visible to anyone who can access this Simulation.";
+const PRIVATE_SITE_DISCLOSURE_TOOLTIP =
+  "This Site is Private in the Library, but is visible to anyone who can access this Shared Simulation.";
 
 const UserBadge = ({ name, avatarUrl }: { name: string; avatarUrl?: string | null }) => (
   <span className="user-list-row">
@@ -343,6 +347,21 @@ export function Sidebar({
     const simulation = scenarioOptions.find((candidate) => candidate.id === simulationId);
     return simulation ? `${simulation.name}` : "no simulation selected";
   }, [selectedSimulationRef, simulationPresets, scenarioOptions]);
+  const privateReferencedLibrarySiteIds = useMemo(() => {
+    if (readOnly || !selectedScenarioId) return new Set<string>();
+    const activeSimulation = simulationPresets.find((simulation) => simulation.id === selectedScenarioId);
+    if (!activeSimulation || toAccessVisibility(activeSimulation.visibility) !== "shared") return new Set<string>();
+    const privateLibraryIds = new Set(
+      siteLibrary
+        .filter((entry) => toAccessVisibility(entry.visibility) === "private")
+        .map((entry) => entry.id),
+    );
+    return new Set(
+      activeSimulation.snapshot.sites
+        .map((site) => site.libraryEntryId)
+        .filter((id): id is string => Boolean(id && privateLibraryIds.has(id))),
+    );
+  }, [readOnly, selectedScenarioId, simulationPresets, siteLibrary]);
   const openActiveSimulationDetails = (triggerEl?: Element | null) => {
     if (!selectedSimulationRef.startsWith("saved:")) return;
     const presetId = selectedSimulationRef.replace("saved:", "");
@@ -688,6 +707,16 @@ export function Sidebar({
             <span className="field-help">Sign in to browse the simulation library.</span>
           )}
         </div>
+        {privateReferencedLibrarySiteIds.size ? (
+          <div className="app-notification-item app-notification-item-warning app-notification-item-static" role="status">
+            <span className="app-notification-glyph" aria-hidden="true">
+              <CircleAlert size={14} strokeWidth={2} />
+            </span>
+            <div className="app-notification-copy">
+              <span>{PRIVATE_SITE_DISCLOSURE_NOTICE}</span>
+            </div>
+          </div>
+        ) : null}
       </section>
 
       <section className="panel-section section-sites">
@@ -706,6 +735,9 @@ export function Sidebar({
               >
                 {site.name}
               </button>
+              {site.libraryEntryId && privateReferencedLibrarySiteIds.has(site.libraryEntryId) ? (
+                <InfoTip text={PRIVATE_SITE_DISCLOSURE_TOOLTIP} />
+              ) : null}
               <div className="row-actions">
                 {readOnly ? (
                   <ActionButton

--- a/src/components/StatsPage.test.tsx
+++ b/src/components/StatsPage.test.tsx
@@ -71,6 +71,7 @@ const statsPayload = {
   },
   latestSimulations: [
     {
+      visibility: "shared",
       id: "sim-2",
       name: "Shared Ridge",
       href: "/Grace/Shared-Ridge",
@@ -78,6 +79,11 @@ const statsPayload = {
       owner: { userId: "u2", username: "Grace", avatarUrl: "" },
       siteCount: 3,
       linkCount: 2,
+    },
+    {
+      visibility: "private",
+      siteCount: 4,
+      linkCount: 1,
     },
   ],
   longestPassingPaths: [
@@ -164,6 +170,8 @@ describe("StatsPage", () => {
     expect(backLink).toHaveClass("btn");
     expect(backLink).not.toHaveClass("btn-ghost");
     expect(screen.getAllByRole("link", { name: /Shared Ridge/i })[0]).toHaveAttribute("href", "/Grace/Shared-Ridge");
+    expect(screen.getByText("Private Simulation")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /Private Simulation/i })).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Ridge ~ Valley/i })).toHaveAttribute("href", "/Grace/Shared-Ridge/Ridge~Valley");
     expect(screen.getByText("+18.8 dB")).toBeInTheDocument();
     expect(screen.getByText("Sites + Simulations")).toBeInTheDocument();

--- a/src/components/StatsPage.tsx
+++ b/src/components/StatsPage.tsx
@@ -332,17 +332,29 @@ export function StatsPage() {
 
         <Panel title="Latest Simulations">
           <div className="stats-simulation-list">
-            {(stats?.latestSimulations ?? []).map((simulation) => (
-              <a className="stats-simulation-row" href={simulation.href} key={simulation.id}>
-                <span>
-                  <strong>{simulation.name}</strong>
-                  <small>by {simulation.owner.username}</small>
-                </span>
-                <span>{simulation.siteCount} Sites</span>
-                <span>{simulation.linkCount} Links</span>
-                <ExternalLink aria-hidden="true" size={15} />
-              </a>
-            ))}
+            {(stats?.latestSimulations ?? []).map((simulation, index) =>
+              simulation.visibility === "private" ? (
+                <div className="stats-simulation-row" key={`private-${index}`}>
+                  <span>
+                    <strong>Private Simulation</strong>
+                    <small>Details anonymized</small>
+                  </span>
+                  <span>{simulation.siteCount} Sites</span>
+                  <span>{simulation.linkCount} Paths</span>
+                  <span aria-hidden="true" />
+                </div>
+              ) : (
+                <a className="stats-simulation-row" href={simulation.href} key={simulation.id}>
+                  <span>
+                    <strong>{simulation.name}</strong>
+                    <small>by {simulation.owner.username}</small>
+                  </span>
+                  <span>{simulation.siteCount} Sites</span>
+                  <span>{simulation.linkCount} Paths</span>
+                  <ExternalLink aria-hidden="true" size={15} />
+                </a>
+              ),
+            )}
             {!stats?.latestSimulations.length ? <p className="field-help">Latest non-empty Simulations will appear here.</p> : null}
           </div>
         </Panel>

--- a/src/components/map/MapEditorPanel.tsx
+++ b/src/components/map/MapEditorPanel.tsx
@@ -929,39 +929,19 @@ function SimulationEditorCard({
       </fieldset>
       )}
 
-      {/* Pending visibility confirmation prompt */}
-      {form.pendingVisibilityConfirm ? (
-        <div className="field-help warning-text">
-          <p>
-            This simulation references {form.pendingVisibilityConfirm.referencedPrivateSiteIds.length} private site(s).
-            Making this simulation shared will also make those sites shared. Continue?
-          </p>
-          <div className="chip-group">
-            <ActionButton onClick={form.applyPendingVisibilityChange} type="button">
-              Make Shared
-            </ActionButton>
-            <ActionButton onClick={() => form.setPendingVisibilityConfirm(null)} type="button">
-              Cancel
-            </ActionButton>
-          </div>
-        </div>
-      ) : null}
-
       {form.simulationNameError ? <p className="field-help field-help-error">{form.simulationNameError}</p> : null}
       {form.status ? <p className="field-help">{form.status}</p> : null}
 
-      {!form.pendingVisibilityConfirm ? (
-        <div className="chip-group">
-          {!isReadOnly ? (
-            <ActionButton onClick={form.handleSaveSimulation} type="button">
-              {isNew ? (isCopySimulation ? "Save a copy" : "Create Simulation") : "Save"}
-            </ActionButton>
-          ) : null}
-          <ActionButton onClick={onClose} type="button">
-            Cancel
+      <div className="chip-group">
+        {!isReadOnly ? (
+          <ActionButton onClick={form.handleSaveSimulation} type="button">
+            {isNew ? (isCopySimulation ? "Save a copy" : "Create Simulation") : "Save"}
           </ActionButton>
-        </div>
-      ) : null}
+        ) : null}
+        <ActionButton onClick={onClose} type="button">
+          Cancel
+        </ActionButton>
+      </div>
 
       {!isNew && form.simulationMetadata ? (
         <EditorMetadataStrip

--- a/src/components/map/useMapEditorFormState.ts
+++ b/src/components/map/useMapEditorFormState.ts
@@ -104,11 +104,6 @@ export function useMapEditorFormState() {
   const [siteSearchBusy, setSiteSearchBusy] = useState(false);
 
   // ─── Simulation-specific ─────────────────────────────────────────────────────
-  const [pendingVisibilityConfirm, setPendingVisibilityConfirm] = useState<{
-    simulationId: string;
-    targetVisibility: "shared";
-    referencedPrivateSiteIds: string[];
-  } | null>(null);
   const [simulationFrequencyPresetId, setSimulationFrequencyPresetId] = useState("");
   const [simulationAutoPropagationEnvironment, setSimulationAutoPropagationEnvironment] = useState(true);
   const [simulationDefaultsOverrideEnabled, setSimulationDefaultsOverrideEnabled] = useState(false);
@@ -139,7 +134,6 @@ export function useMapEditorFormState() {
   useEffect(() => {
     if (!mapEditor) return;
     setStatus("");
-    setPendingVisibilityConfirm(null);
     setIsElevationUserSet(false);
 
     if (mapEditor.kind === "site") {
@@ -763,30 +757,6 @@ export function useMapEditorFormState() {
       return false;
     }
 
-    // Check for private site refs that would need to be promoted
-    if (normalizedVisibility === "shared") {
-      const preset = simulationPresets.find((p) => p.id === mapEditor.resourceId);
-      const referencedPrivateSiteIds = siteLibrary
-        .filter((entry) => {
-          if ((entry.visibility ?? "private") !== "private") return false;
-          const refIds = new Set(
-            (preset?.snapshot.sites ?? [])
-              .map((s) => s.libraryEntryId)
-              .filter((v): v is string => typeof v === "string" && v.length > 0),
-          );
-          return refIds.has(entry.id);
-        })
-        .map((e) => e.id);
-      if (referencedPrivateSiteIds.length > 0) {
-        setPendingVisibilityConfirm({
-          simulationId: mapEditor.resourceId,
-          targetVisibility: "shared",
-          referencedPrivateSiteIds,
-        });
-        return false;
-      }
-    }
-
     try {
       updateSimulationPresetEntry(mapEditor.resourceId, {
         name: trimmedName,
@@ -802,22 +772,6 @@ export function useMapEditorFormState() {
       setStatus(`Save failed: ${getUiErrorMessage(error)}`);
       return false;
     }
-  };
-
-  const applyPendingVisibilityChange = () => {
-    if (!pendingVisibilityConfirm || !mapEditor?.resourceId) return;
-    for (const siteId of pendingVisibilityConfirm.referencedPrivateSiteIds) {
-      updateSiteLibraryEntry(siteId, { visibility: pendingVisibilityConfirm.targetVisibility });
-    }
-    const sharedWith = collaboratorUserIds
-      .filter((id) => id !== ownerUserId)
-      .map((id) => ({ userId: id, role: (collaboratorRoles[id] ?? "viewer") as "viewer" | "editor" }));
-    updateSimulationPresetEntry(pendingVisibilityConfirm.simulationId, {
-      visibility: pendingVisibilityConfirm.targetVisibility,
-      sharedWith,
-    });
-    setPendingVisibilityConfirm(null);
-    closeMapEditor();
   };
 
   const handleSaveLink = (): boolean => {
@@ -939,9 +893,6 @@ export function useMapEditorFormState() {
     handleSeparateGainToggle,
     handleSaveSite,
     // simulation
-    pendingVisibilityConfirm,
-    setPendingVisibilityConfirm,
-    applyPendingVisibilityChange,
     simulationFrequencyPresetId,
     setSimulationFrequencyPresetId,
     simulationAutoPropagationEnvironment,

--- a/src/lib/appShellGuards.test.ts
+++ b/src/lib/appShellGuards.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import {
-  formatPrivateSiteReferenceBlockMessage,
   isAuthSignInRequiredMessage,
   shouldCloseSimulationLibraryOnLoad,
   shouldRewritePathAfterDeepLinkApply,
@@ -111,13 +110,5 @@ describe("shouldCloseSimulationLibraryOnLoad", () => {
   it("does not close for empty simulation selection", () => {
     expect(shouldCloseSimulationLibraryOnLoad({ presetId: "" })).toBe(false);
     expect(shouldCloseSimulationLibraryOnLoad({ presetId: "   " })).toBe(false);
-  });
-});
-
-describe("formatPrivateSiteReferenceBlockMessage", () => {
-  it("lists private Library Site names in the validation message", () => {
-    expect(formatPrivateSiteReferenceBlockMessage(["Alpha", "Beta"])).toBe(
-      "Cannot share this Simulation while private Library Site references exist (Alpha, Beta). Set Simulation visibility to Private or use non-private Site entries.",
-    );
   });
 });

--- a/src/lib/appShellGuards.ts
+++ b/src/lib/appShellGuards.ts
@@ -46,9 +46,3 @@ export const shouldUseReadonlyFallbackForAuthBootstrap = (input: {
 
 export const shouldCloseSimulationLibraryOnLoad = (input: { presetId: string | null | undefined }): boolean =>
   String(input.presetId ?? "").trim().length > 0;
-
-export const formatPrivateSiteReferenceBlockMessage = (siteNames: string[]): string => {
-  const cleaned = siteNames.map((name) => String(name).trim()).filter(Boolean);
-  const nameList = cleaned.length ? ` (${cleaned.join(", ")})` : "";
-  return `Cannot share this Simulation while private Library Site references exist${nameList}. Set Simulation visibility to Private or use non-private Site entries.`;
-};

--- a/src/lib/cloudLibrary.test.ts
+++ b/src/lib/cloudLibrary.test.ts
@@ -55,24 +55,6 @@ describe("cloudLibrary client", () => {
     expect(result).toEqual({ siteLibrary: [{ id: "s1" }], simulationPresets: [] });
   });
 
-  it("throws conflict-specific error for private site reference conflicts", async () => {
-    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
-      new Response(JSON.stringify({ ok: false, conflicts: ["simulation_private_site_reference"] }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      }),
-    );
-
-    await expect(
-      pushCloudLibrary({
-        siteLibrary: [],
-        simulationPresets: [{ id: "sim-1", name: "North Link" }],
-      }),
-    ).rejects.toThrow(
-      "Cannot publish/shared simulation(s) with private Library Site references: North Link.",
-    );
-  });
-
   it("includes simulation names for simulation_name_taken conflicts", async () => {
     vi.mocked(globalThis.fetch).mockResolvedValueOnce(
       new Response(JSON.stringify({ ok: false, conflicts: ["simulation_name_taken"] }), {

--- a/src/lib/cloudLibrary.ts
+++ b/src/lib/cloudLibrary.ts
@@ -75,13 +75,6 @@ export const pushCloudLibrary = async (payload: CloudLibraryPayload): Promise<vo
   });
   const allConflicts = Array.isArray(result.conflicts) ? result.conflicts : [];
   if (!allConflicts.length) return;
-  if (allConflicts.includes("simulation_private_site_reference")) {
-    const simulationNames = listSimulationNames(payload);
-    const suffix = simulationNames.length ? `: ${simulationNames.join(", ")}` : "";
-    throw new Error(
-      `Cannot publish/shared simulation(s) with private Library Site references${suffix}. Set Simulation visibility to Private or use non-private Site entries.`,
-    );
-  }
   if (allConflicts.includes("simulation_name_taken")) {
     const simulationNames = listSimulationNames(payload);
     const suffix = simulationNames.length ? `: ${simulationNames.join(", ")}` : "";

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -47,19 +47,27 @@ export type StatsPayload = {
     medianLinksPerSimulation: number;
     sizeBuckets: Record<"1-2" | "3-5" | "6-10" | "11+", number>;
   };
-  latestSimulations: Array<{
-    id: string;
-    name: string;
-    href: string;
-    createdAt: string | null;
-    owner: {
-      userId: string;
-      username: string;
-      avatarUrl: string;
-    };
-    siteCount: number;
-    linkCount: number;
-  }>;
+  latestSimulations: Array<
+    | {
+        visibility: "private";
+        siteCount: number;
+        linkCount: number;
+      }
+    | {
+        visibility: "shared";
+        id: string;
+        name: string;
+        href: string;
+        createdAt: string | null;
+        owner: {
+          userId: string;
+          username: string;
+          avatarUrl: string;
+        };
+        siteCount: number;
+        linkCount: number;
+      }
+  >;
   longestPassingPaths: Array<{
     id: string;
     label: string;

--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -519,6 +519,49 @@ describe("appStore blank simulation loading", () => {
     const created = useAppStore.getState().simulationPresets.find((entry) => entry.id === createdId);
     expect(created?.effectiveRole).toBe("owner");
   });
+
+  it("keeps a simulation shared when it references a private Library Site", () => {
+    const createdId = useAppStore
+      .getState()
+      .createBlankSimulationPreset("Shared With Private Site", { visibility: "private", ownerUserId: "owner-1" });
+    expect(createdId).toBeTruthy();
+
+    const privateSite = {
+      id: "private-site",
+      name: "Private Site",
+      visibility: "private" as const,
+      ownerUserId: "owner-1",
+      effectiveRole: "owner" as const,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      position: { lat: 60, lon: 10 },
+      groundElevationM: 100,
+      antennaHeightM: 2,
+      txPowerDbm: 20,
+      txGainDbi: 2,
+      rxGainDbi: 2,
+      cableLossDb: 1,
+    };
+    useAppStore.setState((state) => ({
+      siteLibrary: [privateSite],
+      simulationPresets: state.simulationPresets.map((simulation) =>
+        simulation.id === createdId
+          ? {
+              ...simulation,
+              snapshot: {
+                ...simulation.snapshot,
+                sites: [{ ...privateSite, libraryEntryId: privateSite.id }],
+              },
+            }
+          : simulation,
+      ),
+    }));
+
+    useAppStore.getState().updateSimulationPresetEntry(createdId as string, { visibility: "shared" });
+
+    expect(useAppStore.getState().simulationPresets.find((simulation) => simulation.id === createdId)?.visibility)
+      .toBe("shared");
+    expect(useAppStore.getState().siteLibrary[0]?.visibility).toBe("private");
+  });
 });
 
 describe("appStore new simulation default frequency preset", () => {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1039,20 +1039,6 @@ const ensureSitesBackedByLibrary = (
   };
 };
 
-const hasPrivateLibrarySiteReferences = (
-  sites: Site[],
-  siteLibrary: SiteLibraryEntry[],
-): boolean => {
-  if (!sites.length || !siteLibrary.length) return false;
-  const privateIds = new Set(
-    siteLibrary
-      .filter((entry) => (entry.visibility ?? "private") === "private")
-      .map((entry) => entry.id),
-  );
-  if (!privateIds.size) return false;
-  return sites.some((site) => typeof site.libraryEntryId === "string" && privateIds.has(site.libraryEntryId));
-};
-
 const ensureMinimumTopology = (
   inputSites: Site[],
   inputLinks: Link[],
@@ -2780,11 +2766,6 @@ export const useAppStore = create<AppState>((set, get) => ({
       const currentSelectionDescription = current.simulationPresets.find(
         (preset) => preset.id === current.selectedScenarioId,
       )?.description;
-      const visibilityBase = existing?.visibility ?? "private";
-      const visibilitySafe =
-        visibilityBase !== "private" && hasPrivateLibrarySiteReferences(snapshot.sites, mergedLibrary)
-          ? "private"
-          : visibilityBase;
       const nextPreset: SimulationPreset = {
         id: existing?.id ?? makeId("sim"),
         name: presetName,
@@ -2796,7 +2777,7 @@ export const useAppStore = create<AppState>((set, get) => ({
             ...(existing?.slug ? [slugifyValue(existing.slug)] : []),
           ]),
         ).filter((entry) => Boolean(entry) && entry !== slugifyValue(presetName)),
-        visibility: visibilitySafe,
+        visibility: existing?.visibility ?? "private",
         sharedWith: existing?.sharedWith ?? [],
         updatedAt: new Date().toISOString(),
         snapshot,
@@ -2988,18 +2969,13 @@ export const useAppStore = create<AppState>((set, get) => ({
         normalized.addedCount > 0
           ? normalizeSiteLibrary([...normalized.siteLibrary, ...current.siteLibrary])
           : current.siteLibrary;
-      const visibilityBase = existing.visibility ?? "private";
-      const visibilitySafe =
-        visibilityBase !== "private" && hasPrivateLibrarySiteReferences(snapshot.sites, mergedLibrary)
-          ? "private"
-          : visibilityBase;
       const nextPreset: SimulationPreset = {
         id: existing.id,
         name: existing.name,
         description: existing.description,
         slug: existing.slug ?? slugifyValue(existing.name),
         slugAliases: existing.slugAliases ?? [],
-        visibility: visibilitySafe,
+        visibility: existing.visibility ?? "private",
         sharedWith: existing.sharedWith ?? [],
         updatedAt: new Date().toISOString(),
         snapshot,
@@ -3267,11 +3243,7 @@ export const useAppStore = create<AppState>((set, get) => ({
           ...((preset.slugAliases ?? []).map((entry) => slugifyValue(entry))),
         ]);
         aliasSet.delete(nextSlug);
-        const nextVisibilityRaw = patch.visibility ?? preset.visibility ?? "private";
-        const nextVisibility =
-          nextVisibilityRaw !== "private" && hasPrivateLibrarySiteReferences(preset.snapshot.sites, state.siteLibrary)
-            ? "private"
-            : nextVisibilityRaw;
+        const nextVisibility = patch.visibility ?? preset.visibility ?? "private";
         const snapshotPatch =
           patch.simulationDefaultsOverrideEnabled !== undefined || patch.simulationDefaultsOverride !== undefined
             ? {


### PR DESCRIPTION
## Summary

- require real actor authorization for Private Simulations while preserving anonymous Shared Simulation access
- treat an authorized Simulation as the complete rendering boundary for referenced Private Sites without changing their Library visibility
- remove obsolete visibility promotion, downgrade, and private-reference conflict behavior
- anonymize Private Simulation rows in Stats while retaining their aggregate contributions
- show the existing warning and `InfoTip` treatment for every referenced Private Site to Simulation editors

## Root cause

The public Simulation bundle endpoint used an `allowUnlisted` bypass, so possession of a Private Simulation URL could bypass authorization. Sharing flows also coupled Simulation access to referenced Site visibility, and Stats serialized identifying fields without respecting Simulation visibility.

## Validation

- focused authorization, Stats, sharing, and warning suites
- `npm run test -- --run src/lib/deepLink.test.ts`
- `npm run test -- --run functions/api/v1/calculate.test.ts`
- `npm run test -- --run src/store/appStore.test.ts`
- `npm test` (114 files, 617 tests)
- `npm run build`
- `git diff --check`
- `npm run dev:check`

Addresses #931.
Addresses #920.

Both issues remain in milestone `0.24.0`. Versioning and changelog changes are intentionally deferred to the milestone release.