### PR TITLE
Fix sync indicator state messaging

### DIFF
--- a/src/lib/syncIndicator.test.ts
+++ b/src/lib/syncIndicator.test.ts
@@ -2,34 +2,136 @@ import { describe, expect, it } from "vitest";
 import { deriveSyncIndicator } from "./syncIndicator";
 
 describe("deriveSyncIndicator", () => {
-  it("returns error (red) when sync status is error even if pending is true", () => {
-    const indicator = deriveSyncIndicator({
-      isLocalRuntime: false,
-      isOnline: true,
-      authState: "signed_in",
-      syncStatus: "error",
-      syncPending: true,
-      pendingChangesCount: 3,
-      syncErrorMessage: "401 Unauthorized",
-      lastSyncedAt: null,
-    });
-    expect(indicator.state).toBe("error");
-    expect(indicator.className).toBe("sync-error");
-  });
+  const lastSyncedAt = "2026-07-29T10:42:40.000Z";
+  const lastSyncedTime = new Date(lastSyncedAt).toLocaleTimeString();
+  const baseInput: Parameters<typeof deriveSyncIndicator>[0] = {
+    isLocalRuntime: false,
+    isOnline: true,
+    authState: "signed_in",
+    syncStatus: "synced",
+    syncPending: false,
+    pendingChangesCount: 0,
+    syncErrorMessage: null,
+    lastSyncedAt: null,
+  };
 
-  it("returns error (red) when auth state is signed_out", () => {
-    const indicator = deriveSyncIndicator({
-      isLocalRuntime: false,
-      isOnline: true,
-      authState: "signed_out",
-      syncStatus: "synced",
-      syncPending: true,
-      pendingChangesCount: 2,
-      syncErrorMessage: null,
-      lastSyncedAt: null,
-    });
-    expect(indicator.state).toBe("error");
-    expect(indicator.label).toBe("Sync failed");
-    expect(indicator.title).toContain("Not signed in");
+  it.each([
+    {
+      name: "local mode overrides cloud state",
+      input: {
+        isLocalRuntime: true,
+        isOnline: false,
+        authState: "signed_out" as const,
+        syncStatus: "error" as const,
+        syncPending: true,
+        pendingChangesCount: 3,
+      },
+      expected: {
+        state: "local",
+        className: "sync-local",
+        label: "Local mode",
+        title: "Local mode - no cloud sync available",
+      },
+    },
+    {
+      name: "offline state reports plural pending changes",
+      input: {
+        isOnline: false,
+        authState: "signed_out" as const,
+        syncStatus: "error" as const,
+        syncPending: true,
+        pendingChangesCount: 2,
+      },
+      expected: {
+        state: "offline",
+        className: "sync-offline",
+        label: "Offline",
+        title: "Offline. 2 pending changes. Open Sync Status for details.",
+      },
+    },
+    {
+      name: "signed-out state reports unavailable cloud sync",
+      input: {
+        authState: "signed_out" as const,
+        syncPending: true,
+        pendingChangesCount: 1,
+      },
+      expected: {
+        state: "error",
+        className: "sync-error",
+        label: "Sync failed",
+        title: "Not signed in; cloud sync unavailable. Sign in and open Sync Status to recover pending changes.",
+      },
+    },
+    {
+      name: "sync error overrides pending and keeps last-sync context",
+      input: {
+        syncStatus: "error" as const,
+        syncPending: true,
+        pendingChangesCount: 3,
+        syncErrorMessage: "401 Unauthorized",
+        lastSyncedAt,
+      },
+      expected: {
+        state: "error",
+        className: "sync-error",
+        label: "Sync failed",
+        title: `Sync failed. Last synced: ${lastSyncedTime}. 401 Unauthorized`,
+      },
+    },
+    {
+      name: "pending state reports a singular change and last-sync context",
+      input: {
+        syncPending: true,
+        pendingChangesCount: 1,
+        lastSyncedAt,
+      },
+      expected: {
+        state: "pending",
+        className: "sync-pending",
+        label: "Sync pending",
+        title: `Sync pending. Last synced: ${lastSyncedTime}. 1 pending change.`,
+      },
+    },
+    {
+      name: "pending state reports that no sync has completed yet",
+      input: {
+        syncPending: true,
+        pendingChangesCount: 2,
+      },
+      expected: {
+        state: "pending",
+        className: "sync-pending",
+        label: "Sync pending",
+        title: "Sync pending. Last synced: Never. 2 pending changes.",
+      },
+    },
+    {
+      name: "syncing state leads with its current state",
+      input: {
+        syncStatus: "syncing" as const,
+        lastSyncedAt,
+      },
+      expected: {
+        state: "syncing",
+        className: "sync-syncing",
+        label: "Syncing...",
+        title: `Syncing... Last synced: ${lastSyncedTime}.`,
+      },
+    },
+    {
+      name: "synced state remains up to date",
+      input: {
+        lastSyncedAt,
+      },
+      expected: {
+        state: "synced",
+        className: "sync-synced",
+        label: "Up to date",
+        title: `Up to date (synced ${lastSyncedTime}). Click for details.`,
+      },
+    },
+  ])("$name", ({ input, expected }) => {
+    expect(deriveSyncIndicator({ ...baseInput, ...input })).toEqual(expected);
   });
 });

--- a/src/lib/syncIndicator.ts
+++ b/src/lib/syncIndicator.ts
@@ -19,8 +19,14 @@ type Input = {
 };
 
 export const deriveSyncIndicator = (input: Input): SyncIndicator => {
-  const timeLabel = input.lastSyncedAt
-    ? `Up to date (synced ${new Date(input.lastSyncedAt).toLocaleTimeString()})`
+  const lastSyncedTime = input.lastSyncedAt
+    ? new Date(input.lastSyncedAt).toLocaleTimeString()
+    : null;
+  const lastSyncLabel = lastSyncedTime
+    ? `Last synced: ${lastSyncedTime}`
+    : "Last synced: Never";
+  const upToDateLabel = lastSyncedTime
+    ? `Up to date (synced ${lastSyncedTime})`
     : "Up to date";
 
   if (input.isLocalRuntime) {
@@ -50,7 +56,7 @@ export const deriveSyncIndicator = (input: Input): SyncIndicator => {
       state: "error",
       className: "sync-error",
       label: "Sync failed",
-      title: `${timeLabel}. ${input.syncErrorMessage ?? "Open Sync Status for details."}`,
+      title: `Sync failed. ${lastSyncLabel}. ${input.syncErrorMessage ?? "Open Sync Status for details."}`,
     };
   }
 
@@ -59,16 +65,16 @@ export const deriveSyncIndicator = (input: Input): SyncIndicator => {
       state: "pending",
       className: "sync-pending",
       label: "Sync pending",
-      title: `${timeLabel}. ${input.pendingChangesCount} pending change${input.pendingChangesCount === 1 ? "" : "s"}.`,
+      title: `Sync pending. ${lastSyncLabel}. ${input.pendingChangesCount} pending change${input.pendingChangesCount === 1 ? "" : "s"}.`,
     };
   }
 
   switch (input.syncStatus) {
     case "syncing":
-      return { state: "syncing", className: "sync-syncing", label: "Syncing...", title: timeLabel };
+      return { state: "syncing", className: "sync-syncing", label: "Syncing...", title: `Syncing... ${lastSyncLabel}.` };
     case "synced":
-      return { state: "synced", className: "sync-synced", label: "Up to date", title: `${timeLabel}. Click for details.` };
+      return { state: "synced", className: "sync-synced", label: "Up to date", title: `${upToDateLabel}. Click for details.` };
     default:
-      return { state: "synced", className: "sync-synced", label: "Up to date", title: `${timeLabel}. Click for details.` };
+      return { state: "synced", className: "sync-synced", label: "Up to date", title: `${upToDateLabel}. Click for details.` };
   }
 };


### PR DESCRIPTION
## Summary

- make pending, syncing, and failed compact sync tooltips lead with their current state
- retain the last successful sync time as neutral historical context
- expand `deriveSyncIndicator` coverage to the full state matrix

## Root cause

The shared tooltip time label always began with `Up to date`, even when the current indicator state was pending, syncing, or failed.

## User impact

The compact indicator's accessible label, icon state, and tooltip now communicate the same current sync state. No UI elements, public APIs, or version numbers change.

## Verification

- `npm run test -- --run src/lib/syncIndicator.test.ts` (8 passed)
- `npm test` (646 passed)
- `npm run build`
- `git diff --check`
- `npm run dev:check` (no LinkSim dev/watch servers found)

Closes #935