### PR TITLE
release: 0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.25.0] - 2026-08-01
+
+### Fixed
+- Corrected the sync-pending status message and guest-auth recovery feedback so saved work is not misleadingly presented as out of date. (#935, #936)
+- Added visible cloud loading feedback while terrain tiles settle. (#943)
+- Prevented blank map frames during overlay mode and selection changes by preserving prior geometry through the loading handoff, including cancellation recovery. (#948)
+
 ## [0.24.0] - 2026-07-29
 
 ### Changed

--- a/functions/api/deep-link-status.test.ts
+++ b/functions/api/deep-link-status.test.ts
@@ -41,19 +41,53 @@ describe("api/deep-link-status", () => {
     verifyAuthMock.mockResolvedValueOnce(null);
     const res = await onRequestGet(mkCtx(new Request("https://example.test/api/deep-link-status?sim=sim-1")));
     expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      status: "ok",
+      simulationId: "sim-1",
+      authenticated: false,
+      authState: "guest",
+    });
   });
 
   it("returns missing when simulation id is missing", async () => {
     const res = await onRequestGet(mkCtx(new Request("https://example.test/api/deep-link-status")));
     expect(res.status).toBe(200);
-    await expect(res.json()).resolves.toEqual({ status: "missing", authenticated: true });
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    await expect(res.json()).resolves.toEqual({
+      status: "missing",
+      authenticated: true,
+      authState: "authenticated",
+    });
+  });
+
+  it("reports revoked sessions separately from expected guests", async () => {
+    fetchUserProfileMock.mockResolvedValueOnce({
+      id: "u1",
+      isAdmin: false,
+      isModerator: false,
+      accountState: "revoked",
+    });
+
+    const res = await onRequestGet(mkCtx(new Request("https://example.test/api/deep-link-status")));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      status: "missing",
+      authenticated: false,
+      authState: "revoked",
+    });
   });
 
   it("returns access status for simulation id", async () => {
     resolveSimulationAccessForUserMock.mockResolvedValueOnce("forbidden");
     const res = await onRequestGet(mkCtx(new Request("https://example.test/api/deep-link-status?sim=sim-2")));
     expect(res.status).toBe(200);
-    await expect(res.json()).resolves.toEqual({ status: "forbidden", simulationId: "sim-2", authenticated: true });
+    await expect(res.json()).resolves.toEqual({
+      status: "forbidden",
+      simulationId: "sim-2",
+      authenticated: true,
+      authState: "authenticated",
+    });
   });
 
   it("resolves username-scoped slug to simulation id", async () => {
@@ -61,6 +95,11 @@ describe("api/deep-link-status", () => {
     const res = await onRequestGet(mkCtx(new Request("https://example.test/api/deep-link-status?username=Owner&slug=my-sim")));
     expect(res.status).toBe(200);
     expect(resolveSimulationIdByOwnerSlugMock).toHaveBeenCalledWith(expect.anything(), "Owner", "my-sim");
-    await expect(res.json()).resolves.toEqual({ status: "ok", simulationId: "sim-abc", authenticated: true });
+    await expect(res.json()).resolves.toEqual({
+      status: "ok",
+      simulationId: "sim-abc",
+      authenticated: true,
+      authState: "authenticated",
+    });
   });
 });

--- a/functions/api/deep-link-status.ts
+++ b/functions/api/deep-link-status.ts
@@ -5,16 +5,22 @@ import type { Env } from "../_lib/types";
 
 export const onRequestOptions: PagesFunction<Env> = async ({ request }) => handleOptions(request);
 
