### PR TITLE
Prevent duplicate overlay passes

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -73,7 +73,11 @@ import {
   recordSimulationOverlayPerf,
   recordSimulationRunCancelled,
 } from "../lib/simulationPerf";
-import { resolveSimulationBusyIndicatorState } from "../lib/simulationBusyIndicator";
+import {
+  resolveMonotonicOverlayProgress,
+  resolveSimulationBusyIndicatorState,
+  shouldDeferOverlayRasterization,
+} from "../lib/simulationBusyIndicator";
 import { createLatestOnlyTaskScheduler, type LatestOnlyTask } from "../lib/latestOnlyTaskScheduler";
 import { createLruCache } from "../lib/lruCache";
 import { SimulationResultsSection } from "./SimulationResultsSection";
@@ -1508,17 +1512,23 @@ export function MapView({
     coverage: null,
     terrain: null,
   });
+  const overlayProgressFloorRef = useRef<number | null>(null);
+  const overlayJobsInFlightRef = useRef(0);
   const syncOverlayProgressState = useCallback(() => {
     const coverageProgress = overlayProgressByPipelineRef.current.coverage;
     const terrainProgress = overlayProgressByPipelineRef.current.terrain;
-    const numeric = [coverageProgress, terrainProgress].filter((value): value is number => typeof value === "number");
-    if (!numeric.length) {
+    const nextProgress = resolveMonotonicOverlayProgress(
+      overlayProgressFloorRef.current,
+      [coverageProgress, terrainProgress],
+    );
+    if (nextProgress === null) {
       setOverlayProgressMode("indeterminate");
       setOverlayProgressPercent(null);
       return;
     }
+    overlayProgressFloorRef.current = nextProgress;
     setOverlayProgressMode("determinate");
-    setOverlayProgressPercent(Math.max(...numeric));
+    setOverlayProgressPercent(nextProgress);
   }, []);
   const setOverlayPipelineProgress = useCallback(
     (pipeline: "coverage" | "terrain", percent: number | null) => {
@@ -1534,13 +1544,27 @@ export function MapView({
   );
   const beginOverlayJob = useCallback((pipeline: "coverage" | "terrain") => {
     let finished = false;
-    setOverlayJobsInFlight((count) => count + 1);
+    if (overlayJobsInFlightRef.current === 0) {
+      overlayProgressFloorRef.current = null;
+      overlayProgressByPipelineRef.current = { coverage: null, terrain: null };
+      setOverlayProgressMode("indeterminate");
+      setOverlayProgressPercent(null);
+    }
+    overlayJobsInFlightRef.current += 1;
+    setOverlayJobsInFlight(overlayJobsInFlightRef.current);
     setOverlayPipelineProgress(pipeline, null);
     return () => {
       if (finished) return;
       finished = true;
-      setOverlayJobsInFlight((count) => Math.max(0, count - 1));
+      overlayJobsInFlightRef.current = Math.max(0, overlayJobsInFlightRef.current - 1);
+      setOverlayJobsInFlight(overlayJobsInFlightRef.current);
       setOverlayPipelineProgress(pipeline, null);
+      if (overlayJobsInFlightRef.current === 0) {
+        overlayProgressFloorRef.current = null;
+        overlayProgressByPipelineRef.current = { coverage: null, terrain: null };
+        setOverlayProgressMode("indeterminate");
+        setOverlayProgressPercent(null);
+      }
     };
   }, [setOverlayPipelineProgress]);
   const [coverageOverlay, setCoverageOverlay] = useState<(OverlayRaster & { minDbm?: number; maxDbm?: number }) | null>(null);
@@ -1624,6 +1648,16 @@ export function MapView({
     }
     if (!overlayBounds) {
       cancelCoveragePipeline(true);
+      return;
+    }
+    if (
+      shouldDeferOverlayRasterization({
+        isTerrainFetching,
+        isTerrainRecommending,
+        isSimulationRecomputing,
+      })
+    ) {
+      cancelCoveragePipeline(false);
       return;
     }
 
@@ -1915,6 +1949,9 @@ export function MapView({
     calculationWorkAllowed,
     calculationCycleSource,
     completedCoverageRunToken,
+    isTerrainFetching,
+    isTerrainRecommending,
+    isSimulationRecomputing,
   ]);
   const signalRange = useMemo(() => {
     if (!samplesForOverlay.length) return { min: -125, max: -62 };
@@ -1983,6 +2020,16 @@ export function MapView({
 
     if (!showTerrainOverlay || !hasSimulationTerrain || !analysisBounds) {
       cancelTerrainPipeline(true);
+      return;
+    }
+    if (
+      shouldDeferOverlayRasterization({
+        isTerrainFetching,
+        isTerrainRecommending,
+        isSimulationRecomputing,
+      })
+    ) {
+      cancelTerrainPipeline(false);
       return;
     }
 
@@ -2162,6 +2209,9 @@ export function MapView({
     calculationWorkAllowed,
     calculationCycleSource,
     completedCoverageRunToken,
+    isTerrainFetching,
+    isTerrainRecommending,
+    isSimulationRecomputing,
   ]);
 
   const webglAvailable = useMemo(() => supportsWebgl(), []);

--- a/src/lib/simulationBusyIndicator.test.ts
+++ b/src/lib/simulationBusyIndicator.test.ts
@@ -1,5 +1,48 @@
 import { describe, expect, it } from "vitest";
-import { resolveSimulationBusyIndicatorState } from "./simulationBusyIndicator";
+import {
+  resolveMonotonicOverlayProgress,
+  resolveSimulationBusyIndicatorState,
+  shouldDeferOverlayRasterization,
+} from "./simulationBusyIndicator";
+
+describe("overlay progress coordination", () => {
+  it("never moves combined overlay progress backward", () => {
+    expect(resolveMonotonicOverlayProgress(null, [88, 24])).toBe(88);
+    expect(resolveMonotonicOverlayProgress(88, [null, 42])).toBe(88);
+    expect(resolveMonotonicOverlayProgress(88, [null, 96])).toBe(96);
+  });
+
+  it("defers rasterization until terrain and coverage inputs are final", () => {
+    expect(
+      shouldDeferOverlayRasterization({
+        isTerrainFetching: true,
+        isTerrainRecommending: false,
+        isSimulationRecomputing: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldDeferOverlayRasterization({
+        isTerrainFetching: false,
+        isTerrainRecommending: true,
+        isSimulationRecomputing: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldDeferOverlayRasterization({
+        isTerrainFetching: false,
+        isTerrainRecommending: false,
+        isSimulationRecomputing: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldDeferOverlayRasterization({
+        isTerrainFetching: false,
+        isTerrainRecommending: false,
+        isSimulationRecomputing: false,
+      }),
+    ).toBe(false);
+  });
+});
 
 describe("resolveSimulationBusyIndicatorState", () => {
   it("prioritizes active simulation recompute over overlay/background work", () => {

--- a/src/lib/simulationBusyIndicator.ts
+++ b/src/lib/simulationBusyIndicator.ts
@@ -20,6 +20,22 @@ export type SimulationBusyIndicatorState = {
   progressPercent: number | null;
 };
 
+export const resolveMonotonicOverlayProgress = (
+  previous: number | null,
+  pipelineProgress: Array<number | null>,
+): number | null => {
+  const numeric = pipelineProgress.filter((value): value is number => typeof value === "number");
+  if (!numeric.length) return null;
+  return Math.max(previous ?? 0, ...numeric);
+};
+
+export const shouldDeferOverlayRasterization = (input: {
+  isTerrainFetching: boolean;
+  isTerrainRecommending: boolean;
+  isSimulationRecomputing: boolean;
+}): boolean =>
+  input.isTerrainFetching || input.isTerrainRecommending || input.isSimulationRecomputing;
+
 export const resolveSimulationBusyIndicatorState = (
   input: SimulationBusyIndicatorInput,
 ): SimulationBusyIndicatorState | null => {

--- a/src/store/appStore.terrainLoading.test.ts
+++ b/src/store/appStore.terrainLoading.test.ts
@@ -80,7 +80,10 @@ describe("appStore GLO-30 terrain lifecycle", () => {
       fetchedTiles: ["N59E009"],
       cacheHits: [],
     });
-    const recompute = vi.spyOn(useCoverageStore.getState(), "recomputeCoverage");
+    const recompute = vi.spyOn(useCoverageStore.getState(), "recomputeCoverage").mockImplementation(() => {
+      expect(useAppStore.getState().isTerrainFetching).toBe(false);
+      expect(useAppStore.getState().srtmTiles.some((entry) => entry.key === "N59E009")).toBe(true);
+    });
 
     await useAppStore.getState().recommendAndFetchTerrainForCurrentArea(20);
 
@@ -90,6 +93,23 @@ describe("appStore GLO-30 terrain lifecycle", () => {
     );
     expect(recompute).toHaveBeenCalledTimes(1);
     expect(useAppStore.getState().terrainProgressPercent).toBe(100);
+  });
+
+  it("recomputes once after an all-unavailable load has settled", async () => {
+    terrainClient.loadCopernicus30TilesByKeys.mockResolvedValue({
+      tiles: [],
+      failedTiles: ["N59E009"],
+      fetchedTiles: [],
+      cacheHits: [],
+    });
+    const recompute = vi.spyOn(useCoverageStore.getState(), "recomputeCoverage").mockImplementation(() => {
+      expect(useAppStore.getState().isTerrainFetching).toBe(false);
+    });
+
+    await useAppStore.getState().recommendAndFetchTerrainForCurrentArea(20);
+
+    expect(recompute).toHaveBeenCalledTimes(1);
+    expect(useAppStore.getState().terrainFetchStatus).toContain("1 unavailable");
   });
 
   it("cancels the active load and ignores its late result", async () => {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -3687,17 +3687,6 @@ export const useAppStore = create<AppState>((set, get) => ({
       });
       if (controller.signal.aborted || get().terrainLoadEpoch !== epoch) return;
 
-      if (result.tiles.length > 0) {
-        set((state) => {
-          const nextTiles = mergeSrtmTiles(state.srtmTiles, result.tiles);
-          return {
-            srtmTiles: nextTiles,
-            terrainMemoryDiagnostics: estimateTerrainMemoryDiagnostics(nextTiles),
-          };
-        });
-        useCoverageStore.getState().recomputeCoverage();
-      }
-
       const parts = [
         `Loaded ${result.tiles.length} tile(s)`,
         result.fetchedTiles.length ? `${result.fetchedTiles.length} fetched` : "",
@@ -3707,18 +3696,25 @@ export const useAppStore = create<AppState>((set, get) => ({
       const missing = result.failedTiles.length
         ? ` Missing: ${result.failedTiles.slice(0, 4).join(", ")}${result.failedTiles.length > 4 ? "..." : ""}`
         : "";
-      set({
-        terrainFetchStatus: `${parts.join(", ")} from Copernicus GLO-30.${missing}`,
-        isTerrainFetching: false,
-        isTerrainRecommending: false,
-        isHighResTerrainLoaded: result.failedTiles.length === 0,
-        terrainLoadingStartedAtMs: 0,
-        terrainProgressPercent: 100,
-        terrainProgressTransientDecodeBytesEstimated: 0,
-        terrainProgressPhaseLabel: "",
-        terrainProgressPhaseIndex: 0,
-        terrainProgressPhaseTotal: 0,
+      set((state) => {
+        const nextTiles =
+          result.tiles.length > 0 ? mergeSrtmTiles(state.srtmTiles, result.tiles) : state.srtmTiles;
+        return {
+          srtmTiles: nextTiles,
+          terrainMemoryDiagnostics: estimateTerrainMemoryDiagnostics(nextTiles),
+          terrainFetchStatus: `${parts.join(", ")} from Copernicus GLO-30.${missing}`,
+          isTerrainFetching: false,
+          isTerrainRecommending: false,
+          isHighResTerrainLoaded: result.failedTiles.length === 0,
+          terrainLoadingStartedAtMs: 0,
+          terrainProgressPercent: 100,
+          terrainProgressTransientDecodeBytesEstimated: 0,
+          terrainProgressPhaseLabel: "",
+          terrainProgressPhaseIndex: 0,
+          terrainProgressPhaseTotal: 0,
+        };
       });
+      useCoverageStore.getState().recomputeCoverage();
     } catch (error) {
       if (controller.signal.aborted || get().terrainLoadEpoch !== epoch) return;
       set({
@@ -3732,6 +3728,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         terrainProgressPhaseIndex: 0,
         terrainProgressPhaseTotal: 0,
       });
+      useCoverageStore.getState().recomputeCoverage();
     } finally {
       if (terrainLoadAbortController === controller) terrainLoadAbortController = null;
     }

--- a/src/store/coverageStore.test.ts
+++ b/src/store/coverageStore.test.ts
@@ -186,29 +186,26 @@ describe("coverageStore simulation progress phases", () => {
     expect(useCoverageStore.getState().calculationCycleSource).toBe(null);
   });
 
-  it("forces 1x simulation resolution while terrain is fetching", async () => {
-    let capturedGridSize = 0;
-    setAppStoreBridge({
-      getState: () =>
-        ({
-          ...bridgeState,
-          selectedCoverageResolution: "168",
-          isTerrainFetching: true,
-        }) as unknown as Record<string, unknown>,
-      setState: vi.fn(),
-    });
-    vi.spyOn(coverageLib, "buildCoverageAsync").mockImplementation((gridSize) => {
-      capturedGridSize = Number(gridSize);
-      return Promise.resolve([]);
-    });
+  it("defers coverage work until terrain loading has settled", async () => {
+    const buildSpy = vi.spyOn(coverageLib, "buildCoverageAsync").mockResolvedValue([]);
+    bridgeState.isTerrainFetching = true;
 
-    useCoverageStore.getState().startManualCalculation();
+    useCoverageStore.getState().recomputeCoverage();
+    vi.advanceTimersByTime(220);
+    await flushAsyncTicks();
+
+    expect(buildSpy).not.toHaveBeenCalled();
+    expect(useCoverageStore.getState().isSimulationRecomputing).toBe(false);
+
+    bridgeState.isTerrainFetching = false;
+    bridgeState.terrainLoadEpoch += 1;
+    useCoverageStore.getState().recomputeCoverage();
     vi.advanceTimersByTime(220);
     await flushAsyncTicks();
     vi.advanceTimersByTime(700);
     await flushAsyncTicks();
 
-    expect(capturedGridSize).toBe(24);
+    expect(buildSpy).toHaveBeenCalledTimes(1);
   });
 
   it("runs as single-flight with one queued rerun under rapid triggers", async () => {

--- a/src/store/coverageStore.ts
+++ b/src/store/coverageStore.ts
@@ -524,6 +524,19 @@ const flushCoverageRunQueue = async (): Promise<void> => {
 
   const appState = appStoreBridge.getState();
   const inputs = readCoverageInputs(appState);
+  if (inputs.isTerrainFetching) {
+    coverageRerunQueued = false;
+    useCoverageStore.setState({
+      isSimulationRecomputing: false,
+      simulationProgress: 0,
+      simulationProgressMode: "indeterminate",
+      simulationStepLabel: "",
+      simulationSamplesDone: 0,
+      simulationSamplesTotal: 0,
+      simulationRunToken: "",
+    });
+    return;
+  }
   const runSignature = coverageInputSignature(inputs);
 
   if (runSignature === lastAppliedCoverageSignature) {


### PR DESCRIPTION
## Summary

- defer coverage calculation while required GLO-30 terrain is loading
- atomically settle terrain state and merge downloaded tiles before requesting one final recompute
- defer coverage and terrain rasterization until calculation inputs are final
- keep the existing combined overlay progress bar monotonic
- preserve final calculation after partial or unavailable terrain while leaving explicit cancellation stopped

## Root cause

The existing scheduler intentionally ran a provisional 1x coverage pass during terrain loading. The simplified #937 loader now applies its full terrain result once at completion, so that provisional pass could reach finalization before being invalidated and restarted. Separately, the shared raster progress used the maximum active pipeline percentage; clearing the leading pipeline could therefore move the displayed value backward.

## User impact

An uncached terrain load now shows terrain progress followed by one definitive simulation calculation and a non-decreasing finalization bar. No new UI was added.

## Verification

- focused coverage/terrain/progress/MapView tests: 36 passed
- `npm test`: 118 files, 633 tests passed
- `npm run build`: passed
- `git diff --check`: passed
- `npm run dev:check`: no LinkSim dev/watch servers found
- version remains `0.23.0`

Addresses #937