### PR TITLE
chore: release 0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.25.0] - 2026-08-01
+
+### Fixed
+- Corrected the sync-pending status message and guest-auth recovery feedback so saved work is not misleadingly presented as out of date. (#935, #936)
+- Added visible cloud loading feedback while terrain tiles settle. (#943)
+- Prevented blank map frames during overlay mode and selection changes by preserving prior geometry through the loading handoff, including cancellation recovery. (#948)
+
 ## [0.24.0] - 2026-07-29
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linksim",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linksim",
-      "version": "0.24.0",
+      "version": "0.25.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "linksim",
   "private": true,
-  "version": "0.24.0",
+  "version": "0.25.0",
   "license": "GPL-3.0-only",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Prepare the frozen 0.25.0 milestone for the verified staging release tree.

## Changes

- bump the application and lockfile to 0.25.0
- add release notes for #935, #936, #943, and #948

## Validation

- `npm test` (674 tests)
- `npm run build`
- `git diff --check`
- `npm run dev:check`