### PR TITLE
chore: release 0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.24.0] - 2026-07-29
+
+### Changed
+- Clarified how Private Sites behave inside Shared Simulations with owner/editor disclosure while preserving the Site's Library visibility. (#920)
+- Consolidated browser and calculation-API terrain acquisition around one deterministic GLO-30 pipeline with bounded requests, explicit cancellation, and preserved unavailable-terrain behavior. (#937)
+
+### Fixed
+- Prevented anonymous or unauthorized access to Private Simulations and anonymized their public Stats entries while retaining privacy-safe aggregate contributions. (#931)
+- Removed a self-sustaining Panorama render loop that could make otherwise identical overlay calculations roughly 100 times slower. (#933)
+- Deferred overlay calculation until terrain settles, eliminating duplicate provisional passes and keeping combined terrain/coverage progress monotonic. (#937)
+
 ## [0.23.0] - 2026-07-22
 
 ### Added

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -62,7 +62,7 @@
 
 ## Versioning Policy
 - SemVer is mandatory (`MAJOR.MINOR.PATCH`).
-- Current baseline: `0.23.0`.
+- Current baseline: `0.24.0`.
 - Bump level decision rules:
   - `PATCH` (`0.9.x`): bug fixes, polish, performance tuning, and non-breaking UX behavior fixes.
   - `MINOR` (`0.x.0`): new user-facing features or meaningful workflow additions that are backward-compatible.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linksim",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linksim",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "linksim",
   "private": true,
-  "version": "0.23.0",
+  "version": "0.24.0",
   "license": "GPL-3.0-only",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Prepare LinkSim 0.24.0 from the staging-verified milestone tree.

- bump package and release-flow version metadata from 0.23.0 to 0.24.0
- add human-readable release notes for #920, #931, #933, and #937
- make no application behavior or UI changes

## Release impact

This freezes the tested milestone scope and creates the release candidate that will be automatically deployed to shared staging before production promotion.

## Verification

- [x] `npm test` — 118 files, 633 tests passed
- [x] `npm run build`
- [x] version consistency checks
- [x] `git diff --check`
- [x] Milestone release checklist completed: docs/milestone-release-checklist.md