### PR TITLE
Keep Links above Simulation overlays

### DIFF
--- a/src/components/MapView.overlayHandoff.test.tsx
+++ b/src/components/MapView.overlayHandoff.test.tsx
@@ -22,6 +22,7 @@ const overlayMock = vi.hoisted(() => {
 
 const loadingOverlayMock = vi.hoisted(() => ({
   props: null as null | {
+    beforeLayerId?: string;
     handoffKey?: string | null;
     loading?: boolean;
     onCloudEntered?: (requestKey: string) => void;
@@ -206,6 +207,7 @@ describe("MapView overlay handoff", () => {
 
     await resolveNextRaster();
     await waitFor(() => expect(loadingOverlayMock.props?.handoffKey).toBeTruthy());
+    expect(loadingOverlayMock.props?.beforeLayerId).toBe("link-lines-casing");
     const firstKey = loadingOverlayMock.props?.handoffKey;
     expect(firstKey).toBeTruthy();
     act(() => loadingOverlayMock.props?.onCloudReady?.(firstKey!));

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -4152,6 +4152,7 @@ export function MapView({
         ) : null}
 
         <SimulationLoadingOverlay
+          beforeLayerId="link-lines-casing"
           bounds={analysisBounds}
           handoffKey={overlayHandoff.requestKey}
           loading={simulationLoadingOverlayActive}

--- a/src/components/SimulationLoadingOverlay.test.tsx
+++ b/src/components/SimulationLoadingOverlay.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mapMock = vi.hoisted(() => {
   const state = {
+    anchorLayerPresent: false,
     layerPresent: false,
     sourcePresent: false,
     styleLoaded: true,
@@ -26,7 +27,10 @@ const mapMock = vi.hoisted(() => {
       }
       state.sourcePresent = true;
     }),
-    getLayer: vi.fn(() => (state.layerPresent ? {} : undefined)),
+    getLayer: vi.fn((id: string) => {
+      if (id === "link-lines-casing") return state.anchorLayerPresent ? {} : undefined;
+      return state.layerPresent ? {} : undefined;
+    }),
     getSource: vi.fn(() => (state.sourcePresent ? source : undefined)),
     isStyleLoaded: vi.fn(() => state.styleLoaded),
     off: vi.fn(),
@@ -39,6 +43,7 @@ const mapMock = vi.hoisted(() => {
     removeSource: vi.fn(() => {
       state.sourcePresent = false;
     }),
+    moveLayer: vi.fn(),
     setPaintProperty: vi.fn(),
     triggerRepaint: vi.fn(),
   };
@@ -67,6 +72,7 @@ describe("SimulationLoadingOverlay", () => {
 
   beforeEach(() => {
     vi.useFakeTimers();
+    mapMock.state.anchorLayerPresent = false;
     mapMock.state.layerPresent = false;
     mapMock.state.sourcePresent = false;
     mapMock.state.styleLoaded = true;
@@ -200,6 +206,36 @@ describe("SimulationLoadingOverlay", () => {
       "simulation-loading-overlay-source",
     );
     expect(onCloudExited).toHaveBeenCalledWith("heatmap");
+  });
+
+  it("keeps the loading overlay below the Link layers", () => {
+    mapMock.state.anchorLayerPresent = true;
+    vi.mocked(window.matchMedia).mockReturnValue({
+      matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    } as unknown as MediaQueryList);
+
+    render(
+      <SimulationLoadingOverlay
+        beforeLayerId="link-lines-casing"
+        bounds={bounds}
+        handoffKey="heatmap"
+        loading
+        pointMask={() => true}
+      />,
+    );
+
+    expect(mapMock.map.addLayer).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "simulation-loading-overlay-layer" }),
+      "link-lines-casing",
+    );
+
+    act(() => mapMock.state.styleDataListener?.());
+    expect(mapMock.map.moveLayer).toHaveBeenCalledWith(
+      "simulation-loading-overlay-layer",
+      "link-lines-casing",
+    );
   });
 
   it("renders one static cloud frame for reduced motion", () => {

--- a/src/components/SimulationLoadingOverlay.tsx
+++ b/src/components/SimulationLoadingOverlay.tsx
@@ -21,6 +21,7 @@ const SOURCE_ID = "simulation-loading-overlay-source";
 const LAYER_ID = "simulation-loading-overlay-layer";
 
 type SimulationLoadingOverlayProps = {
+  beforeLayerId?: string;
   bounds: TerrainBounds | null;
   handoffKey?: string | null;
   loading: boolean;
@@ -50,6 +51,7 @@ const usePrefersReducedMotion = (): boolean => {
 };
 
 export function SimulationLoadingOverlay({
+  beforeLayerId,
   bounds,
   handoffKey = null,
   loading,
@@ -198,7 +200,7 @@ export function SimulationLoadingOverlay({
         }
         if (!map.getLayer(LAYER_ID)) {
           const transition = resolveSimulationOverlayTransition(false);
-          map.addLayer({
+          const layer = {
             id: LAYER_ID,
             paint: {
               "raster-opacity": transition.loadingOpacity,
@@ -207,8 +209,15 @@ export function SimulationLoadingOverlay({
               },
             },
             source: SOURCE_ID,
-            type: "raster",
-          });
+            type: "raster" as const,
+          };
+          const anchorLayerId = beforeLayerId && map.getLayer(beforeLayerId)
+            ? beforeLayerId
+            : undefined;
+          if (anchorLayerId) map.addLayer(layer, anchorLayerId);
+          else map.addLayer(layer);
+        } else if (beforeLayerId && map.getLayer(beforeLayerId)) {
+          map.moveLayer(LAYER_ID, beforeLayerId);
         }
       } catch {
         // MapLibre can emit styledata before the style accepts custom sources.
@@ -261,6 +270,7 @@ export function SimulationLoadingOverlay({
       map.off("styledata", addAfterStyleChange);
     };
   }, [
+    beforeLayerId,
     canvas,
     coordinates,
     handoffKey,

--- a/src/components/map/MapEditorPanel.test.tsx
+++ b/src/components/map/MapEditorPanel.test.tsx
@@ -447,7 +447,11 @@ describe("MapEditorPanel", () => {
     });
 
     render(<MapEditorPanel isMobile={false} />);
+    const picker = await screen.findByLabelText("Link color");
     const themeSwatch = await screen.findByRole("button", { name: "Use theme Link color" });
+    const presetGroup = screen.getByRole("group", { name: "Link color presets" });
+    expect(presetGroup).toContainElement(picker);
+    expect(picker.nextElementSibling).toHaveClass("simulation-color-separator");
     expect(themeSwatch).toHaveClass("simulation-color-swatch", "is-theme-color");
     expect(themeSwatch.previousElementSibling).toHaveClass("simulation-color-separator");
 

--- a/src/components/map/MapEditorPanel.tsx
+++ b/src/components/map/MapEditorPanel.tsx
@@ -43,16 +43,7 @@ function SimulationColorControl({
   const pickerValue = value ?? SIMULATION_COLOR_PRESETS[4].value;
   return (
     <div className="simulation-color-field">
-      <label className="field-grid">
-        <span>{label}</span>
-        <input
-          aria-label={label}
-          disabled={disabled}
-          onInput={(event) => onChange(event.currentTarget.value)}
-          type="color"
-          value={pickerValue}
-        />
-      </label>
+      <span>{label}</span>
       <div aria-label={`${label} presets`} className="simulation-color-presets" role="group">
         {SIMULATION_COLOR_PRESETS.map((preset) => (
           <button
@@ -67,6 +58,13 @@ function SimulationColorControl({
             type="button"
           />
         ))}
+        <input
+          aria-label={label}
+          disabled={disabled}
+          onInput={(event) => onChange(event.currentTarget.value)}
+          type="color"
+          value={pickerValue}
+        />
         <span aria-hidden="true" className="simulation-color-separator" />
         <button
           aria-label={`Use theme ${label}`}

--- a/src/index.css
+++ b/src/index.css
@@ -727,10 +727,10 @@ button {
 }
 
 .simulation-color-field input[type="color"] {
-  justify-self: end;
-  width: 44px;
-  min-height: 32px;
-  padding: 3px;
+  width: 28px;
+  height: 28px;
+  min-height: 0;
+  padding: 2px;
 }
 
 .simulation-settings-actions {


### PR DESCRIPTION
## Summary

- anchor the animated Simulation loading overlay immediately below the Link casing layer
- reassert that ordering after MapLibre style changes
- keep Site markers above the map-rendered Link layers
- move the native custom color picker into the preset swatch row, before the theme-color separator

## Why

The declarative terrain and coverage overlays were already below Links, but the animated loading-cloud layer is added imperatively and could be inserted above them. The custom picker also occupied a separate row from the presets.

## Validation

- `npm test` — 124 files, 693 tests passed
- `npm run build`
- `git diff --check`
- local browser verification with a selected Link above the Relay overlay and Site markers above the Link
- confirmed no LinkSim dev/watch server remains running

Refs #958