### PR TITLE
Simplify Simulation color choices

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -828,7 +828,7 @@ export function MapView({
   const linkColor = variant.map.linkColor;
   const selectedLinkColor = variant.map.selectedLinkColor;
   const profileColor = variant.map.profileLineColor;
-  const linkCasingColor = theme === "dark" ? MAP_CONTRAST_LIGHT : MAP_CONTRAST_DARK;
+  const linkCasingColor = theme === "dark" ? MAP_CONTRAST_DARK : MAP_CONTRAST_LIGHT;
   const hasActiveSavedSimulation = Boolean(
     selectedScenarioId && simulationPresets.some((preset) => preset.id === selectedScenarioId),
   );

--- a/src/components/MapView.userLocation.test.tsx
+++ b/src/components/MapView.userLocation.test.tsx
@@ -321,10 +321,11 @@ describe("MapView user location flow", () => {
     expect(mapMock.layerProps.find((props) => props.id === "link-lines-casing")?.paint?.["line-opacity"]).toBeLessThan(0.7);
 
     const lightCasingColor = mapMock.layerProps.find((props) => props.id === "link-lines-casing")?.paint?.["line-color"];
+    expect(lightCasingColor).toBe("#ffffff");
     mapMock.layerProps = [];
     act(() => useAppStore.setState({ uiThemePreference: "dark" }));
     const darkCasingColor = mapMock.layerProps.find((props) => props.id === "link-lines-casing")?.paint?.["line-color"];
-    expect(darkCasingColor).not.toEqual(lightCasingColor);
+    expect(darkCasingColor).toBe("#000000");
   });
 
   it("commits the Auto Link colors toggle from the right inspector immediately", () => {

--- a/src/components/map/MapEditorPanel.test.tsx
+++ b/src/components/map/MapEditorPanel.test.tsx
@@ -382,11 +382,12 @@ describe("MapEditorPanel", () => {
     render(<MapEditorPanel isMobile={false} />);
 
     expect(screen.getByText("Applies to this Simulation only.")).toBeInTheDocument();
-    fireEvent.input(screen.getByLabelText("Site icon color"), { target: { value: "#123456" } });
+    expect(screen.queryByLabelText("Site icon color")).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Set Site icon color to Blue" }));
 
     const state = useAppStore.getState();
-    expect(state.siteIconColors).toEqual({ "site-a": "#123456" });
-    expect(state.simulationPresets[0]?.snapshot.siteIconColors).toEqual({ "site-a": "#123456" });
+    expect(state.siteIconColors).toEqual({ "site-a": "#2563eb" });
+    expect(state.simulationPresets[0]?.snapshot.siteIconColors).toEqual({ "site-a": "#2563eb" });
     expect(state.siteLibrary[0]).not.toHaveProperty("color");
   });
 
@@ -429,12 +430,13 @@ describe("MapEditorPanel", () => {
     });
 
     render(<MapEditorPanel isMobile={false} />);
-    fireEvent.input(await screen.findByLabelText("Link color"), { target: { value: "#654321" } });
+    expect(screen.queryByLabelText("Link color")).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Set Link color to Purple" }));
 
-    expect(useAppStore.getState().links[0]?.color).toBe("#654321");
+    expect(useAppStore.getState().links[0]?.color).toBe("#7c3aed");
   });
 
-  it("renders theme color as a separated transparent swatch", async () => {
+  it("renders presets and theme color without an arbitrary picker", async () => {
     const sites = [
       { id: "site-a", name: "Site A", position: { lat: 60, lon: 10 }, groundElevationM: 100, antennaHeightM: 2, txPowerDbm: 20, txGainDbi: 2, rxGainDbi: 2, cableLossDb: 1 },
       { id: "site-b", name: "Site B", position: { lat: 60.1, lon: 10.1 }, groundElevationM: 110, antennaHeightM: 2, txPowerDbm: 20, txGainDbi: 2, rxGainDbi: 2, cableLossDb: 1 },
@@ -447,11 +449,9 @@ describe("MapEditorPanel", () => {
     });
 
     render(<MapEditorPanel isMobile={false} />);
-    const picker = await screen.findByLabelText("Link color");
     const themeSwatch = await screen.findByRole("button", { name: "Use theme Link color" });
     const presetGroup = screen.getByRole("group", { name: "Link color presets" });
-    expect(presetGroup).toContainElement(picker);
-    expect(picker.nextElementSibling).toHaveClass("simulation-color-separator");
+    expect(presetGroup.querySelector('input[type="color"]')).not.toBeInTheDocument();
     expect(themeSwatch).toHaveClass("simulation-color-swatch", "is-theme-color");
     expect(themeSwatch.previousElementSibling).toHaveClass("simulation-color-separator");
 

--- a/src/components/map/MapEditorPanel.tsx
+++ b/src/components/map/MapEditorPanel.tsx
@@ -40,7 +40,6 @@ function SimulationColorControl({
   onChange: (value: string | null) => void;
   disabled?: boolean;
 }) {
-  const pickerValue = value ?? SIMULATION_COLOR_PRESETS[4].value;
   return (
     <div className="simulation-color-field">
       <span>{label}</span>
@@ -58,13 +57,6 @@ function SimulationColorControl({
             type="button"
           />
         ))}
-        <input
-          aria-label={label}
-          disabled={disabled}
-          onInput={(event) => onChange(event.currentTarget.value)}
-          type="color"
-          value={pickerValue}
-        />
         <span aria-hidden="true" className="simulation-color-separator" />
         <button
           aria-label={`Use theme ${label}`}

--- a/src/index.css
+++ b/src/index.css
@@ -726,13 +726,6 @@ button {
   opacity: 0.5;
 }
 
-.simulation-color-field input[type="color"] {
-  width: 28px;
-  height: 28px;
-  min-height: 0;
-  padding: 2px;
-}
-
 .simulation-settings-actions {
   display: flex;
   justify-content: flex-end;


### PR DESCRIPTION
## What changed

- reverse the selected Link casing so light mode uses white and dark mode uses a dark casing
- remove the arbitrary native color picker from Link and Simulation-specific Site icon controls
- retain the six approved presets and the separated theme-color swatch
- update regression coverage for both theme casing directions and preset-only immediate updates

## Why

The previous contrast pairing made selected Links look heavier against each app theme. Arbitrary colors also made a reliable casing choice less predictable, so this follow-up narrows manual selection to the approved palette.

No migration or compatibility fallback is included because the arbitrary picker has not reached production.

## Verification

- `npm test` — 124 files, 693 tests passed
- `npm run build`
- `git diff --check`
- browser QA in light and dark app themes, including the Simulation overlay and Site marker layer ordering

Closes the remaining visual follow-up for #958.