### PR TITLE
Retry terrain after startup cancellation

### DIFF
--- a/src/components/MapView.overlayHandoff.test.tsx
+++ b/src/components/MapView.overlayHandoff.test.tsx
@@ -174,6 +174,7 @@ describe("MapView overlay handoff", () => {
       selectedCoverageResolution: "24",
       selectedOverlayRadiusOption: "20",
       srtmTiles: [],
+      terrainLoadEpoch: 0,
       isTerrainFetching: false,
       isTerrainRecommending: false,
       recommendAndFetchTerrainForCurrentArea: vi.fn(async () => undefined),
@@ -275,6 +276,44 @@ describe("MapView overlay handoff", () => {
     await waitFor(() => expect(loadingOverlayMock.props?.loading).toBe(true));
     expect(loadingOverlayMock.props?.handoffKey).toBeTruthy();
     expect(overlayMock.buildCoverage).not.toHaveBeenCalled();
+  });
+
+  it("retries unchanged cold-start terrain geometry after startup cancels its epoch", async () => {
+    const recommendAndFetchTerrainForCurrentArea = vi.fn(async () => {
+      const currentEpoch = useAppStore.getState().terrainLoadEpoch;
+      useAppStore.setState({
+        isTerrainFetching: true,
+        terrainLoadEpoch: currentEpoch + 1,
+      });
+    });
+    useAppStore.setState({
+      isTerrainFetching: false,
+      terrainLoadEpoch: 0,
+      recommendAndFetchTerrainForCurrentArea,
+    });
+
+    render(
+      <MapView
+        canPersist
+        isMapExpanded={false}
+        onToggleMapExpanded={() => undefined}
+        showInspector={false}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(recommendAndFetchTerrainForCurrentArea).toHaveBeenCalledTimes(1),
+    );
+    act(() => {
+      useAppStore.setState({
+        isTerrainFetching: false,
+        terrainLoadEpoch: 2,
+      });
+    });
+
+    await waitFor(() =>
+      expect(recommendAndFetchTerrainForCurrentArea).toHaveBeenCalledTimes(2),
+    );
   });
 
   it("does not auto-start a manually locked initial calculation", async () => {

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1305,23 +1305,44 @@ export function MapView({
     [requiredTargetRadiusTileKeys, loaded30mTileKeys],
   );
   const targetRadiusTerrainSignature = `${targetRadiusKm}|${requiredTargetRadiusTileKeys.join(",")}`;
-  const targetRadiusFetchAttemptRef = useRef("");
+  const targetRadiusFetchAttemptRef = useRef<{
+    signature: string;
+    terrainLoadEpoch: number;
+  }>({ signature: "", terrainLoadEpoch: -1 });
   useEffect(() => {
     if (!calculationWorkAllowed) {
-      targetRadiusFetchAttemptRef.current = "";
+      targetRadiusFetchAttemptRef.current = {
+        signature: "",
+        terrainLoadEpoch: -1,
+      };
       return;
     }
     if (coverageVizMode === "none") {
-      targetRadiusFetchAttemptRef.current = "";
+      targetRadiusFetchAttemptRef.current = {
+        signature: "",
+        terrainLoadEpoch: -1,
+      };
       return;
     }
     if (!analysisTargetSites.length || missingTargetRadiusTileCount <= 0) {
-      targetRadiusFetchAttemptRef.current = "";
+      targetRadiusFetchAttemptRef.current = {
+        signature: "",
+        terrainLoadEpoch: -1,
+      };
       return;
     }
     if (isTerrainFetching || isTerrainRecommending) return;
-    if (targetRadiusFetchAttemptRef.current === targetRadiusTerrainSignature) return;
-    targetRadiusFetchAttemptRef.current = targetRadiusTerrainSignature;
+    if (
+      targetRadiusFetchAttemptRef.current.signature ===
+        targetRadiusTerrainSignature &&
+      targetRadiusFetchAttemptRef.current.terrainLoadEpoch === terrainLoadEpoch
+    ) {
+      return;
+    }
+    targetRadiusFetchAttemptRef.current = {
+      signature: targetRadiusTerrainSignature,
+      terrainLoadEpoch: terrainLoadEpoch + 1,
+    };
     void recommendAndFetchTerrainForCurrentArea(targetRadiusKm);
   }, [
     coverageVizMode,
@@ -1330,6 +1351,7 @@ export function MapView({
     isTerrainFetching,
     isTerrainRecommending,
     normalizedOverlayRadiusOption,
+    terrainLoadEpoch,
     targetRadiusTerrainSignature,
     recommendAndFetchTerrainForCurrentArea,
     targetRadiusKm,


### PR DESCRIPTION
## Summary
- retry unchanged terrain geometry when startup hydration cancels the initial load epoch
- keep successful and failed attempts deduplicated within their own epoch
- add cold-start regression coverage for the no-interaction deadlock

## Verification
- `npm test` — 122 files, 674 tests passed
- `npm run build`
- `git diff --check`
- changed test lint

Issue #948 remains open pending shared-staging verification and user sign-off.