### PR TITLE
Prevent blank frames during overlay loading handoffs

### DIFF
--- a/src/components/MapView.overlayHandoff.test.tsx
+++ b/src/components/MapView.overlayHandoff.test.tsx
@@ -1,0 +1,223 @@
+// @vitest-environment jsdom
+import React from "react";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Site } from "../types/radio";
+
+const overlayMock = vi.hoisted(() => {
+  const requests: Array<{
+    resolve: (value: { width: number; height: number; pixels: Uint8ClampedArray }) => void;
+  }> = [];
+  return {
+    requests,
+    buildCoverage: vi.fn(
+      () =>
+        new Promise<{ width: number; height: number; pixels: Uint8ClampedArray }>((resolve) => {
+          requests.push({ resolve });
+        }),
+    ),
+    encodedRasterCount: 0,
+  };
+});
+
+const loadingOverlayMock = vi.hoisted(() => ({
+  props: null as null | {
+    handoffKey?: string | null;
+    onCloudEntered?: (requestKey: string) => void;
+    onCloudExited?: (requestKey: string) => void;
+    onCloudReady?: (requestKey: string) => void;
+  },
+}));
+
+vi.hoisted(() => {
+  const data = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: (key: string) => data.get(key) ?? null,
+    setItem: (key: string, value: string) => data.set(key, String(value)),
+    removeItem: (key: string) => data.delete(key),
+    clear: () => data.clear(),
+    key: (index: number) => Array.from(data.keys())[index] ?? null,
+    get length() {
+      return data.size;
+    },
+  });
+});
+
+vi.mock("../lib/overlayRaster", () => ({
+  buildCoverageOverlayPixelsAsync: overlayMock.buildCoverage,
+  buildMeshExtensionOverlayPixelsAsync: vi.fn(),
+  buildRelayCandidateOverlayPixelsAsync: vi.fn(),
+  buildSourcePassFailOverlayPixelsAsync: vi.fn(),
+  buildTerrainShadeOverlayPixelsAsync: vi.fn(async () => null),
+  overlayPixelsToDataUrl: vi.fn(() => ({
+    coordinates: [
+      [10, 61],
+      [11, 61],
+      [11, 60],
+      [10, 60],
+    ],
+    url: `data:image/mock-${++overlayMock.encodedRasterCount}`,
+  })),
+  OverlayTaskCancelledError: class OverlayTaskCancelledError extends Error {},
+}));
+
+vi.mock("./SimulationLoadingOverlay", () => ({
+  SimulationLoadingOverlay: (
+    props: NonNullable<typeof loadingOverlayMock.props>,
+  ) => {
+    loadingOverlayMock.props = props;
+    return <div data-testid="simulation-loading-overlay" />;
+  },
+}));
+
+vi.mock("react-map-gl/maplibre", async () => {
+  const ReactMock = await vi.importActual<typeof import("react")>("react");
+  return {
+    default: ReactMock.forwardRef(
+      (
+        props: { children?: React.ReactNode },
+        ref: React.ForwardedRef<{ easeTo: () => void; queryRenderedFeatures: () => unknown[] }>,
+      ) => {
+        ReactMock.useImperativeHandle(ref, () => ({
+          easeTo: () => undefined,
+          queryRenderedFeatures: () => [],
+        }));
+        return <div>{props.children}</div>;
+      },
+    ),
+    Layer: () => null,
+    Marker: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    Source: ({
+      children,
+      id,
+      url,
+    }: {
+      children?: React.ReactNode;
+      id?: string;
+      url?: string;
+    }) => (
+      <div data-source-id={id} data-testid={id} data-url={url}>
+        {children}
+      </div>
+    ),
+    useMap: () => ({ current: undefined }),
+  };
+});
+
+vi.mock("../lib/meshtasticMqtt", () => ({
+  fetchMeshmapNodes: vi.fn(async () => ({
+    fromCache: false,
+    networkError: false,
+    nodes: [],
+  })),
+}));
+
+import { useAppStore } from "../store/appStore";
+import { useCoverageStore } from "../store/coverageStore";
+import { MapView } from "./MapView";
+
+const site: Site = {
+  id: "site-a",
+  name: "Site A",
+  position: { lat: 60.4, lon: 10.7 },
+  groundElevationM: 120,
+  antennaHeightM: 8,
+  txPowerDbm: 30,
+  txGainDbi: 2,
+  rxGainDbi: 2,
+  cableLossDb: 1,
+};
+
+const resolveNextRaster = async () => {
+  await waitFor(() => expect(overlayMock.requests.length).toBeGreaterThan(0));
+  const request = overlayMock.requests.shift();
+  if (!request) throw new Error("Expected a pending overlay raster request");
+  await act(async () => {
+    request.resolve({
+      width: 1,
+      height: 1,
+      pixels: new Uint8ClampedArray([255, 0, 0, 255]),
+    });
+  });
+};
+
+describe("MapView overlay handoff", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    overlayMock.requests.length = 0;
+    overlayMock.encodedRasterCount = 0;
+    loadingOverlayMock.props = null;
+    Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
+      configurable: true,
+      value: vi.fn(() => ({})),
+    });
+    useAppStore.setState({
+      sites: [site],
+      links: [],
+      selectedSiteId: site.id,
+      selectedSiteIds: [site.id],
+      selectedLinkId: "",
+      mapOverlayMode: "heatmap",
+      selectedCoverageResolution: "24",
+      selectedOverlayRadiusOption: "20",
+      srtmTiles: [],
+      isTerrainFetching: false,
+      isTerrainRecommending: false,
+      recommendAndFetchTerrainForCurrentArea: vi.fn(async () => undefined),
+    });
+    useCoverageStore.setState({
+      coverageSamples: [
+        {
+          lat: site.position.lat,
+          lon: site.position.lon,
+          valueDbm: -80,
+        },
+      ],
+      isSimulationRecomputing: false,
+      autoCalculateEnabled: true,
+      calculationCycleSource: null,
+    });
+  });
+
+  it("keeps the displayed raster mounted until the replacement cloud is ready", async () => {
+    render(
+      <MapView
+        canPersist
+        isMapExpanded={false}
+        onToggleMapExpanded={() => undefined}
+        showInspector={false}
+      />,
+    );
+
+    await resolveNextRaster();
+    await waitFor(() => expect(loadingOverlayMock.props?.handoffKey).toBeTruthy());
+    const firstKey = loadingOverlayMock.props?.handoffKey;
+    expect(firstKey).toBeTruthy();
+    act(() => loadingOverlayMock.props?.onCloudReady?.(firstKey!));
+    act(() => loadingOverlayMock.props?.onCloudEntered?.(firstKey!));
+    await waitFor(() =>
+      expect(screen.getByTestId("coverage-overlay-source")).toHaveAttribute(
+        "data-url",
+        "data:image/mock-1",
+      ),
+    );
+    act(() => loadingOverlayMock.props?.onCloudExited?.(firstKey!));
+
+    act(() => useAppStore.getState().setMapOverlayMode("contours"));
+    await waitFor(() => expect(overlayMock.requests.length).toBeGreaterThan(0));
+
+    expect(screen.getByTestId("coverage-overlay-source")).toHaveAttribute(
+      "data-url",
+      "data:image/mock-1",
+    );
+    const replacementKey = loadingOverlayMock.props?.handoffKey;
+    expect(replacementKey).toBeTruthy();
+    expect(replacementKey).not.toBe(firstKey);
+
+    act(() => loadingOverlayMock.props?.onCloudReady?.(replacementKey!));
+    expect(screen.getByTestId("coverage-overlay-source")).toHaveAttribute(
+      "data-url",
+      "data:image/mock-1",
+    );
+  });
+});

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState, type MouseEvent, type ReactNode } from "react";
 import { Egg, Fullscreen, Layers, Locate, LocateFixed, Maximize2, Minimize2, Play, Rabbit, RefreshCw, Square, SquareStack, ToggleLeft, ToggleRight, ZoomIn, ZoomOut } from "lucide-react";
 import { CompactDetails, CompactDetailsSummary } from "./ui/CompactDetails";
 import { FloatingPopover } from "./ui/FloatingPopover";
