### PR TITLE
Refine simulation color controls

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -140,56 +140,53 @@ const WORLD_POLYGON_GEOJSON = {
   properties: {},
 };
 
-const mapLineSelectionLayer = (selectedColor: string): LayerProps => ({
-  id: "link-lines-selection",
-  type: "line",
-  filter: ["==", ["get", "selected"], 1],
-  paint: {
-    "line-color": selectedColor,
-    "line-width": 11,
-    "line-opacity": 0.95,
-  },
-});
-
-const mapLineCasingLayer = (id: string, color: string, widthOffset: number): LayerProps => ({
-  id,
+const mapLineCasingLayer = (color: string): LayerProps => ({
+  id: "link-lines-casing",
   type: "line",
   paint: {
     "line-color": color,
     "line-width": [
       "case",
       ["==", ["get", "selected"], 1],
-      4.5 + widthOffset,
+      6,
       ["==", ["get", "temporary"], 1],
-      3.5 + widthOffset,
-      3 + widthOffset,
+      4.75,
+      4.25,
     ],
-    "line-opacity": 0.92,
+    "line-opacity": 0.56,
   },
 });
 
 const mapLineLayer = (linkColor: string): LayerProps => ({
   id: "link-lines",
   type: "line",
+  filter: ["!=", ["get", "selected"], 1],
   paint: {
     "line-color": ["coalesce", ["get", "color"], linkColor],
     "line-width": [
       "case",
-      ["==", ["get", "selected"], 1],
-      4.5,
       ["==", ["get", "temporary"], 1],
       3.5,
       3,
     ],
     "line-opacity": [
       "case",
-      ["==", ["get", "selected"], 1],
-      0.98,
       ["==", ["get", "temporary"], 1],
       0.9,
       0.72,
     ],
     "line-dasharray": [1.5, 1],
+  },
+});
+
+const mapLineSelectedLayer = (linkColor: string): LayerProps => ({
+  id: "link-lines-selected",
+  type: "line",
+  filter: ["==", ["get", "selected"], 1],
+  paint: {
+    "line-color": ["coalesce", ["get", "color"], linkColor],
+    "line-width": 4.5,
+    "line-opacity": 0.98,
   },
 });
 
@@ -632,7 +629,7 @@ function SiteMarkerIcon({
   return (
     <Icon
       aria-hidden="true"
-      className={`map-site-icon ${color ? "has-custom-color" : ""}`}
+      className="map-site-icon"
       size={15}
       strokeWidth={1.8}
       style={color ? { color } : undefined}
@@ -744,6 +741,8 @@ export function MapView({
   const sites = useAppStore((state) => state.sites);
   const siteLibrary = useAppStore((state) => state.siteLibrary);
   const links = useAppStore((state) => state.links);
+  const selectedScenarioId = useAppStore((state) => state.selectedScenarioId);
+  const simulationPresets = useAppStore((state) => state.simulationPresets);
   const linkColorMode = useAppStore((state) => state.linkColorMode);
   const siteIconColors = useAppStore((state) => state.siteIconColors);
   const selectedLinkId = useAppStore((state) => state.selectedLinkId);
@@ -760,6 +759,7 @@ export function MapView({
   const clearActiveSelection = useAppStore((state) => state.clearActiveSelection);
   const createLink = useAppStore((state) => state.createLink);
   const updateLink = useAppStore((state) => state.updateLink);
+  const updateSimulationPresetEntry = useAppStore((state) => state.updateSimulationPresetEntry);
   const updateSite = useAppStore((state) => state.updateSite);
   const deleteSite = useAppStore((state) => state.deleteSite);
   const insertSiteFromLibrary = useAppStore((state) => state.insertSiteFromLibrary);
@@ -828,6 +828,10 @@ export function MapView({
   const linkColor = variant.map.linkColor;
   const selectedLinkColor = variant.map.selectedLinkColor;
   const profileColor = variant.map.profileLineColor;
+  const linkCasingColor = theme === "dark" ? MAP_CONTRAST_LIGHT : MAP_CONTRAST_DARK;
+  const hasActiveSavedSimulation = Boolean(
+    selectedScenarioId && simulationPresets.some((preset) => preset.id === selectedScenarioId),
+  );
   const selectedProfile = useMemo(
     () => getSelectedProfile(),
     [
@@ -3411,6 +3415,31 @@ export function MapView({
                 </ActionButton>
               ) : null}
             </div>
+            {hasActiveSavedSimulation ? (
+              <div className="map-calculation-controls map-link-color-controls">
+                <ActionButton
+                  aria-label={linkColorMode === "auto" ? "Turn off Auto Link colors" : "Turn on Auto Link colors"}
+                  aria-pressed={linkColorMode === "auto"}
+                  className={`map-calculation-control map-calculation-toggle ${linkColorMode === "auto" ? "is-on" : "is-off"}`}
+                  disabled={!canPersist || readOnly}
+                  onClick={() => {
+                    if (!selectedScenarioId) return;
+                    updateSimulationPresetEntry(selectedScenarioId, {
+                      linkColorMode: linkColorMode === "auto" ? "manual" : "auto",
+                    });
+                  }}
+                  title={linkColorMode === "auto" ? "Turn off Auto Link colors" : "Turn on Auto Link colors"}
+                  variant="ghost"
+                >
+                  {linkColorMode === "auto" ? (
+                    <ToggleRight aria-hidden="true" size={20} strokeWidth={1.8} />
+                  ) : (
+                    <ToggleLeft aria-hidden="true" size={20} strokeWidth={1.8} />
+                  )}
+                  <span>Auto Link colors</span>
+                </ActionButton>
+              </div>
+            ) : null}
           </div>
           {showHolidayThemeNotice && activeHolidayTheme ? (
             <div className="map-inspector-section map-holiday-note" role="status">
@@ -4158,10 +4187,9 @@ export function MapView({
         ) : null}
 
         <Source data={lineFeatures} id="links" type="geojson">
-          <Layer {...mapLineSelectionLayer(selectedLinkColor)} />
-          <Layer {...mapLineCasingLayer("link-lines-dark-casing", MAP_CONTRAST_DARK, 4)} />
-          <Layer {...mapLineCasingLayer("link-lines-light-casing", MAP_CONTRAST_LIGHT, 2)} />
+          <Layer {...mapLineCasingLayer(linkCasingColor)} />
           <Layer {...mapLineLayer(linkColor)} />
+          <Layer {...mapLineSelectedLayer(linkColor)} />
         </Source>
 
         {sites.map((site) => {

--- a/src/components/MapView.userLocation.test.tsx
+++ b/src/components/MapView.userLocation.test.tsx
@@ -277,10 +277,10 @@ describe("MapView user location flow", () => {
     expect(marker.querySelector(".lucide-ship")).toBeInTheDocument();
     expect(marker.querySelector(".lucide-ship")).toHaveAttribute("aria-hidden", "true");
     expect(marker.querySelector(".lucide-ship")).toHaveStyle({ color: "#123456" });
-    expect(marker.querySelector(".lucide-ship")).toHaveClass("has-custom-color");
+    expect(marker.querySelector(".lucide-ship")).not.toHaveClass("has-custom-color");
   });
 
-  it("keeps a selected manual Link color and renders separate contrast casing", () => {
+  it("keeps a selected manual Link solid with one subtle theme-responsive casing", () => {
     const sites = [
       { id: "site-a", name: "A", position: { lat: 59.9, lon: 10.75 }, groundElevationM: 2, antennaHeightM: 2, txPowerDbm: 22, txGainDbi: 2, rxGainDbi: 2, cableLossDb: 1 },
       { id: "site-b", name: "B", position: { lat: 59.91, lon: 10.76 }, groundElevationM: 2, antennaHeightM: 2, txPowerDbm: 22, txGainDbi: 2, rxGainDbi: 2, cableLossDb: 1 },
@@ -290,6 +290,7 @@ describe("MapView user location flow", () => {
       sites,
       links: [{ id: "link-a", fromSiteId: "site-a", toSiteId: "site-b", frequencyMHz: 869.618, color: "#654321" }],
       linkColorMode: "manual",
+      uiThemePreference: "light",
       selectedLinkId: "link-a",
       selectedSiteIds: ["site-a", "site-b"],
     });
@@ -301,16 +302,68 @@ describe("MapView user location flow", () => {
       features: [expect.objectContaining({ properties: expect.objectContaining({ color: "#654321", selected: 1 }) })],
     });
     expect(mapMock.layerProps.map((props) => props.id)).toEqual(expect.arrayContaining([
+      "link-lines-casing",
+      "link-lines",
+      "link-lines-selected",
+    ]));
+    expect(mapMock.layerProps.map((props) => props.id)).not.toEqual(expect.arrayContaining([
       "link-lines-selection",
       "link-lines-dark-casing",
       "link-lines-light-casing",
-      "link-lines",
     ]));
     expect(mapMock.layerProps.find((props) => props.id === "link-lines")?.paint?.["line-color"]).toEqual([
       "coalesce",
       ["get", "color"],
       expect.any(String),
     ]);
+    expect(mapMock.layerProps.find((props) => props.id === "link-lines")?.paint?.["line-dasharray"]).toEqual([1.5, 1]);
+    expect(mapMock.layerProps.find((props) => props.id === "link-lines-selected")?.paint).not.toHaveProperty("line-dasharray");
+    expect(mapMock.layerProps.find((props) => props.id === "link-lines-casing")?.paint?.["line-opacity"]).toBeLessThan(0.7);
+
+    const lightCasingColor = mapMock.layerProps.find((props) => props.id === "link-lines-casing")?.paint?.["line-color"];
+    mapMock.layerProps = [];
+    act(() => useAppStore.setState({ uiThemePreference: "dark" }));
+    const darkCasingColor = mapMock.layerProps.find((props) => props.id === "link-lines-casing")?.paint?.["line-color"];
+    expect(darkCasingColor).not.toEqual(lightCasingColor);
+  });
+
+  it("commits the Auto Link colors toggle from the right inspector immediately", () => {
+    const simulation = {
+      id: "sim-color-mode",
+      name: "Color mode",
+      ownerUserId: "owner-1",
+      effectiveRole: "owner" as const,
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      snapshot: {
+        sites: [], links: [], systems: [], networks: [],
+        selectedSiteId: "", selectedLinkId: "", selectedNetworkId: "",
+        propagationModel: "ITM" as const, selectedFrequencyPresetId: "custom",
+        rxSensitivityTargetDbm: -120, environmentLossDb: 0,
+        propagationEnvironment: useAppStore.getState().propagationEnvironment,
+        autoPropagationEnvironment: false, terrainDataset: "copernicus30" as const,
+        linkColorMode: "manual" as const,
+      },
+    };
+    useAppStore.setState({
+      currentUser: {
+        id: "owner-1", username: "Owner", avatarUrl: "", role: "user", accountState: "approved",
+        isApproved: true, isAdmin: false, isModerator: false, createdAt: "", updatedAt: null,
+        approvedAt: null, approvedByUserId: null, emailPublic: true, bio: "",
+      },
+      selectedScenarioId: simulation.id,
+      simulationPresets: [simulation],
+      linkColorMode: "manual",
+    });
+
+    renderMapView({ showInspector: true });
+    const toggle = screen.getByRole("button", { name: "Turn on Auto Link colors" });
+    expect(toggle).toHaveAttribute("aria-pressed", "false");
+
+    fireEvent.click(toggle);
+
+    expect(useAppStore.getState().linkColorMode).toBe("auto");
+    expect(useAppStore.getState().simulationPresets[0]?.snapshot.linkColorMode).toBe("auto");
+    expect(screen.getByRole("button", { name: "Turn off Auto Link colors" })).toHaveAttribute("aria-pressed", "true");
   });
 
   it("centers on the first location update and stops following after user pan", () => {

--- a/src/components/map/MapEditorPanel.test.tsx
+++ b/src/components/map/MapEditorPanel.test.tsx
@@ -336,7 +336,7 @@ describe("MapEditorPanel", () => {
     ).toBeInTheDocument();
   });
 
-  it("edits Simulation link mode and per-Site icon colors in Appearance", async () => {
+  it("moves Simulation-scoped icon color to the Site editor and commits it immediately", async () => {
     const site = {
       id: "site-a",
       name: "Site A",
@@ -350,6 +350,14 @@ describe("MapEditorPanel", () => {
     };
     useAppStore.setState({
       selectedScenarioId: "sim-appearance",
+      siteLibrary: [{
+        ...site,
+        visibility: "private",
+        sharedWith: [],
+        ownerUserId: "owner-1",
+        effectiveRole: "owner",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      }],
       sites: [site],
       linkColorMode: "manual",
       siteIconColors: {},
@@ -368,21 +376,47 @@ describe("MapEditorPanel", () => {
           autoPropagationEnvironment: false, terrainDataset: "copernicus30",
         },
       }],
+      mapEditor: { kind: "site", resourceId: "site-a", isNew: false, label: "Site A", anchorRect },
+    });
+
+    render(<MapEditorPanel isMobile={false} />);
+
+    expect(screen.getByText("Applies to this Simulation only.")).toBeInTheDocument();
+    fireEvent.input(screen.getByLabelText("Site icon color"), { target: { value: "#123456" } });
+
+    const state = useAppStore.getState();
+    expect(state.siteIconColors).toEqual({ "site-a": "#123456" });
+    expect(state.simulationPresets[0]?.snapshot.siteIconColors).toEqual({ "site-a": "#123456" });
+    expect(state.siteLibrary[0]).not.toHaveProperty("color");
+  });
+
+  it("does not list Site colors or Link color mode in the Simulation editor", () => {
+    useAppStore.setState({
+      simulationPresets: [{
+        id: "sim-appearance",
+        name: "Appearance Plan",
+        ownerUserId: "owner-1",
+        effectiveRole: "owner",
+        updatedAt: "2026-01-02T00:00:00.000Z",
+        snapshot: {
+          sites: [], links: [], systems: [], networks: [],
+          selectedSiteId: "", selectedLinkId: "", selectedNetworkId: "",
+          propagationModel: "ITM", selectedFrequencyPresetId: "custom",
+          rxSensitivityTargetDbm: -120, environmentLossDb: 0,
+          propagationEnvironment: useAppStore.getState().propagationEnvironment,
+          autoPropagationEnvironment: false, terrainDataset: "copernicus30",
+        },
+      }],
       mapEditor: { kind: "simulation", resourceId: "sim-appearance", isNew: false, label: "Appearance Plan", anchorRect },
     });
 
     render(<MapEditorPanel isMobile={false} />);
 
-    await userEvent.click(screen.getByRole("button", { name: "Auto link colors" }));
-    fireEvent.change(screen.getByLabelText("Site A icon color"), { target: { value: "#123456" } });
-    await userEvent.click(screen.getByRole("button", { name: "Save" }));
-
-    const state = useAppStore.getState();
-    expect(state.linkColorMode).toBe("auto");
-    expect(state.siteIconColors).toEqual({ "site-a": "#123456" });
+    expect(screen.queryByLabelText("Appearance")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Auto link colors" })).not.toBeInTheDocument();
   });
 
-  it("saves a manual color from the existing Link editor", async () => {
+  it("commits a manual Link color immediately without waiting for Save Link", async () => {
     const sites = [
       { id: "site-a", name: "Site A", position: { lat: 60, lon: 10 }, groundElevationM: 100, antennaHeightM: 2, txPowerDbm: 20, txGainDbi: 2, rxGainDbi: 2, cableLossDb: 1 },
       { id: "site-b", name: "Site B", position: { lat: 60.1, lon: 10.1 }, groundElevationM: 110, antennaHeightM: 2, txPowerDbm: 20, txGainDbi: 2, rxGainDbi: 2, cableLossDb: 1 },
@@ -395,10 +429,30 @@ describe("MapEditorPanel", () => {
     });
 
     render(<MapEditorPanel isMobile={false} />);
-    fireEvent.change(await screen.findByLabelText("Link color"), { target: { value: "#654321" } });
-    await userEvent.click(screen.getByRole("button", { name: "Save Link" }));
+    fireEvent.input(await screen.findByLabelText("Link color"), { target: { value: "#654321" } });
 
     expect(useAppStore.getState().links[0]?.color).toBe("#654321");
+  });
+
+  it("renders theme color as a separated transparent swatch", async () => {
+    const sites = [
+      { id: "site-a", name: "Site A", position: { lat: 60, lon: 10 }, groundElevationM: 100, antennaHeightM: 2, txPowerDbm: 20, txGainDbi: 2, rxGainDbi: 2, cableLossDb: 1 },
+      { id: "site-b", name: "Site B", position: { lat: 60.1, lon: 10.1 }, groundElevationM: 110, antennaHeightM: 2, txPowerDbm: 20, txGainDbi: 2, rxGainDbi: 2, cableLossDb: 1 },
+    ];
+    useAppStore.setState({
+      sites,
+      links: [{ id: "link-a", name: "Path A", fromSiteId: "site-a", toSiteId: "site-b", frequencyMHz: 868, color: "#654321" }],
+      linkColorMode: "manual",
+      mapEditor: { kind: "link", resourceId: "link-a", isNew: false, label: "Path A", anchorRect },
+    });
+
+    render(<MapEditorPanel isMobile={false} />);
+    const themeSwatch = await screen.findByRole("button", { name: "Use theme Link color" });
+    expect(themeSwatch).toHaveClass("simulation-color-swatch", "is-theme-color");
+    expect(themeSwatch.previousElementSibling).toHaveClass("simulation-color-separator");
+
+    await userEvent.click(themeSwatch);
+    expect(useAppStore.getState().links[0]?.color).toBeUndefined();
   });
 
   it("renders read-only site details as static text", async () => {

--- a/src/components/map/MapEditorPanel.tsx
+++ b/src/components/map/MapEditorPanel.tsx
@@ -33,10 +33,12 @@ function SimulationColorControl({
   label,
   value,
   onChange,
+  disabled = false,
 }: {
   label: string;
   value: string | null;
   onChange: (value: string | null) => void;
+  disabled?: boolean;
 }) {
   const pickerValue = value ?? SIMULATION_COLOR_PRESETS[4].value;
   return (
@@ -45,7 +47,8 @@ function SimulationColorControl({
         <span>{label}</span>
         <input
           aria-label={label}
-          onChange={(event) => onChange(event.target.value)}
+          disabled={disabled}
+          onInput={(event) => onChange(event.currentTarget.value)}
           type="color"
           value={pickerValue}
         />
@@ -56,6 +59,7 @@ function SimulationColorControl({
             aria-label={`Set ${label} to ${preset.label}`}
             aria-pressed={value === preset.value}
             className="simulation-color-swatch"
+            disabled={disabled}
             key={preset.value}
             onClick={() => onChange(preset.value)}
             style={{ "--simulation-swatch-color": preset.value } as CSSProperties}
@@ -63,9 +67,16 @@ function SimulationColorControl({
             type="button"
           />
         ))}
-        <Button onClick={() => onChange(null)} type="button" variant="ghost">
-          Use theme color
-        </Button>
+        <span aria-hidden="true" className="simulation-color-separator" />
+        <button
+          aria-label={`Use theme ${label}`}
+          aria-pressed={value === null}
+          className="simulation-color-swatch is-theme-color"
+          disabled={disabled}
+          onClick={() => onChange(null)}
+          title="Use theme color"
+          type="button"
+        />
       </div>
     </div>
   );
@@ -301,6 +312,9 @@ function SiteEditorCard({
               <ResolvedIcon aria-label={resolvedIconOption.label} role="img" size={16} strokeWidth={1.8} />
             </span>
           </div>
+          {form.activeSimulationSiteId ? (
+            <StaticField label="Site icon color" value={form.activeSiteIconColor ?? "Theme color"} />
+          ) : null}
           <div className="beam-visualizer-field-group">
             <StaticField label="Antenna (m)" value={form.antennaDraft} />
             <StaticField label="Tx power (dBm)" value={form.txPowerDraft} />
@@ -386,6 +400,18 @@ function SiteEditorCard({
             </div>
           </FloatingPopover>
         </div>
+
+        {form.activeSimulationSiteId ? (
+          <div className="simulation-site-color-control">
+            <SimulationColorControl
+              disabled={!form.canEditActiveSimulationAppearance}
+              label="Site icon color"
+              onChange={form.setActiveSiteIconColor}
+              value={form.activeSiteIconColor}
+            />
+            <p className="field-help">Applies to this Simulation only.</p>
+          </div>
+        ) : null}
 
         <label className="field-grid">
           <span>Description</span>
@@ -844,7 +870,6 @@ function SimulationEditorCard({
           <StaticField label="Name" value={form.nameDraft} />
           <StaticField label="Description" value={form.descriptionDraft} />
           <StaticField label="Visibility" value={form.accessVisibility} />
-          <StaticField label="Link colors" value={form.simulationLinkColorMode === "auto" ? "Auto" : "User-selected"} />
           <div className="simulation-settings-block">
             <div className="simulation-settings-header">
               <span>Simulation settings</span>
@@ -888,40 +913,6 @@ function SimulationEditorCard({
           ownerUserId={form.ownerUserId}
           visibility={form.accessVisibility}
         />
-        <section className="simulation-appearance-section" aria-label="Appearance">
-          <div className="simulation-settings-header">
-            <span>Appearance</span>
-          </div>
-          <div className="chip-group" role="group" aria-label="Link color mode">
-            <ActionButton
-              aria-label="User-selected link colors"
-              aria-pressed={form.simulationLinkColorMode === "manual"}
-              onClick={() => form.setSimulationLinkColorMode("manual")}
-              type="button"
-            >
-              User-selected
-            </ActionButton>
-            <ActionButton
-              aria-label="Auto link colors"
-              aria-pressed={form.simulationLinkColorMode === "auto"}
-              onClick={() => form.setSimulationLinkColorMode("auto")}
-              type="button"
-            >
-              Auto
-            </ActionButton>
-          </div>
-          <p className="field-help">
-            Auto uses the Path Profile pass/fail and terrain-obstruction colors for each Link.
-          </p>
-          {form.simulationAppearanceSites.map((site) => (
-            <SimulationColorControl
-              key={site.id}
-              label={`${site.name} icon color`}
-              onChange={(value) => form.setSimulationSiteIconColor(site.id, value)}
-              value={form.simulationSiteIconColors[site.id] ?? null}
-            />
-          ))}
-        </section>
         <div className="simulation-settings-block">
           <div className="simulation-settings-header">
             <span>Simulation settings</span>

--- a/src/components/map/useMapEditorFormState.ts
+++ b/src/components/map/useMapEditorFormState.ts
@@ -55,6 +55,7 @@ export function useMapEditorFormState() {
   const setMapEditorSiteDraft = useAppStore((state) => state.setMapEditorSiteDraft);
   const siteLibrary = useAppStore((state) => state.siteLibrary);
   const simulationPresets = useAppStore((state) => state.simulationPresets);
+  const selectedScenarioId = useAppStore((state) => state.selectedScenarioId);
   const sites = useAppStore((state) => state.sites);
   const links = useAppStore((state) => state.links);
   const srtmTiles = useAppStore((state) => state.srtmTiles);
@@ -402,6 +403,13 @@ export function useMapEditorFormState() {
     mapEditor?.kind === "simulation" && mapEditor.resourceId
       ? simulationPresets.find((preset) => preset.id === mapEditor.resourceId) ?? null
       : null;
+  const activeSimulationPreset = selectedScenarioId
+    ? simulationPresets.find((preset) => preset.id === selectedScenarioId) ?? null
+    : null;
+  const activeSimulationSite =
+    mapEditor?.kind === "site" && mapEditor.resourceId
+      ? sites.find((site) => site.id === mapEditor.resourceId || site.libraryEntryId === mapEditor.resourceId) ?? null
+      : null;
   const ownerUserId = (() => {
     if (!mapEditor) return "";
     if (mapEditor.kind === "site" && mapEditor.resourceId) {
@@ -441,6 +449,11 @@ export function useMapEditorFormState() {
     };
   });
   const currentUserIsOwner = Boolean(currentUser?.id && ownerUserId && currentUser.id === ownerUserId);
+  const activeSimulationRole = activeSimulationPreset?.effectiveRole ??
+    (activeSimulationPreset?.ownerUserId === currentUser?.id ? "owner" : "viewer");
+  const canEditActiveSimulationAppearance = Boolean(
+    currentUser?.id && activeSimulationPreset && ["owner", "editor", "admin"].includes(activeSimulationRole),
+  );
   const resolveUserSummary = (
     userId: string | null | undefined,
     fallbackName: string | null | undefined,
@@ -828,7 +841,6 @@ export function useMapEditorFormState() {
           txGainDbi: overrideRadio ? linkTxGain : undefined,
           rxGainDbi: overrideRadio ? linkRxGain : undefined,
           cableLossDb: overrideRadio ? linkCableLoss : undefined,
-          color: linkColorDraft ?? undefined,
         });
       }
       closeMapEditor();
@@ -929,18 +941,6 @@ export function useMapEditorFormState() {
     setSimulationDefaultsOverrideEnabled,
     simulationDefaultsDraft,
     simulationNameError,
-    simulationLinkColorMode,
-    setSimulationLinkColorMode,
-    simulationSiteIconColors,
-    setSimulationSiteIconColor: (siteId: string, value: string | null) => {
-      setSimulationSiteIconColors((current) => {
-        const next = { ...current };
-        const color = normalizeSimulationColor(value);
-        if (color) next[siteId] = color;
-        else delete next[siteId];
-        return next;
-      });
-    },
     setSimulationDefaultsDraft: (patch: Partial<SimulationDefaults>) =>
       setSimulationDefaultsDraft((current) => normalizeSimulationDefaults({ ...current, ...patch }, current)),
     handleSaveSimulation,
@@ -954,7 +954,13 @@ export function useMapEditorFormState() {
     linkRxGain, setLinkRxGain: (v: number | string) => setLinkRxGain(parseNumber(String(v))),
     linkCableLoss, setLinkCableLoss: (v: number | string) => setLinkCableLoss(parseNumber(String(v))),
     linkColorDraft,
-    setLinkColorDraft: (value: string | null) => setLinkColorDraft(normalizeSimulationColor(value)),
+    setLinkColorDraft: (value: string | null) => {
+      const color = normalizeSimulationColor(value);
+      setLinkColorDraft(color);
+      if (!mapEditor?.isNew && mapEditor?.resourceId) {
+        updateLink(mapEditor.resourceId, { color: color ?? undefined });
+      }
+    },
     activeLinkColorMode,
     handleSaveLink,
     siteSearchQuery,
@@ -967,9 +973,16 @@ export function useMapEditorFormState() {
     selectSiteSearchResult,
     // raw data for labels
     sites,
-    simulationAppearanceSites: currentSimulationPreset?.snapshot.sites ??
-      (mapEditor?.kind === "simulation" && mapEditor.isNew && mapEditor.simulationSeed?.copyCurrentSimulation
-        ? sites
-        : []),
+    activeSimulationSiteId: activeSimulationSite?.id ?? null,
+    activeSiteIconColor: activeSimulationSite ? activeSiteIconColors[activeSimulationSite.id] ?? null : null,
+    canEditActiveSimulationAppearance,
+    setActiveSiteIconColor: (value: string | null) => {
+      if (!selectedScenarioId || !activeSimulationSite || !canEditActiveSimulationAppearance) return;
+      const next = { ...activeSiteIconColors };
+      const color = normalizeSimulationColor(value);
+      if (color) next[activeSimulationSite.id] = color;
+      else delete next[activeSimulationSite.id];
+      updateSimulationPresetEntry(selectedScenarioId, { siteIconColors: next });
+    },
   };
 }

--- a/src/index.css
+++ b/src/index.css
@@ -21,8 +21,6 @@
   --state-pass-blocked: var(--warning);
   --state-fail-clear: color-mix(in srgb, var(--warning) 45%, var(--danger));
   --state-fail-blocked: var(--danger);
-  --map-contrast-dark: #000000;
-  --map-contrast-light: #ffffff;
   --panel-shell-divider: color-mix(in srgb, var(--border) 84%, transparent);
   --panel-header-row-gap: 10px;
   --panel-header-row-min-height: 34px;
@@ -682,16 +680,10 @@ button {
   margin: 0;
 }
 
-.simulation-appearance-section,
-.simulation-color-field {
+.simulation-color-field,
+.simulation-site-color-control {
   display: grid;
   gap: 8px;
-}
-
-.simulation-appearance-section {
-  margin-top: 10px;
-  padding-top: 10px;
-  border-top: 1px solid var(--border);
 }
 
 .simulation-color-presets {
@@ -714,6 +706,24 @@ button {
 
 .simulation-color-swatch[aria-pressed="true"] {
   box-shadow: 0 0 0 2px var(--selection);
+}
+
+.simulation-color-swatch.is-theme-color {
+  border-color: var(--muted);
+  background: transparent;
+  box-shadow: none;
+}
+
+.simulation-color-separator {
+  width: 1px;
+  height: 20px;
+  margin: 0 2px;
+  background: var(--border);
+}
+
+.simulation-color-swatch:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
 }
 
 .simulation-color-field input[type="color"] {
@@ -2415,6 +2425,11 @@ button {
   box-shadow: none;
 }
 
+.map-link-color-controls {
+  padding-top: 4px;
+  border-top: 1px solid var(--panel-shell-divider);
+}
+
 .map-calculation-toggle.is-on,
 .map-calculation-action.is-start {
   color: var(--success);
@@ -2744,12 +2759,6 @@ button {
 
 .map-site-icon {
   flex: 0 0 auto;
-}
-
-.map-site-icon.has-custom-color {
-  filter:
-    drop-shadow(0 0 1px var(--map-contrast-light))
-    drop-shadow(0 0 1.5px var(--map-contrast-dark));
 }
 
 .map-site-surface:not(.is-muted) {


### PR DESCRIPTION
## Summary

- make selected Links render as one solid colored stroke with a restrained light/dark-aware casing
- remove the extra Site icon glow
- move Auto Link colors to the existing right sidebar
- move Simulation-specific Site icon color to the existing Site editor
- commit existing Link and Site color changes immediately through the normal Simulation sync and change-log flow
- replace the theme-color text action with a separated transparent swatch

## Why

The first Issue #958 implementation introduced stacked dotted selection layers, overly strong contrast treatment, delayed color feedback, and controls in the wrong editors. This follow-up aligns the behavior with the revised interaction design while retaining the original Auto color calculation and flip-direction handling.

## Validation

- `npm test` — 124 files, 692 tests passed
- `npm run build`
- `git diff --check`
- local browser verification of selected-Link rendering in light and dark themes
- confirmed no LinkSim dev/watch server remains running

Refs #958