### PR TITLE
Fix guest auth recovery

### DIFF
--- a/functions/api/deep-link-status.test.ts
+++ b/functions/api/deep-link-status.test.ts
@@ -41,19 +41,53 @@ describe("api/deep-link-status", () => {
     verifyAuthMock.mockResolvedValueOnce(null);
     const res = await onRequestGet(mkCtx(new Request("https://example.test/api/deep-link-status?sim=sim-1")));
     expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      status: "ok",
+      simulationId: "sim-1",
+      authenticated: false,
+      authState: "guest",
+    });
   });
 
   it("returns missing when simulation id is missing", async () => {
     const res = await onRequestGet(mkCtx(new Request("https://example.test/api/deep-link-status")));
     expect(res.status).toBe(200);
-    await expect(res.json()).resolves.toEqual({ status: "missing", authenticated: true });
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    await expect(res.json()).resolves.toEqual({
+      status: "missing",
+      authenticated: true,
+      authState: "authenticated",
+    });
+  });
+
+  it("reports revoked sessions separately from expected guests", async () => {
+    fetchUserProfileMock.mockResolvedValueOnce({
+      id: "u1",
+      isAdmin: false,
+      isModerator: false,
+      accountState: "revoked",
+    });
+
+    const res = await onRequestGet(mkCtx(new Request("https://example.test/api/deep-link-status")));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      status: "missing",
+      authenticated: false,
+      authState: "revoked",
+    });
   });
 
   it("returns access status for simulation id", async () => {
     resolveSimulationAccessForUserMock.mockResolvedValueOnce("forbidden");
     const res = await onRequestGet(mkCtx(new Request("https://example.test/api/deep-link-status?sim=sim-2")));
     expect(res.status).toBe(200);
-    await expect(res.json()).resolves.toEqual({ status: "forbidden", simulationId: "sim-2", authenticated: true });
+    await expect(res.json()).resolves.toEqual({
+      status: "forbidden",
+      simulationId: "sim-2",
+      authenticated: true,
+      authState: "authenticated",
+    });
   });
 
   it("resolves username-scoped slug to simulation id", async () => {
@@ -61,6 +95,11 @@ describe("api/deep-link-status", () => {
     const res = await onRequestGet(mkCtx(new Request("https://example.test/api/deep-link-status?username=Owner&slug=my-sim")));
     expect(res.status).toBe(200);
     expect(resolveSimulationIdByOwnerSlugMock).toHaveBeenCalledWith(expect.anything(), "Owner", "my-sim");
-    await expect(res.json()).resolves.toEqual({ status: "ok", simulationId: "sim-abc", authenticated: true });
+    await expect(res.json()).resolves.toEqual({
+      status: "ok",
+      simulationId: "sim-abc",
+      authenticated: true,
+      authState: "authenticated",
+    });
   });
 });

--- a/functions/api/deep-link-status.ts
+++ b/functions/api/deep-link-status.ts
@@ -5,16 +5,22 @@ import type { Env } from "../_lib/types";
 
 export const onRequestOptions: PagesFunction<Env> = async ({ request }) => handleOptions(request);
 
