### PR TITLE
Show loading clouds before tiles settle

### DIFF
--- a/src/components/MapView.overlayHandoff.test.tsx
+++ b/src/components/MapView.overlayHandoff.test.tsx
@@ -257,6 +257,26 @@ describe("MapView overlay handoff", () => {
     await waitFor(() => expect(recomputeCoverage).toHaveBeenCalledTimes(1));
   });
 
+  it("starts clouds while cold-start terrain loads before Pass/Fail is raster-ready", async () => {
+    useAppStore.setState({
+      mapOverlayMode: "passfail",
+      isTerrainFetching: true,
+    });
+
+    render(
+      <MapView
+        canPersist
+        isMapExpanded={false}
+        onToggleMapExpanded={() => undefined}
+        showInspector={false}
+      />,
+    );
+
+    await waitFor(() => expect(loadingOverlayMock.props?.loading).toBe(true));
+    expect(loadingOverlayMock.props?.handoffKey).toBeTruthy();
+    expect(overlayMock.buildCoverage).not.toHaveBeenCalled();
+  });
+
   it("does not auto-start a manually locked initial calculation", async () => {
     const recomputeCoverage = vi.fn();
     useAppStore.setState({ selectedCoverageResolution: "84" });

--- a/src/components/SimulationLoadingOverlay.test.tsx
+++ b/src/components/SimulationLoadingOverlay.test.tsx
@@ -7,6 +7,7 @@ const mapMock = vi.hoisted(() => {
     layerPresent: false,
     sourcePresent: false,
     styleLoaded: true,
+    rejectSourceUntilStyleLoaded: false,
     styleDataListener: null as null | (() => void),
   };
   const source = {
@@ -17,6 +18,12 @@ const mapMock = vi.hoisted(() => {
       state.layerPresent = true;
     }),
     addSource: vi.fn(() => {
+      if (
+        state.rejectSourceUntilStyleLoaded &&
+        !state.styleLoaded
+      ) {
+        throw new Error("Style is not done loading");
+      }
       state.sourcePresent = true;
     }),
     getLayer: vi.fn(() => (state.layerPresent ? {} : undefined)),
@@ -63,6 +70,7 @@ describe("SimulationLoadingOverlay", () => {
     mapMock.state.layerPresent = false;
     mapMock.state.sourcePresent = false;
     mapMock.state.styleLoaded = true;
+    mapMock.state.rejectSourceUntilStyleLoaded = false;
     mapMock.state.styleDataListener = null;
     Object.values(mapMock.map).forEach((value) => {
       if (typeof value === "function" && "mockClear" in value) {
@@ -252,8 +260,33 @@ describe("SimulationLoadingOverlay", () => {
     expect(onCloudEntered).toHaveBeenCalledWith("heatmap");
   });
 
+  it("attaches clouds while basemap sources are still loading", () => {
+    mapMock.state.styleLoaded = false;
+    vi.mocked(window.matchMedia).mockReturnValue({
+      matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    } as unknown as MediaQueryList);
+    const onCloudReady = vi.fn();
+
+    render(
+      <SimulationLoadingOverlay
+        bounds={bounds}
+        handoffKey="cold-start"
+        loading
+        onCloudReady={onCloudReady}
+        pointMask={() => true}
+      />,
+    );
+
+    expect(mapMock.map.addSource).toHaveBeenCalledTimes(1);
+    expect(mapMock.map.addLayer).toHaveBeenCalledTimes(1);
+    expect(onCloudReady).toHaveBeenCalledWith("cold-start");
+  });
+
   it("emits readiness after a delayed MapLibre style load", () => {
     mapMock.state.styleLoaded = false;
+    mapMock.state.rejectSourceUntilStyleLoaded = true;
     vi.mocked(window.matchMedia).mockReturnValue({
       matches: true,
       addEventListener: vi.fn(),
@@ -273,7 +306,9 @@ describe("SimulationLoadingOverlay", () => {
       />,
     );
 
-    expect(mapMock.map.addSource).not.toHaveBeenCalled();
+    expect(mapMock.map.addSource).toHaveBeenCalledTimes(1);
+    expect(mapMock.state.sourcePresent).toBe(false);
+    expect(onCloudReady).not.toHaveBeenCalled();
     expect(mapMock.state.styleDataListener).toBeTypeOf("function");
 
     mapMock.state.styleLoaded = true;
@@ -283,6 +318,7 @@ describe("SimulationLoadingOverlay", () => {
     });
     expect(onCloudReady).toHaveBeenCalledTimes(1);
     expect(onCloudReady).toHaveBeenCalledWith("initial-load");
+    expect(mapMock.map.addSource).toHaveBeenCalledTimes(2);
     act(() => vi.advanceTimersByTime(350));
     expect(onCloudEntered).toHaveBeenCalledTimes(1);
     expect(onCloudEntered).toHaveBeenCalledWith("initial-load");

--- a/src/components/SimulationLoadingOverlay.tsx
+++ b/src/components/SimulationLoadingOverlay.tsx
@@ -185,7 +185,7 @@ export function SimulationLoadingOverlay({
 
     const addToMap = (key: string, continuing: boolean) => {
       if (addingToMapRef.current) return;
-      if (!coordinates || !map.isStyleLoaded()) return;
+      if (!coordinates) return;
       addingToMapRef.current = true;
       try {
         if (!map.getSource(SOURCE_ID)) {
@@ -210,9 +210,14 @@ export function SimulationLoadingOverlay({
             type: "raster",
           });
         }
+      } catch {
+        // MapLibre can emit styledata before the style accepts custom sources.
+        // Keep the listener active and retry on the next style update.
+        return;
       } finally {
         addingToMapRef.current = false;
       }
+      if (!map.getSource(SOURCE_ID) || !map.getLayer(LAYER_ID)) return;
       if (readyKeyRef.current === key) {
         applyTransition(true);
         return;


### PR DESCRIPTION
## Summary
- attach the cloud canvas as soon as MapLibre accepts custom sources
- do not wait for `isStyleLoaded()` while basemap tiles are still fetching
- retry safely on `styledata` when the style genuinely rejects an early source
- cover cold-start Pass/Fail terrain loading and both attachment paths

## Verification
- `npm test` (122 files, 673 tests)
- `npm run build`
- targeted ESLint
- `git diff --check`

Issue: #948