### PR TITLE
Fix panorama render loop

### DIFF
--- a/src/components/PanoramaChart.test.tsx
+++ b/src/components/PanoramaChart.test.tsx
@@ -1,0 +1,299 @@
+// @vitest-environment jsdom
+import { act, render, screen } from "@testing-library/react";
+import { Profiler, StrictMode, type ProfilerOnRenderCallback } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const testState = vi.hoisted(() => ({
+  buildPanorama: vi.fn(),
+  schedulers: [] as Array<{ dispose: ReturnType<typeof vi.fn> }>,
+  store: {
+    sites: [
+      {
+        id: "site-1",
+        name: "Test site",
+        position: { lat: 59.91, lon: 10.75 },
+        groundElevationM: 100,
+        antennaHeightM: 10,
+        txPowerDbm: 20,
+        txGainDbi: 2,
+        rxGainDbi: 2,
+        cableLossDb: 1,
+      },
+    ],
+    links: [],
+    selectedSiteIds: ["site-1"],
+    selectedNetworkId: "network-1",
+    networks: [
+      {
+        id: "network-1",
+        name: "Test network",
+        frequencyMHz: 868,
+      },
+    ],
+    srtmTiles: [],
+    propagationEnvironment: {
+      atmosphericBendingNUnits: 301,
+      clutterHeightM: 0,
+    },
+    rxSensitivityTargetDbm: -120,
+    environmentLossDb: 0,
+    siteDragPreview: {},
+    siteLibrary: [],
+    discoveryLibraryVisible: false,
+    discoveryMqttVisible: false,
+    mapDiscoveryMqttNodes: [],
+    terrainLoadEpoch: 1,
+  },
+}));
+
+vi.hoisted(() => {
+  const data = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: (key: string) => data.get(key) ?? null,
+    setItem: (key: string, value: string) => data.set(key, String(value)),
+    removeItem: (key: string) => data.delete(key),
+    clear: () => data.clear(),
+    key: (index: number) => Array.from(data.keys())[index] ?? null,
+    get length() {
+      return data.size;
+    },
+  });
+});
+
+vi.mock("../store/appStore", () => ({
+  useAppStore: (selector: (state: typeof testState.store) => unknown) => selector(testState.store),
+}));
+
+vi.mock("../hooks/useThemeVariant", () => ({
+  useThemeVariant: () => ({ theme: "light" }),
+}));
+
+vi.mock("../lib/panoramaPeaks", () => ({
+  loadPanoramaPeaks: vi.fn(async () => []),
+}));
+
+vi.mock("../lib/panorama", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/panorama")>();
+  return {
+    ...actual,
+    buildPanorama: testState.buildPanorama,
+  };
+});
+
+vi.mock("../lib/latestOnlyTaskScheduler", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/latestOnlyTaskScheduler")>();
+  return {
+    ...actual,
+    createLatestOnlyTaskScheduler: () => {
+      const scheduler = actual.createLatestOnlyTaskScheduler();
+      const tracked = {
+        ...scheduler,
+        dispose: vi.fn(scheduler.dispose),
+      };
+      testState.schedulers.push(tracked);
+      return tracked;
+    },
+  };
+});
+
+import { PanoramaChart } from "./PanoramaChart";
+
+const panoramaResult = (detail: boolean) => ({
+  rays: [
+    {
+      azimuthDeg: detail ? 170 : 0,
+      maxDistanceKm: 50,
+      horizonDistanceKm: 10,
+      horizonLat: 59.92,
+      horizonLon: 10.75,
+      horizonTerrainM: 120,
+      horizonAngleDeg: 1,
+      clutterHorizonDistanceKm: 10,
+      clutterHorizonAngleDeg: 1,
+      samples: [
+        {
+          distanceKm: 1,
+          lat: 59.911,
+          lon: 10.75,
+          terrainM: 105,
+          angleDeg: 0.5,
+          maxAngleBeforeDeg: 0,
+        },
+        {
+          distanceKm: 10,
+          lat: 59.92,
+          lon: 10.75,
+          terrainM: 120,
+          angleDeg: 1,
+          maxAngleBeforeDeg: 0.5,
+        },
+      ],
+    },
+    {
+      azimuthDeg: detail ? 190 : 359,
+      maxDistanceKm: 50,
+      horizonDistanceKm: 11,
+      horizonLat: 59.92,
+      horizonLon: 10.76,
+      horizonTerrainM: 125,
+      horizonAngleDeg: 1.1,
+      clutterHorizonDistanceKm: 11,
+      clutterHorizonAngleDeg: 1.1,
+      samples: [
+        {
+          distanceKm: 1,
+          lat: 59.911,
+          lon: 10.751,
+          terrainM: 106,
+          angleDeg: 0.6,
+          maxAngleBeforeDeg: 0,
+        },
+        {
+          distanceKm: 11,
+          lat: 59.92,
+          lon: 10.76,
+          terrainM: 125,
+          angleDeg: 1.1,
+          maxAngleBeforeDeg: 0.6,
+        },
+      ],
+    },
+  ],
+  nodes: [],
+  minAngleDeg: 0,
+  maxAngleDeg: 2,
+  radiusPolicyKm: 50,
+  coverageCenterDeg: detail ? 180 : 0,
+  coverageSpanDeg: detail ? 90 : 360,
+});
+
+const renderChart = (wrapper?: "strict", onRender?: ProfilerOnRenderCallback) => {
+  const chart = (
+    <Profiler id="panorama" onRender={onRender ?? (() => undefined)}>
+      <PanoramaChart isExpanded={false} onToggleExpanded={() => undefined} />
+    </Profiler>
+  );
+  return render(wrapper === "strict" ? <StrictMode>{chart}</StrictMode> : chart);
+};
+
+describe("PanoramaChart scheduling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    testState.schedulers.length = 0;
+    testState.buildPanorama.mockImplementation((input) =>
+      panoramaResult(input.options.windowCenterDeg != null),
+    );
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+      width: 800,
+      height: 300,
+      top: 0,
+      right: 800,
+      bottom: 300,
+      left: 0,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        disconnect() {}
+      },
+    );
+    const context = new Proxy(
+      {},
+      {
+        get: () => vi.fn(),
+        set: () => true,
+      },
+    );
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(
+      context as unknown as CanvasRenderingContext2D,
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders async base/detail results immediately without changing panorama controls", async () => {
+    renderChart();
+
+    expect(await screen.findByRole("img", { name: "Panorama" })).toBeInTheDocument();
+    expect(testState.buildPanorama).toHaveBeenCalledTimes(2);
+  });
+
+  it("settles after the base/detail cache is populated instead of repeatedly rendering", async () => {
+    let renderCount = 0;
+    let now = 0;
+    vi.spyOn(Date, "now").mockImplementation(() => Math.min(++now, 20));
+
+    renderChart(undefined, () => {
+      renderCount += 1;
+    });
+
+    expect(await screen.findByRole("img", { name: "Panorama" })).toBeInTheDocument();
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(testState.buildPanorama).toHaveBeenCalledTimes(2);
+    expect(renderCount).toBeLessThanOrEqual(6);
+  });
+
+  it("reuses cached panorama results without rebuilding or entering another render cycle", async () => {
+    let renderCount = 0;
+    const view = renderChart(undefined, () => {
+      renderCount += 1;
+    });
+    expect(await screen.findByRole("img", { name: "Panorama" })).toBeInTheDocument();
+
+    testState.store.links = [];
+    view.rerender(
+      <Profiler id="panorama" onRender={() => {
+        renderCount += 1;
+      }}>
+        <PanoramaChart isExpanded={false} onToggleExpanded={() => undefined} />
+      </Profiler>,
+    );
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(testState.buildPanorama).toHaveBeenCalledTimes(2);
+    expect(renderCount).toBeLessThanOrEqual(8);
+  });
+
+  it("recreates disposed schedulers during StrictMode replay and still renders", async () => {
+    renderChart("strict");
+
+    expect(await screen.findByRole("img", { name: "Panorama" })).toBeInTheDocument();
+    expect(testState.schedulers.some((scheduler) => scheduler.dispose.mock.calls.length > 0)).toBe(true);
+  });
+
+  it("disposes both live schedulers on unmount", async () => {
+    const view = renderChart();
+    expect(await screen.findByRole("img", { name: "Panorama" })).toBeInTheDocument();
+
+    view.unmount();
+
+    expect(testState.schedulers).toHaveLength(2);
+    expect(testState.schedulers.every((scheduler) => scheduler.dispose.mock.calls.length === 1)).toBe(true);
+  });
+
+  it("does not publish work that is canceled before the scheduler starts it", async () => {
+    const view = renderChart();
+    view.unmount();
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(testState.buildPanorama).not.toHaveBeenCalled();
+    expect(testState.schedulers.every((scheduler) => scheduler.dispose.mock.calls.length === 1)).toBe(true);
+  });
+});

