### PR TITLE
Add drifting cloud loading transition

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -86,6 +86,8 @@ import { StateDot } from "./StateDot";
 import { useMapControls } from "./map/useMapControls";
 import { animateMapToCenter, fitMapToBounds, resolveMapCameraPadding } from "./map/mapCamera";
 import { PanelToolbar } from "./ui/PanelToolbar";
+import { SimulationLoadingOverlay } from "./SimulationLoadingOverlay";
+import { resolveSimulationOverlayTransition } from "../lib/simulationLoadingOverlay";
 
 const UI_SECTION_KEYS = {
   mapViewResults: "linksim-ui-mapview-results-v1",
@@ -180,33 +182,45 @@ const panoramaRayLayer = (color: string): LayerProps => ({
   },
 });
 
-const coverageRasterLayer: LayerProps = {
-  id: "coverage-overlay-layer",
-  type: "raster",
-  paint: {
-    "raster-opacity": 0.68,
-    "raster-contrast": 0.08,
-    "raster-saturation": 0.02,
-  },
+const coverageRasterLayer = (loading: boolean): LayerProps => {
+  const transition = resolveSimulationOverlayTransition(loading);
+  return {
+    id: "coverage-overlay-layer",
+    type: "raster",
+    paint: {
+      "raster-opacity": transition.coverageOpacity,
+      "raster-opacity-transition": {
+        duration: transition.durationMs,
+      },
+      "raster-contrast": 0.08,
+      "raster-saturation": 0.02,
+    },
+  };
 };
 
-const targetContourHaloLayer = (color: string): LayerProps => ({
+const targetContourHaloLayer = (color: string, loading: boolean): LayerProps => ({
   id: "coverage-target-contour-halo-layer",
   type: "line",
   paint: {
     "line-color": color,
     "line-width": 2.5,
-    "line-opacity": 0.82,
+    "line-opacity": loading ? 0 : 0.82,
+    "line-opacity-transition": {
+      duration: resolveSimulationOverlayTransition(loading).durationMs,
+    },
   },
 });
 
-const targetContourLineLayer = (color: string): LayerProps => ({
+const targetContourLineLayer = (color: string, loading: boolean): LayerProps => ({
   id: "coverage-target-contour-line-layer",
   type: "line",
   paint: {
     "line-color": color,
     "line-width": 1.2,
-    "line-opacity": 0.96,
+    "line-opacity": loading ? 0 : 0.96,
+    "line-opacity-transition": {
+      duration: resolveSimulationOverlayTransition(loading).durationMs,
+    },
   },
 });
 
@@ -2290,6 +2304,12 @@ export function MapView({
       terrainProgressTilesTotal,
     ],
   );
+  const simulationLoadingOverlayActive =
+    Boolean(analysisBounds && overlayPointMask) &&
+    (isTerrainFetching || isSimulationRecomputing || overlayJobsInFlight > 0);
+  const simulationOverlayTransition = resolveSimulationOverlayTransition(
+    simulationLoadingOverlayActive,
+  );
   const calculationControlRunning = calculationCycleSource !== null || isSimulationRecomputing;
   const handleStopCalculation = useCallback(() => {
     stopCalculation();
@@ -3756,7 +3776,14 @@ export function MapView({
               type="raster"
               paint={{
                 ...terrainRasterPaint,
-                "raster-opacity": coverageOverlay ? 0.34 : 0.62,
+                "raster-opacity": simulationLoadingOverlayActive
+                  ? 0
+                  : coverageOverlay
+                    ? 0.34
+                    : 0.62,
+                "raster-opacity-transition": {
+                  duration: simulationOverlayTransition.durationMs,
+                },
               }}
             />
           </Source>
@@ -3776,14 +3803,30 @@ export function MapView({
             type="image"
             url={coverageOverlay.url}
           >
-            <Layer {...coverageRasterLayer} />
+            <Layer {...coverageRasterLayer(simulationLoadingOverlayActive)} />
           </Source>
         ) : null}
 
+        <SimulationLoadingOverlay
+          bounds={analysisBounds}
+          loading={simulationLoadingOverlayActive}
+          pointMask={overlayPointMask}
+        />
+
         {showTargetContourLine ? (
           <Source data={targetContourFeatures} id="coverage-target-contour-source" type="geojson">
-            <Layer {...targetContourHaloLayer(variant.cssVars["--bg"] ?? linkColor)} />
-            <Layer {...targetContourLineLayer(variant.cssVars["--muted"] ?? selectedLinkColor)} />
+            <Layer
+              {...targetContourHaloLayer(
+                variant.cssVars["--bg"] ?? linkColor,
+                simulationLoadingOverlayActive,
+              )}
+            />
+            <Layer
+              {...targetContourLineLayer(
+                variant.cssVars["--muted"] ?? selectedLinkColor,
+                simulationLoadingOverlayActive,
+              )}
+            />
           </Source>
         ) : null}
 

--- a/src/components/MapView.userLocation.test.tsx
+++ b/src/components/MapView.userLocation.test.tsx
@@ -61,6 +61,7 @@ vi.mock("react-map-gl/maplibre", async () => {
       return <div>{children}</div>;
     },
     Source: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    useMap: () => ({ current: undefined }),
   };
 });
 

--- a/src/components/SimulationLoadingOverlay.test.tsx
+++ b/src/components/SimulationLoadingOverlay.test.tsx
@@ -1,0 +1,182 @@
+// @vitest-environment jsdom
+import { act, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mapMock = vi.hoisted(() => {
+  const state = {
+    layerPresent: false,
+    sourcePresent: false,
+  };
+  const source = {
+    setCoordinates: vi.fn(),
+  };
+  const map = {
+    addLayer: vi.fn(() => {
+      state.layerPresent = true;
+    }),
+    addSource: vi.fn(() => {
+      state.sourcePresent = true;
+    }),
+    getLayer: vi.fn(() => (state.layerPresent ? {} : undefined)),
+    getSource: vi.fn(() => (state.sourcePresent ? source : undefined)),
+    isStyleLoaded: vi.fn(() => true),
+    off: vi.fn(),
+    on: vi.fn(),
+    removeLayer: vi.fn(() => {
+      state.layerPresent = false;
+    }),
+    removeSource: vi.fn(() => {
+      state.sourcePresent = false;
+    }),
+    setPaintProperty: vi.fn(),
+  };
+  return { map, source, state };
+});
+
+vi.mock("react-map-gl/maplibre", () => ({
+  useMap: () => ({
+    current: {
+      getMap: () => mapMock.map,
+    },
+  }),
+}));
+
+import { SimulationLoadingOverlay } from "./SimulationLoadingOverlay";
+
+const bounds = {
+  minLat: 59.7,
+  maxLat: 60.1,
+  minLon: 10.4,
+  maxLon: 11.2,
+};
+
+describe("SimulationLoadingOverlay", () => {
+  const putImageData = vi.fn();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mapMock.state.layerPresent = false;
+    mapMock.state.sourcePresent = false;
+    Object.values(mapMock.map).forEach((value) => {
+      if (typeof value === "function" && "mockClear" in value) {
+        value.mockClear();
+      }
+    });
+    mapMock.source.setCoordinates.mockClear();
+    putImageData.mockClear();
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      (callback: FrameRequestCallback) =>
+        window.setTimeout(() => callback(performance.now()), 16),
+    );
+    vi.stubGlobal("cancelAnimationFrame", (id: number) =>
+      window.clearTimeout(id),
+    );
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    );
+    Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
+      configurable: true,
+      value: vi.fn(() => ({
+        createImageData: (width: number, height: number) => ({
+          data: new Uint8ClampedArray(width * height * 4),
+          width,
+          height,
+        }),
+        putImageData,
+      })),
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("crossfades into clouds and keeps them mounted through the exit transition", () => {
+    const { rerender } = render(
+      <SimulationLoadingOverlay
+        bounds={bounds}
+        loading
+        pointMask={() => true}
+      />,
+    );
+
+    expect(mapMock.map.addSource).toHaveBeenCalledTimes(1);
+    expect(mapMock.map.addLayer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        paint: expect.objectContaining({
+          "raster-opacity": 0,
+        }),
+      }),
+    );
+
+    act(() => vi.advanceTimersByTime(16));
+
+    expect(mapMock.map.setPaintProperty).toHaveBeenCalledWith(
+      "simulation-loading-overlay-layer",
+      "raster-opacity-transition",
+      { duration: 350 },
+    );
+    expect(mapMock.map.setPaintProperty).toHaveBeenCalledWith(
+      "simulation-loading-overlay-layer",
+      "raster-opacity",
+      0.68,
+    );
+
+    rerender(
+      <SimulationLoadingOverlay
+        bounds={bounds}
+        loading={false}
+        pointMask={() => true}
+      />,
+    );
+
+    expect(mapMock.map.setPaintProperty).toHaveBeenCalledWith(
+      "simulation-loading-overlay-layer",
+      "raster-opacity-transition",
+      { duration: 500 },
+    );
+    expect(mapMock.map.setPaintProperty).toHaveBeenCalledWith(
+      "simulation-loading-overlay-layer",
+      "raster-opacity",
+      0,
+    );
+
+    act(() => vi.advanceTimersByTime(499));
+    expect(mapMock.map.removeLayer).not.toHaveBeenCalled();
+    act(() => vi.advanceTimersByTime(1));
+    expect(mapMock.map.removeLayer).toHaveBeenCalledWith(
+      "simulation-loading-overlay-layer",
+    );
+    expect(mapMock.map.removeSource).toHaveBeenCalledWith(
+      "simulation-loading-overlay-source",
+    );
+  });
+
+  it("renders one static cloud frame for reduced motion", () => {
+    vi.mocked(window.matchMedia).mockReturnValue({
+      matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    } as unknown as MediaQueryList);
+
+    render(
+      <SimulationLoadingOverlay
+        bounds={bounds}
+        loading
+        pointMask={() => true}
+      />,
+    );
+
+    act(() => vi.advanceTimersByTime(16));
+    expect(putImageData).toHaveBeenCalledTimes(1);
+    act(() => vi.advanceTimersByTime(500));
+    expect(putImageData).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/SimulationLoadingOverlay.tsx
+++ b/src/components/SimulationLoadingOverlay.tsx
@@ -1,0 +1,253 @@
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useMap } from "react-map-gl/maplibre";
+import type { CanvasSource } from "maplibre-gl";
+import type { TerrainBounds } from "../lib/overlayRaster";
+import {
+  buildDriftingCloudPixels,
+  loadingOverlayCoordinates,
+  LOADING_OVERLAY_EXIT_MS,
+  resolveDriftingCloudPhase,
+  resolveLoadingOverlayDimensions,
+  resolveSimulationOverlayTransition,
+} from "../lib/simulationLoadingOverlay";
+
+const CLOUD_FRAME_INTERVAL_MS = 50;
+const SOURCE_ID = "simulation-loading-overlay-source";
+const LAYER_ID = "simulation-loading-overlay-layer";
+
+type SimulationLoadingOverlayProps = {
+  bounds: TerrainBounds | null;
+  loading: boolean;
+  pointMask?: (lat: number, lon: number) => boolean;
+};
+
+const usePrefersReducedMotion = (): boolean => {
+  const [reducedMotion, setReducedMotion] = useState(
+    () =>
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+  );
+
+  useEffect(() => {
+    if (typeof window.matchMedia !== "function") return;
+    const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const update = () => setReducedMotion(query.matches);
+    query.addEventListener("change", update);
+    return () => query.removeEventListener("change", update);
+  }, []);
+
+  return reducedMotion;
+};
+
+export function SimulationLoadingOverlay({
+  bounds,
+  loading,
+  pointMask,
+}: SimulationLoadingOverlayProps) {
+  const canvas = useMemo(() => document.createElement("canvas"), []);
+  const { current: mapRef } = useMap();
+  const map = mapRef?.getMap();
+  const reducedMotion = usePrefersReducedMotion();
+  const ready = Boolean(bounds && pointMask);
+  const addingToMapRef = useRef(false);
+  const removalTimeoutRef = useRef<number | null>(null);
+  const fadeInFrameRef = useRef<number | null>(null);
+  const coordinates = useMemo(
+    () => (bounds ? loadingOverlayCoordinates(bounds) : null),
+    [bounds],
+  );
+
+  useEffect(() => {
+    if (!loading || !bounds || !pointMask) return;
+    const dimensions = resolveLoadingOverlayDimensions(bounds);
+    canvas.width = dimensions.width;
+    canvas.height = dimensions.height;
+    const context = canvas.getContext("2d");
+    if (!context) return;
+
+    const startedAt = performance.now();
+    let frameId = 0;
+    let lastPaintAt = Number.NEGATIVE_INFINITY;
+    const paint = (timestamp: number) => {
+      if (
+        reducedMotion ||
+        timestamp - lastPaintAt >= CLOUD_FRAME_INTERVAL_MS
+      ) {
+        const frame = buildDriftingCloudPixels({
+          bounds,
+          width: dimensions.width,
+          height: dimensions.height,
+          phase: resolveDriftingCloudPhase(
+            timestamp - startedAt,
+            reducedMotion,
+          ),
+          pointMask,
+        });
+        const image = context.createImageData(frame.width, frame.height);
+        image.data.set(frame.pixels);
+        context.putImageData(image, 0, 0);
+        lastPaintAt = timestamp;
+      }
+      if (!reducedMotion) {
+        frameId = window.requestAnimationFrame(paint);
+      }
+    };
+
+    frameId = window.requestAnimationFrame(paint);
+    return () => window.cancelAnimationFrame(frameId);
+  }, [bounds, canvas, loading, pointMask, reducedMotion]);
+
+  useEffect(() => {
+    if (!map) return;
+
+    const removeFromMap = () => {
+      if (map.getLayer(LAYER_ID)) map.removeLayer(LAYER_ID);
+      if (map.getSource(SOURCE_ID)) map.removeSource(SOURCE_ID);
+    };
+    const clearPendingRemoval = () => {
+      if (removalTimeoutRef.current !== null) {
+        window.clearTimeout(removalTimeoutRef.current);
+        removalTimeoutRef.current = null;
+      }
+    };
+    const clearPendingFadeIn = () => {
+      if (fadeInFrameRef.current !== null) {
+        window.cancelAnimationFrame(fadeInFrameRef.current);
+        fadeInFrameRef.current = null;
+      }
+    };
+    const applyTransition = (entering: boolean) => {
+      if (!map.getLayer(LAYER_ID)) return;
+      const transition = resolveSimulationOverlayTransition(entering);
+      map.setPaintProperty(LAYER_ID, "raster-opacity-transition", {
+        duration: transition.durationMs,
+      });
+      map.setPaintProperty(
+        LAYER_ID,
+        "raster-opacity",
+        transition.loadingOpacity,
+      );
+    };
+
+    const addToMap = () => {
+      if (addingToMapRef.current) return;
+      if (!coordinates || !map.isStyleLoaded()) return;
+      if (map.getSource(SOURCE_ID) && map.getLayer(LAYER_ID)) return;
+      addingToMapRef.current = true;
+      try {
+        if (!map.getSource(SOURCE_ID)) {
+          map.addSource(SOURCE_ID, {
+            animate: true,
+            canvas,
+            coordinates,
+            type: "canvas",
+          });
+        }
+        if (!map.getLayer(LAYER_ID)) {
+          const transition = resolveSimulationOverlayTransition(false);
+          map.addLayer({
+            id: LAYER_ID,
+            paint: {
+              "raster-opacity": transition.loadingOpacity,
+              "raster-opacity-transition": {
+                duration: transition.durationMs,
+              },
+            },
+            source: SOURCE_ID,
+            type: "raster",
+          });
+        }
+        applyTransition(true);
+      } finally {
+        addingToMapRef.current = false;
+      }
+    };
+
+    clearPendingRemoval();
+    clearPendingFadeIn();
+
+    if (!ready || !coordinates) {
+      removeFromMap();
+      return;
+    }
+
+    if (!loading) {
+      applyTransition(false);
+      removalTimeoutRef.current = window.setTimeout(() => {
+        removeFromMap();
+        removalTimeoutRef.current = null;
+      }, LOADING_OVERLAY_EXIT_MS);
+      return clearPendingRemoval;
+    }
+
+    const addAfterStyleChange = () => addToMap();
+    map.on("styledata", addAfterStyleChange);
+
+    if (map.isStyleLoaded()) {
+      addingToMapRef.current = true;
+      try {
+        if (!map.getSource(SOURCE_ID)) {
+          map.addSource(SOURCE_ID, {
+            animate: true,
+            canvas,
+            coordinates,
+            type: "canvas",
+          });
+        }
+        if (!map.getLayer(LAYER_ID)) {
+          const transition = resolveSimulationOverlayTransition(false);
+          map.addLayer({
+            id: LAYER_ID,
+            paint: {
+              "raster-opacity": transition.loadingOpacity,
+              "raster-opacity-transition": {
+                duration: transition.durationMs,
+              },
+            },
+            source: SOURCE_ID,
+            type: "raster",
+          });
+        }
+      } finally {
+        addingToMapRef.current = false;
+      }
+      fadeInFrameRef.current = window.requestAnimationFrame(() => {
+        fadeInFrameRef.current = null;
+        applyTransition(true);
+      });
+    }
+
+    return () => {
+      map.off("styledata", addAfterStyleChange);
+      clearPendingFadeIn();
+    };
+  }, [canvas, coordinates, loading, map, ready]);
+
+  useEffect(() => {
+    if (!map || !loading || !coordinates) return;
+    const source = map.getSource(SOURCE_ID) as CanvasSource | undefined;
+    source?.setCoordinates(coordinates);
+  }, [coordinates, loading, map]);
+
+  useEffect(() => {
+    if (!map) return;
+    return () => {
+      if (removalTimeoutRef.current !== null) {
+        window.clearTimeout(removalTimeoutRef.current);
+      }
+      if (fadeInFrameRef.current !== null) {
+        window.cancelAnimationFrame(fadeInFrameRef.current);
+      }
+      if (map.getLayer(LAYER_ID)) map.removeLayer(LAYER_ID);
+      if (map.getSource(SOURCE_ID)) map.removeSource(SOURCE_ID);
+    };
+  }, [map]);
+
+  return null;
+}

--- a/src/lib/simulationLoadingOverlay.test.ts
+++ b/src/lib/simulationLoadingOverlay.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDriftingCloudPixels,
+  loadingOverlayCoordinates,
+  resolveDriftingCloudPhase,
+  resolveLoadingOverlayDimensions,
+  resolveSimulationOverlayTransition,
+} from "./simulationLoadingOverlay";
+
+const bounds = {
+  minLat: 59.7,
+  maxLat: 60.1,
+  minLon: 10.4,
+  maxLon: 11.2,
+};
+
+describe("simulation loading overlay", () => {
+  it("uses the same geographic corner order as the finished image overlay", () => {
+    expect(loadingOverlayCoordinates(bounds)).toEqual([
+      [10.4, 60.1],
+      [11.2, 60.1],
+      [11.2, 59.7],
+      [10.4, 59.7],
+    ]);
+  });
+
+  it("keeps the animated canvas bounded while preserving the geographic aspect ratio", () => {
+    expect(resolveLoadingOverlayDimensions(bounds)).toEqual({
+      width: 192,
+      height: 191,
+    });
+    expect(
+      resolveLoadingOverlayDimensions({
+        minLat: 59,
+        maxLat: 61,
+        minLon: 10,
+        maxLon: 10.25,
+      }),
+    ).toEqual({
+      width: 48,
+      height: 192,
+    });
+  });
+
+  it("clips every animated pixel through the finished overlay point mask", () => {
+    const pointMask = (lat: number, lon: number) => lat >= 59.85 && lon <= 10.8;
+    const frame = buildDriftingCloudPixels({
+      bounds,
+      width: 8,
+      height: 6,
+      phase: 0.75,
+      pointMask,
+    });
+
+    for (let row = 0; row < frame.height; row += 1) {
+      for (let column = 0; column < frame.width; column += 1) {
+        const offset = (row * frame.width + column) * 4;
+        const lat = frame.latByRow[row];
+        const lon = frame.lonByColumn[column];
+        const alpha = frame.pixels[offset + 3];
+        expect(alpha > 0).toBe(pointMask(lat, lon));
+      }
+    }
+  });
+
+  it("freezes the cloud field for reduced motion", () => {
+    expect(resolveDriftingCloudPhase(4_250, true)).toBe(0);
+    expect(resolveDriftingCloudPhase(0, false)).toBe(0);
+    expect(resolveDriftingCloudPhase(2_400, false)).toBeCloseTo(Math.PI * 2);
+  });
+
+  it("crossfades the completed overlay fully into and back out of the clouds", () => {
+    expect(resolveSimulationOverlayTransition(true)).toEqual({
+      coverageOpacity: 0,
+      loadingOpacity: 0.68,
+      durationMs: 350,
+    });
+    expect(resolveSimulationOverlayTransition(false)).toEqual({
+      coverageOpacity: 0.68,
+      loadingOpacity: 0,
+      durationMs: 500,
+    });
+  });
+});

--- a/src/lib/simulationLoadingOverlay.ts
+++ b/src/lib/simulationLoadingOverlay.ts
@@ -1,0 +1,169 @@
+import { latitudeForRasterRow, type TerrainBounds } from "./overlayRaster";
+import { interpolateHeatmapColor } from "../themes/heatmapColors";
+
+const MAX_CANVAS_DIMENSION = 192;
+const MIN_CANVAS_DIMENSION = 48;
+const CLOUD_CYCLE_MS = 2_400;
+const CLOUD_ALPHA = 178;
+export const LOADING_OVERLAY_EXIT_MS = 500;
+
+export type LoadingOverlayCoordinates = [
+  [number, number],
+  [number, number],
+  [number, number],
+  [number, number],
+];
+
+export type DriftingCloudFrame = {
+  width: number;
+  height: number;
+  pixels: Uint8ClampedArray;
+  latByRow: Float64Array;
+  lonByColumn: Float64Array;
+};
+
+export type DriftingCloudFrameInput = {
+  bounds: TerrainBounds;
+  width: number;
+  height: number;
+  phase: number;
+  pointMask: (lat: number, lon: number) => boolean;
+};
+
+export type SimulationOverlayTransition = {
+  coverageOpacity: number;
+  loadingOpacity: number;
+  durationMs: number;
+};
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.max(min, Math.min(max, value));
+
+const mercatorYDegrees = (lat: number): number => {
+  const normalized = clamp(lat, -85.05112878, 85.05112878);
+  const radians = (normalized * Math.PI) / 180;
+  return (Math.log(Math.tan(Math.PI / 4 + radians / 2)) * 180) / Math.PI;
+};
+
+export const loadingOverlayCoordinates = (
+  bounds: TerrainBounds,
+): LoadingOverlayCoordinates => [
+  [bounds.minLon, bounds.maxLat],
+  [bounds.maxLon, bounds.maxLat],
+  [bounds.maxLon, bounds.minLat],
+  [bounds.minLon, bounds.minLat],
+];
+
+export const resolveLoadingOverlayDimensions = (
+  bounds: TerrainBounds,
+): { width: number; height: number } => {
+  const lonSpan = Math.max(1e-6, Math.abs(bounds.maxLon - bounds.minLon));
+  const mercatorLatSpan = Math.max(
+    1e-6,
+    Math.abs(mercatorYDegrees(bounds.maxLat) - mercatorYDegrees(bounds.minLat)),
+  );
+  const aspectRatio = lonSpan / mercatorLatSpan;
+  if (aspectRatio >= 1) {
+    return {
+      width: MAX_CANVAS_DIMENSION,
+      height: clamp(
+        Math.round(MAX_CANVAS_DIMENSION / aspectRatio),
+        MIN_CANVAS_DIMENSION,
+        MAX_CANVAS_DIMENSION,
+      ),
+    };
+  }
+  return {
+    width: clamp(
+      Math.round(MAX_CANVAS_DIMENSION * aspectRatio),
+      MIN_CANVAS_DIMENSION,
+      MAX_CANVAS_DIMENSION,
+    ),
+    height: MAX_CANVAS_DIMENSION,
+  };
+};
+
+export const resolveDriftingCloudPhase = (
+  elapsedMs: number,
+  reducedMotion: boolean,
+): number => {
+  if (reducedMotion) return 0;
+  return (Math.max(0, elapsedMs) / CLOUD_CYCLE_MS) * Math.PI * 2;
+};
+
+export const resolveSimulationOverlayTransition = (
+  loading: boolean,
+): SimulationOverlayTransition =>
+  loading
+    ? {
+        coverageOpacity: 0,
+        loadingOpacity: 0.68,
+        durationMs: 350,
+      }
+    : {
+        coverageOpacity: 0.68,
+        loadingOpacity: 0,
+        durationMs: LOADING_OVERLAY_EXIT_MS,
+      };
+
+const cloudStrength = (x: number, y: number, phase: number): number => {
+  const broad =
+    Math.sin(x * 6.1 + phase) * 0.17 +
+    Math.cos(y * 7.4 - phase * 0.72) * 0.14;
+  const diagonal =
+    Math.sin((x + y) * 5.2 + phase * 0.43) * 0.11 +
+    Math.cos((x - y) * 8.3 - phase * 0.31) * 0.08;
+  return clamp(0.58 + broad + diagonal, 0, 1);
+};
+
+export const buildDriftingCloudPixels = (
+  input: DriftingCloudFrameInput,
+): DriftingCloudFrame => {
+  const width = Math.max(1, Math.round(input.width));
+  const height = Math.max(1, Math.round(input.height));
+  const pixels = new Uint8ClampedArray(width * height * 4);
+  const latByRow = new Float64Array(height);
+  const lonByColumn = new Float64Array(width);
+  const lonSpan = input.bounds.maxLon - input.bounds.minLon;
+  const widthDivisor = Math.max(1, width - 1);
+  const heightDivisor = Math.max(1, height - 1);
+
+  for (let row = 0; row < height; row += 1) {
+    latByRow[row] = latitudeForRasterRow(
+      row,
+      height,
+      input.bounds.minLat,
+      input.bounds.maxLat,
+    );
+  }
+  for (let column = 0; column < width; column += 1) {
+    lonByColumn[column] =
+      input.bounds.minLon + lonSpan * (column / widthDivisor);
+  }
+
+  for (let row = 0; row < height; row += 1) {
+    const lat = latByRow[row];
+    const y = row / heightDivisor;
+    for (let column = 0; column < width; column += 1) {
+      const lon = lonByColumn[column];
+      if (!input.pointMask(lat, lon)) continue;
+      const x = column / widthDivisor;
+      const color = interpolateHeatmapColor(
+        cloudStrength(x, y, input.phase),
+      );
+      const offset = (row * width + column) * 4;
+      pixels[offset] = color.r;
+      pixels[offset + 1] = color.g;
+      pixels[offset + 2] = color.b;
+      pixels[offset + 3] = CLOUD_ALPHA;
+    }
+  }
+
+  return {
+    width,
+    height,
+    pixels,
+    latByRow,
+    lonByColumn,
+  };
+};


### PR DESCRIPTION
## Summary
- render the selected drifting-cloud loading treatment with LinkSim’s existing heatmap palette
- clip the animation with the existing exact simulation mask for single-site, corridor, and hull geometry
- crossfade the previous overlay fully into loading, then loading into the new overlay
- honor reduced motion with a single static heatmap wash

## Verification before staging
- `npm test` — 120 files / 640 tests passed
- `npm run build` — passed
- changed support files pass ESLint
- `git diff --check` — passed

Repository-wide `npm run lint` was run and remains red on existing lint debt, including files under `.claude/worktrees`; no new loading-overlay lint findings remain. Acceptance testing will be performed on the shared staging deployment after merge.

Relates to #943