### PR TITLE
Stabilize overlay loading handoffs

### DIFF
--- a/src/components/MapView.overlayHandoff.test.tsx
+++ b/src/components/MapView.overlayHandoff.test.tsx
@@ -23,6 +23,7 @@ const overlayMock = vi.hoisted(() => {
 const loadingOverlayMock = vi.hoisted(() => ({
   props: null as null | {
     handoffKey?: string | null;
+    loading?: boolean;
     onCloudEntered?: (requestKey: string) => void;
     onCloudExited?: (requestKey: string) => void;
     onCloudReady?: (requestKey: string) => void;
@@ -219,5 +220,87 @@ describe("MapView overlay handoff", () => {
       "data-url",
       "data:image/mock-1",
     );
+  });
+
+  it("does not replay clouds when a completed signature is observed again", async () => {
+    render(
+      <MapView
+        canPersist
+        isMapExpanded={false}
+        onToggleMapExpanded={() => undefined}
+        showInspector={false}
+      />,
+    );
+
+    await resolveNextRaster();
+    await waitFor(() => expect(loadingOverlayMock.props?.handoffKey).toBeTruthy());
+    const requestKey = loadingOverlayMock.props?.handoffKey;
+    act(() => loadingOverlayMock.props?.onCloudReady?.(requestKey!));
+    act(() => loadingOverlayMock.props?.onCloudEntered?.(requestKey!));
+    await waitFor(() =>
+      expect(screen.getByTestId("coverage-overlay-source")).toHaveAttribute(
+        "data-url",
+        "data:image/mock-1",
+      ),
+    );
+    act(() => loadingOverlayMock.props?.onCloudExited?.(requestKey!));
+    await waitFor(() => expect(loadingOverlayMock.props?.loading).toBe(false));
+
+    act(() =>
+      useCoverageStore.setState({
+        calculationCycleSource: "auto",
+        completedCoverageRunToken: "repeat-completion",
+      }),
+    );
+
+    await waitFor(() => expect(loadingOverlayMock.props?.loading).toBe(false));
+    expect(overlayMock.buildCoverage).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("coverage-overlay-source")).toHaveAttribute(
+      "data-url",
+      "data:image/mock-1",
+    );
+  });
+
+  it("still bridges a deliberate recalculation of the displayed signature", async () => {
+    render(
+      <MapView
+        canPersist
+        isMapExpanded={false}
+        onToggleMapExpanded={() => undefined}
+        showInspector={false}
+      />,
+    );
+
+    await resolveNextRaster();
+    await waitFor(() => expect(loadingOverlayMock.props?.handoffKey).toBeTruthy());
+    const requestKey = loadingOverlayMock.props?.handoffKey;
+    act(() => loadingOverlayMock.props?.onCloudReady?.(requestKey!));
+    act(() => loadingOverlayMock.props?.onCloudEntered?.(requestKey!));
+    await waitFor(() =>
+      expect(screen.getByTestId("coverage-overlay-source")).toHaveAttribute(
+        "data-url",
+        "data:image/mock-1",
+      ),
+    );
+    act(() => loadingOverlayMock.props?.onCloudExited?.(requestKey!));
+    await waitFor(() => expect(loadingOverlayMock.props?.loading).toBe(false));
+
+    act(() =>
+      useCoverageStore.setState({
+        calculationCycleSource: "manual",
+        isSimulationRecomputing: true,
+      }),
+    );
+    await waitFor(() => expect(loadingOverlayMock.props?.loading).toBe(true));
+
+    act(() =>
+      useCoverageStore.setState({
+        completedCoverageRunToken: "manual-repeat",
+        isSimulationRecomputing: false,
+      }),
+    );
+    expect(loadingOverlayMock.props?.loading).toBe(true);
+    act(() => loadingOverlayMock.props?.onCloudEntered?.(requestKey!));
+    await waitFor(() => expect(loadingOverlayMock.props?.loading).toBe(false));
   });
 });

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1594,6 +1594,7 @@ export function MapView({
   const overlayHandoffRef = useRef(overlayHandoff);
   overlayHandoffRef.current = overlayHandoff;
   const latestCoverageRequestKeyRef = useRef<string | null>(null);
+  const displayedCoverageSignatureRef = useRef<string | null>(null);
   const pendingCoverageOverlayRef = useRef<(OverlayRaster & { minDbm?: number; maxDbm?: number }) | null>(null);
   const pendingTerrainOverlayRef = useRef<OverlayRaster | null>(null);
   const hiddenOverlayTimeoutRef = useRef<number | null>(null);
@@ -1637,7 +1638,10 @@ export function MapView({
     if (overlayHandoff.phase !== "exiting") return;
     if (overlayHandoff.revealReplacement) {
       const replacement = pendingCoverageOverlayRef.current;
-      if (replacement) setCoverageOverlay(replacement);
+      if (replacement) {
+        setCoverageOverlay(replacement);
+        displayedCoverageSignatureRef.current = overlayHandoff.requestKey;
+      }
       if (pendingTerrainOverlayRef.current) {
         setSimulationTerrainOverlay(pendingTerrainOverlayRef.current);
       }
@@ -1652,6 +1656,7 @@ export function MapView({
       setCoverageOverlay(null);
       pendingCoverageOverlayRef.current = null;
       latestCoverageRequestKeyRef.current = null;
+      displayedCoverageSignatureRef.current = null;
       dispatchOverlayHandoff({ type: "hidden" });
       hiddenOverlayTimeoutRef.current = null;
     }, resolveSimulationOverlayTransition(false).durationMs);
@@ -1800,6 +1805,20 @@ export function MapView({
         beginCoverageHandoff(signature);
       }
       cancelCoveragePipeline();
+      return;
+    }
+    const currentHandoff = overlayHandoffRef.current;
+    const handoffWaitingForSignature =
+      currentHandoff.requestKey === signature &&
+      (currentHandoff.phase === "entering" ||
+        currentHandoff.phase === "entered");
+    if (
+      displayedCoverageSignatureRef.current === signature &&
+      !handoffWaitingForSignature
+    ) {
+      scheduler.clearQueue();
+      scheduler.cancelActive();
+      setOverlayPipelineProgress("coverage", null);
       return;
     }
     const hasFreshCoverageCompletion =

--- a/src/components/SimulationLoadingOverlay.test.tsx
+++ b/src/components/SimulationLoadingOverlay.test.tsx
@@ -6,6 +6,8 @@ const mapMock = vi.hoisted(() => {
   const state = {
     layerPresent: false,
     sourcePresent: false,
+    styleLoaded: true,
+    styleDataListener: null as null | (() => void),
   };
   const source = {
     setCoordinates: vi.fn(),
@@ -19,9 +21,11 @@ const mapMock = vi.hoisted(() => {
     }),
     getLayer: vi.fn(() => (state.layerPresent ? {} : undefined)),
     getSource: vi.fn(() => (state.sourcePresent ? source : undefined)),
-    isStyleLoaded: vi.fn(() => true),
+    isStyleLoaded: vi.fn(() => state.styleLoaded),
     off: vi.fn(),
-    on: vi.fn(),
+    on: vi.fn((event: string, listener: () => void) => {
+      if (event === "styledata") state.styleDataListener = listener;
+    }),
     removeLayer: vi.fn(() => {
       state.layerPresent = false;
     }),
@@ -57,6 +61,8 @@ describe("SimulationLoadingOverlay", () => {
     vi.useFakeTimers();
     mapMock.state.layerPresent = false;
     mapMock.state.sourcePresent = false;
+    mapMock.state.styleLoaded = true;
+    mapMock.state.styleDataListener = null;
     Object.values(mapMock.map).forEach((value) => {
       if (typeof value === "function" && "mockClear" in value) {
         value.mockClear();
@@ -239,5 +245,43 @@ describe("SimulationLoadingOverlay", () => {
     act(() => vi.advanceTimersByTime(16));
 
     expect(onCloudEntered).toHaveBeenCalledWith("heatmap");
+  });
+
+  it("emits readiness after a delayed MapLibre style load", () => {
+    mapMock.state.styleLoaded = false;
+    vi.mocked(window.matchMedia).mockReturnValue({
+      matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    } as unknown as MediaQueryList);
+    const onCloudReady = vi.fn();
+    const onCloudEntered = vi.fn();
+
+    render(
+      <SimulationLoadingOverlay
+        bounds={bounds}
+        handoffKey="initial-load"
+        loading
+        onCloudEntered={onCloudEntered}
+        onCloudReady={onCloudReady}
+        pointMask={() => true}
+      />,
+    );
+
+    expect(mapMock.map.addSource).not.toHaveBeenCalled();
+    expect(mapMock.state.styleDataListener).toBeTypeOf("function");
+
+    mapMock.state.styleLoaded = true;
+    act(() => {
+      mapMock.state.styleDataListener?.();
+      mapMock.state.styleDataListener?.();
+    });
+    act(() => vi.advanceTimersByTime(16));
+
+    expect(onCloudReady).toHaveBeenCalledTimes(1);
+    expect(onCloudReady).toHaveBeenCalledWith("initial-load");
+    act(() => vi.advanceTimersByTime(350));
+    expect(onCloudEntered).toHaveBeenCalledTimes(1);
+    expect(onCloudEntered).toHaveBeenCalledWith("initial-load");
   });
 });

--- a/src/components/SimulationLoadingOverlay.tsx
+++ b/src/components/SimulationLoadingOverlay.tsx
@@ -65,6 +65,7 @@ export function SimulationLoadingOverlay({
   const ready = Boolean(bounds && pointMask);
   const addingToMapRef = useRef(false);
   const entryKeyRef = useRef<string | null>(null);
+  const readyKeyRef = useRef<string | null>(null);
   const entryTimeoutRef = useRef<number | null>(null);
   const exitKeyRef = useRef<string | null>(null);
   const removalTimeoutRef = useRef<number | null>(null);
@@ -122,6 +123,8 @@ export function SimulationLoadingOverlay({
     const removeFromMap = () => {
       if (map.getLayer(LAYER_ID)) map.removeLayer(LAYER_ID);
       if (map.getSource(SOURCE_ID)) map.removeSource(SOURCE_ID);
+      entryKeyRef.current = null;
+      readyKeyRef.current = null;
     };
     const clearPendingRemoval = () => {
       if (removalTimeoutRef.current !== null) {
@@ -164,11 +167,34 @@ export function SimulationLoadingOverlay({
         if (exitedKey) onCloudExited?.(exitedKey);
       }, LOADING_OVERLAY_EXIT_MS);
     };
+    const scheduleEntry = (key: string, continuing: boolean) => {
+      if (
+        readyKeyRef.current === key ||
+        fadeInFrameRef.current !== null ||
+        entryTimeoutRef.current !== null
+      ) {
+        return;
+      }
+      fadeInFrameRef.current = window.requestAnimationFrame(() => {
+        fadeInFrameRef.current = null;
+        readyKeyRef.current = key;
+        onCloudReady?.(key);
+        applyTransition(true);
+        if (continuing) {
+          onCloudEntered?.(key);
+          return;
+        }
+        entryTimeoutRef.current = window.setTimeout(() => {
+          entryTimeoutRef.current = null;
+          onCloudEntered?.(key);
+          if (!loadingRef.current) startExit(key);
+        }, resolveSimulationOverlayTransition(true).durationMs);
+      });
+    };
 
-    const addToMap = () => {
+    const addToMap = (key: string, continuing: boolean) => {
       if (addingToMapRef.current) return;
       if (!coordinates || !map.isStyleLoaded()) return;
-      if (map.getSource(SOURCE_ID) && map.getLayer(LAYER_ID)) return;
       addingToMapRef.current = true;
       try {
         if (!map.getSource(SOURCE_ID)) {
@@ -193,10 +219,14 @@ export function SimulationLoadingOverlay({
             type: "raster",
           });
         }
-        applyTransition(true);
       } finally {
         addingToMapRef.current = false;
       }
+      if (readyKeyRef.current === key) {
+        applyTransition(true);
+        return;
+      }
+      scheduleEntry(key, continuing);
     };
 
     const wasExiting = removalTimeoutRef.current !== null;
@@ -227,52 +257,10 @@ export function SimulationLoadingOverlay({
       entryKeyRef.current = handoffKey;
     }
 
-    const addAfterStyleChange = () => addToMap();
+    const addAfterStyleChange = () =>
+      addToMap(handoffKey, continuingEnteredCloud);
     map.on("styledata", addAfterStyleChange);
-
-    if (map.isStyleLoaded()) {
-      addingToMapRef.current = true;
-      try {
-        if (!map.getSource(SOURCE_ID)) {
-          map.addSource(SOURCE_ID, {
-            animate: true,
-            canvas,
-            coordinates,
-            type: "canvas",
-          });
-        }
-        if (!map.getLayer(LAYER_ID)) {
-          const transition = resolveSimulationOverlayTransition(false);
-          map.addLayer({
-            id: LAYER_ID,
-            paint: {
-              "raster-opacity": transition.loadingOpacity,
-              "raster-opacity-transition": {
-                duration: transition.durationMs,
-              },
-            },
-            source: SOURCE_ID,
-            type: "raster",
-          });
-        }
-      } finally {
-        addingToMapRef.current = false;
-      }
-      fadeInFrameRef.current = window.requestAnimationFrame(() => {
-        fadeInFrameRef.current = null;
-        onCloudReady?.(handoffKey);
-        applyTransition(true);
-        if (continuingEnteredCloud) {
-          onCloudEntered?.(handoffKey);
-          return;
-        }
-        entryTimeoutRef.current = window.setTimeout(() => {
-          entryTimeoutRef.current = null;
-          onCloudEntered?.(handoffKey);
-          if (!loadingRef.current) startExit(handoffKey);
-        }, resolveSimulationOverlayTransition(true).durationMs);
-      });
-    }
+    addToMap(handoffKey, continuingEnteredCloud);
 
     return () => {
       map.off("styledata", addAfterStyleChange);


### PR DESCRIPTION
## What changed

- prevents an already displayed overlay signature from starting another cloud bridge when completed calculation/cache state is observed again
- preserves the bridge for a genuine manual or automatic recalculation already in progress
- routes immediate and delayed MapLibre style attachment through one readiness scheduler
- emits cloud-ready and cloud-entered exactly once after delayed `styledata` attachment
- resets attachment readiness when the cloud layer is actually removed

## Root causes

1. After a result was revealed, later calculation-cycle dependency changes re-ran the same signature as a cache hit. That created a second finished → cloud → finished sequence.
2. On cold load, if the MapLibre style was not ready, the `styledata` path added the cloud source/layer but never emitted readiness or entrance callbacks. The state machine could remain stuck with no result reveal.

## Validation

- `npm test` — 122 files, 669 tests passed
- focused handoff suite — 4 files, 29 tests passed
- `npm run build` — passed
- targeted changed-file lint — passed
- `git diff --check` — passed

Corrective follow-up for #948 and PR #949. Issue remains open pending renewed shared-staging acceptance and user sign-off.