+const NO_STORE_HEADERS = { "cache-control": "no-store" };
+
 export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
   try {
     const auth = await verifyAuth(request, env);
     let actor = { id: "", isAdmin: false, isModerator: false };
     let authenticated = false;
+    let authState: "guest" | "authenticated" | "revoked" = "guest";
     if (auth) {
       await ensureUser(env, auth.userId, auth.tokenPayload);
       const me = await fetchUserProfile(env, auth.userId);
-      if (me?.accountState !== "revoked") {
+      if (me?.accountState === "revoked") {
+        authState = "revoked";
+      } else {
         authenticated = true;
+        authState = "authenticated";
         actor = {
           id: me?.id ?? "",
           isAdmin: Boolean(me?.isAdmin),
@@ -31,7 +37,7 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
       simulationId = (await resolveSimulationIdByOwnerSlug(env, username, simulationSlug)) ?? "";
     }
     if (!simulationId) {
-      return withCors(request, json({ status: "missing", authenticated }));
+      return withCors(request, json({ status: "missing", authenticated, authState }, { headers: NO_STORE_HEADERS }));
     }
 
     const status = await resolveSimulationAccessForUser(
@@ -44,7 +50,10 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
       simulationId,
     );
 
-    return withCors(request, json({ status, simulationId, authenticated }));
+    return withCors(
+      request,
+      json({ status, simulationId, authenticated, authState }, { headers: NO_STORE_HEADERS }),
+    );
   } catch (error) {
     return errorResponse(request, error, 500);
   }

--- a/src/components/AppShell.deeplink.test.ts
+++ b/src/components/AppShell.deeplink.test.ts
@@ -246,6 +246,7 @@ describe("AppShell deeplink cold-load flow", () => {
       status: "ok",
       simulationId: "sim-mmtk88wx-2didtk",
       authenticated: true,
+      authState: "authenticated",
     });
     hoisted.fetchCloudLibrary.mockResolvedValue({
       siteLibrary: [],
@@ -336,13 +337,14 @@ describe("AppShell deeplink cold-load flow", () => {
 
       expect(hoisted.fetchMe).toHaveBeenCalledTimes(2);
       expect(document.body.textContent).not.toContain("Cloud save is unavailable");
+      expect(localStorage.getItem("linksim:had-authenticated-session:v1")).toBe("1");
     } finally {
       unmountAppShell(view);
       vi.useRealTimers();
     }
   });
 
-  it("uses quick retries before falling back to the steady retry interval", async () => {
+  it("stops after the bounded quick retry sequence", async () => {
     vi.useFakeTimers();
     window.history.replaceState(null, "", "/");
     hoisted.fetchMe.mockRejectedValue(new Error("524 : server timed out"));
@@ -364,11 +366,10 @@ describe("AppShell deeplink cold-load flow", () => {
       await advanceTimers(10_000);
       expect(hoisted.fetchMe).toHaveBeenCalledTimes(4);
 
-      await advanceTimers(59_999);
+      await advanceTimers(120_000);
       expect(hoisted.fetchMe).toHaveBeenCalledTimes(4);
-
-      await advanceTimers(1);
-      expect(hoisted.fetchMe).toHaveBeenCalledTimes(5);
+      expect(document.body.textContent).toContain("Sign in again to resume cloud saving");
+      expect(document.body.textContent).not.toContain("retrying automatically");
     } finally {
       unmountAppShell(view);
       vi.useRealTimers();
@@ -465,6 +466,7 @@ describe("AppShell deeplink cold-load flow", () => {
       status: "ok",
       simulationId: "sim-mmtk88wx-2didtk",
       authenticated: false,
+      authState: "guest",
     });
 
     const view = await renderAppShell();
@@ -475,6 +477,106 @@ describe("AppShell deeplink cold-load flow", () => {
 
       await advanceTimers(120_000);
       expect(hoisted.fetchMe).not.toHaveBeenCalled();
+    } finally {
+      unmountAppShell(view);
+      vi.useRealTimers();
+    }
+  });
+
+  it("enters quiet demo mode for an expected root guest", async () => {
+    vi.useFakeTimers();
+    window.history.replaceState(null, "", "/");
+    hoisted.fetchDeepLinkStatus.mockResolvedValue({
+      status: "missing",
+      authenticated: false,
+      authState: "guest",
+    });
+
+    const view = await renderAppShell();
+
+    try {
+      expect(hoisted.fetchDeepLinkStatus).toHaveBeenCalledTimes(1);
+      expect(hoisted.fetchMe).not.toHaveBeenCalled();
+      expect(document.body.textContent).not.toContain("Cloud save is unavailable");
+
+      await advanceTimers(120_000);
+      expect(hoisted.fetchDeepLinkStatus).toHaveBeenCalledTimes(1);
+      expect(hoisted.fetchMe).not.toHaveBeenCalled();
+    } finally {
+      unmountAppShell(view);
+      vi.useRealTimers();
+    }
+  });
+
+  it("shows an expired-session warning without retrying for a prior authenticated guest", async () => {
+    vi.useFakeTimers();
+    window.history.replaceState(null, "", "/");
+    localStorage.setItem("linksim:had-authenticated-session:v1", "1");
+    hoisted.fetchDeepLinkStatus.mockResolvedValue({
+      status: "missing",
+      authenticated: false,
+      authState: "guest",
+    });
+
+    const view = await renderAppShell();
+
+    try {
+      expect(document.body.textContent).toContain("Sign in again to resume cloud saving");
+      expect(document.body.textContent).not.toContain("retrying automatically");
+      expect(hoisted.fetchMe).not.toHaveBeenCalled();
+
+      await advanceTimers(120_000);
+      expect(hoisted.fetchDeepLinkStatus).toHaveBeenCalledTimes(1);
+    } finally {
+      unmountAppShell(view);
+      vi.useRealTimers();
+    }
+  });
+
+  it("shows an actionable revoked-session warning without retrying", async () => {
+    vi.useFakeTimers();
+    window.history.replaceState(null, "", "/");
+    hoisted.fetchDeepLinkStatus.mockResolvedValue({
+      status: "missing",
+      authenticated: false,
+      authState: "revoked",
+    });
+
+    const view = await renderAppShell();
+
+    try {
+      expect(document.body.textContent).toContain("Account access is unavailable");
+      expect(document.body.textContent).not.toContain("retrying automatically");
+      expect(hoisted.fetchMe).not.toHaveBeenCalled();
+
+      await advanceTimers(120_000);
+      expect(hoisted.fetchDeepLinkStatus).toHaveBeenCalledTimes(1);
+    } finally {
+      unmountAppShell(view);
+      vi.useRealTimers();
+    }
+  });
+
+  it("uses a bounded neutral recovery path when the public auth probe fails", async () => {
+    vi.useFakeTimers();
+    window.history.replaceState(null, "", "/");
+    hoisted.fetchDeepLinkStatus.mockRejectedValue(new Error("Failed to fetch"));
+
+    const view = await renderAppShell();
+
+    try {
+      expect(document.body.textContent).toContain("Sign-in status could not be checked");
+      expect(document.body.textContent).not.toContain("Cloud save is unavailable");
+
+      await advanceTimers(2_000);
+      await advanceTimers(5_000);
+      await advanceTimers(10_000);
+      expect(hoisted.fetchDeepLinkStatus).toHaveBeenCalledTimes(4);
+
+      await advanceTimers(120_000);
+      expect(hoisted.fetchDeepLinkStatus).toHaveBeenCalledTimes(4);
+      expect(document.body.textContent).toContain("Try signing in again");
+      expect(document.body.textContent).not.toContain("retrying automatically");
     } finally {
       unmountAppShell(view);
       vi.useRealTimers();

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -5,9 +5,11 @@ import { fetchCloudLibrary, fetchPublicSimulationLibrary, pushCloudLibrary } fro
 import { buildDeepLinkPathname, buildDeepLinkUrl, buildSettingsPath, canonicalizeDeepLinkKey, matchSettingsPath, parseDeepLinkFromLocation, slugifyName, type SettingsSectionId } from "../lib/deepLink";
 import { canRunDeepLinkApply } from "../lib/deepLinkApplyGate";
 import {
+  hasAuthenticatedSessionMarker,
+  markAuthenticatedSession,
+  resolveAuthBootstrapState,
   type DeepLinkApplyOutcome,
   shouldRewritePathAfterDeepLinkApply,
-  shouldUseReadonlyFallbackForAuthBootstrap,
 } from "../lib/appShellGuards";
 import { handleSimulationLibraryLoad } from "../lib/simulationLibraryLoad";
 import { emptyWorkspaceState } from "../lib/emptyWorkspaceState";
@@ -49,7 +51,6 @@ const LOCAL_FORCE_READONLY_KEY = "linksim:local-force-readonly:v1";
 const ACCESS_CHECK_TIMEOUT_MS = 10_000;
 const ACCESS_FETCH_TIMEOUT_MS = 8_000;
 const AUTH_RECOVERY_QUICK_RETRY_DELAYS_MS = [2_000, 5_000, 10_000] as const;
-const AUTH_RECOVERY_STEADY_RETRY_MS = 60_000;
 const ACCESS_CHECKING_NOTICE_ID = "access-checking";
 const AUTH_DEGRADED_NOTICE_ID = "auth-degraded";
 const OFFLINE_SYNC_NOTICE_ID = "offline-sync";
@@ -273,7 +274,7 @@ export function AppShell() {
   const mapExpandedInspectorWasHiddenRef = useRef(false);
   const mapExpandedProfileWasHiddenRef = useRef(false);
   const mapExpandToggleTimerRef = useRef<number | null>(null);
-  const hadAuthenticatedSessionRef = useRef(false);
+  const hadAuthenticatedSessionRef = useRef(hasAuthenticatedSessionMarker());
   const authCheckInFlightRef = useRef(false);
   const authRecoveryActiveRef = useRef(false);
   const authRecoveryDisabledRef = useRef(false);
@@ -583,44 +584,61 @@ export function AppShell() {
   }, [clearAuthRetryTimer]);
 
   const scheduleAuthRecoveryRetry = useCallback(
-    (source: "timeout" | "failure") => {
-      if (authRecoveryDisabledRef.current) return;
+    (source: "timeout" | "failure"): boolean => {
+      if (authRecoveryDisabledRef.current) return false;
       const online = typeof navigator === "undefined" ? true : navigator.onLine;
-      if (!online) return;
-      if (authRetryTimerRef.current !== null) return;
+      if (!online) return false;
+      if (authRetryTimerRef.current !== null) return true;
 
       const quickAttempt = authRetryQuickAttemptRef.current;
-      const delayMs =
-        quickAttempt < AUTH_RECOVERY_QUICK_RETRY_DELAYS_MS.length
-          ? AUTH_RECOVERY_QUICK_RETRY_DELAYS_MS[quickAttempt]
-          : AUTH_RECOVERY_STEADY_RETRY_MS;
-      if (quickAttempt < AUTH_RECOVERY_QUICK_RETRY_DELAYS_MS.length) {
-        authRetryQuickAttemptRef.current = quickAttempt + 1;
-      }
+      if (quickAttempt >= AUTH_RECOVERY_QUICK_RETRY_DELAYS_MS.length) return false;
+      const delayMs = AUTH_RECOVERY_QUICK_RETRY_DELAYS_MS[quickAttempt];
+      authRetryQuickAttemptRef.current = quickAttempt + 1;
 
       console.info("[AppShell] Scheduling auth recovery retry", {
         source,
         delayMs,
-        quickAttempt: Math.min(quickAttempt + 1, AUTH_RECOVERY_QUICK_RETRY_DELAYS_MS.length),
+        quickAttempt: quickAttempt + 1,
       });
       authRetryTimerRef.current = window.setTimeout(() => {
         authRetryTimerRef.current = null;
         runAccessCheckRef.current("retry");
       }, delayMs);
+      return true;
     },
     [],
   );
 
   const setAuthDegraded = useCallback(
-    (message: string, source: "timeout" | "failure") => {
-      authRecoveryActiveRef.current = true;
+    (
+      messages: { retrying: string; exhausted: string },
+      source: "timeout" | "failure",
+    ) => {
+      setCurrentUser(null);
+      setAuthState("signed_out");
+      setAccessState("readonly");
+      const retryScheduled = scheduleAuthRecoveryRetry(source);
+      authRecoveryActiveRef.current = retryScheduled;
+      if (!retryScheduled) {
+        authRecoveryDisabledRef.current = true;
+      }
+      setAccessDiagnosticMessage(retryScheduled ? messages.retrying : messages.exhausted);
+    },
+    [scheduleAuthRecoveryRetry, setAuthState, setCurrentUser],
+  );
+
+  const settleReadonlySession = useCallback(
+    (message: string | null) => {
+      clearAuthRetryTimer();
+      authRecoveryActiveRef.current = false;
+      authRecoveryDisabledRef.current = true;
+      authRetryQuickAttemptRef.current = 0;
       setAccessDiagnosticMessage(message);
       setCurrentUser(null);
       setAuthState("signed_out");
       setAccessState("readonly");
-      scheduleAuthRecoveryRetry(source);
     },
-    [scheduleAuthRecoveryRetry, setAuthState, setCurrentUser],
+    [clearAuthRetryTimer, setAuthState, setCurrentUser],
   );
 
   const applyRecoveredProfile = useCallback(
@@ -633,6 +651,7 @@ export function AppShell() {
       setCurrentUser(profile);
       setAuthState("signed_in");
       hadAuthenticatedSessionRef.current = true;
+      markAuthenticatedSession();
       setActiveUserId(profile.id);
       if (profile.needsUsername) {
         setAccessState("pending");
@@ -668,6 +687,8 @@ export function AppShell() {
       setCurrentUser(profile);
       setAuthState("signed_in");
       setActiveUserId(profile.id);
+      hadAuthenticatedSessionRef.current = true;
+      markAuthenticatedSession();
       setAccessDiagnosticMessage(null);
       setAccessState("granted");
       try {
@@ -704,6 +725,38 @@ export function AppShell() {
         isInitializing: isInitializingRef.current,
       });
 
+      let failureStage: "probe" | "profile" = isLocalRuntime ? "profile" : "probe";
+      const applyRecoverableFailure = (
+        source: "timeout" | "failure",
+        serverTimeout: boolean,
+        detail?: string,
+      ) => {
+        const knownAuthenticatedSession =
+          failureStage === "profile" || hadAuthenticatedSessionRef.current;
+        if (knownAuthenticatedSession) {
+          setAuthDegraded(
+            {
+              retrying: serverTimeout
+                ? "Cloud save is unavailable. Your changes may not be saved. The sign-in service timed out; LinkSim is retrying automatically."
+                : `Cloud save is unavailable. Your changes may not be saved. LinkSim is retrying sign-in automatically.${detail ? ` (${detail})` : ""}`,
+              exhausted:
+                "Cloud save is unavailable. Your changes may not be saved. Sign in again to resume cloud saving.",
+            },
+            source,
+          );
+          return;
+        }
+        setAuthDegraded(
+          {
+            retrying:
+              "Sign-in status could not be checked. Continuing in read-only demo mode. LinkSim is retrying automatically.",
+            exhausted:
+              "Sign-in status could not be checked. Continuing in read-only demo mode. Try signing in again.",
+          },
+          source,
+        );
+      };
+
       let timedOut = false;
       const timeoutId = window.setTimeout(() => {
         if (authCheckGenerationRef.current !== runId) return;
@@ -717,10 +770,7 @@ export function AppShell() {
           online: typeof navigator === "undefined" ? true : navigator.onLine,
           isInitializing: isInitializingRef.current,
         });
-        setAuthDegraded(
-          "Cloud save is unavailable. Your changes may not be saved. The sign-in check timed out; LinkSim is retrying automatically.",
-          "timeout",
-        );
+        applyRecoverableFailure("timeout", true);
       }, ACCESS_CHECK_TIMEOUT_MS);
 
       void (async () => {
@@ -737,34 +787,48 @@ export function AppShell() {
             })();
           if (localForceReadonly) {
             if (!isCurrentRun()) return;
-            authRecoveryActiveRef.current = false;
-            authRecoveryDisabledRef.current = true;
-            authRetryQuickAttemptRef.current = 0;
             window.clearTimeout(timeoutId);
-            setAccessDiagnosticMessage(null);
-            setCurrentUser(null);
-            setAuthState("signed_out");
-            setAccessState("readonly");
+            settleReadonlySession(null);
             return;
           }
-          if (deepLinkParse.ok && !isLocalRuntime) {
-          const deepLinkStatus = await fetchDeepLinkStatus({
-            simulationId: deepLinkParse.payload.simulationId,
-            username: deepLinkParse.payload.username,
-            simulationSlug: deepLinkParse.payload.simulationSlug,
-          });
-            if (!deepLinkStatus.authenticated) {
-              if (!isCurrentRun()) return;
-              authRecoveryActiveRef.current = false;
-              authRecoveryDisabledRef.current = true;
-              authRetryQuickAttemptRef.current = 0;
+          if (!isLocalRuntime) {
+            const deepLinkStatus = await fetchDeepLinkStatus(
+              deepLinkParse.ok
+                ? {
+                    simulationId: deepLinkParse.payload.simulationId,
+                    username: deepLinkParse.payload.username,
+                    simulationSlug: deepLinkParse.payload.simulationSlug,
+                  }
+                : {},
+            );
+            if (!isCurrentRun()) return;
+            const bootstrapState = resolveAuthBootstrapState({
+              authState: deepLinkStatus.authState,
+              hadAuthenticatedSession: hadAuthenticatedSessionRef.current,
+            });
+            if (bootstrapState === "revoked") {
               window.clearTimeout(timeoutId);
-              setAccessDiagnosticMessage(null);
-              setCurrentUser(null);
-              setAuthState("signed_out");
-              setAccessState("readonly");
+              settleReadonlySession(
+                "Account access is unavailable. Your changes may not be saved. Sign in again or contact an admin if you need access restored.",
+              );
               return;
             }
+            if (bootstrapState === "guest" || bootstrapState === "expired") {
+              if (!isCurrentRun()) return;
+              window.clearTimeout(timeoutId);
+              const expiredSessionMessage = bootstrapState === "expired"
+                ? "Cloud save is unavailable. Your changes may not be saved. Sign in again to resume cloud saving."
+                : null;
+              console.info("[AppShell] Access check resolved to guest", {
+                reason,
+                deepLinkMode: deepLinkParse.ok,
+                priorAuthenticatedSession: hadAuthenticatedSessionRef.current,
+              });
+              settleReadonlySession(expiredSessionMessage);
+              return;
+            }
+            hadAuthenticatedSessionRef.current = true;
+            failureStage = "profile";
           }
           const profile = await fetchMe({ timeoutMs: ACCESS_FETCH_TIMEOUT_MS });
           if (!isCurrentRun()) return;
@@ -778,59 +842,21 @@ export function AppShell() {
             error instanceof CloudApiError &&
             (error.code === "timeout" || error.code === "server_timeout" || error.code === "auth_timeout" || error.status === 524);
           const isOnlineNow = typeof navigator === "undefined" ? true : navigator.onLine;
-          const fallbackToReadonly = shouldUseReadonlyFallbackForAuthBootstrap({
+          console.error("[AppShell] Access check failed", {
+            reason,
             message,
-            deepLinkMode: deepLinkParse.ok,
+            failureStage,
             isLocalRuntime,
-            isOnline: isOnlineNow,
-            userAgent: typeof navigator === "undefined" ? "" : navigator.userAgent,
+            deepLinkMode: deepLinkParse.ok,
+            online: isOnlineNow,
           });
-          if (deepLinkParse.ok) {
-            console.info("[AppShell] Guest deep-link bootstrap using read-only fallback", {
-              reason,
-              message,
-              isLocalRuntime,
-              deepLinkMode: deepLinkParse.ok,
-              online: isOnlineNow,
-            });
-          } else {
-            console.error("[AppShell] Access check failed", {
-              reason,
-              message,
-              isLocalRuntime,
-              deepLinkMode: deepLinkParse.ok,
-              online: isOnlineNow,
-              fallbackToReadonly,
-            });
-          }
           if (message.includes("Session revoked by admin")) {
-            setAuthDegraded(
-              "Cloud save is unavailable. Your changes may not be saved. Sign in again to resume cloud saving; LinkSim is retrying automatically.",
-              "failure",
+            settleReadonlySession(
+              "Cloud save is unavailable. Your changes may not be saved. Sign in again to resume cloud saving.",
             );
             return;
           }
-          if (deepLinkParse.ok) {
-            authRecoveryActiveRef.current = false;
-            authRecoveryDisabledRef.current = true;
-            authRetryQuickAttemptRef.current = 0;
-            setAccessState("readonly");
-            return;
-          }
-          if (fallbackToReadonly && !hadAuthenticatedSessionRef.current) {
-            authRecoveryActiveRef.current = false;
-            authRecoveryDisabledRef.current = true;
-            authRetryQuickAttemptRef.current = 0;
-            setAccessDiagnosticMessage("Sign-in check was blocked by browser auth redirects. Continuing in read-only demo mode.");
-            setAccessState("readonly");
-            return;
-          }
-          setAuthDegraded(
-            isServerTimeout
-              ? "Cloud save is unavailable. Your changes may not be saved. The sign-in service timed out; LinkSim is retrying automatically."
-              : `Cloud save is unavailable. Your changes may not be saved. LinkSim is retrying sign-in automatically. (${message})`,
-            "failure",
-          );
+          applyRecoverableFailure("failure", isServerTimeout, message);
         } finally {
           if (authCheckGenerationRef.current === runId && !timedOut) {
             authCheckInFlightRef.current = false;
@@ -844,6 +870,7 @@ export function AppShell() {
       deepLinkParse,
       isLocalRuntime,
       setAuthDegraded,
+      settleReadonlySession,
       setAuthState,
       setCurrentUser,
     ],
@@ -865,12 +892,12 @@ export function AppShell() {
   useEffect(() => {
     if (authState !== "signed_out") return;
     if (accessState === "checking") return;
+    if (accessState === "readonly") return;
     if (!hadAuthenticatedSessionRef.current) return;
-    setAuthDegraded(
-      "Cloud save is unavailable. Your changes may not be saved. LinkSim is retrying sign-in automatically.",
-      "failure",
+    settleReadonlySession(
+      "Cloud save is unavailable. Your changes may not be saved. Sign in again to resume cloud saving.",
     );
-  }, [accessState, authState, setAuthDegraded]);
+  }, [accessState, authState, settleReadonlySession]);
 
   useEffect(() => {
     if (!accessDiagnosticMessage) {

--- a/src/components/settings/SettingsPanel.test.tsx
+++ b/src/components/settings/SettingsPanel.test.tsx
@@ -6,7 +6,12 @@ import { SettingsPanel } from "./SettingsPanel";
 
 // Stub sub-sections so SettingsPanel tests focus on panel-level behaviour.
 vi.mock("./sections/ProfileSection", () => ({
-  ProfileSection: () => <div data-testid="profile-section">Profile Section</div>,
+  ProfileSection: ({ onSignOut }: { onSignOut?: () => void }) => (
+    <div data-testid="profile-section">
+      Profile Section
+      {onSignOut ? <button onClick={onSignOut}>Sign out</button> : null}
+    </div>
+  ),
 }));
 vi.mock("./sections/PreferencesSection", () => ({
   PreferencesSection: () => <div data-testid="preferences-section">Preferences Section</div>,
@@ -46,6 +51,20 @@ beforeEach(() => {
   // Stub history methods to avoid jsdom URL errors.
   vi.spyOn(window.history, "replaceState").mockImplementation(() => {});
   vi.spyOn(window.history, "pushState").mockImplementation(() => {});
+  const storageValues = new Map<string, string>();
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (key: string) => storageValues.get(key) ?? null,
+      setItem: (key: string, value: string) => storageValues.set(key, String(value)),
+      removeItem: (key: string) => storageValues.delete(key),
+      clear: () => storageValues.clear(),
+      key: (index: number) => Array.from(storageValues.keys())[index] ?? null,
+      get length() {
+        return storageValues.size;
+      },
+    },
+  });
 });
 
 describe("SettingsPanel", () => {
@@ -107,6 +126,24 @@ describe("SettingsPanel", () => {
     render(<SettingsPanel initialSection={null} onClose={onClose} />);
     fireEvent.keyDown(window, { key: "Escape" });
     expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("clears the authenticated-session marker on explicit sign out", () => {
+    mockState.currentUser = {
+      id: "u1",
+      username: "Alice",
+      email: "alice@example.com",
+      isAdmin: false,
+      isModerator: false,
+      isApproved: true,
+    } as CloudUser;
+    mockState.authState = "signed_in";
+    localStorage.setItem("linksim:had-authenticated-session:v1", "1");
+
+    render(<SettingsPanel initialSection={null} onClose={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Sign out" }));
+
+    expect(localStorage.getItem("linksim:had-authenticated-session:v1")).toBeNull();
   });
 
   it("switches to Preferences section when its nav item is clicked", () => {

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -4,6 +4,7 @@ import { buildSettingsPath, matchSettingsPath, type SettingsSectionId } from "..
 import { useAppStore } from "../../store/appStore";
 import { fetchMe, type CloudUser } from "../../lib/cloudUser";
 import { getUiErrorMessage } from "../../lib/uiError";
+import { clearAuthenticatedSessionMarker } from "../../lib/appShellGuards";
 import { ProfileSection } from "./sections/ProfileSection";
 import { PreferencesSection } from "./sections/PreferencesSection";
 import { SettingsNav, settingsNavIcons, type SettingsNavItem } from "./SettingsNav";
@@ -116,6 +117,7 @@ export function SettingsPanel({ initialSection, onClose }: SettingsPanelProps) {
   );
 
   const handleSignOut = useCallback(() => {
+    clearAuthenticatedSessionMarker();
     setMe(null);
     setCurrentUser(null);
     setAuthState("signed_out");

--- a/src/lib/appShellGuards.test.ts
+++ b/src/lib/appShellGuards.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
+  AUTHENTICATED_SESSION_MARKER_KEY,
+  clearAuthenticatedSessionMarker,
+  hasAuthenticatedSessionMarker,
   isAuthSignInRequiredMessage,
+  markAuthenticatedSession,
+  resolveAuthBootstrapState,
   shouldCloseSimulationLibraryOnLoad,
   shouldRewritePathAfterDeepLinkApply,
-  shouldUseReadonlyFallbackForAuthBootstrap,
 } from "./appShellGuards";
 
 describe("shouldRewritePathAfterDeepLinkApply", () => {
@@ -54,51 +58,53 @@ describe("isAuthSignInRequiredMessage", () => {
   });
 });
 
-describe("shouldUseReadonlyFallbackForAuthBootstrap", () => {
-  it("uses readonly fallback for Firefox auth bootstrap network failure", () => {
-    expect(
-      shouldUseReadonlyFallbackForAuthBootstrap({
-        message: "NetworkError when attempting to fetch resource.",
-        deepLinkMode: false,
-        isLocalRuntime: false,
-        isOnline: true,
-        userAgent: "Mozilla/5.0 Firefox/124.0",
-      }),
-    ).toBe(true);
+describe("authenticated session marker", () => {
+  it("records and clears a prior authenticated session", () => {
+    const values = new Map<string, string>();
+    const storage = {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+      removeItem: (key: string) => values.delete(key),
+    };
+
+    expect(hasAuthenticatedSessionMarker(storage)).toBe(false);
+    markAuthenticatedSession(storage);
+    expect(values.get(AUTHENTICATED_SESSION_MARKER_KEY)).toBe("1");
+    expect(hasAuthenticatedSessionMarker(storage)).toBe(true);
+    clearAuthenticatedSessionMarker(storage);
+    expect(hasAuthenticatedSessionMarker(storage)).toBe(false);
   });
 
-  it("does not use readonly fallback for unrelated failures", () => {
-    expect(
-      shouldUseReadonlyFallbackForAuthBootstrap({
-        message: "Network timeout",
-        deepLinkMode: false,
-        isLocalRuntime: false,
-        isOnline: true,
-        userAgent: "Mozilla/5.0 Firefox/124.0",
-      }),
-    ).toBe(false);
+  it("fails safely when storage is unavailable", () => {
+    const storage = {
+      getItem: () => {
+        throw new Error("blocked");
+      },
+      setItem: () => {
+        throw new Error("blocked");
+      },
+      removeItem: () => {
+        throw new Error("blocked");
+      },
+    };
 
-    expect(
-      shouldUseReadonlyFallbackForAuthBootstrap({
-        message: "NetworkError when attempting to fetch resource.",
-        deepLinkMode: false,
-        isLocalRuntime: false,
-        isOnline: true,
-        userAgent: "Mozilla/5.0 AppleWebKit Safari/605.1.15",
-      }),
-    ).toBe(false);
+    expect(hasAuthenticatedSessionMarker(storage)).toBe(false);
+    expect(() => markAuthenticatedSession(storage)).not.toThrow();
+    expect(() => clearAuthenticatedSessionMarker(storage)).not.toThrow();
+  });
+});
+
+describe("resolveAuthBootstrapState", () => {
+  it("distinguishes expected guests from expired sessions", () => {
+    expect(resolveAuthBootstrapState({ authState: "guest", hadAuthenticatedSession: false })).toBe("guest");
+    expect(resolveAuthBootstrapState({ authState: "guest", hadAuthenticatedSession: true })).toBe("expired");
   });
 
-  it("keeps deep-link flow unchanged", () => {
-    expect(
-      shouldUseReadonlyFallbackForAuthBootstrap({
-        message: "NetworkError when attempting to fetch resource.",
-        deepLinkMode: true,
-        isLocalRuntime: false,
-        isOnline: true,
-        userAgent: "Mozilla/5.0 Firefox/124.0",
-      }),
-    ).toBe(false);
+  it("preserves authenticated and revoked states", () => {
+    expect(resolveAuthBootstrapState({ authState: "authenticated", hadAuthenticatedSession: false })).toBe(
+      "authenticated",
+    );
+    expect(resolveAuthBootstrapState({ authState: "revoked", hadAuthenticatedSession: true })).toBe("revoked");
   });
 });
 

--- a/src/lib/appShellGuards.ts
+++ b/src/lib/appShellGuards.ts
@@ -1,5 +1,54 @@
 export type DeepLinkApplyOutcome = "idle" | "succeeded" | "failed";
 
+type AuthSessionMarkerStorage = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+export const AUTHENTICATED_SESSION_MARKER_KEY = "linksim:had-authenticated-session:v1";
+
+const getAuthSessionMarkerStorage = (): AuthSessionMarkerStorage | null => {
+  if (typeof localStorage === "undefined") return null;
+  return localStorage;
+};
+
+export const hasAuthenticatedSessionMarker = (
+  storage: AuthSessionMarkerStorage | null = getAuthSessionMarkerStorage(),
+): boolean => {
+  try {
+    return storage?.getItem(AUTHENTICATED_SESSION_MARKER_KEY) === "1";
+  } catch {
+    return false;
+  }
+};
+
+export const markAuthenticatedSession = (
+  storage: AuthSessionMarkerStorage | null = getAuthSessionMarkerStorage(),
+): void => {
+  try {
+    storage?.setItem(AUTHENTICATED_SESSION_MARKER_KEY, "1");
+  } catch {
+    // Authentication must still work when storage is blocked.
+  }
+};
+
+export const clearAuthenticatedSessionMarker = (
+  storage: AuthSessionMarkerStorage | null = getAuthSessionMarkerStorage(),
+): void => {
+  try {
+    storage?.removeItem(AUTHENTICATED_SESSION_MARKER_KEY);
+  } catch {
+    // Sign-out must still continue when storage is blocked.
+  }
+};
+
+export type AuthBootstrapState = "guest" | "expired" | "authenticated" | "revoked";
+
+export const resolveAuthBootstrapState = (input: {
+  authState: "guest" | "authenticated" | "revoked";
+  hadAuthenticatedSession: boolean;
+}): AuthBootstrapState => {
+  if (input.authState === "guest" && input.hadAuthenticatedSession) return "expired";
+  return input.authState;
+};
+
 export const shouldRewritePathAfterDeepLinkApply = (input: {
   deepLinkApplied: boolean;
   deepLinkParseOk: boolean;
@@ -25,23 +74,6 @@ export const isAuthSignInRequiredMessage = (message: string | null | undefined):
     normalized.includes("authentication required") ||
     normalized.includes("not authenticated")
   );
-};
-
-export const shouldUseReadonlyFallbackForAuthBootstrap = (input: {
-  message: string | null | undefined;
-  deepLinkMode: boolean;
-  isLocalRuntime: boolean;
-  isOnline: boolean;
-  userAgent: string;
-}): boolean => {
-  if (input.deepLinkMode) return false;
-  if (input.isLocalRuntime) return false;
-  if (!input.isOnline) return false;
-  const normalized = String(input.message ?? "").trim().toLowerCase();
-  if (!normalized) return false;
-  const isFirefox = /firefox/i.test(input.userAgent);
-  if (!isFirefox) return false;
-  return normalized.includes("networkerror when attempting to fetch resource");
 };
 
 export const shouldCloseSimulationLibraryOnLoad = (input: { presetId: string | null | undefined }): boolean =>

--- a/src/lib/cloudUser.ts
+++ b/src/lib/cloudUser.ts
@@ -126,7 +126,13 @@ export type CollaboratorDirectoryUser = {
 };
 
 export type DeepLinkStatus = "ok" | "forbidden" | "missing";
-export type DeepLinkStatusResult = { status: DeepLinkStatus; simulationId?: string; authenticated?: boolean };
+export type DeepLinkAuthState = "guest" | "authenticated" | "revoked";
+export type DeepLinkStatusResult = {
+  status: DeepLinkStatus;
+  simulationId?: string;
+  authenticated?: boolean;
+  authState: DeepLinkAuthState;
+};
 
 export class CloudApiError extends Error {
   status: number | null;
@@ -413,22 +419,34 @@ export const fetchDeepLinkStatus = async (input: {
   simulationId?: string;
   username?: string;
   simulationSlug?: string;
-}): Promise<DeepLinkStatusResult> => {
+} = {}): Promise<DeepLinkStatusResult> => {
   const params = new URLSearchParams();
   if (input.simulationId?.trim()) params.set("sim", input.simulationId.trim());
   if (input.username?.trim()) params.set("username", input.username.trim());
   if (input.simulationSlug?.trim()) params.set("slug", input.simulationSlug.trim());
-  const data = await apiCall<{ status?: unknown; simulationId?: unknown; authenticated?: unknown }>(
+  const data = await apiCall<{
+    status?: unknown;
+    simulationId?: unknown;
+    authenticated?: unknown;
+    authState?: unknown;
+  }>(
     `/api/deep-link-status?${params.toString()}`,
     { method: "GET" },
   );
   const status = data.status;
   const normalized: DeepLinkStatus =
     status === "ok" || status === "forbidden" || status === "missing" ? status : "missing";
+  const authState: DeepLinkAuthState =
+    data.authState === "authenticated" || data.authState === "revoked" || data.authState === "guest"
+      ? data.authState
+      : data.authenticated === true
+        ? "authenticated"
+        : "guest";
   return {
     status: normalized,
     simulationId: typeof data.simulationId === "string" && data.simulationId.trim() ? data.simulationId : undefined,
     authenticated: data.authenticated === true,
+    authState,
   };
 };
 


### PR DESCRIPTION
## Summary
- probe public auth state before calling protected `/api/me`
- keep expected guests quiet while preserving actionable expired/revoked session warnings
- bound transient auth recovery to the existing 2s/5s/10s quick retries
- persist a boolean prior-session marker and clear it on explicit sign-out
- return backward-compatible auth state from `/api/deep-link-status` with `Cache-Control: no-store`

## Root cause
Root loads called the Access-protected `/api/me` directly. Signed-out Access challenges surfaced as browser-specific network errors, and only one Firefox error string was recognized as a guest fallback. Other guests entered the same unbounded recovery path as authenticated-session failures.

## Validation
- `npm test` — 120 files / 653 tests passed
- `npm run build`
- `npm run test -- --run src/lib/deepLink.test.ts`
- `npm run test -- --run functions/api/v1/calculate.test.ts`
- `npm run test -- --run src/store/appStore.test.ts`
- `git diff --check`

Closes #936