@@ -88,6 +88,10 @@ import { animateMapToCenter, fitMapToBounds, resolveMapCameraPadding } from "./m
 import { PanelToolbar } from "./ui/PanelToolbar";
 import { SimulationLoadingOverlay } from "./SimulationLoadingOverlay";
 import { resolveSimulationOverlayTransition } from "../lib/simulationLoadingOverlay";
+import {
+  initialSimulationOverlayHandoffState,
+  reduceSimulationOverlayHandoff,
+} from "../lib/simulationOverlayHandoff";
 
 const UI_SECTION_KEYS = {
   mapViewResults: "linksim-ui-mapview-results-v1",
@@ -182,13 +186,13 @@ const panoramaRayLayer = (color: string): LayerProps => ({
   },
 });
 
-const coverageRasterLayer = (loading: boolean): LayerProps => {
-  const transition = resolveSimulationOverlayTransition(loading);
+const coverageRasterLayer = (fadedForCloud: boolean, hidden: boolean): LayerProps => {
+  const transition = resolveSimulationOverlayTransition(fadedForCloud);
   return {
     id: "coverage-overlay-layer",
     type: "raster",
     paint: {
-      "raster-opacity": transition.coverageOpacity,
+      "raster-opacity": hidden ? 0 : transition.coverageOpacity,
       "raster-opacity-transition": {
         duration: transition.durationMs,
       },
@@ -198,28 +202,28 @@ const coverageRasterLayer = (loading: boolean): LayerProps => {
   };
 };
 
-const targetContourHaloLayer = (color: string, loading: boolean): LayerProps => ({
+const targetContourHaloLayer = (color: string, fadedForCloud: boolean, hidden: boolean): LayerProps => ({
   id: "coverage-target-contour-halo-layer",
   type: "line",
   paint: {
     "line-color": color,
     "line-width": 2.5,
-    "line-opacity": loading ? 0 : 0.82,
+    "line-opacity": fadedForCloud || hidden ? 0 : 0.82,
     "line-opacity-transition": {
-      duration: resolveSimulationOverlayTransition(loading).durationMs,
+      duration: resolveSimulationOverlayTransition(fadedForCloud).durationMs,
     },
   },
 });
 
-const targetContourLineLayer = (color: string, loading: boolean): LayerProps => ({
+const targetContourLineLayer = (color: string, fadedForCloud: boolean, hidden: boolean): LayerProps => ({
   id: "coverage-target-contour-line-layer",
   type: "line",
   paint: {
     "line-color": color,
     "line-width": 1.2,
-    "line-opacity": loading ? 0 : 0.96,
+    "line-opacity": fadedForCloud || hidden ? 0 : 0.96,
     "line-opacity-transition": {
-      duration: resolveSimulationOverlayTransition(loading).durationMs,
+      duration: resolveSimulationOverlayTransition(fadedForCloud).durationMs,
     },
   },
 });
@@ -1583,6 +1587,81 @@ export function MapView({
   }, [setOverlayPipelineProgress]);
   const [coverageOverlay, setCoverageOverlay] = useState<(OverlayRaster & { minDbm?: number; maxDbm?: number }) | null>(null);
   const [simulationTerrainOverlay, setSimulationTerrainOverlay] = useState<OverlayRaster | null>(null);
+  const [overlayHandoff, dispatchOverlayHandoff] = useReducer(
+    reduceSimulationOverlayHandoff,
+    initialSimulationOverlayHandoffState,
+  );
+  const overlayHandoffRef = useRef(overlayHandoff);
+  overlayHandoffRef.current = overlayHandoff;
+  const latestCoverageRequestKeyRef = useRef<string | null>(null);
+  const pendingCoverageOverlayRef = useRef<(OverlayRaster & { minDbm?: number; maxDbm?: number }) | null>(null);
+  const pendingTerrainOverlayRef = useRef<OverlayRaster | null>(null);
+  const hiddenOverlayTimeoutRef = useRef<number | null>(null);
+  const beginCoverageHandoff = useCallback((requestKey: string) => {
+    if (hiddenOverlayTimeoutRef.current !== null) {
+      window.clearTimeout(hiddenOverlayTimeoutRef.current);
+      hiddenOverlayTimeoutRef.current = null;
+    }
+    latestCoverageRequestKeyRef.current = requestKey;
+    dispatchOverlayHandoff({ type: "request", requestKey });
+  }, []);
+  const completeCoverageHandoff = useCallback(
+    (
+      requestKey: string,
+      overlay: (OverlayRaster & { minDbm?: number; maxDbm?: number }) | null,
+    ) => {
+      if (latestCoverageRequestKeyRef.current !== requestKey) return;
+      if (!overlay) {
+        dispatchOverlayHandoff({ type: "request-failed", requestKey });
+        return;
+      }
+      pendingCoverageOverlayRef.current = overlay;
+      dispatchOverlayHandoff({ type: "replacement-ready", requestKey });
+    },
+    [],
+  );
+  const failCoverageHandoff = useCallback((requestKey: string) => {
+    if (latestCoverageRequestKeyRef.current !== requestKey) return;
+    dispatchOverlayHandoff({ type: "request-failed", requestKey });
+  }, []);
+  const commitTerrainOverlay = useCallback((overlay: OverlayRaster | null) => {
+    const phase = overlayHandoffRef.current.phase;
+    if (phase === "entering" || phase === "entered") {
+      pendingTerrainOverlayRef.current = overlay;
+      return;
+    }
+    setSimulationTerrainOverlay(overlay);
+  }, []);
+
+  useEffect(() => {
+    if (overlayHandoff.phase !== "exiting") return;
+    if (overlayHandoff.revealReplacement) {
+      const replacement = pendingCoverageOverlayRef.current;
+      if (replacement) setCoverageOverlay(replacement);
+      if (pendingTerrainOverlayRef.current) {
+        setSimulationTerrainOverlay(pendingTerrainOverlayRef.current);
+      }
+    }
+    pendingCoverageOverlayRef.current = null;
+    pendingTerrainOverlayRef.current = null;
+  }, [overlayHandoff.phase, overlayHandoff.revealReplacement]);
+
+  useEffect(() => {
+    if (overlayHandoff.phase !== "hiding") return;
+    hiddenOverlayTimeoutRef.current = window.setTimeout(() => {
+      setCoverageOverlay(null);
+      pendingCoverageOverlayRef.current = null;
+      latestCoverageRequestKeyRef.current = null;
+      dispatchOverlayHandoff({ type: "hidden" });
+      hiddenOverlayTimeoutRef.current = null;
+    }, resolveSimulationOverlayTransition(false).durationMs);
+    return () => {
+      if (hiddenOverlayTimeoutRef.current !== null) {
+        window.clearTimeout(hiddenOverlayTimeoutRef.current);
+        hiddenOverlayTimeoutRef.current = null;
+      }
+    };
+  }, [overlayHandoff.phase]);
 
   const logOverlaySchedulerEvent = useCallback(
     (
@@ -1616,6 +1695,9 @@ export function MapView({
     return () => {
       coverageOverlaySchedulerRef.current?.dispose();
       terrainOverlaySchedulerRef.current?.dispose();
+      if (hiddenOverlayTimeoutRef.current !== null) {
+        window.clearTimeout(hiddenOverlayTimeoutRef.current);
+      }
     };
   }, []);
 
@@ -1649,43 +1731,36 @@ export function MapView({
 
   useEffect(() => {
     const scheduler = coverageOverlaySchedulerRef.current!;
-    const cancelCoveragePipeline = (clearOverlay: boolean) => {
+    const cancelCoveragePipeline = () => {
       scheduler.clearQueue();
       scheduler.cancelActive();
       setOverlayPipelineProgress("coverage", null);
-      if (clearOverlay) setCoverageOverlay(null);
     };
 
     if (coverageVizMode === "none") {
-      cancelCoveragePipeline(true);
+      cancelCoveragePipeline();
+      latestCoverageRequestKeyRef.current = null;
+      dispatchOverlayHandoff({ type: "hide" });
       return;
     }
     if (!overlayBounds) {
-      cancelCoveragePipeline(true);
-      return;
-    }
-    if (
-      shouldDeferOverlayRasterization({
-        isTerrainFetching,
-        isTerrainRecommending,
-        isSimulationRecomputing,
-      })
-    ) {
-      cancelCoveragePipeline(false);
+      cancelCoveragePipeline();
+      latestCoverageRequestKeyRef.current = null;
+      dispatchOverlayHandoff({ type: "hide" });
       return;
     }
 
     const mode = coverageVizMode;
     if (mode === "passfail" && (!activeSelectionLink || !selectedFromSite || !hasPassFailTopology)) {
-      cancelCoveragePipeline(true);
+      cancelCoveragePipeline();
       return;
     }
     if (mode === "relay" && (!activeSelectionLink || !selectedFromSite || !selectedToSite || !hasRelayTopology)) {
-      cancelCoveragePipeline(true);
+      cancelCoveragePipeline();
       return;
     }
     if (mode === "mesh-extension" && !meshExtensionSites.length) {
-      cancelCoveragePipeline(true);
+      cancelCoveragePipeline();
       return;
     }
 
@@ -1714,6 +1789,19 @@ export function MapView({
       selectedSiteRadioDigest,
       meshExtensionFrequencyMHz,
     ].join("|");
+    if (
+      shouldDeferOverlayRasterization({
+        isTerrainFetching,
+        isTerrainRecommending,
+        isSimulationRecomputing,
+      })
+    ) {
+      if (isTerrainFetching || isSimulationRecomputing) {
+        beginCoverageHandoff(signature);
+      }
+      cancelCoveragePipeline();
+      return;
+    }
     const hasFreshCoverageCompletion =
       calculationCycleSource !== null &&
       completedCoverageRunToken !== "" &&
@@ -1731,12 +1819,13 @@ export function MapView({
       lastCoverageOverlayCompletionRef.current = completedCoverageRunToken;
     }
     const cached = coverageOverlayCacheRef.current.get(signature);
+    beginCoverageHandoff(signature);
     if (cached) {
       scheduler.clearQueue();
       scheduler.cancelActive();
       setOverlayPipelineProgress("coverage", null);
       logOverlaySchedulerEvent("coverage", "cache-hit", signature);
-      setCoverageOverlay(cached);
+      completeCoverageHandoff(signature, cached);
       return;
     }
 
@@ -1869,10 +1958,11 @@ export function MapView({
               signature,
               mode,
             });
+            failCoverageHandoff(signature);
             return;
           }
           if (!rasterPixels) {
-            setCoverageOverlay(null);
+            failCoverageHandoff(signature);
             return;
           }
           const raster = overlayPixelsToDataUrl(rasterPixels);
@@ -1885,6 +1975,7 @@ export function MapView({
               signature,
               mode,
             });
+            failCoverageHandoff(signature);
             return;
           }
           recordSimulationOverlayPerf({
@@ -1903,7 +1994,7 @@ export function MapView({
             coverageOverlayCacheRef.current.set(signature, overlayValue);
           }
           setOverlayPipelineProgress("coverage", 100);
-          setCoverageOverlay(overlayValue);
+          completeCoverageHandoff(signature, overlayValue);
         } catch (error) {
           if (error instanceof OverlayTaskCancelledError) {
             recordSimulationRunCancelled({
@@ -1913,9 +2004,11 @@ export function MapView({
               signature,
               mode,
             });
+            failCoverageHandoff(signature);
             return;
           }
           console.error("Failed to render simulation overlay", error);
+          failCoverageHandoff(signature);
         } finally {
           endOverlayJob();
         }
@@ -1958,6 +2051,9 @@ export function MapView({
     selectedNetwork,
     showOverlayDiagnostics,
     beginOverlayJob,
+    beginCoverageHandoff,
+    completeCoverageHandoff,
+    failCoverageHandoff,
     setOverlayPipelineProgress,
     logOverlaySchedulerEvent,
     calculationWorkAllowed,
@@ -1997,7 +2093,41 @@ export function MapView({
         : { type: "FeatureCollection" as const, features: [] },
     [coverageVizMode, overlayBounds, overlayPointMask, rxSensitivityTargetDbm, samplesForOverlay],
   );
-  const showTargetContourLine = coverageVizMode === "contours" && targetContourFeatures.features.length > 0;
+  const [displayedTargetContourFeatures, setDisplayedTargetContourFeatures] =
+    useState(targetContourFeatures);
+  const pendingTargetContourFeaturesRef = useRef(targetContourFeatures);
+  useEffect(() => {
+    if (
+      coverageVizMode === "contours" &&
+      targetContourFeatures.features.length > 0
+    ) {
+      if (
+        overlayHandoff.phase === "entering" ||
+        overlayHandoff.phase === "entered"
+      ) {
+        pendingTargetContourFeaturesRef.current = targetContourFeatures;
+      } else {
+        setDisplayedTargetContourFeatures(targetContourFeatures);
+      }
+    }
+    if (overlayHandoff.phase === "exiting") {
+      setDisplayedTargetContourFeatures(
+        coverageVizMode === "contours"
+          ? pendingTargetContourFeaturesRef.current
+          : { type: "FeatureCollection", features: [] },
+      );
+    }
+    if (overlayHandoff.phase !== "hiding") return;
+    const timeoutId = window.setTimeout(() => {
+      setDisplayedTargetContourFeatures({
+        type: "FeatureCollection",
+        features: [],
+      });
+    }, resolveSimulationOverlayTransition(false).durationMs);
+    return () => window.clearTimeout(timeoutId);
+  }, [coverageVizMode, overlayHandoff.phase, targetContourFeatures]);
+  const showTargetContourLine =
+    displayedTargetContourFeatures.features.length > 0;
   const coverageScaleRange = useMemo(() => {
     if (!coverageOverlay || (coverageVizMode !== "heatmap" && coverageVizMode !== "contours" && coverageVizMode !== "weakest")) {
       return null;
@@ -2082,7 +2212,7 @@ export function MapView({
       scheduler.cancelActive();
       setOverlayPipelineProgress("terrain", null);
       logOverlaySchedulerEvent("terrain", "cache-hit", signature);
-      setSimulationTerrainOverlay(cached);
+      commitTerrainOverlay(cached);
       return;
     }
 
@@ -2151,7 +2281,6 @@ export function MapView({
             return;
           }
           if (!rasterPixels) {
-            setSimulationTerrainOverlay(null);
             return;
           }
           const raster = overlayPixelsToDataUrl(rasterPixels);
@@ -2182,7 +2311,7 @@ export function MapView({
             terrainOverlayCacheRef.current.set(signature, overlayValue);
           }
           setOverlayPipelineProgress("terrain", 100);
-          setSimulationTerrainOverlay(overlayValue);
+          commitTerrainOverlay(overlayValue);
         } catch (error) {
           if (error instanceof OverlayTaskCancelledError) {
             recordSimulationRunCancelled({
@@ -2218,6 +2347,7 @@ export function MapView({
     overlayRadiusKm,
     showOverlayDiagnostics,
     beginOverlayJob,
+    commitTerrainOverlay,
     setOverlayPipelineProgress,
     logOverlaySchedulerEvent,
     calculationWorkAllowed,
@@ -2305,11 +2435,23 @@ export function MapView({
     ],
   );
   const simulationLoadingOverlayActive =
-    Boolean(analysisBounds && overlayPointMask) &&
-    (isTerrainFetching || isSimulationRecomputing || overlayJobsInFlight > 0);
+    Boolean(analysisBounds && overlayPointMask && overlayHandoff.requestKey) &&
+    (overlayHandoff.phase === "entering" || overlayHandoff.phase === "entered");
+  const simulationOverlayFadedForCloud =
+    simulationLoadingOverlayActive && overlayHandoff.cloudReady;
+  const simulationOverlayHidden = overlayHandoff.phase === "hiding";
   const simulationOverlayTransition = resolveSimulationOverlayTransition(
-    simulationLoadingOverlayActive,
+    simulationOverlayFadedForCloud,
   );
+  const handleLoadingCloudReady = useCallback((requestKey: string) => {
+    dispatchOverlayHandoff({ type: "cloud-ready", requestKey });
+  }, []);
+  const handleLoadingCloudEntered = useCallback((requestKey: string) => {
+    dispatchOverlayHandoff({ type: "cloud-entered", requestKey });
+  }, []);
+  const handleLoadingCloudExited = useCallback((requestKey: string) => {
+    dispatchOverlayHandoff({ type: "exit-complete", requestKey });
+  }, []);
   const calculationControlRunning = calculationCycleSource !== null || isSimulationRecomputing;
   const handleStopCalculation = useCallback(() => {
     stopCalculation();
@@ -2320,7 +2462,9 @@ export function MapView({
     terrainOverlaySchedulerRef.current?.cancelActive();
     setOverlayPipelineProgress("coverage", null);
     setOverlayPipelineProgress("terrain", null);
-  }, [cancelTerrainLoad, setOverlayPipelineProgress, stopCalculation]);
+    const requestKey = overlayHandoffRef.current.requestKey;
+    if (requestKey) failCoverageHandoff(requestKey);
+  }, [cancelTerrainLoad, failCoverageHandoff, setOverlayPipelineProgress, stopCalculation]);
   useEffect(() => {
     if (!calculationCycleSource || isSimulationRecomputing || overlayJobsInFlight > 0 || isTerrainFetching || isTerrainRecommending) {
       return;
@@ -3776,7 +3920,7 @@ export function MapView({
               type="raster"
               paint={{
                 ...terrainRasterPaint,
-                "raster-opacity": simulationLoadingOverlayActive
+                "raster-opacity": simulationOverlayFadedForCloud || simulationOverlayHidden
                   ? 0
                   : coverageOverlay
                     ? 0.34
@@ -3803,28 +3947,39 @@ export function MapView({
             type="image"
             url={coverageOverlay.url}
           >
-            <Layer {...coverageRasterLayer(simulationLoadingOverlayActive)} />
+            <Layer
+              {...coverageRasterLayer(
+                simulationOverlayFadedForCloud,
+                simulationOverlayHidden,
+              )}
+            />
           </Source>
         ) : null}
 
         <SimulationLoadingOverlay
           bounds={analysisBounds}
+          handoffKey={overlayHandoff.requestKey}
           loading={simulationLoadingOverlayActive}
+          onCloudEntered={handleLoadingCloudEntered}
+          onCloudExited={handleLoadingCloudExited}
+          onCloudReady={handleLoadingCloudReady}
           pointMask={overlayPointMask}
         />
 
         {showTargetContourLine ? (
-          <Source data={targetContourFeatures} id="coverage-target-contour-source" type="geojson">
+          <Source data={displayedTargetContourFeatures} id="coverage-target-contour-source" type="geojson">
             <Layer
               {...targetContourHaloLayer(
                 variant.cssVars["--bg"] ?? linkColor,
-                simulationLoadingOverlayActive,
+                simulationOverlayFadedForCloud,
+                simulationOverlayHidden,
               )}
             />
             <Layer
               {...targetContourLineLayer(
                 variant.cssVars["--muted"] ?? selectedLinkColor,
-                simulationLoadingOverlayActive,
+                simulationOverlayFadedForCloud,
+                simulationOverlayHidden,
               )}
             />
           </Source>

--- a/src/components/SimulationLoadingOverlay.test.tsx
+++ b/src/components/SimulationLoadingOverlay.test.tsx
@@ -99,10 +99,17 @@ describe("SimulationLoadingOverlay", () => {
   });
 
   it("crossfades into clouds and keeps them mounted through the exit transition", () => {
+    const onCloudReady = vi.fn();
+    const onCloudEntered = vi.fn();
+    const onCloudExited = vi.fn();
     const { rerender } = render(
       <SimulationLoadingOverlay
         bounds={bounds}
+        handoffKey="heatmap"
         loading
+        onCloudEntered={onCloudEntered}
+        onCloudExited={onCloudExited}
+        onCloudReady={onCloudReady}
         pointMask={() => true}
       />,
     );
@@ -118,6 +125,7 @@ describe("SimulationLoadingOverlay", () => {
 
     act(() => vi.advanceTimersByTime(16));
 
+    expect(onCloudReady).toHaveBeenCalledWith("heatmap");
     expect(mapMock.map.setPaintProperty).toHaveBeenCalledWith(
       "simulation-loading-overlay-layer",
       "raster-opacity-transition",
@@ -132,11 +140,26 @@ describe("SimulationLoadingOverlay", () => {
     rerender(
       <SimulationLoadingOverlay
         bounds={bounds}
+        handoffKey="heatmap"
         loading={false}
+        onCloudEntered={onCloudEntered}
+        onCloudExited={onCloudExited}
+        onCloudReady={onCloudReady}
         pointMask={() => true}
       />,
     );
 
+    expect(onCloudEntered).not.toHaveBeenCalled();
+    expect(mapMock.map.setPaintProperty).not.toHaveBeenCalledWith(
+      "simulation-loading-overlay-layer",
+      "raster-opacity-transition",
+      { duration: 500 },
+    );
+
+    act(() => vi.advanceTimersByTime(349));
+    expect(onCloudEntered).not.toHaveBeenCalled();
+    act(() => vi.advanceTimersByTime(1));
+    expect(onCloudEntered).toHaveBeenCalledWith("heatmap");
     expect(mapMock.map.setPaintProperty).toHaveBeenCalledWith(
       "simulation-loading-overlay-layer",
       "raster-opacity-transition",
@@ -157,6 +180,7 @@ describe("SimulationLoadingOverlay", () => {
     expect(mapMock.map.removeSource).toHaveBeenCalledWith(
       "simulation-loading-overlay-source",
     );
+    expect(onCloudExited).toHaveBeenCalledWith("heatmap");
   });
 
   it("renders one static cloud frame for reduced motion", () => {
@@ -169,6 +193,7 @@ describe("SimulationLoadingOverlay", () => {
     render(
       <SimulationLoadingOverlay
         bounds={bounds}
+        handoffKey="heatmap"
         loading
         pointMask={() => true}
       />,
@@ -178,5 +203,41 @@ describe("SimulationLoadingOverlay", () => {
     expect(putImageData).toHaveBeenCalledTimes(1);
     act(() => vi.advanceTimersByTime(500));
     expect(putImageData).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses an entered cloud without replaying its 350 ms entrance", () => {
+    vi.mocked(window.matchMedia).mockReturnValue({
+      matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    } as unknown as MediaQueryList);
+    const onCloudEntered = vi.fn();
+    const pointMask = () => true;
+    const { rerender } = render(
+      <SimulationLoadingOverlay
+        bounds={bounds}
+        handoffKey="relay"
+        loading
+        onCloudEntered={onCloudEntered}
+        pointMask={pointMask}
+      />,
+    );
+
+    act(() => vi.advanceTimersByTime(16));
+    act(() => vi.advanceTimersByTime(350));
+    expect(onCloudEntered).toHaveBeenCalledWith("relay");
+
+    rerender(
+      <SimulationLoadingOverlay
+        bounds={bounds}
+        handoffKey="heatmap"
+        loading
+        onCloudEntered={onCloudEntered}
+        pointMask={pointMask}
+      />,
+    );
+    act(() => vi.advanceTimersByTime(16));
+
+    expect(onCloudEntered).toHaveBeenCalledWith("heatmap");
   });
 });

--- a/src/components/SimulationLoadingOverlay.tsx
+++ b/src/components/SimulationLoadingOverlay.tsx
@@ -22,7 +22,11 @@ const LAYER_ID = "simulation-loading-overlay-layer";
 
 type SimulationLoadingOverlayProps = {
   bounds: TerrainBounds | null;
+  handoffKey?: string | null;
   loading: boolean;
+  onCloudEntered?: (handoffKey: string) => void;
+  onCloudExited?: (handoffKey: string) => void;
+  onCloudReady?: (handoffKey: string) => void;
   pointMask?: (lat: number, lon: number) => boolean;
 };
 
@@ -47,7 +51,11 @@ const usePrefersReducedMotion = (): boolean => {
 
 export function SimulationLoadingOverlay({
   bounds,
+  handoffKey = null,
   loading,
+  onCloudEntered,
+  onCloudExited,
+  onCloudReady,
   pointMask,
 }: SimulationLoadingOverlayProps) {
   const canvas = useMemo(() => document.createElement("canvas"), []);
@@ -56,8 +64,13 @@ export function SimulationLoadingOverlay({
   const reducedMotion = usePrefersReducedMotion();
   const ready = Boolean(bounds && pointMask);
   const addingToMapRef = useRef(false);
+  const entryKeyRef = useRef<string | null>(null);
+  const entryTimeoutRef = useRef<number | null>(null);
+  const exitKeyRef = useRef<string | null>(null);
   const removalTimeoutRef = useRef<number | null>(null);
   const fadeInFrameRef = useRef<number | null>(null);
+  const loadingRef = useRef(loading);
+  loadingRef.current = loading;
   const coordinates = useMemo(
     () => (bounds ? loadingOverlayCoordinates(bounds) : null),
     [bounds],
@@ -99,7 +112,7 @@ export function SimulationLoadingOverlay({
       }
     };
 
-    frameId = window.requestAnimationFrame(paint);
+    paint(startedAt);
     return () => window.cancelAnimationFrame(frameId);
   }, [bounds, canvas, loading, pointMask, reducedMotion]);
 
@@ -122,6 +135,12 @@ export function SimulationLoadingOverlay({
         fadeInFrameRef.current = null;
       }
     };
+    const clearPendingEntry = () => {
+      if (entryTimeoutRef.current !== null) {
+        window.clearTimeout(entryTimeoutRef.current);
+        entryTimeoutRef.current = null;
+      }
+    };
     const applyTransition = (entering: boolean) => {
       if (!map.getLayer(LAYER_ID)) return;
       const transition = resolveSimulationOverlayTransition(entering);
@@ -133,6 +152,17 @@ export function SimulationLoadingOverlay({
         "raster-opacity",
         transition.loadingOpacity,
       );
+    };
+    const startExit = (key: string) => {
+      applyTransition(false);
+      exitKeyRef.current = key;
+      removalTimeoutRef.current = window.setTimeout(() => {
+        removeFromMap();
+        removalTimeoutRef.current = null;
+        const exitedKey = exitKeyRef.current;
+        exitKeyRef.current = null;
+        if (exitedKey) onCloudExited?.(exitedKey);
+      }, LOADING_OVERLAY_EXIT_MS);
     };
 
     const addToMap = () => {
@@ -169,21 +199,32 @@ export function SimulationLoadingOverlay({
       }
     };
 
+    const wasExiting = removalTimeoutRef.current !== null;
+    const continuingEnteredCloud =
+      loading &&
+      entryKeyRef.current !== null &&
+      entryKeyRef.current !== handoffKey &&
+      entryTimeoutRef.current === null &&
+      !wasExiting &&
+      Boolean(map.getLayer(LAYER_ID));
     clearPendingRemoval();
     clearPendingFadeIn();
 
-    if (!ready || !coordinates) {
+    if (!ready || !coordinates || !handoffKey) {
+      clearPendingEntry();
       removeFromMap();
       return;
     }
 
     if (!loading) {
-      applyTransition(false);
-      removalTimeoutRef.current = window.setTimeout(() => {
-        removeFromMap();
-        removalTimeoutRef.current = null;
-      }, LOADING_OVERLAY_EXIT_MS);
+      if (entryTimeoutRef.current !== null) return;
+      startExit(handoffKey);
       return clearPendingRemoval;
+    }
+
+    if (entryKeyRef.current !== handoffKey) {
+      clearPendingEntry();
+      entryKeyRef.current = handoffKey;
     }
 
     const addAfterStyleChange = () => addToMap();
@@ -219,7 +260,17 @@ export function SimulationLoadingOverlay({
       }
       fadeInFrameRef.current = window.requestAnimationFrame(() => {
         fadeInFrameRef.current = null;
+        onCloudReady?.(handoffKey);
         applyTransition(true);
+        if (continuingEnteredCloud) {
+          onCloudEntered?.(handoffKey);
+          return;
+        }
+        entryTimeoutRef.current = window.setTimeout(() => {
+          entryTimeoutRef.current = null;
+          onCloudEntered?.(handoffKey);
+          if (!loadingRef.current) startExit(handoffKey);
+        }, resolveSimulationOverlayTransition(true).durationMs);
       });
     }
 
@@ -227,7 +278,17 @@ export function SimulationLoadingOverlay({
       map.off("styledata", addAfterStyleChange);
       clearPendingFadeIn();
     };
-  }, [canvas, coordinates, loading, map, ready]);
+  }, [
+    canvas,
+    coordinates,
+    handoffKey,
+    loading,
+    map,
+    onCloudEntered,
+    onCloudExited,
+    onCloudReady,
+    ready,
+  ]);
 
   useEffect(() => {
     if (!map || !loading || !coordinates) return;
@@ -243,6 +304,9 @@ export function SimulationLoadingOverlay({
       }
       if (fadeInFrameRef.current !== null) {
         window.cancelAnimationFrame(fadeInFrameRef.current);
+      }
+      if (entryTimeoutRef.current !== null) {
+        window.clearTimeout(entryTimeoutRef.current);
       }
       if (map.getLayer(LAYER_ID)) map.removeLayer(LAYER_ID);
       if (map.getSource(SOURCE_ID)) map.removeSource(SOURCE_ID);

--- a/src/lib/simulationOverlayHandoff.test.ts
+++ b/src/lib/simulationOverlayHandoff.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import {
+  initialSimulationOverlayHandoffState,
+  reduceSimulationOverlayHandoff,
+} from "./simulationOverlayHandoff";
+
+describe("simulation overlay handoff", () => {
+  it("holds a fast replacement until the cloud entrance completes", () => {
+    let state = reduceSimulationOverlayHandoff(
+      initialSimulationOverlayHandoffState,
+      { type: "request", requestKey: "heatmap" },
+    );
+    state = reduceSimulationOverlayHandoff(state, {
+      type: "replacement-ready",
+      requestKey: "heatmap",
+    });
+    expect(state.phase).toBe("entering");
+    expect(state.revealReplacement).toBe(false);
+
+    state = reduceSimulationOverlayHandoff(state, {
+      type: "cloud-ready",
+      requestKey: "heatmap",
+    });
+    state = reduceSimulationOverlayHandoff(state, {
+      type: "cloud-entered",
+      requestKey: "heatmap",
+    });
+    expect(state.phase).toBe("exiting");
+    expect(state.revealReplacement).toBe(true);
+  });
+
+  it("keeps an entered cloud active while rapid requests replace the target", () => {
+    let state = reduceSimulationOverlayHandoff(
+      initialSimulationOverlayHandoffState,
+      { type: "request", requestKey: "relay" },
+    );
+    state = reduceSimulationOverlayHandoff(state, {
+      type: "cloud-ready",
+      requestKey: "relay",
+    });
+    state = reduceSimulationOverlayHandoff(state, {
+      type: "cloud-entered",
+      requestKey: "relay",
+    });
+    state = reduceSimulationOverlayHandoff(state, {
+      type: "request",
+      requestKey: "heatmap",
+    });
+
+    expect(state).toMatchObject({
+      phase: "entered",
+      requestKey: "heatmap",
+      cloudReady: true,
+      cloudEntered: true,
+      replacementReady: false,
+    });
+    expect(
+      reduceSimulationOverlayHandoff(state, {
+        type: "replacement-ready",
+        requestKey: "relay",
+      }),
+    ).toEqual(state);
+  });
+
+  it("restores the retained overlay when the latest replacement fails", () => {
+    let state = reduceSimulationOverlayHandoff(
+      initialSimulationOverlayHandoffState,
+      { type: "request", requestKey: "weakest" },
+    );
+    state = reduceSimulationOverlayHandoff(state, {
+      type: "cloud-ready",
+      requestKey: "weakest",
+    });
+    state = reduceSimulationOverlayHandoff(state, {
+      type: "request-failed",
+      requestKey: "weakest",
+    });
+
+    expect(state.phase).toBe("exiting");
+    expect(state.revealReplacement).toBe(false);
+  });
+
+  it("abandons an unpainted failed request without fading the retained overlay", () => {
+    const requested = reduceSimulationOverlayHandoff(
+      initialSimulationOverlayHandoffState,
+      { type: "request", requestKey: "mesh-extension" },
+    );
+    expect(
+      reduceSimulationOverlayHandoff(requested, {
+        type: "request-failed",
+        requestKey: "mesh-extension",
+      }),
+    ).toEqual(initialSimulationOverlayHandoffState);
+  });
+
+  it("hides directly without starting a cloud handoff", () => {
+    const hiding = reduceSimulationOverlayHandoff(
+      initialSimulationOverlayHandoffState,
+      { type: "hide" },
+    );
+    expect(hiding.phase).toBe("hiding");
+    expect(hiding.cloudReady).toBe(false);
+    expect(
+      reduceSimulationOverlayHandoff(hiding, { type: "hidden" }),
+    ).toEqual(initialSimulationOverlayHandoffState);
+  });
+
+  it("lets an already visible cloud fade out when Hidden is selected", () => {
+    let state = reduceSimulationOverlayHandoff(
+      initialSimulationOverlayHandoffState,
+      { type: "request", requestKey: "relay" },
+    );
+    state = reduceSimulationOverlayHandoff(state, {
+      type: "cloud-ready",
+      requestKey: "relay",
+    });
+    state = reduceSimulationOverlayHandoff(state, { type: "hide" });
+
+    expect(state).toMatchObject({
+      phase: "hiding",
+      requestKey: "relay",
+      cloudReady: true,
+    });
+    expect(
+      reduceSimulationOverlayHandoff(state, {
+        type: "exit-complete",
+        requestKey: "relay",
+      }),
+    ).toEqual(state);
+  });
+});

--- a/src/lib/simulationOverlayHandoff.ts
+++ b/src/lib/simulationOverlayHandoff.ts
@@ -1,0 +1,107 @@
+export type SimulationOverlayHandoffPhase =
+  | "idle"
+  | "entering"
+  | "entered"
+  | "exiting"
+  | "hiding";
+
+export type SimulationOverlayHandoffState = {
+  phase: SimulationOverlayHandoffPhase;
+  requestKey: string | null;
+  cloudReady: boolean;
+  cloudEntered: boolean;
+  replacementReady: boolean;
+  revealReplacement: boolean;
+};
+
+export type SimulationOverlayHandoffEvent =
+  | { type: "request"; requestKey: string }
+  | { type: "cloud-ready"; requestKey: string }
+  | { type: "cloud-entered"; requestKey: string }
+  | { type: "replacement-ready"; requestKey: string }
+  | { type: "request-failed"; requestKey: string }
+  | { type: "exit-complete"; requestKey: string }
+  | { type: "hide" }
+  | { type: "hidden" };
+
+export const initialSimulationOverlayHandoffState: SimulationOverlayHandoffState = {
+  phase: "idle",
+  requestKey: null,
+  cloudReady: false,
+  cloudEntered: false,
+  replacementReady: false,
+  revealReplacement: false,
+};
+
+export const reduceSimulationOverlayHandoff = (
+  state: SimulationOverlayHandoffState,
+  event: SimulationOverlayHandoffEvent,
+): SimulationOverlayHandoffState => {
+  switch (event.type) {
+    case "request": {
+      const keepEnteredCloud =
+        state.phase === "entering" || state.phase === "entered";
+      return {
+        phase:
+          keepEnteredCloud && state.cloudEntered
+            ? "entered"
+            : "entering",
+        requestKey: event.requestKey,
+        cloudReady: keepEnteredCloud && state.cloudReady,
+        cloudEntered: keepEnteredCloud && state.cloudEntered,
+        replacementReady: false,
+        revealReplacement: false,
+      };
+    }
+    case "cloud-ready":
+      if (state.requestKey !== event.requestKey) return state;
+      return { ...state, cloudReady: true };
+    case "cloud-entered":
+      if (state.requestKey !== event.requestKey) return state;
+      if (state.replacementReady) {
+        return {
+          ...state,
+          phase: "exiting",
+          cloudEntered: true,
+          revealReplacement: true,
+        };
+      }
+      return { ...state, phase: "entered", cloudEntered: true };
+    case "replacement-ready":
+      if (state.requestKey !== event.requestKey) return state;
+      if (state.cloudEntered) {
+        return {
+          ...state,
+          phase: "exiting",
+          replacementReady: true,
+          revealReplacement: true,
+        };
+      }
+      return { ...state, replacementReady: true };
+    case "request-failed":
+      if (state.requestKey !== event.requestKey) return state;
+      if (!state.cloudReady) return initialSimulationOverlayHandoffState;
+      return {
+        ...state,
+        phase: "exiting",
+        replacementReady: false,
+        revealReplacement: false,
+      };
+    case "exit-complete":
+      if (
+        state.phase !== "exiting" ||
+        state.requestKey !== event.requestKey
+      ) return state;
+      return initialSimulationOverlayHandoffState;
+    case "hide":
+      return {
+        ...state,
+        phase: "hiding",
+        replacementReady: false,
+        revealReplacement: false,
+      };
+    case "hidden":
+      if (state.phase !== "hiding") return state;
+      return initialSimulationOverlayHandoffState;
+  }
+};


### PR DESCRIPTION
## What changed

- added an internal overlay handoff state machine that retains the displayed coverage, contour, and terrain visuals until the cloud layer has painted and entered
- holds fast replacements behind the cloud bridge and reveals them during the existing 500 ms exit
- reuses one entered cloud across rapid mode/selection changes and ignores stale scheduler completions
- restores the retained overlay on cancellation, Stop, or failure
- fades Hidden directly to the basemap without starting clouds
- added state-machine, loading-overlay timing, reduced-motion, rapid-change, and MapView source-lifecycle regressions

## Root cause

The rendered overlay and latest calculation result shared one state path. Mode/topology changes could clear or replace that state before the cloud canvas and MapLibre layer had painted, briefly exposing the bare basemap.

## Validation

- `npm test` — 122 files, 666 tests passed
- focused handoff suite — 4 files, 26 tests passed
- `npm run build` — passed
- targeted changed-file lint — passed outside `MapView.tsx`; MapView retains pre-existing repository lint findings
- `git diff --check` — passed

No new controls or public APIs. No version bump in this staging batch.

Tracks #948. Shared-staging acceptance and issue closure remain gated on deployment verification and user sign-off.