### PR TITLE
Start overlay loading handoffs immediately

### DIFF
--- a/src/components/MapView.overlayHandoff.test.tsx
+++ b/src/components/MapView.overlayHandoff.test.tsx
@@ -30,6 +30,10 @@ const loadingOverlayMock = vi.hoisted(() => ({
   },
 }));
 
+const layerMock = vi.hoisted(() => ({
+  coveragePaint: null as null | Record<string, unknown>,
+}));
+
 vi.hoisted(() => {
   const data = new Map<string, string>();
   vi.stubGlobal("localStorage", {
@@ -86,7 +90,12 @@ vi.mock("react-map-gl/maplibre", async () => {
         return <div>{props.children}</div>;
       },
     ),
-    Layer: () => null,
+    Layer: (props: { id?: string; paint?: Record<string, unknown> }) => {
+      if (props.id === "coverage-overlay-layer") {
+        layerMock.coveragePaint = props.paint ?? null;
+      }
+      return null;
+    },
     Marker: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
     Source: ({
       children,
@@ -116,6 +125,8 @@ vi.mock("../lib/meshtasticMqtt", () => ({
 import { useAppStore } from "../store/appStore";
 import { useCoverageStore } from "../store/coverageStore";
 import { MapView } from "./MapView";
+
+const recomputeCoverageAction = useCoverageStore.getState().recomputeCoverage;
 
 const site: Site = {
   id: "site-a",
@@ -148,6 +159,7 @@ describe("MapView overlay handoff", () => {
     overlayMock.requests.length = 0;
     overlayMock.encodedRasterCount = 0;
     loadingOverlayMock.props = null;
+    layerMock.coveragePaint = null;
     Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
       configurable: true,
       value: vi.fn(() => ({})),
@@ -177,6 +189,7 @@ describe("MapView overlay handoff", () => {
       isSimulationRecomputing: false,
       autoCalculateEnabled: true,
       calculationCycleSource: null,
+      recomputeCoverage: recomputeCoverageAction,
     });
   });
 
@@ -214,12 +227,57 @@ describe("MapView overlay handoff", () => {
     const replacementKey = loadingOverlayMock.props?.handoffKey;
     expect(replacementKey).toBeTruthy();
     expect(replacementKey).not.toBe(firstKey);
+    expect(layerMock.coveragePaint?.["raster-opacity"]).toBe(0);
 
     act(() => loadingOverlayMock.props?.onCloudReady?.(replacementKey!));
     expect(screen.getByTestId("coverage-overlay-source")).toHaveAttribute(
       "data-url",
       "data:image/mock-1",
     );
+  });
+
+  it("starts the initial automatic calculation without waiting for interaction", async () => {
+    const recomputeCoverage = vi.fn();
+    useCoverageStore.setState({
+      coverageSamples: [],
+      completedCoverageRunToken: "",
+      isSimulationRecomputing: false,
+      recomputeCoverage,
+    });
+
+    render(
+      <MapView
+        canPersist
+        isMapExpanded={false}
+        onToggleMapExpanded={() => undefined}
+        showInspector={false}
+      />,
+    );
+
+    await waitFor(() => expect(recomputeCoverage).toHaveBeenCalledTimes(1));
+  });
+
+  it("does not auto-start a manually locked initial calculation", async () => {
+    const recomputeCoverage = vi.fn();
+    useAppStore.setState({ selectedCoverageResolution: "84" });
+    useCoverageStore.setState({
+      coverageSamples: [],
+      completedCoverageRunToken: "",
+      isSimulationRecomputing: false,
+      recomputeCoverage,
+    });
+
+    render(
+      <MapView
+        canPersist
+        isMapExpanded={false}
+        onToggleMapExpanded={() => undefined}
+        showInspector={false}
+      />,
+    );
+
+    await act(async () => undefined);
+    expect(recomputeCoverage).not.toHaveBeenCalled();
   });
 
   it("does not replay clouds when a completed signature is observed again", async () => {

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -762,6 +762,7 @@ export function MapView({
   const automaticLockNoticeShown = useCoverageStore((state) => state.automaticLockNoticeShown);
   const calculationCycleSource = useCoverageStore((state) => state.calculationCycleSource);
   const markAutomaticLockNoticeShown = useCoverageStore((state) => state.markAutomaticLockNoticeShown);
+  const recomputeCoverage = useCoverageStore((state) => state.recomputeCoverage);
   const setAutoCalculateEnabled = useCoverageStore((state) => state.setAutoCalculateEnabled);
   const startManualCalculation = useCoverageStore((state) => state.startManualCalculation);
   const stopCalculation = useCoverageStore((state) => state.stopCalculation);
@@ -1193,6 +1194,37 @@ export function MapView({
   const previousAutomaticCalculationLockedRef = useRef(automaticCalculationLocked);
   const calculationWorkAllowed =
     (autoCalculateEnabled && !automaticCalculationLocked) || calculationCycleSource === "manual";
+  const initialAutomaticCalculationRequestedRef = useRef(false);
+  useEffect(() => {
+    if (initialAutomaticCalculationRequestedRef.current) return;
+    if (
+      !autoCalculateEnabled ||
+      automaticCalculationLocked ||
+      coverageVizMode === "none" ||
+      analysisTargetSites.length === 0
+    ) {
+      return;
+    }
+    if (
+      coverageSamples.length > 0 ||
+      isSimulationRecomputing ||
+      completedCoverageRunToken !== ""
+    ) {
+      initialAutomaticCalculationRequestedRef.current = true;
+      return;
+    }
+    initialAutomaticCalculationRequestedRef.current = true;
+    recomputeCoverage();
+  }, [
+    analysisTargetSites.length,
+    autoCalculateEnabled,
+    automaticCalculationLocked,
+    completedCoverageRunToken,
+    coverageSamples.length,
+    coverageVizMode,
+    isSimulationRecomputing,
+    recomputeCoverage,
+  ]);
   useEffect(() => {
     const becameLocked = automaticCalculationLocked && !previousAutomaticCalculationLockedRef.current;
     previousAutomaticCalculationLockedRef.current = automaticCalculationLocked;
@@ -2456,8 +2488,7 @@ export function MapView({
   const simulationLoadingOverlayActive =
     Boolean(analysisBounds && overlayPointMask && overlayHandoff.requestKey) &&
     (overlayHandoff.phase === "entering" || overlayHandoff.phase === "entered");
-  const simulationOverlayFadedForCloud =
-    simulationLoadingOverlayActive && overlayHandoff.cloudReady;
+  const simulationOverlayFadedForCloud = simulationLoadingOverlayActive;
   const simulationOverlayHidden = overlayHandoff.phase === "hiding";
   const simulationOverlayTransition = resolveSimulationOverlayTransition(
     simulationOverlayFadedForCloud,

--- a/src/components/SimulationLoadingOverlay.test.tsx
+++ b/src/components/SimulationLoadingOverlay.test.tsx
@@ -33,6 +33,7 @@ const mapMock = vi.hoisted(() => {
       state.sourcePresent = false;
     }),
     setPaintProperty: vi.fn(),
+    triggerRepaint: vi.fn(),
   };
   return { map, source, state };
 });
@@ -129,9 +130,13 @@ describe("SimulationLoadingOverlay", () => {
       }),
     );
 
-    act(() => vi.advanceTimersByTime(16));
-
     expect(onCloudReady).toHaveBeenCalledWith("heatmap");
+    expect(mapMock.map.triggerRepaint).toHaveBeenCalled();
+    const repaintCountAtReady = mapMock.map.triggerRepaint.mock.calls.length;
+    act(() => vi.advanceTimersByTime(100));
+    expect(mapMock.map.triggerRepaint.mock.calls.length).toBeGreaterThan(
+      repaintCountAtReady,
+    );
     expect(mapMock.map.setPaintProperty).toHaveBeenCalledWith(
       "simulation-loading-overlay-layer",
       "raster-opacity-transition",
@@ -162,7 +167,7 @@ describe("SimulationLoadingOverlay", () => {
       { duration: 500 },
     );
 
-    act(() => vi.advanceTimersByTime(349));
+    act(() => vi.advanceTimersByTime(249));
     expect(onCloudEntered).not.toHaveBeenCalled();
     act(() => vi.advanceTimersByTime(1));
     expect(onCloudEntered).toHaveBeenCalledWith("heatmap");
@@ -276,8 +281,6 @@ describe("SimulationLoadingOverlay", () => {
       mapMock.state.styleDataListener?.();
       mapMock.state.styleDataListener?.();
     });
-    act(() => vi.advanceTimersByTime(16));
-
     expect(onCloudReady).toHaveBeenCalledTimes(1);
     expect(onCloudReady).toHaveBeenCalledWith("initial-load");
     act(() => vi.advanceTimersByTime(350));

--- a/src/components/SimulationLoadingOverlay.tsx
+++ b/src/components/SimulationLoadingOverlay.tsx
@@ -69,7 +69,6 @@ export function SimulationLoadingOverlay({
   const entryTimeoutRef = useRef<number | null>(null);
   const exitKeyRef = useRef<string | null>(null);
   const removalTimeoutRef = useRef<number | null>(null);
-  const fadeInFrameRef = useRef<number | null>(null);
   const loadingRef = useRef(loading);
   loadingRef.current = loading;
   const coordinates = useMemo(
@@ -106,6 +105,7 @@ export function SimulationLoadingOverlay({
         const image = context.createImageData(frame.width, frame.height);
         image.data.set(frame.pixels);
         context.putImageData(image, 0, 0);
+        map?.triggerRepaint();
         lastPaintAt = timestamp;
       }
       if (!reducedMotion) {
@@ -115,7 +115,7 @@ export function SimulationLoadingOverlay({
 
     paint(startedAt);
     return () => window.cancelAnimationFrame(frameId);
-  }, [bounds, canvas, loading, pointMask, reducedMotion]);
+  }, [bounds, canvas, loading, map, pointMask, reducedMotion]);
 
   useEffect(() => {
     if (!map) return;
@@ -130,12 +130,6 @@ export function SimulationLoadingOverlay({
       if (removalTimeoutRef.current !== null) {
         window.clearTimeout(removalTimeoutRef.current);
         removalTimeoutRef.current = null;
-      }
-    };
-    const clearPendingFadeIn = () => {
-      if (fadeInFrameRef.current !== null) {
-        window.cancelAnimationFrame(fadeInFrameRef.current);
-        fadeInFrameRef.current = null;
       }
     };
     const clearPendingEntry = () => {
@@ -170,26 +164,23 @@ export function SimulationLoadingOverlay({
     const scheduleEntry = (key: string, continuing: boolean) => {
       if (
         readyKeyRef.current === key ||
-        fadeInFrameRef.current !== null ||
         entryTimeoutRef.current !== null
       ) {
         return;
       }
-      fadeInFrameRef.current = window.requestAnimationFrame(() => {
-        fadeInFrameRef.current = null;
-        readyKeyRef.current = key;
-        onCloudReady?.(key);
-        applyTransition(true);
-        if (continuing) {
-          onCloudEntered?.(key);
-          return;
-        }
-        entryTimeoutRef.current = window.setTimeout(() => {
-          entryTimeoutRef.current = null;
-          onCloudEntered?.(key);
-          if (!loadingRef.current) startExit(key);
-        }, resolveSimulationOverlayTransition(true).durationMs);
-      });
+      readyKeyRef.current = key;
+      onCloudReady?.(key);
+      applyTransition(true);
+      map.triggerRepaint();
+      if (continuing) {
+        onCloudEntered?.(key);
+        return;
+      }
+      entryTimeoutRef.current = window.setTimeout(() => {
+        entryTimeoutRef.current = null;
+        onCloudEntered?.(key);
+        if (!loadingRef.current) startExit(key);
+      }, resolveSimulationOverlayTransition(true).durationMs);
     };
 
     const addToMap = (key: string, continuing: boolean) => {
@@ -238,7 +229,6 @@ export function SimulationLoadingOverlay({
       !wasExiting &&
       Boolean(map.getLayer(LAYER_ID));
     clearPendingRemoval();
-    clearPendingFadeIn();
 
     if (!ready || !coordinates || !handoffKey) {
       clearPendingEntry();
@@ -264,7 +254,6 @@ export function SimulationLoadingOverlay({
 
     return () => {
       map.off("styledata", addAfterStyleChange);
-      clearPendingFadeIn();
     };
   }, [
     canvas,
@@ -289,9 +278,6 @@ export function SimulationLoadingOverlay({
     return () => {
       if (removalTimeoutRef.current !== null) {
         window.clearTimeout(removalTimeoutRef.current);
-      }
-      if (fadeInFrameRef.current !== null) {
-        window.cancelAnimationFrame(fadeInFrameRef.current);
       }
       if (entryTimeoutRef.current !== null) {
         window.clearTimeout(entryTimeoutRef.current);


### PR DESCRIPTION
## Summary
- bootstrap the first automatic coverage calculation after a hard refresh
- fade retained overlays as soon as a replacement handoff begins
- attach ready clouds synchronously and keep MapLibre repainting their canvas
- preserve manual calculation locks and the existing 350 ms / 500 ms transitions

## Verification
- `npm test` (122 files, 671 tests)
- `npm run build`
- changed-file lint
- `git diff --check`

Issue: #948