### PR TITLE
Fix public guest auth probing (#936)

### DIFF
--- a/functions/api/public-simulation.test.ts
+++ b/functions/api/public-simulation.test.ts
@@ -35,6 +35,53 @@ beforeEach(() => {
 });
 
 describe("api/public-simulation", () => {
+  it("reports expected guests through the public auth-status mode", async () => {
+    verifyAuthMock.mockResolvedValueOnce(null);
+
+    const res = await onRequestGet(
+      mkCtx(new Request("https://example.test/api/public-simulation?mode=auth")),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    await expect(res.json()).resolves.toEqual({ authenticated: false, authState: "guest" });
+    expect(fetchPublicSimulationBundleMock).not.toHaveBeenCalled();
+  });
+
+  it("reports authenticated and revoked auth-status states", async () => {
+    verifyAuthMock.mockResolvedValue({ userId: "user-42", tokenPayload: {} });
+    fetchUserProfileMock
+      .mockResolvedValueOnce({ id: "user-42", accountState: "approved" })
+      .mockResolvedValueOnce({ id: "user-42", accountState: "revoked" });
+
+    const authenticated = await onRequestGet(
+      mkCtx(new Request("https://example.test/api/public-simulation?mode=auth")),
+    );
+    const revoked = await onRequestGet(
+      mkCtx(new Request("https://example.test/api/public-simulation?mode=auth")),
+    );
+
+    await expect(authenticated.json()).resolves.toEqual({
+      authenticated: true,
+      authState: "authenticated",
+    });
+    await expect(revoked.json()).resolves.toEqual({
+      authenticated: false,
+      authState: "revoked",
+    });
+    expect(fetchPublicSimulationBundleMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces auth verification failures in auth-status mode", async () => {
+    verifyAuthMock.mockRejectedValueOnce(new Error("Auth verification timed out"));
+
+    const res = await onRequestGet(
+      mkCtx(new Request("https://example.test/api/public-simulation?mode=auth")),
+    );
+
+    expect(res.status).toBe(503);
+  });
+
   it("returns no-store when request is invalid", async () => {
     const res = await onRequestGet(mkCtx(new Request("https://example.test/api/public-simulation")));
     expect(res.status).toBe(400);

--- a/functions/api/public-simulation.ts
+++ b/functions/api/public-simulation.ts
@@ -7,9 +7,52 @@ export const onRequestOptions: PagesFunction<Env> = async ({ request }) => handl
 
 const NO_STORE_HEADERS = { "cache-control": "no-store" };
 
+type PublicAuthState = "guest" | "authenticated" | "revoked";
+type PublicActor = { id: string; isAdmin: boolean; isModerator: boolean };
+
+const resolveAuth = async (
+  request: Request,
+  env: Env,
+  strict: boolean,
+): Promise<{ authenticated: boolean; authState: PublicAuthState; actor: PublicActor | null }> => {
+  const auth = strict
+    ? await verifyAuth(request, env)
+    : await verifyAuth(request, env).catch(() => null);
+  if (!auth) {
+    return { authenticated: false, authState: "guest", actor: null };
+  }
+
+  await ensureUser(env, auth.userId, auth.tokenPayload);
+  const profile = await fetchUserProfile(env, auth.userId);
+  if (profile?.accountState === "revoked") {
+    return { authenticated: false, authState: "revoked", actor: null };
+  }
+
+  return {
+    authenticated: true,
+    authState: "authenticated",
+    actor: {
+      id: profile?.id ?? auth.userId,
+      isAdmin: Boolean(profile?.isAdmin),
+      isModerator: Boolean(profile?.isModerator),
+    },
+  };
+};
+
 export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
   try {
     const url = new URL(request.url);
+    if (url.searchParams.get("mode") === "auth") {
+      const auth = await resolveAuth(request, env, true);
+      return withCors(
+        request,
+        json(
+          { authenticated: auth.authenticated, authState: auth.authState },
+          { headers: NO_STORE_HEADERS },
+        ),
+      );
+    }
+
     const simulationId = (url.searchParams.get("sim") ?? "").trim();
     const username = (url.searchParams.get("username") ?? "").trim();
     const simulationSlug = (url.searchParams.get("slug") ?? "").trim();
@@ -17,19 +60,7 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
       return withCors(request, json({ error: "Missing simulation id or username-scoped slug" }, { status: 400, headers: NO_STORE_HEADERS }));
     }
 
-    const auth = await verifyAuth(request, env).catch(() => null);
-    let actor: { id: string; isAdmin: boolean; isModerator: boolean } | null = null;
-    if (auth) {
-      await ensureUser(env, auth.userId, auth.tokenPayload);
-      const profile = await fetchUserProfile(env, auth.userId);
-      if (profile?.accountState !== "revoked") {
-        actor = {
-          id: profile?.id ?? auth.userId,
-          isAdmin: Boolean(profile?.isAdmin),
-          isModerator: Boolean(profile?.isModerator),
-        };
-      }
-    }
+    const { actor } = await resolveAuth(request, env, false);
 
     const bundle = await fetchPublicSimulationBundle(env, {
       simulationId: simulationId || undefined,

--- a/src/components/AppShell.copyFlow.test.tsx
+++ b/src/components/AppShell.copyFlow.test.tsx
@@ -30,6 +30,7 @@ const { pushCloudLibraryMock } = vi.hoisted(() => ({
 const sidebarCalls: Array<{ readOnly?: boolean; panelToggleControl?: unknown }> = [];
 
 vi.mock("../lib/cloudUser", () => ({
+  fetchAuthStatus: vi.fn(async () => ({ authenticated: true, authState: "authenticated" })),
   fetchCollaboratorDirectory: vi.fn(async () => []),
   fetchDeepLinkStatus: vi.fn(async () => ({ status: "ok", simulationId: null, authenticated: true })),
   fetchMe: vi.fn(async () => ({

--- a/src/components/AppShell.deeplink.test.ts
+++ b/src/components/AppShell.deeplink.test.ts
@@ -5,7 +5,7 @@ import { act, render } from "@testing-library/react";
 
 const hoisted = vi.hoisted(() => {
   const fetchMe = vi.fn();
-  const fetchDeepLinkStatus = vi.fn();
+  const fetchAuthStatus = vi.fn();
   const fetchCloudLibrary = vi.fn();
   const fetchPublicSimulationLibrary = vi.fn();
   const loadSimulationPreset = vi.fn();
@@ -68,7 +68,7 @@ const hoisted = vi.hoisted(() => {
 
   return {
     fetchMe,
-    fetchDeepLinkStatus,
+    fetchAuthStatus,
     fetchCloudLibrary,
     fetchPublicSimulationLibrary,
     loadSimulationPreset,
@@ -90,7 +90,7 @@ vi.mock("../lib/cloudUser", () => ({
     }
   },
   fetchCollaboratorDirectory: vi.fn(async () => []),
-  fetchDeepLinkStatus: hoisted.fetchDeepLinkStatus,
+  fetchAuthStatus: hoisted.fetchAuthStatus,
   fetchMe: hoisted.fetchMe,
   setLocalDevRole: vi.fn(async () => ({})),
 }));
@@ -242,9 +242,7 @@ describe("AppShell deeplink cold-load flow", () => {
       updatedAt: "2026-01-01T00:00:00.000Z",
       bio: "",
     });
-    hoisted.fetchDeepLinkStatus.mockResolvedValue({
-      status: "ok",
-      simulationId: "sim-mmtk88wx-2didtk",
+    hoisted.fetchAuthStatus.mockResolvedValue({
       authenticated: true,
       authState: "authenticated",
     });
@@ -462,9 +460,7 @@ describe("AppShell deeplink cold-load flow", () => {
 
   it("does not start auth recovery for unauthenticated deep-link guests", async () => {
     vi.useFakeTimers();
-    hoisted.fetchDeepLinkStatus.mockResolvedValue({
-      status: "ok",
-      simulationId: "sim-mmtk88wx-2didtk",
+    hoisted.fetchAuthStatus.mockResolvedValue({
       authenticated: false,
       authState: "guest",
     });
@@ -472,7 +468,7 @@ describe("AppShell deeplink cold-load flow", () => {
     const view = await renderAppShell();
 
     try {
-      expect(hoisted.fetchDeepLinkStatus).toHaveBeenCalledTimes(1);
+      expect(hoisted.fetchAuthStatus).toHaveBeenCalledTimes(1);
       expect(hoisted.fetchMe).not.toHaveBeenCalled();
 
       await advanceTimers(120_000);
@@ -486,8 +482,7 @@ describe("AppShell deeplink cold-load flow", () => {
   it("enters quiet demo mode for an expected root guest", async () => {
     vi.useFakeTimers();
     window.history.replaceState(null, "", "/");
-    hoisted.fetchDeepLinkStatus.mockResolvedValue({
-      status: "missing",
+    hoisted.fetchAuthStatus.mockResolvedValue({
       authenticated: false,
       authState: "guest",
     });
@@ -495,12 +490,12 @@ describe("AppShell deeplink cold-load flow", () => {
     const view = await renderAppShell();
 
     try {
-      expect(hoisted.fetchDeepLinkStatus).toHaveBeenCalledTimes(1);
+      expect(hoisted.fetchAuthStatus).toHaveBeenCalledTimes(1);
       expect(hoisted.fetchMe).not.toHaveBeenCalled();
       expect(document.body.textContent).not.toContain("Cloud save is unavailable");
 
       await advanceTimers(120_000);
-      expect(hoisted.fetchDeepLinkStatus).toHaveBeenCalledTimes(1);
+      expect(hoisted.fetchAuthStatus).toHaveBeenCalledTimes(1);
       expect(hoisted.fetchMe).not.toHaveBeenCalled();
     } finally {
       unmountAppShell(view);
@@ -512,8 +507,7 @@ describe("AppShell deeplink cold-load flow", () => {
     vi.useFakeTimers();
     window.history.replaceState(null, "", "/");
     localStorage.setItem("linksim:had-authenticated-session:v1", "1");
-    hoisted.fetchDeepLinkStatus.mockResolvedValue({
-      status: "missing",
+    hoisted.fetchAuthStatus.mockResolvedValue({
       authenticated: false,
       authState: "guest",
     });
@@ -526,7 +520,7 @@ describe("AppShell deeplink cold-load flow", () => {
       expect(hoisted.fetchMe).not.toHaveBeenCalled();
 
       await advanceTimers(120_000);
-      expect(hoisted.fetchDeepLinkStatus).toHaveBeenCalledTimes(1);
+      expect(hoisted.fetchAuthStatus).toHaveBeenCalledTimes(1);
     } finally {
       unmountAppShell(view);
       vi.useRealTimers();
@@ -536,8 +530,7 @@ describe("AppShell deeplink cold-load flow", () => {
   it("shows an actionable revoked-session warning without retrying", async () => {
     vi.useFakeTimers();
     window.history.replaceState(null, "", "/");
-    hoisted.fetchDeepLinkStatus.mockResolvedValue({
-      status: "missing",
+    hoisted.fetchAuthStatus.mockResolvedValue({
       authenticated: false,
       authState: "revoked",
     });
@@ -550,7 +543,7 @@ describe("AppShell deeplink cold-load flow", () => {
       expect(hoisted.fetchMe).not.toHaveBeenCalled();
 
       await advanceTimers(120_000);
-      expect(hoisted.fetchDeepLinkStatus).toHaveBeenCalledTimes(1);
+      expect(hoisted.fetchAuthStatus).toHaveBeenCalledTimes(1);
     } finally {
       unmountAppShell(view);
       vi.useRealTimers();
@@ -560,7 +553,7 @@ describe("AppShell deeplink cold-load flow", () => {
   it("uses a bounded neutral recovery path when the public auth probe fails", async () => {
     vi.useFakeTimers();
     window.history.replaceState(null, "", "/");
-    hoisted.fetchDeepLinkStatus.mockRejectedValue(new Error("Failed to fetch"));
+    hoisted.fetchAuthStatus.mockRejectedValue(new Error("Failed to fetch"));
 
     const view = await renderAppShell();
 
@@ -571,10 +564,10 @@ describe("AppShell deeplink cold-load flow", () => {
       await advanceTimers(2_000);
       await advanceTimers(5_000);
       await advanceTimers(10_000);
-      expect(hoisted.fetchDeepLinkStatus).toHaveBeenCalledTimes(4);
+      expect(hoisted.fetchAuthStatus).toHaveBeenCalledTimes(4);
 
       await advanceTimers(120_000);
-      expect(hoisted.fetchDeepLinkStatus).toHaveBeenCalledTimes(4);
+      expect(hoisted.fetchAuthStatus).toHaveBeenCalledTimes(4);
       expect(document.body.textContent).toContain("Try signing in again");
       expect(document.body.textContent).not.toContain("retrying automatically");
     } finally {

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,6 +1,6 @@
 import { type CSSProperties, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CircleAlert, CircleCheck, CircleX, Copy, Globe, Info, PanelBottomClose, PanelBottomOpen, PanelLeftClose, PanelLeftOpen, PanelRightClose, PanelRightOpen, Share, UserRoundPlus, UserRoundSearch, Users, X } from "lucide-react";
-import { CloudApiError, type CloudUser, type CollaboratorDirectoryUser, fetchCollaboratorDirectory, fetchDeepLinkStatus, fetchMe } from "../lib/cloudUser";
+import { CloudApiError, type CloudUser, type CollaboratorDirectoryUser, fetchAuthStatus, fetchCollaboratorDirectory, fetchDeepLinkStatus, fetchMe } from "../lib/cloudUser";
 import { fetchCloudLibrary, fetchPublicSimulationLibrary, pushCloudLibrary } from "../lib/cloudLibrary";
 import { buildDeepLinkPathname, buildDeepLinkUrl, buildSettingsPath, canonicalizeDeepLinkKey, matchSettingsPath, parseDeepLinkFromLocation, slugifyName, type SettingsSectionId } from "../lib/deepLink";
 import { canRunDeepLinkApply } from "../lib/deepLinkApplyGate";
@@ -792,18 +792,10 @@ export function AppShell() {
             return;
           }
           if (!isLocalRuntime) {
-            const deepLinkStatus = await fetchDeepLinkStatus(
-              deepLinkParse.ok
-                ? {
-                    simulationId: deepLinkParse.payload.simulationId,
-                    username: deepLinkParse.payload.username,
-                    simulationSlug: deepLinkParse.payload.simulationSlug,
-                  }
-                : {},
-            );
+            const authStatus = await fetchAuthStatus();
             if (!isCurrentRun()) return;
             const bootstrapState = resolveAuthBootstrapState({
-              authState: deepLinkStatus.authState,
+              authState: authStatus.authState,
               hadAuthenticatedSession: hadAuthenticatedSessionRef.current,
             });
             if (bootstrapState === "revoked") {

--- a/src/components/UserAdminPanel.chip.test.tsx
+++ b/src/components/UserAdminPanel.chip.test.tsx
@@ -10,8 +10,12 @@ import { UserAdminPanel } from "./UserAdminPanel";
 
 // --- Module mocks ----------------------------------------------------------
 
+const { fetchMeMock } = vi.hoisted(() => ({
+  fetchMeMock: vi.fn(),
+}));
+
 vi.mock("../lib/cloudUser", () => ({
-  fetchMe: vi.fn().mockResolvedValue(null),
+  fetchMe: fetchMeMock,
   fetchUsers: vi.fn().mockResolvedValue([]),
   fetchAdminAuditEvents: vi.fn().mockResolvedValue([]),
   fetchAuthDiagnostics: vi.fn().mockResolvedValue({}),
@@ -82,8 +86,10 @@ vi.mock("../store/appStore", () => ({
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
+  vi.clearAllMocks();
   mockStoreState.currentUser = signedInUser;
   mockStoreState.authState = "signed_in";
+  fetchMeMock.mockResolvedValue(signedInUser);
 });
 
 describe("UserAdminPanel chip — onOpenSettings", () => {
@@ -119,5 +125,14 @@ describe("UserAdminPanel chip — onOpenSettings", () => {
     render(<UserAdminPanel />);
     expect(screen.getByRole("button", { name: /sign in/i })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /open user settings/i })).not.toBeInTheDocument();
+  });
+
+  it("does not fetch the protected profile while auth is still checking", () => {
+    mockStoreState.authState = "checking";
+    mockStoreState.currentUser = null;
+
+    render(<UserAdminPanel />);
+
+    expect(fetchMeMock).not.toHaveBeenCalled();
   });
 });

--- a/src/components/UserAdminPanel.tsx
+++ b/src/components/UserAdminPanel.tsx
@@ -280,6 +280,7 @@ export function UserAdminPanel({
       setMe(null);
       return;
     }
+    if (authState !== "signed_in") return;
     void load();
   }, [authState]);
 

--- a/src/lib/cloudUser.test.ts
+++ b/src/lib/cloudUser.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearMeCache,
+  fetchAuthStatus,
   fetchMe,
   fetchUsers,
   fetchResourceChanges,
@@ -33,6 +34,21 @@ describe("cloudUser client", () => {
     const [, init] = vi.mocked(globalThis.fetch).mock.calls[0] ?? [];
     const headers = new Headers((init as RequestInit | undefined)?.headers ?? {});
     expect(headers.has("content-type")).toBe(false);
+  });
+
+  it("reads auth state from the existing public simulation boundary", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ authenticated: false, authState: "guest" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    await expect(fetchAuthStatus()).resolves.toEqual({ authenticated: false, authState: "guest" });
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "/api/public-simulation?mode=auth",
+      expect.objectContaining({ method: "GET" }),
+    );
   });
 
   it("preserves username setup state from fetchMe", async () => {

--- a/src/lib/cloudUser.ts
+++ b/src/lib/cloudUser.ts
@@ -127,11 +127,31 @@ export type CollaboratorDirectoryUser = {
 
 export type DeepLinkStatus = "ok" | "forbidden" | "missing";
 export type DeepLinkAuthState = "guest" | "authenticated" | "revoked";
+export type AuthStatusResult = {
+  authenticated: boolean;
+  authState: DeepLinkAuthState;
+};
 export type DeepLinkStatusResult = {
   status: DeepLinkStatus;
   simulationId?: string;
   authenticated?: boolean;
   authState: DeepLinkAuthState;
+};
+
+const normalizeAuthStatus = (data: {
+  authenticated?: unknown;
+  authState?: unknown;
+}): AuthStatusResult => {
+  const authState: DeepLinkAuthState =
+    data.authState === "authenticated" || data.authState === "revoked" || data.authState === "guest"
+      ? data.authState
+      : data.authenticated === true
+        ? "authenticated"
+        : "guest";
+  return {
+    authenticated: data.authenticated === true,
+    authState,
+  };
 };
 
 export class CloudApiError extends Error {
@@ -415,6 +435,14 @@ export const uploadAvatar = async (originalDataUrl: string, thumbDataUrl: string
     }),
   });
 
+export const fetchAuthStatus = async (): Promise<AuthStatusResult> => {
+  const data = await apiCall<{
+    authenticated?: unknown;
+    authState?: unknown;
+  }>("/api/public-simulation?mode=auth", { method: "GET" });
+  return normalizeAuthStatus(data);
+};
+
 export const fetchDeepLinkStatus = async (input: {
   simulationId?: string;
   username?: string;
@@ -436,17 +464,11 @@ export const fetchDeepLinkStatus = async (input: {
   const status = data.status;
   const normalized: DeepLinkStatus =
     status === "ok" || status === "forbidden" || status === "missing" ? status : "missing";
-  const authState: DeepLinkAuthState =
-    data.authState === "authenticated" || data.authState === "revoked" || data.authState === "guest"
-      ? data.authState
-      : data.authenticated === true
-        ? "authenticated"
-        : "guest";
+  const authStatus = normalizeAuthStatus(data);
   return {
     status: normalized,
     simulationId: typeof data.simulationId === "string" && data.simulationId.trim() ? data.simulationId : undefined,
-    authenticated: data.authenticated === true,
-    authState,
+    ...authStatus,
   };
 };
 


### PR DESCRIPTION
## Summary
- route auth bootstrap through the existing public simulation API boundary
- preserve explicit guest, authenticated, and revoked states without probing protected `/api/me` for guests
- defer the admin profile request until auth is confirmed signed in

## Verification
- `npm test` (120 files, 658 tests)
- `npm run build`
- mandated deep-link/API/store test commands
- `git diff --check`

Refs #936