+const NO_STORE_HEADERS = { "cache-control": "no-store" };
+
 export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
   try {
     const auth = await verifyAuth(request, env);
     let actor = { id: "", isAdmin: false, isModerator: false };
     let authenticated = false;
+    let authState: "guest" | "authenticated" | "revoked" = "guest";
     if (auth) {
       await ensureUser(env, auth.userId, auth.tokenPayload);
       const me = await fetchUserProfile(env, auth.userId);
-      if (me?.accountState !== "revoked") {
+      if (me?.accountState === "revoked") {
+        authState = "revoked";
+      } else {
         authenticated = true;
+        authState = "authenticated";
         actor = {
           id: me?.id ?? "",
           isAdmin: Boolean(me?.isAdmin),
@@ -31,7 +37,7 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
       simulationId = (await resolveSimulationIdByOwnerSlug(env, username, simulationSlug)) ?? "";
     }
     if (!simulationId) {
-      return withCors(request, json({ status: "missing", authenticated }));
+      return withCors(request, json({ status: "missing", authenticated, authState }, { headers: NO_STORE_HEADERS }));
     }
 
     const status = await resolveSimulationAccessForUser(
@@ -44,7 +50,10 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
       simulationId,
     );
 
-    return withCors(request, json({ status, simulationId, authenticated }));
+    return withCors(
+      request,
+      json({ status, simulationId, authenticated, authState }, { headers: NO_STORE_HEADERS }),
+    );
   } catch (error) {
     return errorResponse(request, error, 500);
   }

--- a/functions/api/public-simulation.test.ts
+++ b/functions/api/public-simulation.test.ts
@@ -35,6 +35,53 @@ beforeEach(() => {
 });
 
 describe("api/public-simulation", () => {
+  it("reports expected guests through the public auth-status mode", async () => {
+    verifyAuthMock.mockResolvedValueOnce(null);
+
+    const res = await onRequestGet(
+      mkCtx(new Request("https://example.test/api/public-simulation?mode=auth")),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    await expect(res.json()).resolves.toEqual({ authenticated: false, authState: "guest" });
+    expect(fetchPublicSimulationBundleMock).not.toHaveBeenCalled();
+  });
+
+  it("reports authenticated and revoked auth-status states", async () => {
+    verifyAuthMock.mockResolvedValue({ userId: "user-42", tokenPayload: {} });
+    fetchUserProfileMock
+      .mockResolvedValueOnce({ id: "user-42", accountState: "approved" })
+      .mockResolvedValueOnce({ id: "user-42", accountState: "revoked" });
+
+    const authenticated = await onRequestGet(
+      mkCtx(new Request("https://example.test/api/public-simulation?mode=auth")),
+    );
+    const revoked = await onRequestGet(
+      mkCtx(new Request("https://example.test/api/public-simulation?mode=auth")),
+    );
+
+    await expect(authenticated.json()).resolves.toEqual({
+      authenticated: true,
+      authState: "authenticated",
+    });
+    await expect(revoked.json()).resolves.toEqual({
+      authenticated: false,
+      authState: "revoked",
+    });
+    expect(fetchPublicSimulationBundleMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces auth verification failures in auth-status mode", async () => {
+    verifyAuthMock.mockRejectedValueOnce(new Error("Auth verification timed out"));
+
+    const res = await onRequestGet(
+      mkCtx(new Request("https://example.test/api/public-simulation?mode=auth")),
+    );
+
+    expect(res.status).toBe(503);
+  });
+
   it("returns no-store when request is invalid", async () => {
     const res = await onRequestGet(mkCtx(new Request("https://example.test/api/public-simulation")));
     expect(res.status).toBe(400);

--- a/functions/api/public-simulation.ts
+++ b/functions/api/public-simulation.ts
@@ -7,9 +7,52 @@ export const onRequestOptions: PagesFunction<Env> = async ({ request }) => handl
 
 const NO_STORE_HEADERS = { "cache-control": "no-store" };
 
+type PublicAuthState = "guest" | "authenticated" | "revoked";
+type PublicActor = { id: string; isAdmin: boolean; isModerator: boolean };
+
+const resolveAuth = async (
+  request: Request,
+  env: Env,
+  strict: boolean,
+): Promise<{ authenticated: boolean; authState: PublicAuthState; actor: PublicActor | null }> => {
+  const auth = strict
+    ? await verifyAuth(request, env)
+    : await verifyAuth(request, env).catch(() => null);
+  if (!auth) {
+    return { authenticated: false, authState: "guest", actor: null };
+  }
+
+  await ensureUser(env, auth.userId, auth.tokenPayload);
+  const profile = await fetchUserProfile(env, auth.userId);
+  if (profile?.accountState === "revoked") {
+    return { authenticated: false, authState: "revoked", actor: null };
+  }
+
+  return {
+    authenticated: true,
+    authState: "authenticated",
+    actor: {
+      id: profile?.id ?? auth.userId,
+      isAdmin: Boolean(profile?.isAdmin),
+      isModerator: Boolean(profile?.isModerator),
+    },
+  };
+};
+
 export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
   try {
     const url = new URL(request.url);
+    if (url.searchParams.get("mode") === "auth") {
+      const auth = await resolveAuth(request, env, true);
+      return withCors(
+        request,
+        json(
+          { authenticated: auth.authenticated, authState: auth.authState },
+          { headers: NO_STORE_HEADERS },
+        ),
+      );
+    }
+
     const simulationId = (url.searchParams.get("sim") ?? "").trim();
     const username = (url.searchParams.get("username") ?? "").trim();
     const simulationSlug = (url.searchParams.get("slug") ?? "").trim();
@@ -17,19 +60,7 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
       return withCors(request, json({ error: "Missing simulation id or username-scoped slug" }, { status: 400, headers: NO_STORE_HEADERS }));
     }
 
-    const auth = await verifyAuth(request, env).catch(() => null);
-    let actor: { id: string; isAdmin: boolean; isModerator: boolean } | null = null;
-    if (auth) {
-      await ensureUser(env, auth.userId, auth.tokenPayload);
-      const profile = await fetchUserProfile(env, auth.userId);
-      if (profile?.accountState !== "revoked") {
-        actor = {
-          id: profile?.id ?? auth.userId,
-          isAdmin: Boolean(profile?.isAdmin),
-          isModerator: Boolean(profile?.isModerator),
-        };
-      }
-    }
+    const { actor } = await resolveAuth(request, env, false);
 
     const bundle = await fetchPublicSimulationBundle(env, {
       simulationId: simulationId || undefined,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linksim",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linksim",
-      "version": "0.24.0",
+      "version": "0.25.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "linksim",
   "private": true,
-  "version": "0.24.0",
+  "version": "0.25.0",
   "license": "GPL-3.0-only",
   "type": "module",
   "scripts": {

--- a/src/components/AppShell.copyFlow.test.tsx
+++ b/src/components/AppShell.copyFlow.test.tsx
@@ -30,6 +30,7 @@ const { pushCloudLibraryMock } = vi.hoisted(() => ({
 const sidebarCalls: Array<{ readOnly?: boolean; panelToggleControl?: unknown }> = [];
 
 vi.mock("../lib/cloudUser", () => ({
+  fetchAuthStatus: vi.fn(async () => ({ authenticated: true, authState: "authenticated" })),
   fetchCollaboratorDirectory: vi.fn(async () => []),
   fetchDeepLinkStatus: vi.fn(async () => ({ status: "ok", simulationId: null, authenticated: true })),
   fetchMe: vi.fn(async () => ({

--- a/src/components/AppShell.deeplink.test.ts
+++ b/src/components/AppShell.deeplink.test.ts
@@ -5,7 +5,7 @@ import { act, render } from "@testing-library/react";
 
 const hoisted = vi.hoisted(() => {
   const fetchMe = vi.fn();
-  const fetchDeepLinkStatus = vi.fn();
+  const fetchAuthStatus = vi.fn();
   const fetchCloudLibrary = vi.fn();
   const fetchPublicSimulationLibrary = vi.fn();
   const loadSimulationPreset = vi.fn();
@@ -68,7 +68,7 @@ const hoisted = vi.hoisted(() => {
 
   return {
     fetchMe,
-    fetchDeepLinkStatus,
+    fetchAuthStatus,
     fetchCloudLibrary,
     fetchPublicSimulationLibrary,
     loadSimulationPreset,
@@ -90,7 +90,7 @@ vi.mock("../lib/cloudUser", () => ({
     }
   },
   fetchCollaboratorDirectory: vi.fn(async () => []),
-  fetchDeepLinkStatus: hoisted.fetchDeepLinkStatus,
+  fetchAuthStatus: hoisted.fetchAuthStatus,
   fetchMe: hoisted.fetchMe,
   setLocalDevRole: vi.fn(async () => ({})),
 }));
@@ -242,10 +242,9 @@ describe("AppShell deeplink cold-load flow", () => {
       updatedAt: "2026-01-01T00:00:00.000Z",
       bio: "",
     });
-    hoisted.fetchDeepLinkStatus.mockResolvedValue({
-      status: "ok",
-      simulationId: "sim-mmtk88wx-2didtk",
+    hoisted.fetchAuthStatus.mockResolvedValue({
       authenticated: true,
+      authState: "authenticated",
     });
     hoisted.fetchCloudLibrary.mockResolvedValue({
       siteLibrary: [],
@@ -336,13 +335,14 @@ describe("AppShell deeplink cold-load flow", () => {
 
       expect(hoisted.fetchMe).toHaveBeenCalledTimes(2);
       expect(document.body.textContent).not.toContain("Cloud save is unavailable");
+      expect(localStorage.getItem("linksim:had-authenticated-session:v1")).toBe("1");
     } finally {
       unmountAppShell(view);
       vi.useRealTimers();
     }
   });
 
-  it("uses quick retries before falling back to the steady retry interval", async () => {
+  it("stops after the bounded quick retry sequence", async () => {
     vi.useFakeTimers();
     window.history.replaceState(null, "", "/");
     hoisted.fetchMe.mockRejectedValue(new Error("524 : server timed out"));
@@ -364,11 +364,10 @@ describe("AppShell deeplink cold-load flow", () => {
       await advanceTimers(10_000);
       expect(hoisted.fetchMe).toHaveBeenCalledTimes(4);
 
-      await advanceTimers(59_999);
+      await advanceTimers(120_000);
       expect(hoisted.fetchMe).toHaveBeenCalledTimes(4);
-
-      await advanceTimers(1);
-      expect(hoisted.fetchMe).toHaveBeenCalledTimes(5);
+      expect(document.body.textContent).toContain("Sign in again to resume cloud saving");
+      expect(document.body.textContent).not.toContain("retrying automatically");
     } finally {
       unmountAppShell(view);
       vi.useRealTimers();
@@ -461,20 +460,116 @@ describe("AppShell deeplink cold-load flow", () => {
 
   it("does not start auth recovery for unauthenticated deep-link guests", async () => {
     vi.useFakeTimers();
-    hoisted.fetchDeepLinkStatus.mockResolvedValue({
-      status: "ok",
-      simulationId: "sim-mmtk88wx-2didtk",
+    hoisted.fetchAuthStatus.mockResolvedValue({
       authenticated: false,
+      authState: "guest",
     });
 
     const view = await renderAppShell();
 
     try {
-      expect(hoisted.fetchDeepLinkStatus).toHaveBeenCalledTimes(1);
+      expect(hoisted.fetchAuthStatus).toHaveBeenCalledTimes(1);
       expect(hoisted.fetchMe).not.toHaveBeenCalled();
 
       await advanceTimers(120_000);
       expect(hoisted.fetchMe).not.toHaveBeenCalled();
+    } finally {
+      unmountAppShell(view);
+      vi.useRealTimers();
+    }
+  });
+
+  it("enters quiet demo mode for an expected root guest", async () => {
+    vi.useFakeTimers();
+    window.history.replaceState(null, "", "/");
+    hoisted.fetchAuthStatus.mockResolvedValue({
+      authenticated: false,
+      authState: "guest",
+    });
+
+    const view = await renderAppShell();
+
+    try {
+      expect(hoisted.fetchAuthStatus).toHaveBeenCalledTimes(1);
+      expect(hoisted.fetchMe).not.toHaveBeenCalled();
+      expect(document.body.textContent).not.toContain("Cloud save is unavailable");
+
+      await advanceTimers(120_000);
+      expect(hoisted.fetchAuthStatus).toHaveBeenCalledTimes(1);
+      expect(hoisted.fetchMe).not.toHaveBeenCalled();
+    } finally {
+      unmountAppShell(view);
+      vi.useRealTimers();
+    }
+  });
+
+  it("shows an expired-session warning without retrying for a prior authenticated guest", async () => {
+    vi.useFakeTimers();
+    window.history.replaceState(null, "", "/");
+    localStorage.setItem("linksim:had-authenticated-session:v1", "1");
+    hoisted.fetchAuthStatus.mockResolvedValue({
+      authenticated: false,
+      authState: "guest",
+    });
+
+    const view = await renderAppShell();
+
+    try {
+      expect(document.body.textContent).toContain("Sign in again to resume cloud saving");
+      expect(document.body.textContent).not.toContain("retrying automatically");
+      expect(hoisted.fetchMe).not.toHaveBeenCalled();
+
+      await advanceTimers(120_000);
+      expect(hoisted.fetchAuthStatus).toHaveBeenCalledTimes(1);
+    } finally {
+      unmountAppShell(view);
+      vi.useRealTimers();
+    }
+  });
+
+  it("shows an actionable revoked-session warning without retrying", async () => {
+    vi.useFakeTimers();
+    window.history.replaceState(null, "", "/");
+    hoisted.fetchAuthStatus.mockResolvedValue({
+      authenticated: false,
+      authState: "revoked",
+    });
+
+    const view = await renderAppShell();
+
+    try {
+      expect(document.body.textContent).toContain("Account access is unavailable");
+      expect(document.body.textContent).not.toContain("retrying automatically");
+      expect(hoisted.fetchMe).not.toHaveBeenCalled();
+
+      await advanceTimers(120_000);
+      expect(hoisted.fetchAuthStatus).toHaveBeenCalledTimes(1);
+    } finally {
+      unmountAppShell(view);
+      vi.useRealTimers();
+    }
+  });
+
+  it("uses a bounded neutral recovery path when the public auth probe fails", async () => {
+    vi.useFakeTimers();
+    window.history.replaceState(null, "", "/");
+    hoisted.fetchAuthStatus.mockRejectedValue(new Error("Failed to fetch"));
+
+    const view = await renderAppShell();
+
+    try {
+      expect(document.body.textContent).toContain("Sign-in status could not be checked");
+      expect(document.body.textContent).not.toContain("Cloud save is unavailable");
+
+      await advanceTimers(2_000);
+      await advanceTimers(5_000);
+      await advanceTimers(10_000);
+      expect(hoisted.fetchAuthStatus).toHaveBeenCalledTimes(4);
+
+      await advanceTimers(120_000);
+      expect(hoisted.fetchAuthStatus).toHaveBeenCalledTimes(4);
+      expect(document.body.textContent).toContain("Try signing in again");
+      expect(document.body.textContent).not.toContain("retrying automatically");
     } finally {
       unmountAppShell(view);
       vi.useRealTimers();

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,13 +1,15 @@
 import { type CSSProperties, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CircleAlert, CircleCheck, CircleX, Copy, Globe, Info, PanelBottomClose, PanelBottomOpen, PanelLeftClose, PanelLeftOpen, PanelRightClose, PanelRightOpen, Share, UserRoundPlus, UserRoundSearch, Users, X } from "lucide-react";
-import { CloudApiError, type CloudUser, type CollaboratorDirectoryUser, fetchCollaboratorDirectory, fetchDeepLinkStatus, fetchMe } from "../lib/cloudUser";
+import { CloudApiError, type CloudUser, type CollaboratorDirectoryUser, fetchAuthStatus, fetchCollaboratorDirectory, fetchDeepLinkStatus, fetchMe } from "../lib/cloudUser";
 import { fetchCloudLibrary, fetchPublicSimulationLibrary, pushCloudLibrary } from "../lib/cloudLibrary";
 import { buildDeepLinkPathname, buildDeepLinkUrl, buildSettingsPath, canonicalizeDeepLinkKey, matchSettingsPath, parseDeepLinkFromLocation, slugifyName, type SettingsSectionId } from "../lib/deepLink";
 import { canRunDeepLinkApply } from "../lib/deepLinkApplyGate";
 import {
+  hasAuthenticatedSessionMarker,
+  markAuthenticatedSession,
+  resolveAuthBootstrapState,
   type DeepLinkApplyOutcome,
   shouldRewritePathAfterDeepLinkApply,
-  shouldUseReadonlyFallbackForAuthBootstrap,
 } from "../lib/appShellGuards";
 import { handleSimulationLibraryLoad } from "../lib/simulationLibraryLoad";
 import { emptyWorkspaceState } from "../lib/emptyWorkspaceState";
@@ -49,7 +51,6 @@ const LOCAL_FORCE_READONLY_KEY = "linksim:local-force-readonly:v1";
 const ACCESS_CHECK_TIMEOUT_MS = 10_000;
 const ACCESS_FETCH_TIMEOUT_MS = 8_000;
 const AUTH_RECOVERY_QUICK_RETRY_DELAYS_MS = [2_000, 5_000, 10_000] as const;
-const AUTH_RECOVERY_STEADY_RETRY_MS = 60_000;
 const ACCESS_CHECKING_NOTICE_ID = "access-checking";
 const AUTH_DEGRADED_NOTICE_ID = "auth-degraded";
 const OFFLINE_SYNC_NOTICE_ID = "offline-sync";
@@ -273,7 +274,7 @@ export function AppShell() {
   const mapExpandedInspectorWasHiddenRef = useRef(false);
   const mapExpandedProfileWasHiddenRef = useRef(false);
   const mapExpandToggleTimerRef = useRef<number | null>(null);
-  const hadAuthenticatedSessionRef = useRef(false);
+  const hadAuthenticatedSessionRef = useRef(hasAuthenticatedSessionMarker());
   const authCheckInFlightRef = useRef(false);
   const authRecoveryActiveRef = useRef(false);
   const authRecoveryDisabledRef = useRef(false);
@@ -583,44 +584,61 @@ export function AppShell() {
   }, [clearAuthRetryTimer]);
 
   const scheduleAuthRecoveryRetry = useCallback(
-    (source: "timeout" | "failure") => {
-      if (authRecoveryDisabledRef.current) return;
+    (source: "timeout" | "failure"): boolean => {
+      if (authRecoveryDisabledRef.current) return false;
       const online = typeof navigator === "undefined" ? true : navigator.onLine;
-      if (!online) return;
-      if (authRetryTimerRef.current !== null) return;
+      if (!online) return false;
+      if (authRetryTimerRef.current !== null) return true;
 
       const quickAttempt = authRetryQuickAttemptRef.current;
-      const delayMs =
-        quickAttempt < AUTH_RECOVERY_QUICK_RETRY_DELAYS_MS.length
-          ? AUTH_RECOVERY_QUICK_RETRY_DELAYS_MS[quickAttempt]
-          : AUTH_RECOVERY_STEADY_RETRY_MS;
-      if (quickAttempt < AUTH_RECOVERY_QUICK_RETRY_DELAYS_MS.length) {
-        authRetryQuickAttemptRef.current = quickAttempt + 1;
-      }
+      if (quickAttempt >= AUTH_RECOVERY_QUICK_RETRY_DELAYS_MS.length) return false;
+      const delayMs = AUTH_RECOVERY_QUICK_RETRY_DELAYS_MS[quickAttempt];
+      authRetryQuickAttemptRef.current = quickAttempt + 1;
 
       console.info("[AppShell] Scheduling auth recovery retry", {
         source,
         delayMs,
-        quickAttempt: Math.min(quickAttempt + 1, AUTH_RECOVERY_QUICK_RETRY_DELAYS_MS.length),
+        quickAttempt: quickAttempt + 1,
       });
       authRetryTimerRef.current = window.setTimeout(() => {
         authRetryTimerRef.current = null;
         runAccessCheckRef.current("retry");
       }, delayMs);
+      return true;
     },
     [],
   );
 
   const setAuthDegraded = useCallback(
-    (message: string, source: "timeout" | "failure") => {
-      authRecoveryActiveRef.current = true;
+    (
+      messages: { retrying: string; exhausted: string },
+      source: "timeout" | "failure",
+    ) => {
+      setCurrentUser(null);
+      setAuthState("signed_out");
+      setAccessState("readonly");
+      const retryScheduled = scheduleAuthRecoveryRetry(source);
+      authRecoveryActiveRef.current = retryScheduled;
+      if (!retryScheduled) {
+        authRecoveryDisabledRef.current = true;
+      }
+      setAccessDiagnosticMessage(retryScheduled ? messages.retrying : messages.exhausted);
+    },
+    [scheduleAuthRecoveryRetry, setAuthState, setCurrentUser],
+  );
+
+  const settleReadonlySession = useCallback(
+    (message: string | null) => {
+      clearAuthRetryTimer();
+      authRecoveryActiveRef.current = false;
+      authRecoveryDisabledRef.current = true;
+      authRetryQuickAttemptRef.current = 0;
       setAccessDiagnosticMessage(message);
       setCurrentUser(null);
       setAuthState("signed_out");
       setAccessState("readonly");
-      scheduleAuthRecoveryRetry(source);
     },
-    [scheduleAuthRecoveryRetry, setAuthState, setCurrentUser],
+    [clearAuthRetryTimer, setAuthState, setCurrentUser],
   );
 
   const applyRecoveredProfile = useCallback(
@@ -633,6 +651,7 @@ export function AppShell() {
       setCurrentUser(profile);
       setAuthState("signed_in");
       hadAuthenticatedSessionRef.current = true;
+      markAuthenticatedSession();
       setActiveUserId(profile.id);
       if (profile.needsUsername) {
         setAccessState("pending");
@@ -668,6 +687,8 @@ export function AppShell() {
       setCurrentUser(profile);
       setAuthState("signed_in");
       setActiveUserId(profile.id);
+      hadAuthenticatedSessionRef.current = true;
+      markAuthenticatedSession();
       setAccessDiagnosticMessage(null);
       setAccessState("granted");
       try {
@@ -704,6 +725,38 @@ export function AppShell() {
         isInitializing: isInitializingRef.current,
       });
 
+      let failureStage: "probe" | "profile" = isLocalRuntime ? "profile" : "probe";
+      const applyRecoverableFailure = (
+        source: "timeout" | "failure",
+        serverTimeout: boolean,
+        detail?: string,
+      ) => {
+        const knownAuthenticatedSession =
+          failureStage === "profile" || hadAuthenticatedSessionRef.current;
+        if (knownAuthenticatedSession) {
+          setAuthDegraded(
+            {
+              retrying: serverTimeout
+                ? "Cloud save is unavailable. Your changes may not be saved. The sign-in service timed out; LinkSim is retrying automatically."
+                : `Cloud save is unavailable. Your changes may not be saved. LinkSim is retrying sign-in automatically.${detail ? ` (${detail})` : ""}`,
+              exhausted:
+                "Cloud save is unavailable. Your changes may not be saved. Sign in again to resume cloud saving.",
+            },
+            source,
+          );
+          return;
+        }
+        setAuthDegraded(
+          {
+            retrying:
+              "Sign-in status could not be checked. Continuing in read-only demo mode. LinkSim is retrying automatically.",
+            exhausted:
+              "Sign-in status could not be checked. Continuing in read-only demo mode. Try signing in again.",
+          },
+          source,
+        );
+      };
+
       let timedOut = false;
       const timeoutId = window.setTimeout(() => {
         if (authCheckGenerationRef.current !== runId) return;
@@ -717,10 +770,7 @@ export function AppShell() {
           online: typeof navigator === "undefined" ? true : navigator.onLine,
           isInitializing: isInitializingRef.current,
         });
-        setAuthDegraded(
-          "Cloud save is unavailable. Your changes may not be saved. The sign-in check timed out; LinkSim is retrying automatically.",
-          "timeout",
-        );
+        applyRecoverableFailure("timeout", true);
       }, ACCESS_CHECK_TIMEOUT_MS);
 
       void (async () => {
@@ -737,34 +787,40 @@ export function AppShell() {
             })();
           if (localForceReadonly) {
             if (!isCurrentRun()) return;
-            authRecoveryActiveRef.current = false;
-            authRecoveryDisabledRef.current = true;
-            authRetryQuickAttemptRef.current = 0;
             window.clearTimeout(timeoutId);
-            setAccessDiagnosticMessage(null);
-            setCurrentUser(null);
-            setAuthState("signed_out");
-            setAccessState("readonly");
+            settleReadonlySession(null);
             return;
           }
-          if (deepLinkParse.ok && !isLocalRuntime) {
-          const deepLinkStatus = await fetchDeepLinkStatus({
-            simulationId: deepLinkParse.payload.simulationId,
-            username: deepLinkParse.payload.username,
-            simulationSlug: deepLinkParse.payload.simulationSlug,
-          });
-            if (!deepLinkStatus.authenticated) {
-              if (!isCurrentRun()) return;
-              authRecoveryActiveRef.current = false;
-              authRecoveryDisabledRef.current = true;
-              authRetryQuickAttemptRef.current = 0;
+          if (!isLocalRuntime) {
+            const authStatus = await fetchAuthStatus();
+            if (!isCurrentRun()) return;
+            const bootstrapState = resolveAuthBootstrapState({
+              authState: authStatus.authState,
+              hadAuthenticatedSession: hadAuthenticatedSessionRef.current,
+            });
+            if (bootstrapState === "revoked") {
               window.clearTimeout(timeoutId);
-              setAccessDiagnosticMessage(null);
-              setCurrentUser(null);
-              setAuthState("signed_out");
-              setAccessState("readonly");
+              settleReadonlySession(
+                "Account access is unavailable. Your changes may not be saved. Sign in again or contact an admin if you need access restored.",
+              );
               return;
             }
+            if (bootstrapState === "guest" || bootstrapState === "expired") {
+              if (!isCurrentRun()) return;
+              window.clearTimeout(timeoutId);
+              const expiredSessionMessage = bootstrapState === "expired"
+                ? "Cloud save is unavailable. Your changes may not be saved. Sign in again to resume cloud saving."
+                : null;
+              console.info("[AppShell] Access check resolved to guest", {
+                reason,
+                deepLinkMode: deepLinkParse.ok,
+                priorAuthenticatedSession: hadAuthenticatedSessionRef.current,
+              });
+              settleReadonlySession(expiredSessionMessage);
+              return;
+            }
+            hadAuthenticatedSessionRef.current = true;
+            failureStage = "profile";
           }
           const profile = await fetchMe({ timeoutMs: ACCESS_FETCH_TIMEOUT_MS });
           if (!isCurrentRun()) return;
@@ -778,59 +834,21 @@ export function AppShell() {
             error instanceof CloudApiError &&
             (error.code === "timeout" || error.code === "server_timeout" || error.code === "auth_timeout" || error.status === 524);
           const isOnlineNow = typeof navigator === "undefined" ? true : navigator.onLine;
-          const fallbackToReadonly = shouldUseReadonlyFallbackForAuthBootstrap({
+          console.error("[AppShell] Access check failed", {
+            reason,
             message,
-            deepLinkMode: deepLinkParse.ok,
+            failureStage,
             isLocalRuntime,
-            isOnline: isOnlineNow,
-            userAgent: typeof navigator === "undefined" ? "" : navigator.userAgent,
+            deepLinkMode: deepLinkParse.ok,
+            online: isOnlineNow,
           });
-          if (deepLinkParse.ok) {
-            console.info("[AppShell] Guest deep-link bootstrap using read-only fallback", {
-              reason,
-              message,
-              isLocalRuntime,
-              deepLinkMode: deepLinkParse.ok,
-              online: isOnlineNow,
-            });
-          } else {
-            console.error("[AppShell] Access check failed", {
-              reason,
-              message,
-              isLocalRuntime,
-              deepLinkMode: deepLinkParse.ok,
-              online: isOnlineNow,
-              fallbackToReadonly,
-            });
-          }
           if (message.includes("Session revoked by admin")) {
-            setAuthDegraded(
-              "Cloud save is unavailable. Your changes may not be saved. Sign in again to resume cloud saving; LinkSim is retrying automatically.",
-              "failure",
+            settleReadonlySession(
+              "Cloud save is unavailable. Your changes may not be saved. Sign in again to resume cloud saving.",
             );
             return;
           }
-          if (deepLinkParse.ok) {
-            authRecoveryActiveRef.current = false;
-            authRecoveryDisabledRef.current = true;
-            authRetryQuickAttemptRef.current = 0;
-            setAccessState("readonly");
-            return;
-          }
-          if (fallbackToReadonly && !hadAuthenticatedSessionRef.current) {
-            authRecoveryActiveRef.current = false;
-            authRecoveryDisabledRef.current = true;
-            authRetryQuickAttemptRef.current = 0;
-            setAccessDiagnosticMessage("Sign-in check was blocked by browser auth redirects. Continuing in read-only demo mode.");
-            setAccessState("readonly");
-            return;
-          }
-          setAuthDegraded(
-            isServerTimeout
-              ? "Cloud save is unavailable. Your changes may not be saved. The sign-in service timed out; LinkSim is retrying automatically."
-              : `Cloud save is unavailable. Your changes may not be saved. LinkSim is retrying sign-in automatically. (${message})`,
-            "failure",
-          );
+          applyRecoverableFailure("failure", isServerTimeout, message);
         } finally {
           if (authCheckGenerationRef.current === runId && !timedOut) {
             authCheckInFlightRef.current = false;
@@ -844,6 +862,7 @@ export function AppShell() {
       deepLinkParse,
       isLocalRuntime,
       setAuthDegraded,
+      settleReadonlySession,
       setAuthState,
       setCurrentUser,
     ],
@@ -865,12 +884,12 @@ export function AppShell() {
   useEffect(() => {
     if (authState !== "signed_out") return;
     if (accessState === "checking") return;
+    if (accessState === "readonly") return;
     if (!hadAuthenticatedSessionRef.current) return;
-    setAuthDegraded(
-      "Cloud save is unavailable. Your changes may not be saved. LinkSim is retrying sign-in automatically.",
-      "failure",
+    settleReadonlySession(
+      "Cloud save is unavailable. Your changes may not be saved. Sign in again to resume cloud saving.",
     );
-  }, [accessState, authState, setAuthDegraded]);
+  }, [accessState, authState, settleReadonlySession]);
 
   useEffect(() => {
     if (!accessDiagnosticMessage) {

--- a/src/components/MapView.overlayHandoff.test.tsx
+++ b/src/components/MapView.overlayHandoff.test.tsx
@@ -1,0 +1,423 @@
+// @vitest-environment jsdom
+import React from "react";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Site } from "../types/radio";
+
+const overlayMock = vi.hoisted(() => {
+  const requests: Array<{
+    resolve: (value: { width: number; height: number; pixels: Uint8ClampedArray }) => void;
+  }> = [];
+  return {
+    requests,
+    buildCoverage: vi.fn(
+      () =>
+        new Promise<{ width: number; height: number; pixels: Uint8ClampedArray }>((resolve) => {
+          requests.push({ resolve });
+        }),
+    ),
+    encodedRasterCount: 0,
+  };
+});
+
+const loadingOverlayMock = vi.hoisted(() => ({
+  props: null as null | {
+    handoffKey?: string | null;
+    loading?: boolean;
+    onCloudEntered?: (requestKey: string) => void;
+    onCloudExited?: (requestKey: string) => void;
+    onCloudReady?: (requestKey: string) => void;
+  },
+}));
+
+const layerMock = vi.hoisted(() => ({
+  coveragePaint: null as null | Record<string, unknown>,
+}));
+
+vi.hoisted(() => {
+  const data = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: (key: string) => data.get(key) ?? null,
+    setItem: (key: string, value: string) => data.set(key, String(value)),
+    removeItem: (key: string) => data.delete(key),
+    clear: () => data.clear(),
+    key: (index: number) => Array.from(data.keys())[index] ?? null,
+    get length() {
+      return data.size;
+    },
+  });
+});
+
+vi.mock("../lib/overlayRaster", () => ({
+  buildCoverageOverlayPixelsAsync: overlayMock.buildCoverage,
+  buildMeshExtensionOverlayPixelsAsync: vi.fn(),
+  buildRelayCandidateOverlayPixelsAsync: vi.fn(),
+  buildSourcePassFailOverlayPixelsAsync: vi.fn(),
+  buildTerrainShadeOverlayPixelsAsync: vi.fn(async () => null),
+  overlayPixelsToDataUrl: vi.fn(() => ({
+    coordinates: [
+      [10, 61],
+      [11, 61],
+      [11, 60],
+      [10, 60],
+    ],
+    url: `data:image/mock-${++overlayMock.encodedRasterCount}`,
+  })),
+  OverlayTaskCancelledError: class OverlayTaskCancelledError extends Error {},
+}));
+
+vi.mock("./SimulationLoadingOverlay", () => ({
+  SimulationLoadingOverlay: (
+    props: NonNullable<typeof loadingOverlayMock.props>,
+  ) => {
+    loadingOverlayMock.props = props;
+    return <div data-testid="simulation-loading-overlay" />;
+  },
+}));
+
+vi.mock("react-map-gl/maplibre", async () => {
+  const ReactMock = await vi.importActual<typeof import("react")>("react");
+  return {
+    default: ReactMock.forwardRef(
+      (
+        props: { children?: React.ReactNode },
+        ref: React.ForwardedRef<{ easeTo: () => void; queryRenderedFeatures: () => unknown[] }>,
+      ) => {
+        ReactMock.useImperativeHandle(ref, () => ({
+          easeTo: () => undefined,
+          queryRenderedFeatures: () => [],
+        }));
+        return <div>{props.children}</div>;
+      },
+    ),
+    Layer: (props: { id?: string; paint?: Record<string, unknown> }) => {
+      if (props.id === "coverage-overlay-layer") {
+        layerMock.coveragePaint = props.paint ?? null;
+      }
+      return null;
+    },
+    Marker: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    Source: ({
+      children,
+      id,
+      url,
+    }: {
+      children?: React.ReactNode;
+      id?: string;
+      url?: string;
+    }) => (
+      <div data-source-id={id} data-testid={id} data-url={url}>
+        {children}
+      </div>
+    ),
+    useMap: () => ({ current: undefined }),
+  };
+});
+
+vi.mock("../lib/meshtasticMqtt", () => ({
+  fetchMeshmapNodes: vi.fn(async () => ({
+    fromCache: false,
+    networkError: false,
+    nodes: [],
+  })),
+}));
+
+import { useAppStore } from "../store/appStore";
+import { useCoverageStore } from "../store/coverageStore";
+import { MapView } from "./MapView";
+
+const recomputeCoverageAction = useCoverageStore.getState().recomputeCoverage;
+
+const site: Site = {
+  id: "site-a",
+  name: "Site A",
+  position: { lat: 60.4, lon: 10.7 },
+  groundElevationM: 120,
+  antennaHeightM: 8,
+  txPowerDbm: 30,
+  txGainDbi: 2,
+  rxGainDbi: 2,
+  cableLossDb: 1,
+};
+
+const resolveNextRaster = async () => {
+  await waitFor(() => expect(overlayMock.requests.length).toBeGreaterThan(0));
+  const request = overlayMock.requests.shift();
+  if (!request) throw new Error("Expected a pending overlay raster request");
+  await act(async () => {
+    request.resolve({
+      width: 1,
+      height: 1,
+      pixels: new Uint8ClampedArray([255, 0, 0, 255]),
+    });
+  });
+};
+
+describe("MapView overlay handoff", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    overlayMock.requests.length = 0;
+    overlayMock.encodedRasterCount = 0;
+    loadingOverlayMock.props = null;
+    layerMock.coveragePaint = null;
+    Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
+      configurable: true,
+      value: vi.fn(() => ({})),
+    });
+    useAppStore.setState({
+      sites: [site],
+      links: [],
+      selectedSiteId: site.id,
+      selectedSiteIds: [site.id],
+      selectedLinkId: "",
+      mapOverlayMode: "heatmap",
+      selectedCoverageResolution: "24",
+      selectedOverlayRadiusOption: "20",
+      srtmTiles: [],
+      terrainLoadEpoch: 0,
+      isTerrainFetching: false,
+      isTerrainRecommending: false,
+      recommendAndFetchTerrainForCurrentArea: vi.fn(async () => undefined),
+    });
+    useCoverageStore.setState({
+      coverageSamples: [
+        {
+          lat: site.position.lat,
+          lon: site.position.lon,
+          valueDbm: -80,
+        },
+      ],
+      isSimulationRecomputing: false,
+      autoCalculateEnabled: true,
+      calculationCycleSource: null,
+      recomputeCoverage: recomputeCoverageAction,
+    });
+  });
+
+  it("keeps the displayed raster mounted until the replacement cloud is ready", async () => {
+    render(
+      <MapView
+        canPersist
+        isMapExpanded={false}
+        onToggleMapExpanded={() => undefined}
+        showInspector={false}
+      />,
+    );
+
+    await resolveNextRaster();
+    await waitFor(() => expect(loadingOverlayMock.props?.handoffKey).toBeTruthy());
+    const firstKey = loadingOverlayMock.props?.handoffKey;
+    expect(firstKey).toBeTruthy();
+    act(() => loadingOverlayMock.props?.onCloudReady?.(firstKey!));
+    act(() => loadingOverlayMock.props?.onCloudEntered?.(firstKey!));
+    await waitFor(() =>
+      expect(screen.getByTestId("coverage-overlay-source")).toHaveAttribute(
+        "data-url",
+        "data:image/mock-1",
+      ),
+    );
+    act(() => loadingOverlayMock.props?.onCloudExited?.(firstKey!));
+
+    act(() => useAppStore.getState().setMapOverlayMode("contours"));
+    await waitFor(() => expect(overlayMock.requests.length).toBeGreaterThan(0));
+
+    expect(screen.getByTestId("coverage-overlay-source")).toHaveAttribute(
+      "data-url",
+      "data:image/mock-1",
+    );
+    const replacementKey = loadingOverlayMock.props?.handoffKey;
+    expect(replacementKey).toBeTruthy();
+    expect(replacementKey).not.toBe(firstKey);
+    expect(layerMock.coveragePaint?.["raster-opacity"]).toBe(0);
+
+    act(() => loadingOverlayMock.props?.onCloudReady?.(replacementKey!));
+    expect(screen.getByTestId("coverage-overlay-source")).toHaveAttribute(
+      "data-url",
+      "data:image/mock-1",
+    );
+  });
+
+  it("starts the initial automatic calculation without waiting for interaction", async () => {
+    const recomputeCoverage = vi.fn();
+    useCoverageStore.setState({
+      coverageSamples: [],
+      completedCoverageRunToken: "",
+      isSimulationRecomputing: false,
+      recomputeCoverage,
+    });
+
+    render(
+      <MapView
+        canPersist
+        isMapExpanded={false}
+        onToggleMapExpanded={() => undefined}
+        showInspector={false}
+      />,
+    );
+
+    await waitFor(() => expect(recomputeCoverage).toHaveBeenCalledTimes(1));
+  });
+
+  it("starts clouds while cold-start terrain loads before Pass/Fail is raster-ready", async () => {
+    useAppStore.setState({
+      mapOverlayMode: "passfail",
+      isTerrainFetching: true,
+    });
+
+    render(
+      <MapView
+        canPersist
+        isMapExpanded={false}
+        onToggleMapExpanded={() => undefined}
+        showInspector={false}
+      />,
+    );
+
+    await waitFor(() => expect(loadingOverlayMock.props?.loading).toBe(true));
+    expect(loadingOverlayMock.props?.handoffKey).toBeTruthy();
+    expect(overlayMock.buildCoverage).not.toHaveBeenCalled();
+  });
+
+  it("retries unchanged cold-start terrain geometry after startup cancels its epoch", async () => {
+    const recommendAndFetchTerrainForCurrentArea = vi.fn(async () => {
+      const currentEpoch = useAppStore.getState().terrainLoadEpoch;
+      useAppStore.setState({
+        isTerrainFetching: true,
+        terrainLoadEpoch: currentEpoch + 1,
+      });
+    });
+    useAppStore.setState({
+      isTerrainFetching: false,
+      terrainLoadEpoch: 0,
+      recommendAndFetchTerrainForCurrentArea,
+    });
+
+    render(
+      <MapView
+        canPersist
+        isMapExpanded={false}
+        onToggleMapExpanded={() => undefined}
+        showInspector={false}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(recommendAndFetchTerrainForCurrentArea).toHaveBeenCalledTimes(1),
+    );
+    act(() => {
+      useAppStore.setState({
+        isTerrainFetching: false,
+        terrainLoadEpoch: 2,
+      });
+    });
+
+    await waitFor(() =>
+      expect(recommendAndFetchTerrainForCurrentArea).toHaveBeenCalledTimes(2),
+    );
+  });
+
+  it("does not auto-start a manually locked initial calculation", async () => {
+    const recomputeCoverage = vi.fn();
+    useAppStore.setState({ selectedCoverageResolution: "84" });
+    useCoverageStore.setState({
+      coverageSamples: [],
+      completedCoverageRunToken: "",
+      isSimulationRecomputing: false,
+      recomputeCoverage,
+    });
+
+    render(
+      <MapView
+        canPersist
+        isMapExpanded={false}
+        onToggleMapExpanded={() => undefined}
+        showInspector={false}
+      />,
+    );
+
+    await act(async () => undefined);
+    expect(recomputeCoverage).not.toHaveBeenCalled();
+  });
+
+  it("does not replay clouds when a completed signature is observed again", async () => {
+    render(
+      <MapView
+        canPersist
+        isMapExpanded={false}
+        onToggleMapExpanded={() => undefined}
+        showInspector={false}
+      />,
+    );
+
+    await resolveNextRaster();
+    await waitFor(() => expect(loadingOverlayMock.props?.handoffKey).toBeTruthy());
+    const requestKey = loadingOverlayMock.props?.handoffKey;
+    act(() => loadingOverlayMock.props?.onCloudReady?.(requestKey!));
+    act(() => loadingOverlayMock.props?.onCloudEntered?.(requestKey!));
+    await waitFor(() =>
+      expect(screen.getByTestId("coverage-overlay-source")).toHaveAttribute(
+        "data-url",
+        "data:image/mock-1",
+      ),
+    );
+    act(() => loadingOverlayMock.props?.onCloudExited?.(requestKey!));
+    await waitFor(() => expect(loadingOverlayMock.props?.loading).toBe(false));
+
+    act(() =>
+      useCoverageStore.setState({
+        calculationCycleSource: "auto",
+        completedCoverageRunToken: "repeat-completion",
+      }),
+    );
+
+    await waitFor(() => expect(loadingOverlayMock.props?.loading).toBe(false));
+    expect(overlayMock.buildCoverage).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("coverage-overlay-source")).toHaveAttribute(
+      "data-url",
+      "data:image/mock-1",
+    );
+  });
+
+  it("still bridges a deliberate recalculation of the displayed signature", async () => {
+    render(
+      <MapView
+        canPersist
+        isMapExpanded={false}
+        onToggleMapExpanded={() => undefined}
+        showInspector={false}
+      />,
+    );
+
+    await resolveNextRaster();
+    await waitFor(() => expect(loadingOverlayMock.props?.handoffKey).toBeTruthy());
+    const requestKey = loadingOverlayMock.props?.handoffKey;
+    act(() => loadingOverlayMock.props?.onCloudReady?.(requestKey!));
+    act(() => loadingOverlayMock.props?.onCloudEntered?.(requestKey!));
+    await waitFor(() =>
+      expect(screen.getByTestId("coverage-overlay-source")).toHaveAttribute(
+        "data-url",
+        "data:image/mock-1",
+      ),
+    );
+    act(() => loadingOverlayMock.props?.onCloudExited?.(requestKey!));
+    await waitFor(() => expect(loadingOverlayMock.props?.loading).toBe(false));
+
+    act(() =>
+      useCoverageStore.setState({
+        calculationCycleSource: "manual",
+        isSimulationRecomputing: true,
+      }),
+    );
+    await waitFor(() => expect(loadingOverlayMock.props?.loading).toBe(true));
+
+    act(() =>
+      useCoverageStore.setState({
+        completedCoverageRunToken: "manual-repeat",
+        isSimulationRecomputing: false,
+      }),
+    );
+    expect(loadingOverlayMock.props?.loading).toBe(true);
+    act(() => loadingOverlayMock.props?.onCloudEntered?.(requestKey!));
+    await waitFor(() => expect(loadingOverlayMock.props?.loading).toBe(false));
+  });
+});

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState, type MouseEvent, type ReactNode } from "react";
 import { Egg, Fullscreen, Layers, Locate, LocateFixed, Maximize2, Minimize2, Play, Rabbit, RefreshCw, Square, SquareStack, ToggleLeft, ToggleRight, ZoomIn, ZoomOut } from "lucide-react";
 import { CompactDetails, CompactDetailsSummary } from "./ui/CompactDetails";
 import { FloatingPopover } from "./ui/FloatingPopover";
@@ -86,6 +86,12 @@ import { StateDot } from "./StateDot";
 import { useMapControls } from "./map/useMapControls";
 import { animateMapToCenter, fitMapToBounds, resolveMapCameraPadding } from "./map/mapCamera";
 import { PanelToolbar } from "./ui/PanelToolbar";
+import { SimulationLoadingOverlay } from "./SimulationLoadingOverlay";
+import { resolveSimulationOverlayTransition } from "../lib/simulationLoadingOverlay";
+import {
+  initialSimulationOverlayHandoffState,
+  reduceSimulationOverlayHandoff,
+} from "../lib/simulationOverlayHandoff";
 
 const UI_SECTION_KEYS = {
   mapViewResults: "linksim-ui-mapview-results-v1",
@@ -180,33 +186,45 @@ const panoramaRayLayer = (color: string): LayerProps => ({
   },
 });
 
-const coverageRasterLayer: LayerProps = {
-  id: "coverage-overlay-layer",
-  type: "raster",
-  paint: {
-    "raster-opacity": 0.68,
-    "raster-contrast": 0.08,
-    "raster-saturation": 0.02,
-  },
+const coverageRasterLayer = (fadedForCloud: boolean, hidden: boolean): LayerProps => {
+  const transition = resolveSimulationOverlayTransition(fadedForCloud);
+  return {
+    id: "coverage-overlay-layer",
+    type: "raster",
+    paint: {
+      "raster-opacity": hidden ? 0 : transition.coverageOpacity,
+      "raster-opacity-transition": {
+        duration: transition.durationMs,
+      },
+      "raster-contrast": 0.08,
+      "raster-saturation": 0.02,
+    },
+  };
 };
 
-const targetContourHaloLayer = (color: string): LayerProps => ({
+const targetContourHaloLayer = (color: string, fadedForCloud: boolean, hidden: boolean): LayerProps => ({
   id: "coverage-target-contour-halo-layer",
   type: "line",
   paint: {
     "line-color": color,
     "line-width": 2.5,
-    "line-opacity": 0.82,
+    "line-opacity": fadedForCloud || hidden ? 0 : 0.82,
+    "line-opacity-transition": {
+      duration: resolveSimulationOverlayTransition(fadedForCloud).durationMs,
+    },
   },
 });
 
-const targetContourLineLayer = (color: string): LayerProps => ({
+const targetContourLineLayer = (color: string, fadedForCloud: boolean, hidden: boolean): LayerProps => ({
   id: "coverage-target-contour-line-layer",
   type: "line",
   paint: {
     "line-color": color,
     "line-width": 1.2,
-    "line-opacity": 0.96,
+    "line-opacity": fadedForCloud || hidden ? 0 : 0.96,
+    "line-opacity-transition": {
+      duration: resolveSimulationOverlayTransition(fadedForCloud).durationMs,
+    },
   },
 });
 
@@ -744,6 +762,7 @@ export function MapView({
   const automaticLockNoticeShown = useCoverageStore((state) => state.automaticLockNoticeShown);
   const calculationCycleSource = useCoverageStore((state) => state.calculationCycleSource);
   const markAutomaticLockNoticeShown = useCoverageStore((state) => state.markAutomaticLockNoticeShown);
+  const recomputeCoverage = useCoverageStore((state) => state.recomputeCoverage);
   const setAutoCalculateEnabled = useCoverageStore((state) => state.setAutoCalculateEnabled);
   const startManualCalculation = useCoverageStore((state) => state.startManualCalculation);
   const stopCalculation = useCoverageStore((state) => state.stopCalculation);
@@ -1175,6 +1194,37 @@ export function MapView({
   const previousAutomaticCalculationLockedRef = useRef(automaticCalculationLocked);
   const calculationWorkAllowed =
     (autoCalculateEnabled && !automaticCalculationLocked) || calculationCycleSource === "manual";
+  const initialAutomaticCalculationRequestedRef = useRef(false);
+  useEffect(() => {
+    if (initialAutomaticCalculationRequestedRef.current) return;
+    if (
+      !autoCalculateEnabled ||
+      automaticCalculationLocked ||
+      coverageVizMode === "none" ||
+      analysisTargetSites.length === 0
+    ) {
+      return;
+    }
+    if (
+      coverageSamples.length > 0 ||
+      isSimulationRecomputing ||
+      completedCoverageRunToken !== ""
+    ) {
+      initialAutomaticCalculationRequestedRef.current = true;
+      return;
+    }
+    initialAutomaticCalculationRequestedRef.current = true;
+    recomputeCoverage();
+  }, [
+    analysisTargetSites.length,
+    autoCalculateEnabled,
+    automaticCalculationLocked,
+    completedCoverageRunToken,
+    coverageSamples.length,
+    coverageVizMode,
+    isSimulationRecomputing,
+    recomputeCoverage,
+  ]);
   useEffect(() => {
     const becameLocked = automaticCalculationLocked && !previousAutomaticCalculationLockedRef.current;
     previousAutomaticCalculationLockedRef.current = automaticCalculationLocked;
@@ -1255,23 +1305,44 @@ export function MapView({
     [requiredTargetRadiusTileKeys, loaded30mTileKeys],
   );
   const targetRadiusTerrainSignature = `${targetRadiusKm}|${requiredTargetRadiusTileKeys.join(",")}`;
-  const targetRadiusFetchAttemptRef = useRef("");
+  const targetRadiusFetchAttemptRef = useRef<{
+    signature: string;
+    terrainLoadEpoch: number;
+  }>({ signature: "", terrainLoadEpoch: -1 });
   useEffect(() => {
     if (!calculationWorkAllowed) {
-      targetRadiusFetchAttemptRef.current = "";
+      targetRadiusFetchAttemptRef.current = {
+        signature: "",
+        terrainLoadEpoch: -1,
+      };
       return;
     }
     if (coverageVizMode === "none") {
-      targetRadiusFetchAttemptRef.current = "";
+      targetRadiusFetchAttemptRef.current = {
+        signature: "",
+        terrainLoadEpoch: -1,
+      };
       return;
     }
     if (!analysisTargetSites.length || missingTargetRadiusTileCount <= 0) {
-      targetRadiusFetchAttemptRef.current = "";
+      targetRadiusFetchAttemptRef.current = {
+        signature: "",
+        terrainLoadEpoch: -1,
+      };
       return;
     }
     if (isTerrainFetching || isTerrainRecommending) return;
-    if (targetRadiusFetchAttemptRef.current === targetRadiusTerrainSignature) return;
-    targetRadiusFetchAttemptRef.current = targetRadiusTerrainSignature;
+    if (
+      targetRadiusFetchAttemptRef.current.signature ===
+        targetRadiusTerrainSignature &&
+      targetRadiusFetchAttemptRef.current.terrainLoadEpoch === terrainLoadEpoch
+    ) {
+      return;
+    }
+    targetRadiusFetchAttemptRef.current = {
+      signature: targetRadiusTerrainSignature,
+      terrainLoadEpoch: terrainLoadEpoch + 1,
+    };
     void recommendAndFetchTerrainForCurrentArea(targetRadiusKm);
   }, [
     coverageVizMode,
@@ -1280,6 +1351,7 @@ export function MapView({
     isTerrainFetching,
     isTerrainRecommending,
     normalizedOverlayRadiusOption,
+    terrainLoadEpoch,
     targetRadiusTerrainSignature,
     recommendAndFetchTerrainForCurrentArea,
     targetRadiusKm,
@@ -1569,6 +1641,86 @@ export function MapView({
   }, [setOverlayPipelineProgress]);
   const [coverageOverlay, setCoverageOverlay] = useState<(OverlayRaster & { minDbm?: number; maxDbm?: number }) | null>(null);
   const [simulationTerrainOverlay, setSimulationTerrainOverlay] = useState<OverlayRaster | null>(null);
+  const [overlayHandoff, dispatchOverlayHandoff] = useReducer(
+    reduceSimulationOverlayHandoff,
+    initialSimulationOverlayHandoffState,
+  );
+  const overlayHandoffRef = useRef(overlayHandoff);
+  overlayHandoffRef.current = overlayHandoff;
+  const latestCoverageRequestKeyRef = useRef<string | null>(null);
+  const displayedCoverageSignatureRef = useRef<string | null>(null);
+  const pendingCoverageOverlayRef = useRef<(OverlayRaster & { minDbm?: number; maxDbm?: number }) | null>(null);
+  const pendingTerrainOverlayRef = useRef<OverlayRaster | null>(null);
+  const hiddenOverlayTimeoutRef = useRef<number | null>(null);
+  const beginCoverageHandoff = useCallback((requestKey: string) => {
+    if (hiddenOverlayTimeoutRef.current !== null) {
+      window.clearTimeout(hiddenOverlayTimeoutRef.current);
+      hiddenOverlayTimeoutRef.current = null;
+    }
+    latestCoverageRequestKeyRef.current = requestKey;
+    dispatchOverlayHandoff({ type: "request", requestKey });
+  }, []);
+  const completeCoverageHandoff = useCallback(
+    (
+      requestKey: string,
+      overlay: (OverlayRaster & { minDbm?: number; maxDbm?: number }) | null,
+    ) => {
+      if (latestCoverageRequestKeyRef.current !== requestKey) return;
+      if (!overlay) {
+        dispatchOverlayHandoff({ type: "request-failed", requestKey });
+        return;
+      }
+      pendingCoverageOverlayRef.current = overlay;
+      dispatchOverlayHandoff({ type: "replacement-ready", requestKey });
+    },
+    [],
+  );
+  const failCoverageHandoff = useCallback((requestKey: string) => {
+    if (latestCoverageRequestKeyRef.current !== requestKey) return;
+    dispatchOverlayHandoff({ type: "request-failed", requestKey });
+  }, []);
+  const commitTerrainOverlay = useCallback((overlay: OverlayRaster | null) => {
+    const phase = overlayHandoffRef.current.phase;
+    if (phase === "entering" || phase === "entered") {
+      pendingTerrainOverlayRef.current = overlay;
+      return;
+    }
+    setSimulationTerrainOverlay(overlay);
+  }, []);
+
+  useEffect(() => {
+    if (overlayHandoff.phase !== "exiting") return;
+    if (overlayHandoff.revealReplacement) {
+      const replacement = pendingCoverageOverlayRef.current;
+      if (replacement) {
+        setCoverageOverlay(replacement);
+        displayedCoverageSignatureRef.current = overlayHandoff.requestKey;
+      }
+      if (pendingTerrainOverlayRef.current) {
+        setSimulationTerrainOverlay(pendingTerrainOverlayRef.current);
+      }
+    }
+    pendingCoverageOverlayRef.current = null;
+    pendingTerrainOverlayRef.current = null;
+  }, [overlayHandoff.phase, overlayHandoff.revealReplacement]);
+
+  useEffect(() => {
+    if (overlayHandoff.phase !== "hiding") return;
+    hiddenOverlayTimeoutRef.current = window.setTimeout(() => {
+      setCoverageOverlay(null);
+      pendingCoverageOverlayRef.current = null;
+      latestCoverageRequestKeyRef.current = null;
+      displayedCoverageSignatureRef.current = null;
+      dispatchOverlayHandoff({ type: "hidden" });
+      hiddenOverlayTimeoutRef.current = null;
+    }, resolveSimulationOverlayTransition(false).durationMs);
+    return () => {
+      if (hiddenOverlayTimeoutRef.current !== null) {
+        window.clearTimeout(hiddenOverlayTimeoutRef.current);
+        hiddenOverlayTimeoutRef.current = null;
+      }
+    };
+  }, [overlayHandoff.phase]);
 
   const logOverlaySchedulerEvent = useCallback(
     (
@@ -1602,6 +1754,9 @@ export function MapView({
     return () => {
       coverageOverlaySchedulerRef.current?.dispose();
       terrainOverlaySchedulerRef.current?.dispose();
+      if (hiddenOverlayTimeoutRef.current !== null) {
+        window.clearTimeout(hiddenOverlayTimeoutRef.current);
+      }
     };
   }, []);
 
@@ -1635,43 +1790,36 @@ export function MapView({
 
   useEffect(() => {
     const scheduler = coverageOverlaySchedulerRef.current!;
-    const cancelCoveragePipeline = (clearOverlay: boolean) => {
+    const cancelCoveragePipeline = () => {
       scheduler.clearQueue();
       scheduler.cancelActive();
       setOverlayPipelineProgress("coverage", null);
-      if (clearOverlay) setCoverageOverlay(null);
     };
 
     if (coverageVizMode === "none") {
-      cancelCoveragePipeline(true);
+      cancelCoveragePipeline();
+      latestCoverageRequestKeyRef.current = null;
+      dispatchOverlayHandoff({ type: "hide" });
       return;
     }
     if (!overlayBounds) {
-      cancelCoveragePipeline(true);
-      return;
-    }
-    if (
-      shouldDeferOverlayRasterization({
-        isTerrainFetching,
-        isTerrainRecommending,
-        isSimulationRecomputing,
-      })
-    ) {
-      cancelCoveragePipeline(false);
+      cancelCoveragePipeline();
+      latestCoverageRequestKeyRef.current = null;
+      dispatchOverlayHandoff({ type: "hide" });
       return;
     }
 
     const mode = coverageVizMode;
     if (mode === "passfail" && (!activeSelectionLink || !selectedFromSite || !hasPassFailTopology)) {
-      cancelCoveragePipeline(true);
+      cancelCoveragePipeline();
       return;
     }
     if (mode === "relay" && (!activeSelectionLink || !selectedFromSite || !selectedToSite || !hasRelayTopology)) {
-      cancelCoveragePipeline(true);
+      cancelCoveragePipeline();
       return;
     }
     if (mode === "mesh-extension" && !meshExtensionSites.length) {
-      cancelCoveragePipeline(true);
+      cancelCoveragePipeline();
       return;
     }
 
@@ -1700,6 +1848,33 @@ export function MapView({
       selectedSiteRadioDigest,
       meshExtensionFrequencyMHz,
     ].join("|");
+    if (
+      shouldDeferOverlayRasterization({
+        isTerrainFetching,
+        isTerrainRecommending,
+        isSimulationRecomputing,
+      })
+    ) {
+      if (isTerrainFetching || isSimulationRecomputing) {
+        beginCoverageHandoff(signature);
+      }
+      cancelCoveragePipeline();
+      return;
+    }
+    const currentHandoff = overlayHandoffRef.current;
+    const handoffWaitingForSignature =
+      currentHandoff.requestKey === signature &&
+      (currentHandoff.phase === "entering" ||
+        currentHandoff.phase === "entered");
+    if (
+      displayedCoverageSignatureRef.current === signature &&
+      !handoffWaitingForSignature
+    ) {
+      scheduler.clearQueue();
+      scheduler.cancelActive();
+      setOverlayPipelineProgress("coverage", null);
+      return;
+    }
     const hasFreshCoverageCompletion =
       calculationCycleSource !== null &&
       completedCoverageRunToken !== "" &&
@@ -1717,12 +1892,13 @@ export function MapView({
       lastCoverageOverlayCompletionRef.current = completedCoverageRunToken;
     }
     const cached = coverageOverlayCacheRef.current.get(signature);
+    beginCoverageHandoff(signature);
     if (cached) {
       scheduler.clearQueue();
       scheduler.cancelActive();
       setOverlayPipelineProgress("coverage", null);
       logOverlaySchedulerEvent("coverage", "cache-hit", signature);
-      setCoverageOverlay(cached);
+      completeCoverageHandoff(signature, cached);
       return;
     }
 
@@ -1855,10 +2031,11 @@ export function MapView({
               signature,
               mode,
             });
+            failCoverageHandoff(signature);
             return;
           }
           if (!rasterPixels) {
-            setCoverageOverlay(null);
+            failCoverageHandoff(signature);
             return;
           }
           const raster = overlayPixelsToDataUrl(rasterPixels);
@@ -1871,6 +2048,7 @@ export function MapView({
               signature,
               mode,
             });
+            failCoverageHandoff(signature);
             return;
           }
           recordSimulationOverlayPerf({
@@ -1889,7 +2067,7 @@ export function MapView({
             coverageOverlayCacheRef.current.set(signature, overlayValue);
           }
           setOverlayPipelineProgress("coverage", 100);
-          setCoverageOverlay(overlayValue);
+          completeCoverageHandoff(signature, overlayValue);
         } catch (error) {
           if (error instanceof OverlayTaskCancelledError) {
             recordSimulationRunCancelled({
@@ -1899,9 +2077,11 @@ export function MapView({
               signature,
               mode,
             });
+            failCoverageHandoff(signature);
             return;
           }
           console.error("Failed to render simulation overlay", error);
+          failCoverageHandoff(signature);
         } finally {
           endOverlayJob();
         }
@@ -1944,6 +2124,9 @@ export function MapView({
     selectedNetwork,
     showOverlayDiagnostics,
     beginOverlayJob,
+    beginCoverageHandoff,
+    completeCoverageHandoff,
+    failCoverageHandoff,
     setOverlayPipelineProgress,
     logOverlaySchedulerEvent,
     calculationWorkAllowed,
@@ -1983,7 +2166,41 @@ export function MapView({
         : { type: "FeatureCollection" as const, features: [] },
     [coverageVizMode, overlayBounds, overlayPointMask, rxSensitivityTargetDbm, samplesForOverlay],
   );
-  const showTargetContourLine = coverageVizMode === "contours" && targetContourFeatures.features.length > 0;
+  const [displayedTargetContourFeatures, setDisplayedTargetContourFeatures] =
+    useState(targetContourFeatures);
+  const pendingTargetContourFeaturesRef = useRef(targetContourFeatures);
+  useEffect(() => {
+    if (
+      coverageVizMode === "contours" &&
+      targetContourFeatures.features.length > 0
+    ) {
+      if (
+        overlayHandoff.phase === "entering" ||
+        overlayHandoff.phase === "entered"
+      ) {
+        pendingTargetContourFeaturesRef.current = targetContourFeatures;
+      } else {
+        setDisplayedTargetContourFeatures(targetContourFeatures);
+      }
+    }
+    if (overlayHandoff.phase === "exiting") {
+      setDisplayedTargetContourFeatures(
+        coverageVizMode === "contours"
+          ? pendingTargetContourFeaturesRef.current
+          : { type: "FeatureCollection", features: [] },
+      );
+    }
+    if (overlayHandoff.phase !== "hiding") return;
+    const timeoutId = window.setTimeout(() => {
+      setDisplayedTargetContourFeatures({
+        type: "FeatureCollection",
+        features: [],
+      });
+    }, resolveSimulationOverlayTransition(false).durationMs);
+    return () => window.clearTimeout(timeoutId);
+  }, [coverageVizMode, overlayHandoff.phase, targetContourFeatures]);
+  const showTargetContourLine =
+    displayedTargetContourFeatures.features.length > 0;
   const coverageScaleRange = useMemo(() => {
     if (!coverageOverlay || (coverageVizMode !== "heatmap" && coverageVizMode !== "contours" && coverageVizMode !== "weakest")) {
       return null;
@@ -2068,7 +2285,7 @@ export function MapView({
       scheduler.cancelActive();
       setOverlayPipelineProgress("terrain", null);
       logOverlaySchedulerEvent("terrain", "cache-hit", signature);
-      setSimulationTerrainOverlay(cached);
+      commitTerrainOverlay(cached);
       return;
     }
 
@@ -2137,7 +2354,6 @@ export function MapView({
             return;
           }
           if (!rasterPixels) {
-            setSimulationTerrainOverlay(null);
             return;
           }
           const raster = overlayPixelsToDataUrl(rasterPixels);
@@ -2168,7 +2384,7 @@ export function MapView({
             terrainOverlayCacheRef.current.set(signature, overlayValue);
           }
           setOverlayPipelineProgress("terrain", 100);
-          setSimulationTerrainOverlay(overlayValue);
+          commitTerrainOverlay(overlayValue);
         } catch (error) {
           if (error instanceof OverlayTaskCancelledError) {
             recordSimulationRunCancelled({
@@ -2204,6 +2420,7 @@ export function MapView({
     overlayRadiusKm,
     showOverlayDiagnostics,
     beginOverlayJob,
+    commitTerrainOverlay,
     setOverlayPipelineProgress,
     logOverlaySchedulerEvent,
     calculationWorkAllowed,
@@ -2290,6 +2507,23 @@ export function MapView({
       terrainProgressTilesTotal,
     ],
   );
+  const simulationLoadingOverlayActive =
+    Boolean(analysisBounds && overlayPointMask && overlayHandoff.requestKey) &&
+    (overlayHandoff.phase === "entering" || overlayHandoff.phase === "entered");
+  const simulationOverlayFadedForCloud = simulationLoadingOverlayActive;
+  const simulationOverlayHidden = overlayHandoff.phase === "hiding";
+  const simulationOverlayTransition = resolveSimulationOverlayTransition(
+    simulationOverlayFadedForCloud,
+  );
+  const handleLoadingCloudReady = useCallback((requestKey: string) => {
+    dispatchOverlayHandoff({ type: "cloud-ready", requestKey });
+  }, []);
+  const handleLoadingCloudEntered = useCallback((requestKey: string) => {
+    dispatchOverlayHandoff({ type: "cloud-entered", requestKey });
+  }, []);
+  const handleLoadingCloudExited = useCallback((requestKey: string) => {
+    dispatchOverlayHandoff({ type: "exit-complete", requestKey });
+  }, []);
   const calculationControlRunning = calculationCycleSource !== null || isSimulationRecomputing;
   const handleStopCalculation = useCallback(() => {
     stopCalculation();
@@ -2300,7 +2534,9 @@ export function MapView({
     terrainOverlaySchedulerRef.current?.cancelActive();
     setOverlayPipelineProgress("coverage", null);
     setOverlayPipelineProgress("terrain", null);
-  }, [cancelTerrainLoad, setOverlayPipelineProgress, stopCalculation]);
+    const requestKey = overlayHandoffRef.current.requestKey;
+    if (requestKey) failCoverageHandoff(requestKey);
+  }, [cancelTerrainLoad, failCoverageHandoff, setOverlayPipelineProgress, stopCalculation]);
   useEffect(() => {
     if (!calculationCycleSource || isSimulationRecomputing || overlayJobsInFlight > 0 || isTerrainFetching || isTerrainRecommending) {
       return;
@@ -3756,7 +3992,14 @@ export function MapView({
               type="raster"
               paint={{
                 ...terrainRasterPaint,
-                "raster-opacity": coverageOverlay ? 0.34 : 0.62,
+                "raster-opacity": simulationOverlayFadedForCloud || simulationOverlayHidden
+                  ? 0
+                  : coverageOverlay
+                    ? 0.34
+                    : 0.62,
+                "raster-opacity-transition": {
+                  duration: simulationOverlayTransition.durationMs,
+                },
               }}
             />
           </Source>
@@ -3776,14 +4019,41 @@ export function MapView({
             type="image"
             url={coverageOverlay.url}
           >
-            <Layer {...coverageRasterLayer} />
+            <Layer
+              {...coverageRasterLayer(
+                simulationOverlayFadedForCloud,
+                simulationOverlayHidden,
+              )}
+            />
           </Source>
         ) : null}
 
+        <SimulationLoadingOverlay
+          bounds={analysisBounds}
+          handoffKey={overlayHandoff.requestKey}
+          loading={simulationLoadingOverlayActive}
+          onCloudEntered={handleLoadingCloudEntered}
+          onCloudExited={handleLoadingCloudExited}
+          onCloudReady={handleLoadingCloudReady}
+          pointMask={overlayPointMask}
+        />
+
         {showTargetContourLine ? (
-          <Source data={targetContourFeatures} id="coverage-target-contour-source" type="geojson">
-            <Layer {...targetContourHaloLayer(variant.cssVars["--bg"] ?? linkColor)} />
-            <Layer {...targetContourLineLayer(variant.cssVars["--muted"] ?? selectedLinkColor)} />
+          <Source data={displayedTargetContourFeatures} id="coverage-target-contour-source" type="geojson">
+            <Layer
+              {...targetContourHaloLayer(
+                variant.cssVars["--bg"] ?? linkColor,
+                simulationOverlayFadedForCloud,
+                simulationOverlayHidden,
+              )}
+            />
+            <Layer
+              {...targetContourLineLayer(
+                variant.cssVars["--muted"] ?? selectedLinkColor,
+                simulationOverlayFadedForCloud,
+                simulationOverlayHidden,
+              )}
+            />
           </Source>
         ) : null}
 

--- a/src/components/MapView.userLocation.test.tsx
+++ b/src/components/MapView.userLocation.test.tsx
@@ -61,6 +61,7 @@ vi.mock("react-map-gl/maplibre", async () => {
       return <div>{children}</div>;
     },
     Source: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    useMap: () => ({ current: undefined }),
   };
 });
 

--- a/src/components/SimulationLoadingOverlay.test.tsx
+++ b/src/components/SimulationLoadingOverlay.test.tsx
@@ -1,0 +1,326 @@
+// @vitest-environment jsdom
+import { act, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mapMock = vi.hoisted(() => {
+  const state = {
+    layerPresent: false,
+    sourcePresent: false,
+    styleLoaded: true,
+    rejectSourceUntilStyleLoaded: false,
+    styleDataListener: null as null | (() => void),
+  };
+  const source = {
+    setCoordinates: vi.fn(),
+  };
+  const map = {
+    addLayer: vi.fn(() => {
+      state.layerPresent = true;
+    }),
+    addSource: vi.fn(() => {
+      if (
+        state.rejectSourceUntilStyleLoaded &&
+        !state.styleLoaded
+      ) {
+        throw new Error("Style is not done loading");
+      }
+      state.sourcePresent = true;
+    }),
+    getLayer: vi.fn(() => (state.layerPresent ? {} : undefined)),
+    getSource: vi.fn(() => (state.sourcePresent ? source : undefined)),
+    isStyleLoaded: vi.fn(() => state.styleLoaded),
+    off: vi.fn(),
+    on: vi.fn((event: string, listener: () => void) => {
+      if (event === "styledata") state.styleDataListener = listener;
+    }),
+    removeLayer: vi.fn(() => {
+      state.layerPresent = false;
+    }),
+    removeSource: vi.fn(() => {
+      state.sourcePresent = false;
+    }),
+    setPaintProperty: vi.fn(),
+    triggerRepaint: vi.fn(),
+  };
+  return { map, source, state };
+});
+
+vi.mock("react-map-gl/maplibre", () => ({
+  useMap: () => ({
+    current: {
+      getMap: () => mapMock.map,
+    },
+  }),
+}));
+
+import { SimulationLoadingOverlay } from "./SimulationLoadingOverlay";
+
+const bounds = {
+  minLat: 59.7,
+  maxLat: 60.1,
+  minLon: 10.4,
+  maxLon: 11.2,
+};
+
+describe("SimulationLoadingOverlay", () => {
+  const putImageData = vi.fn();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mapMock.state.layerPresent = false;
+    mapMock.state.sourcePresent = false;
+    mapMock.state.styleLoaded = true;
+    mapMock.state.rejectSourceUntilStyleLoaded = false;
+    mapMock.state.styleDataListener = null;
+    Object.values(mapMock.map).forEach((value) => {
+      if (typeof value === "function" && "mockClear" in value) {
+        value.mockClear();
+      }
+    });
+    mapMock.source.setCoordinates.mockClear();
+    putImageData.mockClear();
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      (callback: FrameRequestCallback) =>
+        window.setTimeout(() => callback(performance.now()), 16),
+    );
+    vi.stubGlobal("cancelAnimationFrame", (id: number) =>
+      window.clearTimeout(id),
+    );
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    );
+    Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
+      configurable: true,
+      value: vi.fn(() => ({
+        createImageData: (width: number, height: number) => ({
+          data: new Uint8ClampedArray(width * height * 4),
+          width,
+          height,
+        }),
+        putImageData,
+      })),
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("crossfades into clouds and keeps them mounted through the exit transition", () => {
+    const onCloudReady = vi.fn();
+    const onCloudEntered = vi.fn();
+    const onCloudExited = vi.fn();
+    const { rerender } = render(
+      <SimulationLoadingOverlay
+        bounds={bounds}
+        handoffKey="heatmap"
+        loading
+        onCloudEntered={onCloudEntered}
+        onCloudExited={onCloudExited}
+        onCloudReady={onCloudReady}
+        pointMask={() => true}
+      />,
+    );
+
+    expect(mapMock.map.addSource).toHaveBeenCalledTimes(1);
+    expect(mapMock.map.addLayer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        paint: expect.objectContaining({
+          "raster-opacity": 0,
+        }),
+      }),
+    );
+
+    expect(onCloudReady).toHaveBeenCalledWith("heatmap");
+    expect(mapMock.map.triggerRepaint).toHaveBeenCalled();
+    const repaintCountAtReady = mapMock.map.triggerRepaint.mock.calls.length;
+    act(() => vi.advanceTimersByTime(100));
+    expect(mapMock.map.triggerRepaint.mock.calls.length).toBeGreaterThan(
+      repaintCountAtReady,
+    );
+    expect(mapMock.map.setPaintProperty).toHaveBeenCalledWith(
+      "simulation-loading-overlay-layer",
+      "raster-opacity-transition",
+      { duration: 350 },
+    );
+    expect(mapMock.map.setPaintProperty).toHaveBeenCalledWith(
+      "simulation-loading-overlay-layer",
+      "raster-opacity",
+      0.68,
+    );
+
+    rerender(
+      <SimulationLoadingOverlay
+        bounds={bounds}
+        handoffKey="heatmap"
+        loading={false}
+        onCloudEntered={onCloudEntered}
+        onCloudExited={onCloudExited}
+        onCloudReady={onCloudReady}
+        pointMask={() => true}
+      />,
+    );
+
+    expect(onCloudEntered).not.toHaveBeenCalled();
+    expect(mapMock.map.setPaintProperty).not.toHaveBeenCalledWith(
+      "simulation-loading-overlay-layer",
+      "raster-opacity-transition",
+      { duration: 500 },
+    );
+
+    act(() => vi.advanceTimersByTime(249));
+    expect(onCloudEntered).not.toHaveBeenCalled();
+    act(() => vi.advanceTimersByTime(1));
+    expect(onCloudEntered).toHaveBeenCalledWith("heatmap");
+    expect(mapMock.map.setPaintProperty).toHaveBeenCalledWith(
+      "simulation-loading-overlay-layer",
+      "raster-opacity-transition",
+      { duration: 500 },
+    );
+    expect(mapMock.map.setPaintProperty).toHaveBeenCalledWith(
+      "simulation-loading-overlay-layer",
+      "raster-opacity",
+      0,
+    );
+
+    act(() => vi.advanceTimersByTime(499));
+    expect(mapMock.map.removeLayer).not.toHaveBeenCalled();
+    act(() => vi.advanceTimersByTime(1));
+    expect(mapMock.map.removeLayer).toHaveBeenCalledWith(
+      "simulation-loading-overlay-layer",
+    );
+    expect(mapMock.map.removeSource).toHaveBeenCalledWith(
+      "simulation-loading-overlay-source",
+    );
+    expect(onCloudExited).toHaveBeenCalledWith("heatmap");
+  });
+
+  it("renders one static cloud frame for reduced motion", () => {
+    vi.mocked(window.matchMedia).mockReturnValue({
+      matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    } as unknown as MediaQueryList);
+
+    render(
+      <SimulationLoadingOverlay
+        bounds={bounds}
+        handoffKey="heatmap"
+        loading
+        pointMask={() => true}
+      />,
+    );
+
+    act(() => vi.advanceTimersByTime(16));
+    expect(putImageData).toHaveBeenCalledTimes(1);
+    act(() => vi.advanceTimersByTime(500));
+    expect(putImageData).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses an entered cloud without replaying its 350 ms entrance", () => {
+    vi.mocked(window.matchMedia).mockReturnValue({
+      matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    } as unknown as MediaQueryList);
+    const onCloudEntered = vi.fn();
+    const pointMask = () => true;
+    const { rerender } = render(
+      <SimulationLoadingOverlay
+        bounds={bounds}
+        handoffKey="relay"
+        loading
+        onCloudEntered={onCloudEntered}
+        pointMask={pointMask}
+      />,
+    );
+
+    act(() => vi.advanceTimersByTime(16));
+    act(() => vi.advanceTimersByTime(350));
+    expect(onCloudEntered).toHaveBeenCalledWith("relay");
+
+    rerender(
+      <SimulationLoadingOverlay
+        bounds={bounds}
+        handoffKey="heatmap"
+        loading
+        onCloudEntered={onCloudEntered}
+        pointMask={pointMask}
+      />,
+    );
+    act(() => vi.advanceTimersByTime(16));
+
+    expect(onCloudEntered).toHaveBeenCalledWith("heatmap");
+  });
+
+  it("attaches clouds while basemap sources are still loading", () => {
+    mapMock.state.styleLoaded = false;
+    vi.mocked(window.matchMedia).mockReturnValue({
+      matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    } as unknown as MediaQueryList);
+    const onCloudReady = vi.fn();
+
+    render(
+      <SimulationLoadingOverlay
+        bounds={bounds}
+        handoffKey="cold-start"
+        loading
+        onCloudReady={onCloudReady}
+        pointMask={() => true}
+      />,
+    );
+
+    expect(mapMock.map.addSource).toHaveBeenCalledTimes(1);
+    expect(mapMock.map.addLayer).toHaveBeenCalledTimes(1);
+    expect(onCloudReady).toHaveBeenCalledWith("cold-start");
+  });
+
+  it("emits readiness after a delayed MapLibre style load", () => {
+    mapMock.state.styleLoaded = false;
+    mapMock.state.rejectSourceUntilStyleLoaded = true;
+    vi.mocked(window.matchMedia).mockReturnValue({
+      matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    } as unknown as MediaQueryList);
+    const onCloudReady = vi.fn();
+    const onCloudEntered = vi.fn();
+
+    render(
+      <SimulationLoadingOverlay
+        bounds={bounds}
+        handoffKey="initial-load"
+        loading
+        onCloudEntered={onCloudEntered}
+        onCloudReady={onCloudReady}
+        pointMask={() => true}
+      />,
+    );
+
+    expect(mapMock.map.addSource).toHaveBeenCalledTimes(1);
+    expect(mapMock.state.sourcePresent).toBe(false);
+    expect(onCloudReady).not.toHaveBeenCalled();
+    expect(mapMock.state.styleDataListener).toBeTypeOf("function");
+
+    mapMock.state.styleLoaded = true;
+    act(() => {
+      mapMock.state.styleDataListener?.();
+      mapMock.state.styleDataListener?.();
+    });
+    expect(onCloudReady).toHaveBeenCalledTimes(1);
+    expect(onCloudReady).toHaveBeenCalledWith("initial-load");
+    expect(mapMock.map.addSource).toHaveBeenCalledTimes(2);
+    act(() => vi.advanceTimersByTime(350));
+    expect(onCloudEntered).toHaveBeenCalledTimes(1);
+    expect(onCloudEntered).toHaveBeenCalledWith("initial-load");
+  });
+});

--- a/src/components/SimulationLoadingOverlay.tsx
+++ b/src/components/SimulationLoadingOverlay.tsx
@@ -1,0 +1,296 @@
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useMap } from "react-map-gl/maplibre";
+import type { CanvasSource } from "maplibre-gl";
+import type { TerrainBounds } from "../lib/overlayRaster";
+import {
+  buildDriftingCloudPixels,
+  loadingOverlayCoordinates,
+  LOADING_OVERLAY_EXIT_MS,
+  resolveDriftingCloudPhase,
+  resolveLoadingOverlayDimensions,
+  resolveSimulationOverlayTransition,
+} from "../lib/simulationLoadingOverlay";
+
+const CLOUD_FRAME_INTERVAL_MS = 50;
+const SOURCE_ID = "simulation-loading-overlay-source";
+const LAYER_ID = "simulation-loading-overlay-layer";
+
+type SimulationLoadingOverlayProps = {
+  bounds: TerrainBounds | null;
+  handoffKey?: string | null;
+  loading: boolean;
+  onCloudEntered?: (handoffKey: string) => void;
+  onCloudExited?: (handoffKey: string) => void;
+  onCloudReady?: (handoffKey: string) => void;
+  pointMask?: (lat: number, lon: number) => boolean;
+};
+
+const usePrefersReducedMotion = (): boolean => {
+  const [reducedMotion, setReducedMotion] = useState(
+    () =>
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+  );
+
+  useEffect(() => {
+    if (typeof window.matchMedia !== "function") return;
+    const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const update = () => setReducedMotion(query.matches);
+    query.addEventListener("change", update);
+    return () => query.removeEventListener("change", update);
+  }, []);
+
+  return reducedMotion;
+};
+
+export function SimulationLoadingOverlay({
+  bounds,
+  handoffKey = null,
+  loading,
+  onCloudEntered,
+  onCloudExited,
+  onCloudReady,
+  pointMask,
+}: SimulationLoadingOverlayProps) {
+  const canvas = useMemo(() => document.createElement("canvas"), []);
+  const { current: mapRef } = useMap();
+  const map = mapRef?.getMap();
+  const reducedMotion = usePrefersReducedMotion();
+  const ready = Boolean(bounds && pointMask);
+  const addingToMapRef = useRef(false);
+  const entryKeyRef = useRef<string | null>(null);
+  const readyKeyRef = useRef<string | null>(null);
+  const entryTimeoutRef = useRef<number | null>(null);
+  const exitKeyRef = useRef<string | null>(null);
+  const removalTimeoutRef = useRef<number | null>(null);
+  const loadingRef = useRef(loading);
+  loadingRef.current = loading;
+  const coordinates = useMemo(
+    () => (bounds ? loadingOverlayCoordinates(bounds) : null),
+    [bounds],
+  );
+
+  useEffect(() => {
+    if (!loading || !bounds || !pointMask) return;
+    const dimensions = resolveLoadingOverlayDimensions(bounds);
+    canvas.width = dimensions.width;
+    canvas.height = dimensions.height;
+    const context = canvas.getContext("2d");
+    if (!context) return;
+
+    const startedAt = performance.now();
+    let frameId = 0;
+    let lastPaintAt = Number.NEGATIVE_INFINITY;
+    const paint = (timestamp: number) => {
+      if (
+        reducedMotion ||
+        timestamp - lastPaintAt >= CLOUD_FRAME_INTERVAL_MS
+      ) {
+        const frame = buildDriftingCloudPixels({
+          bounds,
+          width: dimensions.width,
+          height: dimensions.height,
+          phase: resolveDriftingCloudPhase(
+            timestamp - startedAt,
+            reducedMotion,
+          ),
+          pointMask,
+        });
+        const image = context.createImageData(frame.width, frame.height);
+        image.data.set(frame.pixels);
+        context.putImageData(image, 0, 0);
+        map?.triggerRepaint();
+        lastPaintAt = timestamp;
+      }
+      if (!reducedMotion) {
+        frameId = window.requestAnimationFrame(paint);
+      }
+    };
+
+    paint(startedAt);
+    return () => window.cancelAnimationFrame(frameId);
+  }, [bounds, canvas, loading, map, pointMask, reducedMotion]);
+
+  useEffect(() => {
+    if (!map) return;
+
+    const removeFromMap = () => {
+      if (map.getLayer(LAYER_ID)) map.removeLayer(LAYER_ID);
+      if (map.getSource(SOURCE_ID)) map.removeSource(SOURCE_ID);
+      entryKeyRef.current = null;
+      readyKeyRef.current = null;
+    };
+    const clearPendingRemoval = () => {
+      if (removalTimeoutRef.current !== null) {
+        window.clearTimeout(removalTimeoutRef.current);
+        removalTimeoutRef.current = null;
+      }
+    };
+    const clearPendingEntry = () => {
+      if (entryTimeoutRef.current !== null) {
+        window.clearTimeout(entryTimeoutRef.current);
+        entryTimeoutRef.current = null;
+      }
+    };
+    const applyTransition = (entering: boolean) => {
+      if (!map.getLayer(LAYER_ID)) return;
+      const transition = resolveSimulationOverlayTransition(entering);
+      map.setPaintProperty(LAYER_ID, "raster-opacity-transition", {
+        duration: transition.durationMs,
+      });
+      map.setPaintProperty(
+        LAYER_ID,
+        "raster-opacity",
+        transition.loadingOpacity,
+      );
+    };
+    const startExit = (key: string) => {
+      applyTransition(false);
+      exitKeyRef.current = key;
+      removalTimeoutRef.current = window.setTimeout(() => {
+        removeFromMap();
+        removalTimeoutRef.current = null;
+        const exitedKey = exitKeyRef.current;
+        exitKeyRef.current = null;
+        if (exitedKey) onCloudExited?.(exitedKey);
+      }, LOADING_OVERLAY_EXIT_MS);
+    };
+    const scheduleEntry = (key: string, continuing: boolean) => {
+      if (
+        readyKeyRef.current === key ||
+        entryTimeoutRef.current !== null
+      ) {
+        return;
+      }
+      readyKeyRef.current = key;
+      onCloudReady?.(key);
+      applyTransition(true);
+      map.triggerRepaint();
+      if (continuing) {
+        onCloudEntered?.(key);
+        return;
+      }
+      entryTimeoutRef.current = window.setTimeout(() => {
+        entryTimeoutRef.current = null;
+        onCloudEntered?.(key);
+        if (!loadingRef.current) startExit(key);
+      }, resolveSimulationOverlayTransition(true).durationMs);
+    };
+
+    const addToMap = (key: string, continuing: boolean) => {
+      if (addingToMapRef.current) return;
+      if (!coordinates) return;
+      addingToMapRef.current = true;
+      try {
+        if (!map.getSource(SOURCE_ID)) {
+          map.addSource(SOURCE_ID, {
+            animate: true,
+            canvas,
+            coordinates,
+            type: "canvas",
+          });
+        }
+        if (!map.getLayer(LAYER_ID)) {
+          const transition = resolveSimulationOverlayTransition(false);
+          map.addLayer({
+            id: LAYER_ID,
+            paint: {
+              "raster-opacity": transition.loadingOpacity,
+              "raster-opacity-transition": {
+                duration: transition.durationMs,
+              },
+            },
+            source: SOURCE_ID,
+            type: "raster",
+          });
+        }
+      } catch {
+        // MapLibre can emit styledata before the style accepts custom sources.
+        // Keep the listener active and retry on the next style update.
+        return;
+      } finally {
+        addingToMapRef.current = false;
+      }
+      if (!map.getSource(SOURCE_ID) || !map.getLayer(LAYER_ID)) return;
+      if (readyKeyRef.current === key) {
+        applyTransition(true);
+        return;
+      }
+      scheduleEntry(key, continuing);
+    };
+
+    const wasExiting = removalTimeoutRef.current !== null;
+    const continuingEnteredCloud =
+      loading &&
+      entryKeyRef.current !== null &&
+      entryKeyRef.current !== handoffKey &&
+      entryTimeoutRef.current === null &&
+      !wasExiting &&
+      Boolean(map.getLayer(LAYER_ID));
+    clearPendingRemoval();
+
+    if (!ready || !coordinates || !handoffKey) {
+      clearPendingEntry();
+      removeFromMap();
+      return;
+    }
+
+    if (!loading) {
+      if (entryTimeoutRef.current !== null) return;
+      startExit(handoffKey);
+      return clearPendingRemoval;
+    }
+
+    if (entryKeyRef.current !== handoffKey) {
+      clearPendingEntry();
+      entryKeyRef.current = handoffKey;
+    }
+
+    const addAfterStyleChange = () =>
+      addToMap(handoffKey, continuingEnteredCloud);
+    map.on("styledata", addAfterStyleChange);
+    addToMap(handoffKey, continuingEnteredCloud);
+
+    return () => {
+      map.off("styledata", addAfterStyleChange);
+    };
+  }, [
+    canvas,
+    coordinates,
+    handoffKey,
+    loading,
+    map,
+    onCloudEntered,
+    onCloudExited,
+    onCloudReady,
+    ready,
+  ]);
+
+  useEffect(() => {
+    if (!map || !loading || !coordinates) return;
+    const source = map.getSource(SOURCE_ID) as CanvasSource | undefined;
+    source?.setCoordinates(coordinates);
+  }, [coordinates, loading, map]);
+
+  useEffect(() => {
+    if (!map) return;
+    return () => {
+      if (removalTimeoutRef.current !== null) {
+        window.clearTimeout(removalTimeoutRef.current);
+      }
+      if (entryTimeoutRef.current !== null) {
+        window.clearTimeout(entryTimeoutRef.current);
+      }
+      if (map.getLayer(LAYER_ID)) map.removeLayer(LAYER_ID);
+      if (map.getSource(SOURCE_ID)) map.removeSource(SOURCE_ID);
+    };
+  }, [map]);
+
+  return null;
+}

--- a/src/components/UserAdminPanel.chip.test.tsx
+++ b/src/components/UserAdminPanel.chip.test.tsx
@@ -10,8 +10,12 @@ import { UserAdminPanel } from "./UserAdminPanel";
 
 // --- Module mocks ----------------------------------------------------------
 
+const { fetchMeMock } = vi.hoisted(() => ({
+  fetchMeMock: vi.fn(),
+}));
+
 vi.mock("../lib/cloudUser", () => ({
-  fetchMe: vi.fn().mockResolvedValue(null),
+  fetchMe: fetchMeMock,
   fetchUsers: vi.fn().mockResolvedValue([]),
   fetchAdminAuditEvents: vi.fn().mockResolvedValue([]),
   fetchAuthDiagnostics: vi.fn().mockResolvedValue({}),
@@ -82,8 +86,10 @@ vi.mock("../store/appStore", () => ({
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
+  vi.clearAllMocks();
   mockStoreState.currentUser = signedInUser;
   mockStoreState.authState = "signed_in";
+  fetchMeMock.mockResolvedValue(signedInUser);
 });
 
 describe("UserAdminPanel chip — onOpenSettings", () => {
@@ -119,5 +125,14 @@ describe("UserAdminPanel chip — onOpenSettings", () => {
     render(<UserAdminPanel />);
     expect(screen.getByRole("button", { name: /sign in/i })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /open user settings/i })).not.toBeInTheDocument();
+  });
+
+  it("does not fetch the protected profile while auth is still checking", () => {
+    mockStoreState.authState = "checking";
+    mockStoreState.currentUser = null;
+
+    render(<UserAdminPanel />);
+
+    expect(fetchMeMock).not.toHaveBeenCalled();
   });
 });

--- a/src/components/UserAdminPanel.tsx
+++ b/src/components/UserAdminPanel.tsx
@@ -280,6 +280,7 @@ export function UserAdminPanel({
       setMe(null);
       return;
     }
+    if (authState !== "signed_in") return;
     void load();
   }, [authState]);
 

--- a/src/components/settings/SettingsPanel.test.tsx
+++ b/src/components/settings/SettingsPanel.test.tsx
@@ -6,7 +6,12 @@ import { SettingsPanel } from "./SettingsPanel";
 
 // Stub sub-sections so SettingsPanel tests focus on panel-level behaviour.
 vi.mock("./sections/ProfileSection", () => ({
-  ProfileSection: () => <div data-testid="profile-section">Profile Section</div>,
+  ProfileSection: ({ onSignOut }: { onSignOut?: () => void }) => (
+    <div data-testid="profile-section">
+      Profile Section
+      {onSignOut ? <button onClick={onSignOut}>Sign out</button> : null}
+    </div>
+  ),
 }));
 vi.mock("./sections/PreferencesSection", () => ({
   PreferencesSection: () => <div data-testid="preferences-section">Preferences Section</div>,
@@ -46,6 +51,20 @@ beforeEach(() => {
   // Stub history methods to avoid jsdom URL errors.
   vi.spyOn(window.history, "replaceState").mockImplementation(() => {});
   vi.spyOn(window.history, "pushState").mockImplementation(() => {});
+  const storageValues = new Map<string, string>();
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (key: string) => storageValues.get(key) ?? null,
+      setItem: (key: string, value: string) => storageValues.set(key, String(value)),
+      removeItem: (key: string) => storageValues.delete(key),
+      clear: () => storageValues.clear(),
+      key: (index: number) => Array.from(storageValues.keys())[index] ?? null,
+      get length() {
+        return storageValues.size;
+      },
+    },
+  });
 });
 
 describe("SettingsPanel", () => {
@@ -107,6 +126,24 @@ describe("SettingsPanel", () => {
     render(<SettingsPanel initialSection={null} onClose={onClose} />);
     fireEvent.keyDown(window, { key: "Escape" });
     expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("clears the authenticated-session marker on explicit sign out", () => {
+    mockState.currentUser = {
+      id: "u1",
+      username: "Alice",
+      email: "alice@example.com",
+      isAdmin: false,
+      isModerator: false,
+      isApproved: true,
+    } as CloudUser;
+    mockState.authState = "signed_in";
+    localStorage.setItem("linksim:had-authenticated-session:v1", "1");
+
+    render(<SettingsPanel initialSection={null} onClose={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Sign out" }));
+
+    expect(localStorage.getItem("linksim:had-authenticated-session:v1")).toBeNull();
   });
 
   it("switches to Preferences section when its nav item is clicked", () => {

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -4,6 +4,7 @@ import { buildSettingsPath, matchSettingsPath, type SettingsSectionId } from "..
 import { useAppStore } from "../../store/appStore";
 import { fetchMe, type CloudUser } from "../../lib/cloudUser";
 import { getUiErrorMessage } from "../../lib/uiError";
+import { clearAuthenticatedSessionMarker } from "../../lib/appShellGuards";
 import { ProfileSection } from "./sections/ProfileSection";
 import { PreferencesSection } from "./sections/PreferencesSection";
 import { SettingsNav, settingsNavIcons, type SettingsNavItem } from "./SettingsNav";
@@ -116,6 +117,7 @@ export function SettingsPanel({ initialSection, onClose }: SettingsPanelProps) {
   );
 
   const handleSignOut = useCallback(() => {
+    clearAuthenticatedSessionMarker();
     setMe(null);
     setCurrentUser(null);
     setAuthState("signed_out");

--- a/src/lib/appShellGuards.test.ts
+++ b/src/lib/appShellGuards.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
+  AUTHENTICATED_SESSION_MARKER_KEY,
+  clearAuthenticatedSessionMarker,
+  hasAuthenticatedSessionMarker,
   isAuthSignInRequiredMessage,
+  markAuthenticatedSession,
+  resolveAuthBootstrapState,
   shouldCloseSimulationLibraryOnLoad,
   shouldRewritePathAfterDeepLinkApply,
-  shouldUseReadonlyFallbackForAuthBootstrap,
 } from "./appShellGuards";
 
 describe("shouldRewritePathAfterDeepLinkApply", () => {
@@ -54,51 +58,53 @@ describe("isAuthSignInRequiredMessage", () => {
   });
 });
 
-describe("shouldUseReadonlyFallbackForAuthBootstrap", () => {
-  it("uses readonly fallback for Firefox auth bootstrap network failure", () => {
-    expect(
-      shouldUseReadonlyFallbackForAuthBootstrap({
-        message: "NetworkError when attempting to fetch resource.",
-        deepLinkMode: false,
-        isLocalRuntime: false,
-        isOnline: true,
-        userAgent: "Mozilla/5.0 Firefox/124.0",
-      }),
-    ).toBe(true);
+describe("authenticated session marker", () => {
+  it("records and clears a prior authenticated session", () => {
+    const values = new Map<string, string>();
+    const storage = {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+      removeItem: (key: string) => values.delete(key),
+    };
+
+    expect(hasAuthenticatedSessionMarker(storage)).toBe(false);
+    markAuthenticatedSession(storage);
+    expect(values.get(AUTHENTICATED_SESSION_MARKER_KEY)).toBe("1");
+    expect(hasAuthenticatedSessionMarker(storage)).toBe(true);
+    clearAuthenticatedSessionMarker(storage);
+    expect(hasAuthenticatedSessionMarker(storage)).toBe(false);
   });
 
-  it("does not use readonly fallback for unrelated failures", () => {
-    expect(
-      shouldUseReadonlyFallbackForAuthBootstrap({
-        message: "Network timeout",
-        deepLinkMode: false,
-        isLocalRuntime: false,
-        isOnline: true,
-        userAgent: "Mozilla/5.0 Firefox/124.0",
-      }),
-    ).toBe(false);
+  it("fails safely when storage is unavailable", () => {
+    const storage = {
+      getItem: () => {
+        throw new Error("blocked");
+      },
+      setItem: () => {
+        throw new Error("blocked");
+      },
+      removeItem: () => {
+        throw new Error("blocked");
+      },
+    };
 
-    expect(
-      shouldUseReadonlyFallbackForAuthBootstrap({
-        message: "NetworkError when attempting to fetch resource.",
-        deepLinkMode: false,
-        isLocalRuntime: false,
-        isOnline: true,
-        userAgent: "Mozilla/5.0 AppleWebKit Safari/605.1.15",
-      }),
-    ).toBe(false);
+    expect(hasAuthenticatedSessionMarker(storage)).toBe(false);
+    expect(() => markAuthenticatedSession(storage)).not.toThrow();
+    expect(() => clearAuthenticatedSessionMarker(storage)).not.toThrow();
+  });
+});
+
+describe("resolveAuthBootstrapState", () => {
+  it("distinguishes expected guests from expired sessions", () => {
+    expect(resolveAuthBootstrapState({ authState: "guest", hadAuthenticatedSession: false })).toBe("guest");
+    expect(resolveAuthBootstrapState({ authState: "guest", hadAuthenticatedSession: true })).toBe("expired");
   });
 
-  it("keeps deep-link flow unchanged", () => {
-    expect(
-      shouldUseReadonlyFallbackForAuthBootstrap({
-        message: "NetworkError when attempting to fetch resource.",
-        deepLinkMode: true,
-        isLocalRuntime: false,
-        isOnline: true,
-        userAgent: "Mozilla/5.0 Firefox/124.0",
-      }),
-    ).toBe(false);
+  it("preserves authenticated and revoked states", () => {
+    expect(resolveAuthBootstrapState({ authState: "authenticated", hadAuthenticatedSession: false })).toBe(
+      "authenticated",
+    );
+    expect(resolveAuthBootstrapState({ authState: "revoked", hadAuthenticatedSession: true })).toBe("revoked");
   });
 });
 

--- a/src/lib/appShellGuards.ts
+++ b/src/lib/appShellGuards.ts
@@ -1,5 +1,54 @@
 export type DeepLinkApplyOutcome = "idle" | "succeeded" | "failed";
 
+type AuthSessionMarkerStorage = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+export const AUTHENTICATED_SESSION_MARKER_KEY = "linksim:had-authenticated-session:v1";
+
+const getAuthSessionMarkerStorage = (): AuthSessionMarkerStorage | null => {
+  if (typeof localStorage === "undefined") return null;
+  return localStorage;
+};
+
+export const hasAuthenticatedSessionMarker = (
+  storage: AuthSessionMarkerStorage | null = getAuthSessionMarkerStorage(),
+): boolean => {
+  try {
+    return storage?.getItem(AUTHENTICATED_SESSION_MARKER_KEY) === "1";
+  } catch {
+    return false;
+  }
+};
+
+export const markAuthenticatedSession = (
+  storage: AuthSessionMarkerStorage | null = getAuthSessionMarkerStorage(),
+): void => {
+  try {
+    storage?.setItem(AUTHENTICATED_SESSION_MARKER_KEY, "1");
+  } catch {
+    // Authentication must still work when storage is blocked.
+  }
+};
+
+export const clearAuthenticatedSessionMarker = (
+  storage: AuthSessionMarkerStorage | null = getAuthSessionMarkerStorage(),
+): void => {
+  try {
+    storage?.removeItem(AUTHENTICATED_SESSION_MARKER_KEY);
+  } catch {
+    // Sign-out must still continue when storage is blocked.
+  }
+};
+
+export type AuthBootstrapState = "guest" | "expired" | "authenticated" | "revoked";
+
+export const resolveAuthBootstrapState = (input: {
+  authState: "guest" | "authenticated" | "revoked";
+  hadAuthenticatedSession: boolean;
+}): AuthBootstrapState => {
+  if (input.authState === "guest" && input.hadAuthenticatedSession) return "expired";
+  return input.authState;
+};
+
 export const shouldRewritePathAfterDeepLinkApply = (input: {
   deepLinkApplied: boolean;
   deepLinkParseOk: boolean;
@@ -25,23 +74,6 @@ export const isAuthSignInRequiredMessage = (message: string | null | undefined):
     normalized.includes("authentication required") ||
     normalized.includes("not authenticated")
   );
-};
-
-export const shouldUseReadonlyFallbackForAuthBootstrap = (input: {
-  message: string | null | undefined;
-  deepLinkMode: boolean;
-  isLocalRuntime: boolean;
-  isOnline: boolean;
-  userAgent: string;
-}): boolean => {
-  if (input.deepLinkMode) return false;
-  if (input.isLocalRuntime) return false;
-  if (!input.isOnline) return false;
-  const normalized = String(input.message ?? "").trim().toLowerCase();
-  if (!normalized) return false;
-  const isFirefox = /firefox/i.test(input.userAgent);
-  if (!isFirefox) return false;
-  return normalized.includes("networkerror when attempting to fetch resource");
 };
 
 export const shouldCloseSimulationLibraryOnLoad = (input: { presetId: string | null | undefined }): boolean =>

--- a/src/lib/cloudUser.test.ts
+++ b/src/lib/cloudUser.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearMeCache,
+  fetchAuthStatus,
   fetchMe,
   fetchUsers,
   fetchResourceChanges,
@@ -33,6 +34,21 @@ describe("cloudUser client", () => {
     const [, init] = vi.mocked(globalThis.fetch).mock.calls[0] ?? [];
     const headers = new Headers((init as RequestInit | undefined)?.headers ?? {});
     expect(headers.has("content-type")).toBe(false);
+  });
+
+  it("reads auth state from the existing public simulation boundary", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ authenticated: false, authState: "guest" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    await expect(fetchAuthStatus()).resolves.toEqual({ authenticated: false, authState: "guest" });
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "/api/public-simulation?mode=auth",
+      expect.objectContaining({ method: "GET" }),
+    );
   });
 
   it("preserves username setup state from fetchMe", async () => {

--- a/src/lib/cloudUser.ts
+++ b/src/lib/cloudUser.ts
@@ -126,7 +126,33 @@ export type CollaboratorDirectoryUser = {
 };
 
 export type DeepLinkStatus = "ok" | "forbidden" | "missing";
-export type DeepLinkStatusResult = { status: DeepLinkStatus; simulationId?: string; authenticated?: boolean };
+export type DeepLinkAuthState = "guest" | "authenticated" | "revoked";
+export type AuthStatusResult = {
+  authenticated: boolean;
+  authState: DeepLinkAuthState;
+};
+export type DeepLinkStatusResult = {
+  status: DeepLinkStatus;
+  simulationId?: string;
+  authenticated?: boolean;
+  authState: DeepLinkAuthState;
+};
+
+const normalizeAuthStatus = (data: {
+  authenticated?: unknown;
+  authState?: unknown;
+}): AuthStatusResult => {
+  const authState: DeepLinkAuthState =
+    data.authState === "authenticated" || data.authState === "revoked" || data.authState === "guest"
+      ? data.authState
+      : data.authenticated === true
+        ? "authenticated"
+        : "guest";
+  return {
+    authenticated: data.authenticated === true,
+    authState,
+  };
+};
 
 export class CloudApiError extends Error {
   status: number | null;
@@ -409,26 +435,40 @@ export const uploadAvatar = async (originalDataUrl: string, thumbDataUrl: string
     }),
   });
 
+export const fetchAuthStatus = async (): Promise<AuthStatusResult> => {
+  const data = await apiCall<{
+    authenticated?: unknown;
+    authState?: unknown;
+  }>("/api/public-simulation?mode=auth", { method: "GET" });
+  return normalizeAuthStatus(data);
+};
+
 export const fetchDeepLinkStatus = async (input: {
   simulationId?: string;
   username?: string;
   simulationSlug?: string;
-}): Promise<DeepLinkStatusResult> => {
+} = {}): Promise<DeepLinkStatusResult> => {
   const params = new URLSearchParams();
   if (input.simulationId?.trim()) params.set("sim", input.simulationId.trim());
   if (input.username?.trim()) params.set("username", input.username.trim());
   if (input.simulationSlug?.trim()) params.set("slug", input.simulationSlug.trim());
-  const data = await apiCall<{ status?: unknown; simulationId?: unknown; authenticated?: unknown }>(
+  const data = await apiCall<{
+    status?: unknown;
+    simulationId?: unknown;
+    authenticated?: unknown;
+    authState?: unknown;
+  }>(
     `/api/deep-link-status?${params.toString()}`,
     { method: "GET" },
   );
   const status = data.status;
   const normalized: DeepLinkStatus =
     status === "ok" || status === "forbidden" || status === "missing" ? status : "missing";
+  const authStatus = normalizeAuthStatus(data);
   return {
     status: normalized,
     simulationId: typeof data.simulationId === "string" && data.simulationId.trim() ? data.simulationId : undefined,
-    authenticated: data.authenticated === true,
+    ...authStatus,
   };
 };
 

--- a/src/lib/simulationLoadingOverlay.test.ts
+++ b/src/lib/simulationLoadingOverlay.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDriftingCloudPixels,
+  loadingOverlayCoordinates,
+  resolveDriftingCloudPhase,
+  resolveLoadingOverlayDimensions,
+  resolveSimulationOverlayTransition,
+} from "./simulationLoadingOverlay";
+
+const bounds = {
+  minLat: 59.7,
+  maxLat: 60.1,
+  minLon: 10.4,
+  maxLon: 11.2,
+};
+
+describe("simulation loading overlay", () => {
+  it("uses the same geographic corner order as the finished image overlay", () => {
+    expect(loadingOverlayCoordinates(bounds)).toEqual([
+      [10.4, 60.1],
+      [11.2, 60.1],
+      [11.2, 59.7],
+      [10.4, 59.7],
+    ]);
+  });
+
+  it("keeps the animated canvas bounded while preserving the geographic aspect ratio", () => {
+    expect(resolveLoadingOverlayDimensions(bounds)).toEqual({
+      width: 192,
+      height: 191,
+    });
+    expect(
+      resolveLoadingOverlayDimensions({
+        minLat: 59,
+        maxLat: 61,
+        minLon: 10,
+        maxLon: 10.25,
+      }),
+    ).toEqual({
+      width: 48,
+      height: 192,
+    });
+  });
+
+  it("clips every animated pixel through the finished overlay point mask", () => {
+    const pointMask = (lat: number, lon: number) => lat >= 59.85 && lon <= 10.8;
+    const frame = buildDriftingCloudPixels({
+      bounds,
+      width: 8,
+      height: 6,
+      phase: 0.75,
+      pointMask,
+    });
+
+    for (let row = 0; row < frame.height; row += 1) {
+      for (let column = 0; column < frame.width; column += 1) {
+        const offset = (row * frame.width + column) * 4;
+        const lat = frame.latByRow[row];
+        const lon = frame.lonByColumn[column];
+        const alpha = frame.pixels[offset + 3];
+        expect(alpha > 0).toBe(pointMask(lat, lon));
+      }
+    }
+  });
+
+  it("freezes the cloud field for reduced motion", () => {
+    expect(resolveDriftingCloudPhase(4_250, true)).toBe(0);
+    expect(resolveDriftingCloudPhase(0, false)).toBe(0);
+    expect(resolveDriftingCloudPhase(2_400, false)).toBeCloseTo(Math.PI * 2);
+  });
+
+  it("crossfades the completed overlay fully into and back out of the clouds", () => {
+    expect(resolveSimulationOverlayTransition(true)).toEqual({
+      coverageOpacity: 0,
+      loadingOpacity: 0.68,
+      durationMs: 350,
+    });
+    expect(resolveSimulationOverlayTransition(false)).toEqual({
+      coverageOpacity: 0.68,
+      loadingOpacity: 0,
+      durationMs: 500,
+    });
+  });
+});

--- a/src/lib/simulationLoadingOverlay.ts
+++ b/src/lib/simulationLoadingOverlay.ts
@@ -1,0 +1,169 @@
+import { latitudeForRasterRow, type TerrainBounds } from "./overlayRaster";
+import { interpolateHeatmapColor } from "../themes/heatmapColors";
+
+const MAX_CANVAS_DIMENSION = 192;
+const MIN_CANVAS_DIMENSION = 48;
+const CLOUD_CYCLE_MS = 2_400;
+const CLOUD_ALPHA = 178;
+export const LOADING_OVERLAY_EXIT_MS = 500;
+
+export type LoadingOverlayCoordinates = [
+  [number, number],
+  [number, number],
+  [number, number],
+  [number, number],
+];
+
+export type DriftingCloudFrame = {
+  width: number;
+  height: number;
+  pixels: Uint8ClampedArray;
+  latByRow: Float64Array;
+  lonByColumn: Float64Array;
+};
+
+export type DriftingCloudFrameInput = {
+  bounds: TerrainBounds;
+  width: number;
+  height: number;
+  phase: number;
+  pointMask: (lat: number, lon: number) => boolean;
+};
+
+export type SimulationOverlayTransition = {
+  coverageOpacity: number;
+  loadingOpacity: number;
+  durationMs: number;
+};
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.max(min, Math.min(max, value));
+
+const mercatorYDegrees = (lat: number): number => {
+  const normalized = clamp(lat, -85.05112878, 85.05112878);
+  const radians = (normalized * Math.PI) / 180;
+  return (Math.log(Math.tan(Math.PI / 4 + radians / 2)) * 180) / Math.PI;
+};
+
+export const loadingOverlayCoordinates = (
+  bounds: TerrainBounds,
+): LoadingOverlayCoordinates => [
+  [bounds.minLon, bounds.maxLat],
+  [bounds.maxLon, bounds.maxLat],
+  [bounds.maxLon, bounds.minLat],
+  [bounds.minLon, bounds.minLat],
+];
+
+export const resolveLoadingOverlayDimensions = (
+  bounds: TerrainBounds,
+): { width: number; height: number } => {
+  const lonSpan = Math.max(1e-6, Math.abs(bounds.maxLon - bounds.minLon));
+  const mercatorLatSpan = Math.max(
+    1e-6,
+    Math.abs(mercatorYDegrees(bounds.maxLat) - mercatorYDegrees(bounds.minLat)),
+  );
+  const aspectRatio = lonSpan / mercatorLatSpan;
+  if (aspectRatio >= 1) {
+    return {
+      width: MAX_CANVAS_DIMENSION,
+      height: clamp(
+        Math.round(MAX_CANVAS_DIMENSION / aspectRatio),
+        MIN_CANVAS_DIMENSION,
+        MAX_CANVAS_DIMENSION,
+      ),
+    };
+  }
+  return {
+    width: clamp(
+      Math.round(MAX_CANVAS_DIMENSION * aspectRatio),
+      MIN_CANVAS_DIMENSION,
+      MAX_CANVAS_DIMENSION,
+    ),
+    height: MAX_CANVAS_DIMENSION,
+  };
+};
+
+export const resolveDriftingCloudPhase = (
+  elapsedMs: number,
+  reducedMotion: boolean,
+): number => {
+  if (reducedMotion) return 0;
+  return (Math.max(0, elapsedMs) / CLOUD_CYCLE_MS) * Math.PI * 2;
+};
+
+export const resolveSimulationOverlayTransition = (
+  loading: boolean,
+): SimulationOverlayTransition =>
+  loading
+    ? {
+        coverageOpacity: 0,
+        loadingOpacity: 0.68,
+        durationMs: 350,
+      }
+    : {
+        coverageOpacity: 0.68,
+        loadingOpacity: 0,
+        durationMs: LOADING_OVERLAY_EXIT_MS,
+      };
+
+const cloudStrength = (x: number, y: number, phase: number): number => {
+  const broad =
+    Math.sin(x * 6.1 + phase) * 0.17 +
+    Math.cos(y * 7.4 - phase * 0.72) * 0.14;
+  const diagonal =
+    Math.sin((x + y) * 5.2 + phase * 0.43) * 0.11 +
+    Math.cos((x - y) * 8.3 - phase * 0.31) * 0.08;
+  return clamp(0.58 + broad + diagonal, 0, 1);
+};
+
+export const buildDriftingCloudPixels = (
+  input: DriftingCloudFrameInput,
+): DriftingCloudFrame => {
+  const width = Math.max(1, Math.round(input.width));
+  const height = Math.max(1, Math.round(input.height));
+  const pixels = new Uint8ClampedArray(width * height * 4);
+  const latByRow = new Float64Array(height);
+  const lonByColumn = new Float64Array(width);
+  const lonSpan = input.bounds.maxLon - input.bounds.minLon;
+  const widthDivisor = Math.max(1, width - 1);
+  const heightDivisor = Math.max(1, height - 1);
+
+  for (let row = 0; row < height; row += 1) {
+    latByRow[row] = latitudeForRasterRow(
+      row,
+      height,
+      input.bounds.minLat,
+      input.bounds.maxLat,
+    );
+  }
+  for (let column = 0; column < width; column += 1) {
+    lonByColumn[column] =
+      input.bounds.minLon + lonSpan * (column / widthDivisor);
+  }
+
+  for (let row = 0; row < height; row += 1) {
+    const lat = latByRow[row];
+    const y = row / heightDivisor;
+    for (let column = 0; column < width; column += 1) {
+      const lon = lonByColumn[column];
+      if (!input.pointMask(lat, lon)) continue;
+      const x = column / widthDivisor;
+      const color = interpolateHeatmapColor(
+        cloudStrength(x, y, input.phase),
+      );
+      const offset = (row * width + column) * 4;
+      pixels[offset] = color.r;
+      pixels[offset + 1] = color.g;
+      pixels[offset + 2] = color.b;
+      pixels[offset + 3] = CLOUD_ALPHA;
+    }
+  }
+
+  return {
+    width,
+    height,
+    pixels,
+    latByRow,
+    lonByColumn,
+  };
+};

--- a/src/lib/simulationOverlayHandoff.test.ts
+++ b/src/lib/simulationOverlayHandoff.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import {
+  initialSimulationOverlayHandoffState,
+  reduceSimulationOverlayHandoff,
+} from "./simulationOverlayHandoff";
+
+describe("simulation overlay handoff", () => {
+  it("holds a fast replacement until the cloud entrance completes", () => {
+    let state = reduceSimulationOverlayHandoff(
+      initialSimulationOverlayHandoffState,
+      { type: "request", requestKey: "heatmap" },
+    );
+    state = reduceSimulationOverlayHandoff(state, {
+      type: "replacement-ready",
+      requestKey: "heatmap",
+    });
+    expect(state.phase).toBe("entering");
+    expect(state.revealReplacement).toBe(false);
+
+    state = reduceSimulationOverlayHandoff(state, {
+      type: "cloud-ready",
+      requestKey: "heatmap",
+    });
+    state = reduceSimulationOverlayHandoff(state, {
+      type: "cloud-entered",
+      requestKey: "heatmap",
+    });
+    expect(state.phase).toBe("exiting");
+    expect(state.revealReplacement).toBe(true);
+  });
+
+  it("keeps an entered cloud active while rapid requests replace the target", () => {
+    let state = reduceSimulationOverlayHandoff(
+      initialSimulationOverlayHandoffState,
+      { type: "request", requestKey: "relay" },
+    );
+    state = reduceSimulationOverlayHandoff(state, {
+      type: "cloud-ready",
+      requestKey: "relay",
+    });
+    state = reduceSimulationOverlayHandoff(state, {
+      type: "cloud-entered",
+      requestKey: "relay",
+    });
+    state = reduceSimulationOverlayHandoff(state, {
+      type: "request",
+      requestKey: "heatmap",
+    });
+
+    expect(state).toMatchObject({
+      phase: "entered",
+      requestKey: "heatmap",
+      cloudReady: true,
+      cloudEntered: true,
+      replacementReady: false,
+    });
+    expect(
+      reduceSimulationOverlayHandoff(state, {
+        type: "replacement-ready",
+        requestKey: "relay",
+      }),
+    ).toEqual(state);
+  });
+
+  it("restores the retained overlay when the latest replacement fails", () => {
+    let state = reduceSimulationOverlayHandoff(
+      initialSimulationOverlayHandoffState,
+      { type: "request", requestKey: "weakest" },
+    );
+    state = reduceSimulationOverlayHandoff(state, {
+      type: "cloud-ready",
+      requestKey: "weakest",
+    });
+    state = reduceSimulationOverlayHandoff(state, {
+      type: "request-failed",
+      requestKey: "weakest",
+    });
+
+    expect(state.phase).toBe("exiting");
+    expect(state.revealReplacement).toBe(false);
+  });
+
+  it("abandons an unpainted failed request without fading the retained overlay", () => {
+    const requested = reduceSimulationOverlayHandoff(
+      initialSimulationOverlayHandoffState,
+      { type: "request", requestKey: "mesh-extension" },
+    );
+    expect(
+      reduceSimulationOverlayHandoff(requested, {
+        type: "request-failed",
+        requestKey: "mesh-extension",
+      }),
+    ).toEqual(initialSimulationOverlayHandoffState);
+  });
+
+  it("hides directly without starting a cloud handoff", () => {
+    const hiding = reduceSimulationOverlayHandoff(
+      initialSimulationOverlayHandoffState,
+      { type: "hide" },
+    );
+    expect(hiding.phase).toBe("hiding");
+    expect(hiding.cloudReady).toBe(false);
+    expect(
+      reduceSimulationOverlayHandoff(hiding, { type: "hidden" }),
+    ).toEqual(initialSimulationOverlayHandoffState);
+  });
+
+  it("lets an already visible cloud fade out when Hidden is selected", () => {
+    let state = reduceSimulationOverlayHandoff(
+      initialSimulationOverlayHandoffState,
+      { type: "request", requestKey: "relay" },
+    );
+    state = reduceSimulationOverlayHandoff(state, {
+      type: "cloud-ready",
+      requestKey: "relay",
+    });
+    state = reduceSimulationOverlayHandoff(state, { type: "hide" });
+
+    expect(state).toMatchObject({
+      phase: "hiding",
+      requestKey: "relay",
+      cloudReady: true,
+    });
+    expect(
+      reduceSimulationOverlayHandoff(state, {
+        type: "exit-complete",
+        requestKey: "relay",
+      }),
+    ).toEqual(state);
+  });
+});

--- a/src/lib/simulationOverlayHandoff.ts
+++ b/src/lib/simulationOverlayHandoff.ts
@@ -1,0 +1,107 @@
+export type SimulationOverlayHandoffPhase =
+  | "idle"
+  | "entering"
+  | "entered"
+  | "exiting"
+  | "hiding";
+
+export type SimulationOverlayHandoffState = {
+  phase: SimulationOverlayHandoffPhase;
+  requestKey: string | null;
+  cloudReady: boolean;
+  cloudEntered: boolean;
+  replacementReady: boolean;
+  revealReplacement: boolean;
+};
+
+export type SimulationOverlayHandoffEvent =
+  | { type: "request"; requestKey: string }
+  | { type: "cloud-ready"; requestKey: string }
+  | { type: "cloud-entered"; requestKey: string }
+  | { type: "replacement-ready"; requestKey: string }
+  | { type: "request-failed"; requestKey: string }
+  | { type: "exit-complete"; requestKey: string }
+  | { type: "hide" }
+  | { type: "hidden" };
+
+export const initialSimulationOverlayHandoffState: SimulationOverlayHandoffState = {
+  phase: "idle",
+  requestKey: null,
+  cloudReady: false,
+  cloudEntered: false,
+  replacementReady: false,
+  revealReplacement: false,
+};
+
+export const reduceSimulationOverlayHandoff = (
+  state: SimulationOverlayHandoffState,
+  event: SimulationOverlayHandoffEvent,
+): SimulationOverlayHandoffState => {
+  switch (event.type) {
+    case "request": {
+      const keepEnteredCloud =
+        state.phase === "entering" || state.phase === "entered";
+      return {
+        phase:
+          keepEnteredCloud && state.cloudEntered
+            ? "entered"
+            : "entering",
+        requestKey: event.requestKey,
+        cloudReady: keepEnteredCloud && state.cloudReady,
+        cloudEntered: keepEnteredCloud && state.cloudEntered,
+        replacementReady: false,
+        revealReplacement: false,
+      };
+    }
+    case "cloud-ready":
+      if (state.requestKey !== event.requestKey) return state;
+      return { ...state, cloudReady: true };
+    case "cloud-entered":
+      if (state.requestKey !== event.requestKey) return state;
+      if (state.replacementReady) {
+        return {
+          ...state,
+          phase: "exiting",
+          cloudEntered: true,
+          revealReplacement: true,
+        };
+      }
+      return { ...state, phase: "entered", cloudEntered: true };
+    case "replacement-ready":
+      if (state.requestKey !== event.requestKey) return state;
+      if (state.cloudEntered) {
+        return {
+          ...state,
+          phase: "exiting",
+          replacementReady: true,
+          revealReplacement: true,
+        };
+      }
+      return { ...state, replacementReady: true };
+    case "request-failed":
+      if (state.requestKey !== event.requestKey) return state;
+      if (!state.cloudReady) return initialSimulationOverlayHandoffState;
+      return {
+        ...state,
+        phase: "exiting",
+        replacementReady: false,
+        revealReplacement: false,
+      };
+    case "exit-complete":
+      if (
+        state.phase !== "exiting" ||
+        state.requestKey !== event.requestKey
+      ) return state;
+      return initialSimulationOverlayHandoffState;
+    case "hide":
+      return {
+        ...state,
+        phase: "hiding",
+        replacementReady: false,
+        revealReplacement: false,
+      };
+    case "hidden":
+      if (state.phase !== "hiding") return state;
+      return initialSimulationOverlayHandoffState;
+  }
+};

--- a/src/lib/syncIndicator.test.ts
+++ b/src/lib/syncIndicator.test.ts
@@ -2,34 +2,136 @@ import { describe, expect, it } from "vitest";
 import { deriveSyncIndicator } from "./syncIndicator";
 
 describe("deriveSyncIndicator", () => {
-  it("returns error (red) when sync status is error even if pending is true", () => {
-    const indicator = deriveSyncIndicator({
-      isLocalRuntime: false,
-      isOnline: true,
-      authState: "signed_in",
-      syncStatus: "error",
-      syncPending: true,
-      pendingChangesCount: 3,
-      syncErrorMessage: "401 Unauthorized",
-      lastSyncedAt: null,
-    });
-    expect(indicator.state).toBe("error");
-    expect(indicator.className).toBe("sync-error");
-  });
+  const lastSyncedAt = "2026-07-29T10:42:40.000Z";
+  const lastSyncedTime = new Date(lastSyncedAt).toLocaleTimeString();
+  const baseInput: Parameters<typeof deriveSyncIndicator>[0] = {
+    isLocalRuntime: false,
+    isOnline: true,
+    authState: "signed_in",
+    syncStatus: "synced",
+    syncPending: false,
+    pendingChangesCount: 0,
+    syncErrorMessage: null,
+    lastSyncedAt: null,
+  };
 
-  it("returns error (red) when auth state is signed_out", () => {
-    const indicator = deriveSyncIndicator({
-      isLocalRuntime: false,
-      isOnline: true,
-      authState: "signed_out",
-      syncStatus: "synced",
-      syncPending: true,
-      pendingChangesCount: 2,
-      syncErrorMessage: null,
-      lastSyncedAt: null,
-    });
-    expect(indicator.state).toBe("error");
-    expect(indicator.label).toBe("Sync failed");
-    expect(indicator.title).toContain("Not signed in");
+  it.each([
+    {
+      name: "local mode overrides cloud state",
+      input: {
+        isLocalRuntime: true,
+        isOnline: false,
+        authState: "signed_out" as const,
+        syncStatus: "error" as const,
+        syncPending: true,
+        pendingChangesCount: 3,
+      },
+      expected: {
+        state: "local",
+        className: "sync-local",
+        label: "Local mode",
+        title: "Local mode - no cloud sync available",
+      },
+    },
+    {
+      name: "offline state reports plural pending changes",
+      input: {
+        isOnline: false,
+        authState: "signed_out" as const,
+        syncStatus: "error" as const,
+        syncPending: true,
+        pendingChangesCount: 2,
+      },
+      expected: {
+        state: "offline",
+        className: "sync-offline",
+        label: "Offline",
+        title: "Offline. 2 pending changes. Open Sync Status for details.",
+      },
+    },
+    {
+      name: "signed-out state reports unavailable cloud sync",
+      input: {
+        authState: "signed_out" as const,
+        syncPending: true,
+        pendingChangesCount: 1,
+      },
+      expected: {
+        state: "error",
+        className: "sync-error",
+        label: "Sync failed",
+        title: "Not signed in; cloud sync unavailable. Sign in and open Sync Status to recover pending changes.",
+      },
+    },
+    {
+      name: "sync error overrides pending and keeps last-sync context",
+      input: {
+        syncStatus: "error" as const,
+        syncPending: true,
+        pendingChangesCount: 3,
+        syncErrorMessage: "401 Unauthorized",
+        lastSyncedAt,
+      },
+      expected: {
+        state: "error",
+        className: "sync-error",
+        label: "Sync failed",
+        title: `Sync failed. Last synced: ${lastSyncedTime}. 401 Unauthorized`,
+      },
+    },
+    {
+      name: "pending state reports a singular change and last-sync context",
+      input: {
+        syncPending: true,
+        pendingChangesCount: 1,
+        lastSyncedAt,
+      },
+      expected: {
+        state: "pending",
+        className: "sync-pending",
+        label: "Sync pending",
+        title: `Sync pending. Last synced: ${lastSyncedTime}. 1 pending change.`,
+      },
+    },
+    {
+      name: "pending state reports that no sync has completed yet",
+      input: {
+        syncPending: true,
+        pendingChangesCount: 2,
+      },
+      expected: {
+        state: "pending",
+        className: "sync-pending",
+        label: "Sync pending",
+        title: "Sync pending. Last synced: Never. 2 pending changes.",
+      },
+    },
+    {
+      name: "syncing state leads with its current state",
+      input: {
+        syncStatus: "syncing" as const,
+        lastSyncedAt,
+      },
+      expected: {
+        state: "syncing",
+        className: "sync-syncing",
+        label: "Syncing...",
+        title: `Syncing... Last synced: ${lastSyncedTime}.`,
+      },
+    },
+    {
+      name: "synced state remains up to date",
+      input: {
+        lastSyncedAt,
+      },
+      expected: {
+        state: "synced",
+        className: "sync-synced",
+        label: "Up to date",
+        title: `Up to date (synced ${lastSyncedTime}). Click for details.`,
+      },
+    },
+  ])("$name", ({ input, expected }) => {
+    expect(deriveSyncIndicator({ ...baseInput, ...input })).toEqual(expected);
   });
 });

--- a/src/lib/syncIndicator.ts
+++ b/src/lib/syncIndicator.ts
@@ -19,8 +19,14 @@ type Input = {
 };
 
 export const deriveSyncIndicator = (input: Input): SyncIndicator => {
-  const timeLabel = input.lastSyncedAt
-    ? `Up to date (synced ${new Date(input.lastSyncedAt).toLocaleTimeString()})`
+  const lastSyncedTime = input.lastSyncedAt
+    ? new Date(input.lastSyncedAt).toLocaleTimeString()
+    : null;
+  const lastSyncLabel = lastSyncedTime
+    ? `Last synced: ${lastSyncedTime}`
+    : "Last synced: Never";
+  const upToDateLabel = lastSyncedTime
+    ? `Up to date (synced ${lastSyncedTime})`
     : "Up to date";
 
   if (input.isLocalRuntime) {
@@ -50,7 +56,7 @@ export const deriveSyncIndicator = (input: Input): SyncIndicator => {
       state: "error",
       className: "sync-error",
       label: "Sync failed",
-      title: `${timeLabel}. ${input.syncErrorMessage ?? "Open Sync Status for details."}`,
+      title: `Sync failed. ${lastSyncLabel}. ${input.syncErrorMessage ?? "Open Sync Status for details."}`,
     };
   }
 
@@ -59,16 +65,16 @@ export const deriveSyncIndicator = (input: Input): SyncIndicator => {
       state: "pending",
       className: "sync-pending",
       label: "Sync pending",
-      title: `${timeLabel}. ${input.pendingChangesCount} pending change${input.pendingChangesCount === 1 ? "" : "s"}.`,
+      title: `Sync pending. ${lastSyncLabel}. ${input.pendingChangesCount} pending change${input.pendingChangesCount === 1 ? "" : "s"}.`,
     };
   }
 
   switch (input.syncStatus) {
     case "syncing":
-      return { state: "syncing", className: "sync-syncing", label: "Syncing...", title: timeLabel };
+      return { state: "syncing", className: "sync-syncing", label: "Syncing...", title: `Syncing... ${lastSyncLabel}.` };
     case "synced":
-      return { state: "synced", className: "sync-synced", label: "Up to date", title: `${timeLabel}. Click for details.` };
+      return { state: "synced", className: "sync-synced", label: "Up to date", title: `${upToDateLabel}. Click for details.` };
     default:
-      return { state: "synced", className: "sync-synced", label: "Up to date", title: `${timeLabel}. Click for details.` };
+      return { state: "synced", className: "sync-synced", label: "Up to date", title: `${upToDateLabel}. Click for details.` };
   }
 };


### PR DESCRIPTION
## Summary

Promote the verified LinkSim 0.25.0 release tree to production through the documented squash-history fallback.

## Included milestone fixes

- sync-pending status and guest-auth recovery feedback (#935, #936)
- visible terrain loading clouds (#943)
- gap-free overlay loading handoffs (#948)

## Verification

- `npm test` (674 tests)
- `npm run build`
- `git diff --check`
- staging deployment: `de08aa05d1c62dc2fddae1858bad2193b1b4b621`
- `release/v0.25.0` tree equals tag `v0.25.0`

- [x] Milestone release checklist completed: docs/milestone-release-checklist.md