--- a/src/components/PanoramaChart.tsx
+++ b/src/components/PanoramaChart.tsx
@@ -7,7 +7,11 @@ import { Info, MapPinned, Paintbrush, PanelBottomClose, PanelBottomOpen, Mountai
 import type { CSSProperties, MouseEvent as ReactMouseEvent, ReactNode } from "react";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { STANDARD_SITE_RADIO } from "../lib/linkRadio";
-import { createLatestOnlyTaskScheduler, type LatestOnlyTask } from "../lib/latestOnlyTaskScheduler";
+import {
+  createLatestOnlyTaskScheduler,
+  type LatestOnlyTask,
+  type LatestOnlyTaskScheduler,
+} from "../lib/latestOnlyTaskScheduler";
 import { dispatchPanoramaInteraction } from "../lib/panoramaEvents";
 import {
   buildPanorama,
@@ -71,6 +75,25 @@ const parseRgb = (value: string): Rgb | null => {
 
 const toCanvasColor = (color: Rgb, alpha: number): string =>
   `rgba(${clamp(Math.round(color.r), 0, 255)}, ${clamp(Math.round(color.g), 0, 255)}, ${clamp(Math.round(color.b), 0, 255)}, ${clamp(alpha, 0, 1).toFixed(3)})`;
+
+const upsertDetailPanorama = (
+  current: PanoramaResult[],
+  panorama: PanoramaResult,
+): PanoramaResult[] => {
+  const bucketKey = panorama.coverageCenterDeg.toFixed(3);
+  const existing = current.find(
+    (entry) => entry.coverageCenterDeg.toFixed(3) === bucketKey,
+  );
+  if (existing === panorama) return current;
+  const next = [
+    ...current.filter(
+      (entry) => entry.coverageCenterDeg.toFixed(3) !== bucketKey,
+    ),
+    panorama,
+  ];
+  next.sort((a, b) => a.coverageCenterDeg - b.coverageCenterDeg);
+  return next.slice(-12);
+};
 
 const blendRgb = (a: Rgb, b: Rgb, t: number): Rgb => {
   const ratio = clamp(t, 0, 1);
@@ -249,14 +272,31 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
     [],
   );
 
-  const baseSchedulerRef = useRef(createLatestOnlyTaskScheduler());
-  const detailSchedulerRef = useRef(createLatestOnlyTaskScheduler());
+  const baseSchedulerRef = useRef<LatestOnlyTaskScheduler | null>(null);
+  const detailSchedulerRef = useRef<LatestOnlyTaskScheduler | null>(null);
   const cacheRef = useRef<Map<string, PanoramaResult>>(new Map());
   const detailContextRef = useRef<string>("");
   const [basePanorama, setBasePanorama] = useState<PanoramaResult | null>(null);
   const [detailPanoramas, setDetailPanoramas] = useState<PanoramaResult[]>([]);
   const [panoramasReadyEpoch, setPanoramasReadyEpoch] = useState(0);
   const [panoramaLoading, setPanoramaLoading] = useState(false);
+
+  useEffect(() => {
+    const baseScheduler = createLatestOnlyTaskScheduler();
+    const detailScheduler = createLatestOnlyTaskScheduler();
+    baseSchedulerRef.current = baseScheduler;
+    detailSchedulerRef.current = detailScheduler;
+    return () => {
+      baseScheduler.dispose();
+      detailScheduler.dispose();
+      if (baseSchedulerRef.current === baseScheduler) {
+        baseSchedulerRef.current = null;
+      }
+      if (detailSchedulerRef.current === detailScheduler) {
+        detailSchedulerRef.current = null;
+      }
+    };
+  }, []);
 
   const selectedSiteEffective = useMemo(() => {
     if (!selectedSite) return null;
@@ -365,13 +405,15 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
 
   useEffect(() => {
     if (!selectedSiteEffective || !selectedNetwork) {
+      baseSchedulerRef.current?.clearQueue();
+      baseSchedulerRef.current?.cancelActive();
+      detailSchedulerRef.current?.clearQueue();
+      detailSchedulerRef.current?.cancelActive();
       setBasePanorama(null);
       setDetailPanoramas([]);
       setPanoramaLoading(false);
       return;
     }
-
-    setPanoramaLoading(true);
 
     const effectiveLink = links[0]
       ? {
@@ -455,27 +497,26 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
 
     const cachedBase = cacheRef.current.get(baseSignature);
     if (cachedBase) {
-      setBasePanorama(cachedBase);
-      setPanoramasReadyEpoch(Date.now());
+      setBasePanorama((current) => current === cachedBase ? current : cachedBase);
     }
     const cachedDetail = cacheRef.current.get(detailSignature);
     if (cachedDetail) {
-      setDetailPanoramas((current) => {
-        const bucketKey = cachedDetail.coverageCenterDeg.toFixed(3);
-        const next = [...current.filter((entry) => entry.coverageCenterDeg.toFixed(3) !== bucketKey), cachedDetail];
-        next.sort((a, b) => a.coverageCenterDeg - b.coverageCenterDeg);
-        return next.slice(-12);
-      });
-      setPanoramasReadyEpoch(Date.now());
+      setDetailPanoramas((current) => upsertDetailPanorama(current, cachedDetail));
     }
+    if (cachedBase || cachedDetail) {
+      setPanoramasReadyEpoch((epoch) => epoch + 1);
+    }
+    setPanoramaLoading(!(cachedBase && cachedDetail));
 
     if (!cachedBase) {
       const scheduler = baseSchedulerRef.current;
+      if (!scheduler) return;
       scheduler.clearQueue();
       scheduler.cancelActive();
       scheduler.enqueue({
         signature: baseSignature,
         run: async (context) => {
+          if (context.isCancelled()) return;
           const result = buildPanorama({
             selectedSite: selectedSiteEffective,
             effectiveLink,
@@ -499,19 +540,23 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
             if (oldest) cacheRef.current.delete(oldest);
           }
           setBasePanorama(result);
-          setPanoramasReadyEpoch(Date.now());
-          setPanoramaLoading(false);
+          setPanoramasReadyEpoch((epoch) => epoch + 1);
+          if (cacheRef.current.has(detailSignature)) {
+            setPanoramaLoading(false);
+          }
         },
       } satisfies LatestOnlyTask);
     }
 
     if (!cachedDetail) {
       const scheduler = detailSchedulerRef.current;
+      if (!scheduler) return;
       scheduler.clearQueue();
       scheduler.cancelActive();
       scheduler.enqueue({
         signature: detailSignature,
         run: async (context) => {
+          if (context.isCancelled()) return;
           const result = buildPanorama({
             selectedSite: selectedSiteEffective,
             effectiveLink,
@@ -536,14 +581,11 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
             const oldest = cacheRef.current.keys().next().value;
             if (oldest) cacheRef.current.delete(oldest);
           }
-          setDetailPanoramas((current) => {
-            const bucketKey = result.coverageCenterDeg.toFixed(3);
-            const next = [...current.filter((entry) => entry.coverageCenterDeg.toFixed(3) !== bucketKey), result];
-            next.sort((a, b) => a.coverageCenterDeg - b.coverageCenterDeg);
-            return next.slice(-12);
-          });
-          setPanoramasReadyEpoch(Date.now());
-          setPanoramaLoading(false);
+          setDetailPanoramas((current) => upsertDetailPanorama(current, result));
+          setPanoramasReadyEpoch((epoch) => epoch + 1);
+          if (cacheRef.current.has(baseSignature)) {
+            setPanoramaLoading(false);
+          }
         },
       } satisfies LatestOnlyTask);
     }
@@ -561,7 +603,6 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
     normalizedFovScale,
     viewportCenterAzimuthDeg,
     viewportSpanDeg,
-    panoramasReadyEpoch,
   ]);
 
   const panorama = detailPanoramas[detailPanoramas.length - 1] ?? basePanorama;
@@ -587,6 +628,8 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
   );
 
   const geometry = useMemo(() => {
+    // The epoch is a one-way signal that cached results are ready to paint.
+    void panoramasReadyEpoch;
     if (!panorama || !chartSize || !panorama.rays.length) return null;
     const anchorPanorama = basePanorama && basePanorama.rays.length ? basePanorama : panorama;
 


### PR DESCRIPTION
## Summary

- remove the self-triggering panorama cache/render effect loop
- keep the render-ready epoch as a one-way paint signal using functional increments
- make detail-cache installation idempotent and loading depend on the complete base/detail pair
- lifecycle-own both schedulers so StrictMode replay and unmount cancellation are safe
- add focused `PanoramaChart` regression coverage

## Root cause

The panorama build/cache effect both depended on and updated `panoramasReadyEpoch`. Once base or detail data entered the cache, every effect pass wrote a new clock-based epoch, retriggering the same effect and the expensive synchronous panorama geometry/canvas render indefinitely. That main-thread churn starved cooperative overlay calculation work.

## Validation

- `npm test -- --run src/components/PanoramaChart.test.tsx` — 6 passed
- `npm test` — 623 passed
- `npm run build`
- `git diff --check`
- `npm run dev:check` — no LinkSim dev/watch server running

Closes neither issue state nor release scope: #933 remains open for staging verification and user sign-off.
