### PR TITLE
Add simulation link and site-icon colors

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -89,6 +89,12 @@ import { PanelToolbar } from "./ui/PanelToolbar";
 import { SimulationLoadingOverlay } from "./SimulationLoadingOverlay";
 import { resolveSimulationOverlayTransition } from "../lib/simulationLoadingOverlay";
 import {
+  MAP_CONTRAST_DARK,
+  MAP_CONTRAST_LIGHT,
+  resolveAutoLinkStateColor,
+  resolveAutoLinkStateForLink,
+} from "../lib/simulationColors";
+import {
   initialSimulationOverlayHandoffState,
   reduceSimulationOverlayHandoff,
 } from "../lib/simulationOverlayHandoff";
@@ -134,18 +140,39 @@ const WORLD_POLYGON_GEOJSON = {
   properties: {},
 };
 
-const mapLineLayer = (linkColor: string, selectedColor: string): LayerProps => ({
+const mapLineSelectionLayer = (selectedColor: string): LayerProps => ({
+  id: "link-lines-selection",
+  type: "line",
+  filter: ["==", ["get", "selected"], 1],
+  paint: {
+    "line-color": selectedColor,
+    "line-width": 11,
+    "line-opacity": 0.95,
+  },
+});
+
+const mapLineCasingLayer = (id: string, color: string, widthOffset: number): LayerProps => ({
+  id,
+  type: "line",
+  paint: {
+    "line-color": color,
+    "line-width": [
+      "case",
+      ["==", ["get", "selected"], 1],
+      4.5 + widthOffset,
+      ["==", ["get", "temporary"], 1],
+      3.5 + widthOffset,
+      3 + widthOffset,
+    ],
+    "line-opacity": 0.92,
+  },
+});
+
+const mapLineLayer = (linkColor: string): LayerProps => ({
   id: "link-lines",
   type: "line",
   paint: {
-    "line-color": [
-      "case",
-      ["==", ["get", "selected"], 1],
-      selectedColor,
-      ["==", ["get", "temporary"], 1],
-      selectedColor,
-      linkColor,
-    ],
+    "line-color": ["coalesce", ["get", "color"], linkColor],
     "line-width": [
       "case",
       ["==", ["get", "selected"], 1],
@@ -594,9 +621,23 @@ function MarkerActionButton({
   );
 }
 
-function SiteMarkerIcon({ site }: { site: Pick<Site, "name" | "antennaHeightM" | "iconKey"> }) {
+function SiteMarkerIcon({
+  site,
+  color,
+}: {
+  site: Pick<Site, "name" | "antennaHeightM" | "iconKey">;
+  color?: string;
+}) {
   const { Icon } = getSiteIconOption(resolveSiteIconKey(site));
-  return <Icon aria-hidden="true" className="map-site-icon" size={15} strokeWidth={1.8} />;
+  return (
+    <Icon
+      aria-hidden="true"
+      className={`map-site-icon ${color ? "has-custom-color" : ""}`}
+      size={15}
+      strokeWidth={1.8}
+      style={color ? { color } : undefined}
+    />
+  );
 }
 
 type PendingNewSiteDraft = {
@@ -703,6 +744,8 @@ export function MapView({
   const sites = useAppStore((state) => state.sites);
   const siteLibrary = useAppStore((state) => state.siteLibrary);
   const links = useAppStore((state) => state.links);
+  const linkColorMode = useAppStore((state) => state.linkColorMode);
+  const siteIconColors = useAppStore((state) => state.siteIconColors);
   const selectedLinkId = useAppStore((state) => state.selectedLinkId);
   const selectedSiteIds = useAppStore((state) => state.selectedSiteIds);
   const temporaryDirectionReversed = useAppStore((state) => state.temporaryDirectionReversed);
@@ -752,6 +795,7 @@ export function MapView({
   const rxSensitivityTargetDbm = useAppStore((state) => state.rxSensitivityTargetDbm);
   const environmentLossDb = useAppStore((state) => state.environmentLossDb);
   const propagationEnvironment = useAppStore((state) => state.propagationEnvironment);
+  const autoPropagationEnvironment = useAppStore((state) => state.autoPropagationEnvironment);
   const isSimulationRecomputing = useCoverageStore((state) => state.isSimulationRecomputing);
   const simulationProgress = useCoverageStore((state) => state.simulationProgress);
   const simulationProgressMode = useCoverageStore((state) => state.simulationProgressMode);
@@ -1406,9 +1450,41 @@ export function MapView({
           const from = sites.find((site) => site.id === link.fromSiteId);
           const to = sites.find((site) => site.id === link.toSiteId);
           if (!from || !to) return null;
+          const effectiveLink = {
+            ...link,
+            frequencyMHz:
+              selectedNetwork?.frequencyOverrideMHz ?? selectedNetwork?.frequencyMHz ?? link.frequencyMHz,
+          };
+          const autoState = linkColorMode === "auto"
+            ? resolveAutoLinkStateForLink({
+                link: effectiveLink,
+                sites,
+                reversed: link.id === selectedLinkId && temporaryDirectionReversed,
+                environmentLossDb,
+                rxSensitivityTargetDbm,
+                propagationEnvironment,
+                autoPropagationEnvironment,
+                terrainSampler: (lat, lon) => sampleSrtmElevation(srtmTiles, lat, lon),
+              })
+            : null;
+          const color = autoState
+            ? resolveAutoLinkStateColor(autoState, {
+                success: variant.cssVars["--success"],
+                warning: variant.cssVars["--warning"],
+                danger: variant.cssVars["--danger"],
+              })
+            : linkColorMode === "manual"
+              ? link.color ?? linkColor
+              : linkColor;
           return {
             type: "Feature" as const,
-            properties: { id: link.id, selected: showSelectionHighlights && link.id === selectedLinkId ? 1 : 0, temporary: 0 },
+            properties: {
+              id: link.id,
+              selected: showSelectionHighlights && link.id === selectedLinkId ? 1 : 0,
+              temporary: 0,
+              color,
+              autoState: autoState ?? "unavailable",
+            },
             geometry: {
               type: "LineString" as const,
               coordinates: [
@@ -1435,7 +1511,7 @@ export function MapView({
           ? [
               {
                 type: "Feature" as const,
-                properties: { id: "__selection__", selected: 0, temporary: 1 },
+                properties: { id: "__selection__", selected: 0, temporary: 1, color: selectedLinkColor, autoState: "unavailable" },
                 geometry: {
                   type: "LineString" as const,
                   coordinates: [
@@ -1451,7 +1527,25 @@ export function MapView({
         features: [...savedLinkFeatures, ...temporarySelectionFeature],
       };
     },
-    [visibleLinks, selectedLinkId, sites, selectedSites, links, armAddSiteOnNextEmptyMapClick],
+    [
+      visibleLinks,
+      selectedLinkId,
+      sites,
+      selectedSites,
+      links,
+      armAddSiteOnNextEmptyMapClick,
+      selectedNetwork,
+      linkColorMode,
+      temporaryDirectionReversed,
+      environmentLossDb,
+      rxSensitivityTargetDbm,
+      propagationEnvironment,
+      autoPropagationEnvironment,
+      srtmTiles,
+      variant,
+      linkColor,
+      selectedLinkColor,
+    ],
   );
 
   const profileFeatures = useMemo(
@@ -4064,7 +4158,10 @@ export function MapView({
         ) : null}
 
         <Source data={lineFeatures} id="links" type="geojson">
-          <Layer {...mapLineLayer(linkColor, selectedLinkColor)} />
+          <Layer {...mapLineSelectionLayer(selectedLinkColor)} />
+          <Layer {...mapLineCasingLayer("link-lines-dark-casing", MAP_CONTRAST_DARK, 4)} />
+          <Layer {...mapLineCasingLayer("link-lines-light-casing", MAP_CONTRAST_LIGHT, 2)} />
+          <Layer {...mapLineLayer(linkColor)} />
         </Source>
 
         {sites.map((site) => {
@@ -4120,7 +4217,7 @@ export function MapView({
                   onSiteClick(site.id, isMultiSelectMode || Boolean(nativeEvent.ctrlKey || nativeEvent.metaKey));
                 }}
               >
-                <SiteMarkerIcon site={site} />
+                <SiteMarkerIcon color={siteIconColors[site.id]} site={site} />
                 <span>{site.name}</span>
               </MarkerActionButton>
             </Marker>

--- a/src/components/MapView.userLocation.test.tsx
+++ b/src/components/MapView.userLocation.test.tsx
@@ -6,6 +6,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mapMock = vi.hoisted(() => ({
   easeTo: vi.fn(),
   markerProps: [] as Array<{ latitude?: number; longitude?: number }>,
+  layerProps: [] as Array<{ id?: string; paint?: Record<string, unknown> }>,
+  sourceProps: [] as Array<{ id?: string; data?: unknown }>,
   latestProps: null as null | {
     onMove?: (event: { originalEvent?: unknown; viewState: { longitude: number; latitude: number; zoom: number } }) => void;
   },
@@ -47,7 +49,10 @@ vi.mock("react-map-gl/maplibre", async () => {
       }));
       return <div data-testid="mock-map">{props.children}</div>;
     }),
-    Layer: () => null,
+    Layer: (props: { id?: string; paint?: Record<string, unknown> }) => {
+      mapMock.layerProps.push(props);
+      return null;
+    },
     Marker: ({
       children,
       latitude,
@@ -60,7 +65,10 @@ vi.mock("react-map-gl/maplibre", async () => {
       mapMock.markerProps.push({ latitude, longitude });
       return <div>{children}</div>;
     },
-    Source: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    Source: ({ children, ...props }: { children?: React.ReactNode; id?: string; data?: unknown }) => {
+      mapMock.sourceProps.push(props);
+      return <>{children}</>;
+    },
     useMap: () => ({ current: undefined }),
   };
 });
@@ -138,6 +146,8 @@ describe("MapView user location flow", () => {
     vi.clearAllMocks();
     mapMock.latestProps = null;
     mapMock.markerProps = [];
+    mapMock.layerProps = [];
+    mapMock.sourceProps = [];
     installGeolocation();
     watchPosition.mockReturnValue(42);
     Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
@@ -258,6 +268,7 @@ describe("MapView user location flow", () => {
           iconKey: "ship",
         },
       ],
+      siteIconColors: { "site-ship": "#123456" },
     });
 
     renderMapView();
@@ -265,6 +276,41 @@ describe("MapView user location flow", () => {
     const marker = screen.getByRole("button", { name: "Harbour node" });
     expect(marker.querySelector(".lucide-ship")).toBeInTheDocument();
     expect(marker.querySelector(".lucide-ship")).toHaveAttribute("aria-hidden", "true");
+    expect(marker.querySelector(".lucide-ship")).toHaveStyle({ color: "#123456" });
+    expect(marker.querySelector(".lucide-ship")).toHaveClass("has-custom-color");
+  });
+
+  it("keeps a selected manual Link color and renders separate contrast casing", () => {
+    const sites = [
+      { id: "site-a", name: "A", position: { lat: 59.9, lon: 10.75 }, groundElevationM: 2, antennaHeightM: 2, txPowerDbm: 22, txGainDbi: 2, rxGainDbi: 2, cableLossDb: 1 },
+      { id: "site-b", name: "B", position: { lat: 59.91, lon: 10.76 }, groundElevationM: 2, antennaHeightM: 2, txPowerDbm: 22, txGainDbi: 2, rxGainDbi: 2, cableLossDb: 1 },
+    ];
+    useAppStore.setState({
+      mapOverlayMode: "none",
+      sites,
+      links: [{ id: "link-a", fromSiteId: "site-a", toSiteId: "site-b", frequencyMHz: 869.618, color: "#654321" }],
+      linkColorMode: "manual",
+      selectedLinkId: "link-a",
+      selectedSiteIds: ["site-a", "site-b"],
+    });
+
+    renderMapView();
+
+    const linksSource = mapMock.sourceProps.find((props) => props.id === "links");
+    expect(linksSource?.data).toMatchObject({
+      features: [expect.objectContaining({ properties: expect.objectContaining({ color: "#654321", selected: 1 }) })],
+    });
+    expect(mapMock.layerProps.map((props) => props.id)).toEqual(expect.arrayContaining([
+      "link-lines-selection",
+      "link-lines-dark-casing",
+      "link-lines-light-casing",
+      "link-lines",
+    ]));
+    expect(mapMock.layerProps.find((props) => props.id === "link-lines")?.paint?.["line-color"]).toEqual([
+      "coalesce",
+      ["get", "color"],
+      expect.any(String),
+    ]);
   });
 
   it("centers on the first location update and stops following after user pan", () => {

--- a/src/components/map/MapEditorPanel.test.tsx
+++ b/src/components/map/MapEditorPanel.test.tsx
@@ -336,6 +336,71 @@ describe("MapEditorPanel", () => {
     ).toBeInTheDocument();
   });
 
+  it("edits Simulation link mode and per-Site icon colors in Appearance", async () => {
+    const site = {
+      id: "site-a",
+      name: "Site A",
+      position: { lat: 60, lon: 10 },
+      groundElevationM: 100,
+      antennaHeightM: 2,
+      txPowerDbm: 20,
+      txGainDbi: 2,
+      rxGainDbi: 2,
+      cableLossDb: 1,
+    };
+    useAppStore.setState({
+      selectedScenarioId: "sim-appearance",
+      sites: [site],
+      linkColorMode: "manual",
+      siteIconColors: {},
+      simulationPresets: [{
+        id: "sim-appearance",
+        name: "Appearance Plan",
+        ownerUserId: "owner-1",
+        effectiveRole: "owner",
+        updatedAt: "2026-01-02T00:00:00.000Z",
+        snapshot: {
+          sites: [site], links: [], systems: [], networks: [],
+          selectedSiteId: "site-a", selectedLinkId: "", selectedNetworkId: "",
+          propagationModel: "ITM", selectedFrequencyPresetId: "custom",
+          rxSensitivityTargetDbm: -120, environmentLossDb: 0,
+          propagationEnvironment: useAppStore.getState().propagationEnvironment,
+          autoPropagationEnvironment: false, terrainDataset: "copernicus30",
+        },
+      }],
+      mapEditor: { kind: "simulation", resourceId: "sim-appearance", isNew: false, label: "Appearance Plan", anchorRect },
+    });
+
+    render(<MapEditorPanel isMobile={false} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Auto link colors" }));
+    fireEvent.change(screen.getByLabelText("Site A icon color"), { target: { value: "#123456" } });
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    const state = useAppStore.getState();
+    expect(state.linkColorMode).toBe("auto");
+    expect(state.siteIconColors).toEqual({ "site-a": "#123456" });
+  });
+
+  it("saves a manual color from the existing Link editor", async () => {
+    const sites = [
+      { id: "site-a", name: "Site A", position: { lat: 60, lon: 10 }, groundElevationM: 100, antennaHeightM: 2, txPowerDbm: 20, txGainDbi: 2, rxGainDbi: 2, cableLossDb: 1 },
+      { id: "site-b", name: "Site B", position: { lat: 60.1, lon: 10.1 }, groundElevationM: 110, antennaHeightM: 2, txPowerDbm: 20, txGainDbi: 2, rxGainDbi: 2, cableLossDb: 1 },
+    ];
+    useAppStore.setState({
+      sites,
+      links: [{ id: "link-a", name: "Path A", fromSiteId: "site-a", toSiteId: "site-b", frequencyMHz: 868 }],
+      linkColorMode: "manual",
+      mapEditor: { kind: "link", resourceId: "link-a", isNew: false, label: "Path A", anchorRect },
+    });
+
+    render(<MapEditorPanel isMobile={false} />);
+    fireEvent.change(await screen.findByLabelText("Link color"), { target: { value: "#654321" } });
+    await userEvent.click(screen.getByRole("button", { name: "Save Link" }));
+
+    expect(useAppStore.getState().links[0]?.color).toBe("#654321");
+  });
+
   it("renders read-only site details as static text", async () => {
     useAppStore.setState({
       siteLibrary: [

--- a/src/components/map/MapEditorPanel.tsx
+++ b/src/components/map/MapEditorPanel.tsx
@@ -1,5 +1,5 @@
 import { createPortal } from "react-dom";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type CSSProperties } from "react";
 import { ChevronDown, History, Loader2, Pencil, RefreshCw, Search } from "lucide-react";
 import {
   fetchResourceChanges,
@@ -27,6 +27,49 @@ import {
   SITE_ICON_OPTIONS,
   suggestSiteIconKey,
 } from "../../lib/siteIcons";
+import { SIMULATION_COLOR_PRESETS } from "../../lib/simulationColors";
+
+function SimulationColorControl({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: string | null;
+  onChange: (value: string | null) => void;
+}) {
+  const pickerValue = value ?? SIMULATION_COLOR_PRESETS[4].value;
+  return (
+    <div className="simulation-color-field">
+      <label className="field-grid">
+        <span>{label}</span>
+        <input
+          aria-label={label}
+          onChange={(event) => onChange(event.target.value)}
+          type="color"
+          value={pickerValue}
+        />
+      </label>
+      <div aria-label={`${label} presets`} className="simulation-color-presets" role="group">
+        {SIMULATION_COLOR_PRESETS.map((preset) => (
+          <button
+            aria-label={`Set ${label} to ${preset.label}`}
+            aria-pressed={value === preset.value}
+            className="simulation-color-swatch"
+            key={preset.value}
+            onClick={() => onChange(preset.value)}
+            style={{ "--simulation-swatch-color": preset.value } as CSSProperties}
+            title={preset.label}
+            type="button"
+          />
+        ))}
+        <Button onClick={() => onChange(null)} type="button" variant="ghost">
+          Use theme color
+        </Button>
+      </div>
+    </div>
+  );
+}
 
 // ─── Positioning ─────────────────────────────────────────────────────────────
 
@@ -613,6 +656,10 @@ function LinkEditorCard({
           <StaticField label="Link name" value={form.linkNameDraft} />
           <StaticField label="From site" value={fromSiteName} />
           <StaticField label="To site" value={toSiteName} />
+          <StaticField
+            label="Link color"
+            value={form.linkColorDraft ?? (form.activeLinkColorMode === "auto" ? "Automatic" : "Theme color")}
+          />
           <StaticField label="Override site radio settings" value={form.overrideRadio ? "Yes" : "No"} />
           {form.overrideRadio ? (
             <>
@@ -672,6 +719,16 @@ function LinkEditorCard({
             ))}
         </select>
       </label>
+
+      {form.activeLinkColorMode === "manual" ? (
+        <SimulationColorControl
+          label="Link color"
+          onChange={form.setLinkColorDraft}
+          value={form.linkColorDraft}
+        />
+      ) : (
+        <p className="field-help">This Simulation uses automatic Link colors from the Path Profile result.</p>
+      )}
 
         <label className="field-grid">
           <span>Override site radio settings</span>
@@ -787,6 +844,7 @@ function SimulationEditorCard({
           <StaticField label="Name" value={form.nameDraft} />
           <StaticField label="Description" value={form.descriptionDraft} />
           <StaticField label="Visibility" value={form.accessVisibility} />
+          <StaticField label="Link colors" value={form.simulationLinkColorMode === "auto" ? "Auto" : "User-selected"} />
           <div className="simulation-settings-block">
             <div className="simulation-settings-header">
               <span>Simulation settings</span>
@@ -830,6 +888,40 @@ function SimulationEditorCard({
           ownerUserId={form.ownerUserId}
           visibility={form.accessVisibility}
         />
+        <section className="simulation-appearance-section" aria-label="Appearance">
+          <div className="simulation-settings-header">
+            <span>Appearance</span>
+          </div>
+          <div className="chip-group" role="group" aria-label="Link color mode">
+            <ActionButton
+              aria-label="User-selected link colors"
+              aria-pressed={form.simulationLinkColorMode === "manual"}
+              onClick={() => form.setSimulationLinkColorMode("manual")}
+              type="button"
+            >
+              User-selected
+            </ActionButton>
+            <ActionButton
+              aria-label="Auto link colors"
+              aria-pressed={form.simulationLinkColorMode === "auto"}
+              onClick={() => form.setSimulationLinkColorMode("auto")}
+              type="button"
+            >
+              Auto
+            </ActionButton>
+          </div>
+          <p className="field-help">
+            Auto uses the Path Profile pass/fail and terrain-obstruction colors for each Link.
+          </p>
+          {form.simulationAppearanceSites.map((site) => (
+            <SimulationColorControl
+              key={site.id}
+              label={`${site.name} icon color`}
+              onChange={(value) => form.setSimulationSiteIconColor(site.id, value)}
+              value={form.simulationSiteIconColors[site.id] ?? null}
+            />
+          ))}
+        </section>
         <div className="simulation-settings-block">
           <div className="simulation-settings-header">
             <span>Simulation settings</span>

--- a/src/components/map/useMapEditorFormState.ts
+++ b/src/components/map/useMapEditorFormState.ts
@@ -10,6 +10,13 @@ import { sampleSrtmElevation } from "../../lib/srtm";
 import { getUiErrorMessage } from "../../lib/uiError";
 import { hasDuplicateSimulationNameForOwner } from "../../lib/simulationNameValidation";
 import { isSiteIconKey, type SiteIconKey } from "../../lib/siteIcons";
+import {
+  DEFAULT_LINK_COLOR_MODE,
+  normalizeLinkColorMode,
+  normalizeSimulationColor,
+  normalizeSiteIconColors,
+  type LinkColorMode,
+} from "../../lib/simulationColors";
 import { useAppStore } from "../../store/appStore";
 import type { CollaboratorDirectoryUser } from "../../lib/cloudUser";
 import type { AccessRole, AccessVisibility } from "../AccessSettingsEditor";
@@ -65,6 +72,8 @@ export function useMapEditorFormState() {
   const loadSimulationPreset = useAppStore((state) => state.loadSimulationPreset);
   const selectedFrequencyPresetId = useAppStore((state) => state.selectedFrequencyPresetId);
   const autoPropagationEnvironment = useAppStore((state) => state.autoPropagationEnvironment);
+  const activeLinkColorMode = useAppStore((state) => state.linkColorMode);
+  const activeSiteIconColors = useAppStore((state) => state.siteIconColors);
   const createLink = useAppStore((state) => state.createLink);
   const updateLink = useAppStore((state) => state.updateLink);
 
@@ -111,6 +120,8 @@ export function useMapEditorFormState() {
     normalizeSimulationDefaults(null),
   );
   const [simulationNameError, setSimulationNameError] = useState("");
+  const [simulationLinkColorMode, setSimulationLinkColorMode] = useState<LinkColorMode>(DEFAULT_LINK_COLOR_MODE);
+  const [simulationSiteIconColors, setSimulationSiteIconColors] = useState<Record<string, string>>({});
 
   const setDuplicateSimulationNameError = () => setSimulationNameError("Name must be unique.");
 
@@ -123,6 +134,7 @@ export function useMapEditorFormState() {
   const [linkTxGain, setLinkTxGain] = useState(STANDARD_SITE_RADIO.txGainDbi);
   const [linkRxGain, setLinkRxGain] = useState(STANDARD_SITE_RADIO.rxGainDbi);
   const [linkCableLoss, setLinkCableLoss] = useState(STANDARD_SITE_RADIO.cableLossDb);
+  const [linkColorDraft, setLinkColorDraft] = useState<string | null>(null);
 
   const getLinkDefaultName = (fromId: string, toId: string): string => {
     const from = sites.find((site) => site.id === fromId);
@@ -210,6 +222,8 @@ export function useMapEditorFormState() {
         setCollaboratorRoles({});
         setSimulationFrequencyPresetId(seed?.frequencyPresetId ?? selectedFrequencyPresetId);
         setSimulationAutoPropagationEnvironment(seed?.autoPropagationEnvironment ?? autoPropagationEnvironment);
+        setSimulationLinkColorMode(seed?.copyCurrentSimulation ? activeLinkColorMode : DEFAULT_LINK_COLOR_MODE);
+        setSimulationSiteIconColors(seed?.copyCurrentSimulation ? activeSiteIconColors : {});
         if (seed?.copyCurrentSimulation) {
           setSimulationDefaultsOverrideEnabled(Boolean(seed.simulationDefaultsOverrideEnabled));
           setSimulationDefaultsDraft(
@@ -229,6 +243,11 @@ export function useMapEditorFormState() {
         setAccessVisibility(toAccessVisibility(preset?.visibility) as AccessVisibility);
         setSimulationFrequencyPresetId(preset?.snapshot.selectedFrequencyPresetId ?? selectedFrequencyPresetId);
         setSimulationAutoPropagationEnvironment(preset?.snapshot.autoPropagationEnvironment ?? autoPropagationEnvironment);
+        setSimulationLinkColorMode(normalizeLinkColorMode(preset?.snapshot.linkColorMode));
+        setSimulationSiteIconColors(normalizeSiteIconColors(
+          preset?.snapshot.siteIconColors,
+          (preset?.snapshot.sites ?? []).map((site) => site.id),
+        ));
         setSimulationDefaultsOverrideEnabled(Boolean(preset?.snapshot.simulationDefaultsOverrideEnabled));
         setSimulationDefaultsDraft(
           preset?.snapshot.simulationDefaultsOverride
@@ -258,6 +277,7 @@ export function useMapEditorFormState() {
         setLinkTxGain(baseRadio.txGainDbi);
         setLinkRxGain(baseRadio.rxGainDbi);
         setLinkCableLoss(baseRadio.cableLossDb);
+        setLinkColorDraft(null);
       } else {
         const link = links.find((l) => l.id === mapEditor.resourceId);
         const fromSite = sites.find((s) => s.id === link?.fromSiteId) ?? null;
@@ -278,6 +298,7 @@ export function useMapEditorFormState() {
         setLinkTxGain(baseRadio.txGainDbi);
         setLinkRxGain(baseRadio.rxGainDbi);
         setLinkCableLoss(baseRadio.cableLossDb);
+        setLinkColorDraft(normalizeSimulationColor(link?.color));
       }
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -703,6 +724,8 @@ export function useMapEditorFormState() {
             autoPropagationEnvironment: simulationAutoPropagationEnvironment,
             simulationDefaultsOverrideEnabled,
             simulationDefaultsOverride: simulationDefaultsOverrideEnabled ? simulationDefaultsDraft : null,
+            linkColorMode: simulationLinkColorMode,
+            siteIconColors: simulationSiteIconColors,
           });
           if (!createdId) {
             setStatus("Failed creating simulation copy. Check the name and try again.");
@@ -725,6 +748,8 @@ export function useMapEditorFormState() {
           lastEditedByUserId: currentUser.id,
           lastEditedByName: currentUser.username,
           lastEditedByAvatarUrl: currentUser.avatarUrl ?? "",
+          linkColorMode: simulationLinkColorMode,
+          siteIconColors: simulationSiteIconColors,
         });
         if (!createdId) {
           setStatus("Failed creating simulation. Check the name and try again.");
@@ -765,6 +790,8 @@ export function useMapEditorFormState() {
         sharedWith,
         simulationDefaultsOverrideEnabled,
         simulationDefaultsOverride: simulationDefaultsOverrideEnabled ? simulationDefaultsDraft : null,
+        linkColorMode: simulationLinkColorMode,
+        siteIconColors: simulationSiteIconColors,
       });
       closeMapEditor();
       return true;
@@ -791,7 +818,7 @@ export function useMapEditorFormState() {
     }
     try {
       if (mapEditor?.isNew) {
-        createLink(linkFromSiteId, linkToSiteId, linkNameDraft || undefined);
+        createLink(linkFromSiteId, linkToSiteId, linkNameDraft || undefined, linkColorDraft);
       } else if (mapEditor?.resourceId) {
         updateLink(mapEditor.resourceId, {
           name: linkNameDraft || undefined,
@@ -801,6 +828,7 @@ export function useMapEditorFormState() {
           txGainDbi: overrideRadio ? linkTxGain : undefined,
           rxGainDbi: overrideRadio ? linkRxGain : undefined,
           cableLossDb: overrideRadio ? linkCableLoss : undefined,
+          color: linkColorDraft ?? undefined,
         });
       }
       closeMapEditor();
@@ -901,6 +929,18 @@ export function useMapEditorFormState() {
     setSimulationDefaultsOverrideEnabled,
     simulationDefaultsDraft,
     simulationNameError,
+    simulationLinkColorMode,
+    setSimulationLinkColorMode,
+    simulationSiteIconColors,
+    setSimulationSiteIconColor: (siteId: string, value: string | null) => {
+      setSimulationSiteIconColors((current) => {
+        const next = { ...current };
+        const color = normalizeSimulationColor(value);
+        if (color) next[siteId] = color;
+        else delete next[siteId];
+        return next;
+      });
+    },
     setSimulationDefaultsDraft: (patch: Partial<SimulationDefaults>) =>
       setSimulationDefaultsDraft((current) => normalizeSimulationDefaults({ ...current, ...patch }, current)),
     handleSaveSimulation,
@@ -913,6 +953,9 @@ export function useMapEditorFormState() {
     linkTxGain, setLinkTxGain: (v: number | string) => setLinkTxGain(parseNumber(String(v))),
     linkRxGain, setLinkRxGain: (v: number | string) => setLinkRxGain(parseNumber(String(v))),
     linkCableLoss, setLinkCableLoss: (v: number | string) => setLinkCableLoss(parseNumber(String(v))),
+    linkColorDraft,
+    setLinkColorDraft: (value: string | null) => setLinkColorDraft(normalizeSimulationColor(value)),
+    activeLinkColorMode,
     handleSaveLink,
     siteSearchQuery,
     setSiteSearchQuery,
@@ -924,5 +967,9 @@ export function useMapEditorFormState() {
     selectSiteSearchResult,
     // raw data for labels
     sites,
+    simulationAppearanceSites: currentSimulationPreset?.snapshot.sites ??
+      (mapEditor?.kind === "simulation" && mapEditor.isNew && mapEditor.simulationSeed?.copyCurrentSimulation
+        ? sites
+        : []),
   };
 }

--- a/src/index.css
+++ b/src/index.css
@@ -21,6 +21,8 @@
   --state-pass-blocked: var(--warning);
   --state-fail-clear: color-mix(in srgb, var(--warning) 45%, var(--danger));
   --state-fail-blocked: var(--danger);
+  --map-contrast-dark: #000000;
+  --map-contrast-light: #ffffff;
   --panel-shell-divider: color-mix(in srgb, var(--border) 84%, transparent);
   --panel-header-row-gap: 10px;
   --panel-header-row-min-height: 34px;
@@ -678,6 +680,47 @@ button {
 
 .simulation-settings-summary {
   margin: 0;
+}
+
+.simulation-appearance-section,
+.simulation-color-field {
+  display: grid;
+  gap: 8px;
+}
+
+.simulation-appearance-section {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border);
+}
+
+.simulation-color-presets {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.simulation-color-swatch {
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 2px solid var(--surface);
+  border-radius: var(--radius-pill);
+  background: var(--simulation-swatch-color);
+  box-shadow: 0 0 0 1px var(--border);
+  cursor: pointer;
+}
+
+.simulation-color-swatch[aria-pressed="true"] {
+  box-shadow: 0 0 0 2px var(--selection);
+}
+
+.simulation-color-field input[type="color"] {
+  justify-self: end;
+  width: 44px;
+  min-height: 32px;
+  padding: 3px;
 }
 
 .simulation-settings-actions {
@@ -2701,6 +2744,12 @@ button {
 
 .map-site-icon {
   flex: 0 0 auto;
+}
+
+.map-site-icon.has-custom-color {
+  filter:
+    drop-shadow(0 0 1px var(--map-contrast-light))
+    drop-shadow(0 0 1.5px var(--map-contrast-dark));
 }
 
 .map-site-surface:not(.is-muted) {

--- a/src/lib/simulationColors.test.ts
+++ b/src/lib/simulationColors.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  SIMULATION_COLOR_PRESETS,
+  classifyAutoLinkState,
+  normalizeSimulationColor,
+  normalizeSiteIconColors,
+  resolveAutoLinkStateColor,
+  resolveAutoLinkStateForLink,
+} from "./simulationColors";
+
+describe("simulation colors", () => {
+  it("exposes the approved rainbow presets", () => {
+    expect(SIMULATION_COLOR_PRESETS.map((entry) => entry.label)).toEqual([
+      "Red",
+      "Orange",
+      "Yellow",
+      "Green",
+      "Blue",
+      "Purple",
+    ]);
+  });
+
+  it("normalizes supported hex colors and rejects invalid values", () => {
+    expect(normalizeSimulationColor("#ABC")).toBe("#aabbcc");
+    expect(normalizeSimulationColor("#12aBcF")).toBe("#12abcf");
+    expect(normalizeSimulationColor("red")).toBeNull();
+    expect(normalizeSimulationColor("#abcd")).toBeNull();
+  });
+
+  it("normalizes site colors only for current simulation sites", () => {
+    expect(
+      normalizeSiteIconColors(
+        { alpha: "#ABC", beta: "invalid", stale: "#123456" },
+        ["alpha", "beta"],
+      ),
+    ).toEqual({ alpha: "#aabbcc" });
+  });
+
+  it.each([
+    [true, false, "pass_clear"],
+    [true, true, "pass_blocked"],
+    [false, false, "fail_clear"],
+    [false, true, "fail_blocked"],
+  ] as const)("classifies pass=%s blocked=%s as %s", (pass, blocked, expected) => {
+    expect(
+      classifyAutoLinkState({
+        rxDbm: pass ? -109 : -111,
+        environmentLossDb: 10,
+        rxSensitivityTargetDbm: -120,
+        terrainObstructed: blocked,
+      }),
+    ).toBe(expected);
+  });
+
+  it("maps the four states to the existing profile color scheme", () => {
+    const colors = {
+      success: "#00aa44",
+      warning: "#ffcc00",
+      danger: "#dd0033",
+    };
+    expect(resolveAutoLinkStateColor("pass_clear", colors)).toBe(colors.success);
+    expect(resolveAutoLinkStateColor("pass_blocked", colors)).toBe(colors.warning);
+    expect(resolveAutoLinkStateColor("fail_blocked", colors)).toBe(colors.danger);
+    expect(resolveAutoLinkStateColor("fail_clear", colors)).toMatch(/^#[0-9a-f]{6}$/);
+  });
+
+  it("recalculates the selected Link state in the temporarily flipped direction", () => {
+    const from = {
+      id: "from", name: "From", position: { lat: 60, lon: 10 }, groundElevationM: 0,
+      antennaHeightM: 2, txPowerDbm: 30, txGainDbi: 2, rxGainDbi: 2, cableLossDb: 0,
+    };
+    const to = {
+      id: "to", name: "To", position: { lat: 60.01, lon: 10.01 }, groundElevationM: 0,
+      antennaHeightM: 2, txPowerDbm: -30, txGainDbi: 2, rxGainDbi: 2, cableLossDb: 0,
+    };
+    const input = {
+      link: { id: "link", fromSiteId: "from", toSiteId: "to", frequencyMHz: 869.618 },
+      sites: [from, to],
+      environmentLossDb: 0,
+      rxSensitivityTargetDbm: -100,
+      propagationEnvironment: {
+        radioClimate: "Continental Temperate" as const,
+        polarization: "Vertical" as const,
+        clutterHeightM: 0,
+        groundDielectric: 15,
+        groundConductivity: 0.005,
+        atmosphericBendingNUnits: 301,
+      },
+      autoPropagationEnvironment: false,
+      terrainSampler: () => 0,
+    };
+
+    expect(resolveAutoLinkStateForLink({ ...input, reversed: false })).toMatch(/^pass_/);
+    expect(resolveAutoLinkStateForLink({ ...input, reversed: true })).toMatch(/^fail_/);
+  });
+});

--- a/src/lib/simulationColors.ts
+++ b/src/lib/simulationColors.ts
@@ -1,0 +1,145 @@
+import { classifyPassFailState, computeSourceCentricRxMetrics, type PassFailState } from "./passFailState";
+import { deriveDynamicPropagationEnvironment } from "./propagationEnvironment";
+import type { Link, PropagationEnvironment, Site } from "../types/radio";
+
+export type LinkColorMode = "manual" | "auto";
+
+export const DEFAULT_LINK_COLOR_MODE: LinkColorMode = "manual";
+export const MAP_CONTRAST_DARK = "#000000";
+export const MAP_CONTRAST_LIGHT = "#ffffff";
+
+export const SIMULATION_COLOR_PRESETS = [
+  { label: "Red", value: "#dc2626" },
+  { label: "Orange", value: "#ea580c" },
+  { label: "Yellow", value: "#ca8a04" },
+  { label: "Green", value: "#16a34a" },
+  { label: "Blue", value: "#2563eb" },
+  { label: "Purple", value: "#7c3aed" },
+] as const;
+
+const SHORT_HEX = /^#([0-9a-f]{3})$/i;
+const LONG_HEX = /^#([0-9a-f]{6})$/i;
+
+export const normalizeSimulationColor = (value: unknown): string | null => {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  const short = trimmed.match(SHORT_HEX)?.[1];
+  if (short) return `#${short.split("").map((entry) => `${entry}${entry}`).join("")}`.toLowerCase();
+  const long = trimmed.match(LONG_HEX)?.[1];
+  return long ? `#${long.toLowerCase()}` : null;
+};
+
+export const normalizeLinkColorMode = (value: unknown): LinkColorMode =>
+  value === "auto" ? "auto" : DEFAULT_LINK_COLOR_MODE;
+
+export const normalizeSiteIconColors = (
+  value: unknown,
+  siteIds: readonly string[],
+): Record<string, string> => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const allowedIds = new Set(siteIds);
+  const normalized: Record<string, string> = {};
+  for (const [siteId, colorValue] of Object.entries(value)) {
+    if (!allowedIds.has(siteId)) continue;
+    const color = normalizeSimulationColor(colorValue);
+    if (color) normalized[siteId] = color;
+  }
+  return normalized;
+};
+
+export const classifyAutoLinkState = ({
+  rxDbm,
+  environmentLossDb,
+  rxSensitivityTargetDbm,
+  terrainObstructed,
+}: {
+  rxDbm: number;
+  environmentLossDb: number;
+  rxSensitivityTargetDbm: number;
+  terrainObstructed: boolean;
+}): PassFailState =>
+  classifyPassFailState(rxDbm - environmentLossDb >= rxSensitivityTargetDbm, terrainObstructed);
+
+export const resolveAutoLinkStateForLink = ({
+  link,
+  sites,
+  reversed,
+  environmentLossDb,
+  rxSensitivityTargetDbm,
+  propagationEnvironment,
+  autoPropagationEnvironment,
+  terrainSampler,
+}: {
+  link: Link;
+  sites: readonly Site[];
+  reversed: boolean;
+  environmentLossDb: number;
+  rxSensitivityTargetDbm: number;
+  propagationEnvironment: PropagationEnvironment;
+  autoPropagationEnvironment: boolean;
+  terrainSampler: (lat: number, lon: number) => number | null;
+}): PassFailState | null => {
+  const storedFrom = sites.find((site) => site.id === link.fromSiteId);
+  const storedTo = sites.find((site) => site.id === link.toSiteId);
+  if (!storedFrom || !storedTo) return null;
+  const fromSite = reversed ? storedTo : storedFrom;
+  const toSite = reversed ? storedFrom : storedTo;
+  if (terrainSampler(toSite.position.lat, toSite.position.lon) === null) return null;
+  const effectiveEnvironment = autoPropagationEnvironment
+    ? deriveDynamicPropagationEnvironment({
+        from: fromSite.position,
+        to: toSite.position,
+        fromGroundM: fromSite.groundElevationM,
+        toGroundM: toSite.groundElevationM,
+        terrainSampler: ({ lat, lon }) => terrainSampler(lat, lon),
+      }).environment
+    : propagationEnvironment;
+  const metrics = computeSourceCentricRxMetrics(
+    toSite.position.lat,
+    toSite.position.lon,
+    fromSite,
+    link,
+    toSite.antennaHeightM,
+    toSite.rxGainDbi,
+    terrainSampler,
+    24,
+    effectiveEnvironment,
+  );
+  return classifyAutoLinkState({
+    rxDbm: metrics.rxDbm,
+    environmentLossDb,
+    rxSensitivityTargetDbm,
+    terrainObstructed: metrics.terrainObstructed,
+  });
+};
+
+const mixHexColors = (first: string, second: string, firstWeight: number): string => {
+  const a = normalizeSimulationColor(first);
+  const b = normalizeSimulationColor(second);
+  if (!a || !b) return a ?? b ?? "#808080";
+  const weight = Math.max(0, Math.min(1, firstWeight));
+  const channels = [1, 3, 5].map((offset) => {
+    const firstChannel = Number.parseInt(a.slice(offset, offset + 2), 16);
+    const secondChannel = Number.parseInt(b.slice(offset, offset + 2), 16);
+    return Math.round(firstChannel * weight + secondChannel * (1 - weight))
+      .toString(16)
+      .padStart(2, "0");
+  });
+  return `#${channels.join("")}`;
+};
+
+export const resolveAutoLinkStateColor = (
+  state: PassFailState,
+  colors: { success: string; warning: string; danger: string },
+): string => {
+  switch (state) {
+    case "pass_clear":
+      return colors.success;
+    case "pass_blocked":
+      return colors.warning;
+    case "fail_clear":
+      return mixHexColors(colors.warning, colors.danger, 0.45);
+    case "fail_blocked":
+      return colors.danger;
+  }
+};

--- a/src/store/appStore.simulationColors.test.ts
+++ b/src/store/appStore.simulationColors.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const storage = vi.hoisted(() => {
+  const data = new Map<string, string>();
+  const mock = {
+    getItem: (key: string) => data.get(key) ?? null,
+    setItem: (key: string, value: string) => data.set(key, String(value)),
+    removeItem: (key: string) => data.delete(key),
+    clear: () => data.clear(),
+    key: (index: number) => Array.from(data.keys())[index] ?? null,
+    get length() { return data.size; },
+  };
+  vi.stubGlobal("localStorage", mock);
+  vi.stubGlobal("window", { localStorage: mock, setTimeout, clearTimeout });
+  return { mock };
+});
+
+vi.mock("../lib/coverage", () => ({ buildCoverage: vi.fn(() => []) }));
+vi.mock("../lib/elevationService", () => ({ fetchElevations: vi.fn(async () => [123]) }));
+
+import { useAppStore } from "./appStore";
+
+const owner = {
+  id: "owner-1",
+  username: "owner",
+  avatarUrl: "",
+  role: "user" as const,
+  accountState: "approved" as const,
+  isApproved: true,
+  isAdmin: false,
+  isModerator: false,
+  createdAt: "",
+  updatedAt: null,
+  approvedAt: null,
+  approvedByUserId: null,
+  email: undefined,
+  emailPublic: true,
+  bio: "",
+};
+
+const sites = [
+  { id: "site-a", name: "A", position: { lat: 60, lon: 10 }, groundElevationM: 100, antennaHeightM: 2, txPowerDbm: 20, txGainDbi: 2, rxGainDbi: 2, cableLossDb: 1 },
+  { id: "site-b", name: "B", position: { lat: 60.1, lon: 10.1 }, groundElevationM: 110, antennaHeightM: 2, txPowerDbm: 20, txGainDbi: 2, rxGainDbi: 2, cableLossDb: 1 },
+];
+
+const link = { id: "link-a", name: "A to B", fromSiteId: "site-a", toSiteId: "site-b", frequencyMHz: 869.618 };
+
+describe("appStore simulation colors", () => {
+  beforeEach(() => {
+    storage.mock.clear();
+    useAppStore.setState(useAppStore.getInitialState(), true);
+    const base = useAppStore.getState();
+    useAppStore.setState({
+      currentUser: owner,
+      selectedScenarioId: "sim-a",
+      sites,
+      links: [link],
+      linkColorMode: "manual",
+      siteIconColors: {},
+      simulationPresets: [{
+        id: "sim-a",
+        name: "Simulation A",
+        ownerUserId: owner.id,
+        effectiveRole: "owner",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        snapshot: {
+          sites,
+          links: [link],
+          systems: [],
+          networks: [],
+          selectedSiteId: "site-a",
+          selectedLinkId: "link-a",
+          selectedNetworkId: "",
+          propagationModel: "ITM",
+          selectedFrequencyPresetId: "custom",
+          rxSensitivityTargetDbm: -120,
+          environmentLossDb: 0,
+          propagationEnvironment: base.propagationEnvironment,
+          autoPropagationEnvironment: false,
+          terrainDataset: "copernicus30",
+        },
+      }],
+    });
+  });
+
+  it("persists mode and per-site colors in the active Simulation snapshot", () => {
+    useAppStore.getState().updateSimulationPresetEntry("sim-a", {
+      linkColorMode: "auto",
+      siteIconColors: { "site-a": "#ABC" },
+    });
+
+    const snapshot = useAppStore.getState().simulationPresets[0]?.snapshot;
+    expect(snapshot?.linkColorMode).toBe("auto");
+    expect(snapshot?.siteIconColors).toEqual({ "site-a": "#aabbcc" });
+    expect(useAppStore.getState().siteLibrary.every((entry) => !("color" in entry))).toBe(true);
+  });
+
+  it("loads legacy Simulations with manual themed colors", () => {
+    useAppStore.setState({ linkColorMode: "auto", siteIconColors: { "site-a": "#123456" } });
+    useAppStore.getState().loadSimulationPreset("sim-a");
+    expect(useAppStore.getState().linkColorMode).toBe("manual");
+    expect(useAppStore.getState().siteIconColors).toEqual({});
+  });
+
+  it("persists normalized manual Link colors through updateLink", () => {
+    useAppStore.getState().updateLink("link-a", { color: "#F00" });
+    expect(useAppStore.getState().links[0]?.color).toBe("#ff0000");
+    expect(useAppStore.getState().simulationPresets[0]?.snapshot.links[0]?.color).toBe("#ff0000");
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -52,6 +52,13 @@ import {
 } from "../lib/simulationOverlayRadius";
 import type { LocaleCode } from "../i18n/locales";
 import type { UiColorTheme } from "../themes/types";
+import {
+  DEFAULT_LINK_COLOR_MODE,
+  normalizeLinkColorMode,
+  normalizeSimulationColor,
+  normalizeSiteIconColors,
+  type LinkColorMode,
+} from "../lib/simulationColors";
 import { getActiveHolidayTheme } from "../themes/holidayThemes";
 import type { CloudUser } from "../lib/cloudUser";
 import type { MeshmapNode } from "../lib/meshtasticMqtt";
@@ -330,6 +337,8 @@ type SimulationPreset = {
     mapViewport?: MapViewport;
     simulationDefaultsOverrideEnabled?: boolean;
     simulationDefaultsOverride?: SimulationDefaults;
+    linkColorMode?: LinkColorMode;
+    siteIconColors?: Record<string, string>;
   };
 };
 
@@ -396,6 +405,8 @@ type AppState = {
   selectedLinkId: string;
   profileCursorIndex: number;
   temporaryDirectionReversed: boolean;
+  linkColorMode: LinkColorMode;
+  siteIconColors: Record<string, string>;
   selectedSiteId: string;
   selectedSiteIds: string[];
   selectedNetworkId: string;
@@ -540,7 +551,7 @@ type AppState = {
   getEffectiveSimulationDefaults: () => SimulationDefaults;
   addSiteByCoordinates: (name: string, lat: number, lon: number) => void;
   deleteSite: (siteId: string) => void;
-  createLink: (fromSiteId: string, toSiteId: string, name?: string) => void;
+  createLink: (fromSiteId: string, toSiteId: string, name?: string, color?: string | null) => void;
   deleteLink: (linkId: string) => void;
   addSiteLibraryEntry: (
     name: string,
@@ -595,6 +606,8 @@ type AppState = {
       autoPropagationEnvironment?: boolean;
       simulationDefaultsOverrideEnabled?: boolean;
       simulationDefaultsOverride?: SimulationDefaults | null;
+      linkColorMode?: LinkColorMode;
+      siteIconColors?: Record<string, string>;
     },
   ) => string | null;
   createBlankSimulationPreset: (
@@ -611,6 +624,8 @@ type AppState = {
       lastEditedByUserId?: string;
       lastEditedByName?: string;
       lastEditedByAvatarUrl?: string;
+      linkColorMode?: LinkColorMode;
+      siteIconColors?: Record<string, string>;
     },
   ) => string | null;
   overwriteSimulationPreset: (presetId: string) => void;
@@ -622,6 +637,8 @@ type AppState = {
     patch: Partial<Pick<SimulationPreset, "name" | "description" | "visibility" | "sharedWith">> & {
       simulationDefaultsOverrideEnabled?: boolean;
       simulationDefaultsOverride?: SimulationDefaults | null;
+      linkColorMode?: LinkColorMode;
+      siteIconColors?: Record<string, string>;
     },
   ) => void;
   deleteSimulationPreset: (presetId: string) => void;
@@ -759,6 +776,8 @@ const buildSimulationSnapshotFromState = (
     | "terrainDataset"
     | "simulationDefaultsOverrideEnabled"
     | "simulationDefaultsOverride"
+    | "linkColorMode"
+    | "siteIconColors"
   >,
 ): SimulationPreset["snapshot"] => ({
   sites: state.sites,
@@ -779,6 +798,8 @@ const buildSimulationSnapshotFromState = (
   terrainDataset: state.terrainDataset,
   simulationDefaultsOverrideEnabled: state.simulationDefaultsOverrideEnabled,
   simulationDefaultsOverride: state.simulationDefaultsOverride ?? undefined,
+  linkColorMode: state.linkColorMode,
+  siteIconColors: normalizeSiteIconColors(state.siteIconColors, state.sites.map((site) => site.id)),
 });
 
 const legacyDemoSiteFingerprint = new Set([
@@ -876,7 +897,15 @@ const normalizeSimulationPresets = (presets: SimulationPreset[]): SimulationPres
         snapshot: {
           ...preset.snapshot,
           sites: migrated.sites,
-          links: migrated.links,
+          links: migrated.links.map((link) => ({
+            ...link,
+            color: normalizeSimulationColor(link.color) ?? undefined,
+          })),
+          linkColorMode: normalizeLinkColorMode(preset.snapshot.linkColorMode),
+          siteIconColors: normalizeSiteIconColors(
+            preset.snapshot.siteIconColors,
+            migrated.sites.map((site) => site.id),
+          ),
         },
       };
     });
@@ -1318,6 +1347,8 @@ export const useAppStore = create<AppState>((set, get) => ({
   selectedLinkId: "",
   profileCursorIndex: 0,
   temporaryDirectionReversed: false,
+  linkColorMode: DEFAULT_LINK_COLOR_MODE,
+  siteIconColors: {},
   selectedSiteId: "",
   selectedSiteIds: [],
   selectedNetworkId: "",
@@ -1962,6 +1993,8 @@ export const useAppStore = create<AppState>((set, get) => ({
       selectedLinkId: scenario.defaultLinkId,
       profileCursorIndex: 0,
       temporaryDirectionReversed: false,
+      linkColorMode: DEFAULT_LINK_COLOR_MODE,
+      siteIconColors: {},
       selectedNetworkId: scenario.defaultNetworkId,
       selectedFrequencyPresetId: scenario.defaultFrequencyPresetId,
       propagationModel: "ITM",
@@ -2012,6 +2045,8 @@ export const useAppStore = create<AppState>((set, get) => ({
       selectedLinkId: scenario.defaultLinkId,
       profileCursorIndex: 0,
       temporaryDirectionReversed: false,
+      linkColorMode: DEFAULT_LINK_COLOR_MODE,
+      siteIconColors: {},
       selectedNetworkId: scenario.defaultNetworkId,
       selectedFrequencyPresetId: scenario.defaultFrequencyPresetId,
       propagationModel: "ITM",
@@ -2350,6 +2385,8 @@ export const useAppStore = create<AppState>((set, get) => ({
           : remainingSites[0]
             ? [remainingSites[0].id]
             : [];
+      const nextSiteIconColors = { ...state.siteIconColors };
+      delete nextSiteIconColors[siteId];
 
       return {
         sites: remainingSites,
@@ -2357,6 +2394,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         selectedSiteId: nextSelectedIds[0] ?? safeSiteId,
         selectedSiteIds: nextSelectedIds,
         selectedLinkId: safeLinkId,
+        siteIconColors: nextSiteIconColors,
         mapOverlayMode: defaultOverlayModeForSelectionCount(nextSelectedIds.length),
         networks: state.networks.map((network) => ({
           ...network,
@@ -2367,7 +2405,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     useCoverageStore.getState().recomputeCoverage();
     get().updateCurrentSimulationSnapshot();
   },
-  createLink: (fromSiteId, toSiteId, name) => {
+  createLink: (fromSiteId, toSiteId, name, color) => {
     const { currentUser, selectedScenarioId, simulationPresets } = get();
     const user = requireAuth(currentUser, "createLink");
     if (!user) return;
@@ -2395,6 +2433,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       txGainDbi: base?.txGainDbi,
       rxGainDbi: base?.rxGainDbi,
       cableLossDb: base?.cableLossDb,
+      color: normalizeSimulationColor(color) ?? undefined,
     };
     set((state) => ({
       links: [...state.links, link],
@@ -2821,6 +2860,11 @@ export const useAppStore = create<AppState>((set, get) => ({
       simulationDefaultsOverrideEnabled:
         options?.simulationDefaultsOverrideEnabled ?? state.simulationDefaultsOverrideEnabled,
       simulationDefaultsOverride: options?.simulationDefaultsOverride ?? state.simulationDefaultsOverride ?? undefined,
+      linkColorMode: normalizeLinkColorMode(options?.linkColorMode ?? state.linkColorMode),
+      siteIconColors: normalizeSiteIconColors(
+        options?.siteIconColors ?? state.siteIconColors,
+        normalized.sites.map((site) => site.id),
+      ),
     };
     set((current) => {
       const mergedLibrary =
@@ -2891,6 +2935,8 @@ export const useAppStore = create<AppState>((set, get) => ({
         autoPropagationEnvironment: inheritedDefaults.autoPropagationEnvironment,
         terrainDataset: current.terrainDataset,
         simulationDefaultsOverrideEnabled: false,
+        linkColorMode: normalizeLinkColorMode(options?.linkColorMode),
+        siteIconColors: normalizeSiteIconColors(options?.siteIconColors, []),
       };
       const nextPreset: SimulationPreset = {
         id: makeId("sim"),
@@ -2937,25 +2983,10 @@ export const useAppStore = create<AppState>((set, get) => ({
       ),
     );
     const snapshot: SimulationPreset["snapshot"] = {
+      ...buildSimulationSnapshotFromState(state),
       sites: normalized.sites,
       links: normalizedLinks,
-      systems: state.systems,
-      networks: state.networks,
-      selectedSiteId: state.selectedSiteId,
-      selectedLinkId: state.selectedLinkId,
-      selectedNetworkId: state.selectedNetworkId,
-      selectedCoverageResolution: state.selectedCoverageResolution,
-      selectedOverlayRadiusOption: state.selectedOverlayRadiusOption,
-      propagationModel: state.propagationModel,
-      selectedFrequencyPresetId: state.selectedFrequencyPresetId,
-      rxSensitivityTargetDbm: state.rxSensitivityTargetDbm,
-        environmentLossDb: state.environmentLossDb,
-        propagationEnvironment: state.propagationEnvironment,
-        autoPropagationEnvironment: state.autoPropagationEnvironment,
-        terrainDataset: state.terrainDataset,
-        simulationDefaultsOverrideEnabled: state.simulationDefaultsOverrideEnabled,
-        simulationDefaultsOverride: state.simulationDefaultsOverride ?? undefined,
-      };
+    };
     set((current) => {
       const mergedLibrary =
         normalized.addedCount > 0
@@ -3037,6 +3068,11 @@ export const useAppStore = create<AppState>((set, get) => ({
         terrainDataset: get().terrainDataset,
         simulationDefaultsOverrideEnabled: get().simulationDefaultsOverrideEnabled,
         simulationDefaultsOverride: get().simulationDefaultsOverride ?? undefined,
+        linkColorMode: get().linkColorMode,
+        siteIconColors: normalizeSiteIconColors(
+          get().siteIconColors,
+          normalizedSites.sites.map((site) => site.id),
+        ),
       },
       updatedAt: new Date().toISOString(),
       lastEditedByUserId: user.id,
@@ -3083,6 +3119,8 @@ export const useAppStore = create<AppState>((set, get) => ({
         selectedSiteIds: [],
         selectedLinkId: "",
         temporaryDirectionReversed: false,
+        linkColorMode: normalizeLinkColorMode(snap.linkColorMode),
+        siteIconColors: {},
         selectedNetworkId: "",
         selectedCoverageResolution: normalizeCoverageResolution(snap.selectedCoverageResolution),
         selectedOverlayRadiusOption: isOverlayRadiusOption(snap.selectedOverlayRadiusOption)
@@ -3112,7 +3150,10 @@ export const useAppStore = create<AppState>((set, get) => ({
     }
     const recovered = ensureMinimumTopology(
       migratedSnap.sites,
-      migratedSnap.links,
+      migratedSnap.links.map((link) => ({
+        ...link,
+        color: normalizeSimulationColor(link.color) ?? undefined,
+      })),
       Array.isArray(snap.systems) ? snap.systems : [],
       Array.isArray(snap.networks) ? snap.networks : [],
     );
@@ -3139,6 +3180,11 @@ export const useAppStore = create<AppState>((set, get) => ({
       selectedSiteIds: selectedSiteId ? [selectedSiteId] : [],
       selectedLinkId,
       temporaryDirectionReversed: false,
+      linkColorMode: normalizeLinkColorMode(snap.linkColorMode),
+      siteIconColors: normalizeSiteIconColors(
+        snap.siteIconColors,
+        recoveredSites.map((site) => site.id),
+      ),
       selectedNetworkId,
       selectedCoverageResolution: normalizeCoverageResolution(snap.selectedCoverageResolution),
       selectedOverlayRadiusOption: isOverlayRadiusOption(snap.selectedOverlayRadiusOption)
@@ -3238,7 +3284,10 @@ export const useAppStore = create<AppState>((set, get) => ({
         aliasSet.delete(nextSlug);
         const nextVisibility = patch.visibility ?? preset.visibility ?? "private";
         const snapshotPatch =
-          patch.simulationDefaultsOverrideEnabled !== undefined || patch.simulationDefaultsOverride !== undefined
+          patch.simulationDefaultsOverrideEnabled !== undefined ||
+          patch.simulationDefaultsOverride !== undefined ||
+          patch.linkColorMode !== undefined ||
+          patch.siteIconColors !== undefined
             ? {
                 snapshot: {
                   ...preset.snapshot,
@@ -3248,18 +3297,25 @@ export const useAppStore = create<AppState>((set, get) => ({
                     patch.simulationDefaultsOverride === null
                       ? undefined
                       : patch.simulationDefaultsOverride ?? preset.snapshot.simulationDefaultsOverride,
+                  linkColorMode: normalizeLinkColorMode(
+                    patch.linkColorMode ?? preset.snapshot.linkColorMode,
+                  ),
+                  siteIconColors: normalizeSiteIconColors(
+                    patch.siteIconColors ?? preset.snapshot.siteIconColors,
+                    preset.snapshot.sites.map((site) => site.id),
+                  ),
                 },
               }
             : {};
         return {
           ...preset,
-          ...patch,
           ...snapshotPatch,
           name: nextName,
           description: nextDescription,
           slug: nextSlug,
           slugAliases: Array.from(aliasSet).filter(Boolean),
           visibility: nextVisibility,
+          sharedWith: patch.sharedWith ?? preset.sharedWith,
           updatedAt: new Date().toISOString(),
           lastEditedByUserId: user.id,
           lastEditedByName: user.username,
@@ -3267,7 +3323,16 @@ export const useAppStore = create<AppState>((set, get) => ({
         };
       });
       writeStorage(SIM_PRESETS_KEY, next);
-      return { simulationPresets: next };
+      const activeAppearance = state.selectedScenarioId === presetId
+        ? {
+            linkColorMode: normalizeLinkColorMode(patch.linkColorMode ?? state.linkColorMode),
+            siteIconColors: normalizeSiteIconColors(
+              patch.siteIconColors ?? state.siteIconColors,
+              state.sites.map((site) => site.id),
+            ),
+          }
+        : {};
+      return { simulationPresets: next, ...activeAppearance };
     });
   },
   deleteSimulationPreset: (presetId) => {
@@ -3525,6 +3590,9 @@ export const useAppStore = create<AppState>((set, get) => ({
       links: state.links.map((link) => {
         if (link.id !== id) return link;
         const next = { ...link, ...patch };
+        if ("color" in patch) {
+          next.color = normalizeSimulationColor(patch.color) ?? undefined;
+        }
 
         if (next.fromSiteId === next.toSiteId) {
           const alternative = state.sites.find((site) => site.id !== next.fromSiteId);

--- a/src/types/radio.ts
+++ b/src/types/radio.ts
@@ -27,6 +27,7 @@ export type Link = {
   txGainDbi?: number;
   rxGainDbi?: number;
   cableLossDb?: number;
+  color?: string;
 };
 
 export type PropagationModel = "ITM";


### PR DESCRIPTION
## Summary

- add Simulation-level User-selected and Auto Link color modes
- persist per-Link manual colors and Simulation-scoped per-Site icon colors with legacy fallback
- map Auto colors to the four Path Profile states, including temporary selected-Link direction flips
- add high-contrast Link casing, selected-Link outlining, and Site icon halos across themes and basemaps

## Verification

- `npm test` — 124 files, 689 tests passed
- `npm run build` — passed
- focused color/store/editor/map tests — 45 tests passed
- visual QA — light and dark themes plus Street, Terrain, Topographic, Photo, Artistic, and Regional basemap categories
- `npm run dev:check` — no LinkSim dev/watch servers left running

Refs #958