### PR TITLE
Add 868.no as a node source

### DIFF
--- a/functions/node-sources/868-no.test.ts
+++ b/functions/node-sources/868-no.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getClientAddressMock, takeRateLimitTokenMock } = vi.hoisted(() => ({
+  getClientAddressMock: vi.fn(),
+  takeRateLimitTokenMock: vi.fn(),
+}));
+
+vi.mock("../_lib/rateLimit", () => ({
+  getClientAddress: getClientAddressMock,
+  takeRateLimitToken: takeRateLimitTokenMock,
+}));
+
+import { onRequest, parseMeshstellarSnapshot, readMeshstellarSnapshot } from "./868-no";
+
+const feature = (id: string, updatedAt: number, lat = 60.1, lon = 10.2) =>
+  JSON.stringify({
+    type: "Feature",
+    geometry: { type: "Point", coordinates: [lon, lat, 123] },
+    properties: { id, display_name: `S-${id}`, long_name: `Node ${id}`, updated_at: updatedAt },
+  }).replaceAll('"', "&quot;");
+
+const event = (html: string) => `event: update-node\ndata: ${html}\n\n`;
+
+const env = { DB: {}, PROXY_RATE_LIMIT_PER_MINUTE: "120" } as unknown as {
+  DB: D1Database;
+  PROXY_RATE_LIMIT_PER_MINUTE?: string;
+};
+
+const cacheMatch = vi.fn();
+const cachePut = vi.fn();
+const mkCtx = (request: Request) => ({ request, env } as unknown as Parameters<typeof onRequest>[0]);
+
+beforeEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+  vi.stubGlobal("caches", { default: { match: cacheMatch, put: cachePut } });
+  vi.stubGlobal("fetch", vi.fn());
+  cacheMatch.mockResolvedValue(undefined);
+  cachePut.mockResolvedValue(undefined);
+  getClientAddressMock.mockReturnValue("198.51.100.10");
+  takeRateLimitTokenMock.mockReturnValue({ allowed: true, remaining: 29, retryAfterSec: 0 });
+});
+
+describe("868.no Meshstellar snapshot", () => {
+  it("extracts positioned nodes, decodes attributes, and keeps the newest duplicate", () => {
+    const payload = [
+      event(`<li><div data-geojson="${feature("abc123", 1_800_000_000)}"></div></li>`),
+      event(`<li><div data-geojson="${feature("abc123", 1_800_000_200, 61.2, 11.3)}"></div></li>`),
+      event("<li><span>Node without a position</span></li>"),
+      "event: statistics\ndata: ignored\n\n",
+    ].join("");
+
+    expect(parseMeshstellarSnapshot(payload)).toEqual([
+      {
+        altitudeM: 123,
+        lat: 61.2,
+        lon: 11.3,
+        longName: "Node abc123",
+        nodeId: "!abc123",
+        shortName: "S-abc123",
+        updatedAt: 1_800_000_200_000,
+      },
+    ]);
+  });
+
+  it("returns and caches a normalized on-demand snapshot", async () => {
+    const payload = event(`<li><div data-geojson="${feature("abc123", 1_800_000_200)}"></div></li>`);
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(payload, { status: 200, headers: { "content-type": "text/event-stream" } }),
+    );
+
+    const response = await onRequest(mkCtx(new Request("https://example.test/node-sources/868-no")));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual([
+      expect.objectContaining({ nodeId: "!abc123", lat: 60.1, lon: 10.2 }),
+    ]);
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "https://map.868.no/events",
+      expect.objectContaining({ headers: { accept: "text/event-stream" } }),
+    );
+    expect(cachePut).toHaveBeenCalledTimes(1);
+    expect(response.headers.get("cache-control")).toContain("s-maxage=300");
+  });
+
+  it("closes an open stream after the initial node burst becomes idle", async () => {
+    vi.useFakeTimers();
+    const encoder = new TextEncoder();
+    let canceled = false;
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode(event(`<li><div data-geojson="${feature("abc123", 1_800_000_200)}"></div></li>`)));
+      },
+      cancel() {
+        canceled = true;
+      },
+    });
+
+    const snapshot = readMeshstellarSnapshot(stream);
+    await vi.advanceTimersByTimeAsync(1_001);
+
+    await expect(snapshot).resolves.toEqual([
+      expect.objectContaining({ nodeId: "!abc123" }),
+    ]);
+    expect(canceled).toBe(true);
+  });
+
+  it("uses the cached snapshot without opening a new SSE connection", async () => {
+    cacheMatch.mockResolvedValueOnce(new Response("[]", { status: 200 }));
+
+    const response = await onRequest(mkCtx(new Request("https://example.test/node-sources/868-no")));
+
+    expect(response.status).toBe(200);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/functions/node-sources/868-no.ts
+++ b/functions/node-sources/868-no.ts
@@ -1,0 +1,180 @@
+import { getClientAddress, takeRateLimitToken } from "../_lib/rateLimit";
+import type { Env } from "../_lib/types";
+
+const UPSTREAM_URL = "https://map.868.no/events";
+const CACHE_TTL_SEC = 300;
+const SNAPSHOT_IDLE_MS = 1_000;
+const SNAPSHOT_MAX_MS = 8_000;
+const MAX_STREAM_BYTES = 5 * 1024 * 1024;
+
+type MeshstellarNode = {
+  nodeId: string;
+  longName?: string;
+  shortName?: string;
+  lat: number;
+  lon: number;
+  altitudeM?: number;
+  updatedAt?: number;
+};
+
+type MeshstellarFeature = {
+  geometry?: { coordinates?: unknown };
+  properties?: {
+    id?: unknown;
+    display_name?: unknown;
+    long_name?: unknown;
+    updated_at?: unknown;
+  };
+};
+
+const toStringOrUndefined = (value: unknown): string | undefined =>
+  typeof value === "string" && value.trim() ? value.trim() : undefined;
+
+const decodeHtmlAttribute = (value: string): string =>
+  value.replace(/&(#(?:x[0-9a-f]+|\d+)|amp|quot|apos|lt|gt);/gi, (entity, token: string) => {
+    const normalized = token.toLowerCase();
+    if (normalized === "amp") return "&";
+    if (normalized === "quot") return '"';
+    if (normalized === "apos") return "'";
+    if (normalized === "lt") return "<";
+    if (normalized === "gt") return ">";
+    const codePoint = normalized.startsWith("#x")
+      ? Number.parseInt(normalized.slice(2), 16)
+      : Number.parseInt(normalized.slice(1), 10);
+    return Number.isFinite(codePoint) && codePoint >= 0 && codePoint <= 0x10ffff
+      ? String.fromCodePoint(codePoint)
+      : entity;
+  });
+
+const canonicalNodeId = (value: string): string => {
+  const normalized = value.trim().toLowerCase();
+  return normalized.startsWith("!") ? normalized : `!${normalized}`;
+};
+
+const nodeFromEventData = (data: string): MeshstellarNode | null => {
+  const match = data.match(/\bdata-geojson="([^"]+)"/i);
+  if (!match?.[1]) return null;
+  try {
+    const feature = JSON.parse(decodeHtmlAttribute(match[1])) as MeshstellarFeature;
+    const coordinates = feature.geometry?.coordinates;
+    if (!Array.isArray(coordinates) || coordinates.length < 2) return null;
+    const lon = Number(coordinates[0]);
+    const lat = Number(coordinates[1]);
+    if (!Number.isFinite(lat) || !Number.isFinite(lon) || Math.abs(lat) > 90 || Math.abs(lon) > 180) return null;
+    const id = toStringOrUndefined(feature.properties?.id);
+    if (!id) return null;
+    const altitude = Number(coordinates[2]);
+    const updatedAtSec = Number(feature.properties?.updated_at);
+    return {
+      nodeId: canonicalNodeId(id),
+      longName: toStringOrUndefined(feature.properties?.long_name),
+      shortName: toStringOrUndefined(feature.properties?.display_name),
+      lat,
+      lon,
+      altitudeM: Number.isFinite(altitude) ? altitude : undefined,
+      updatedAt: Number.isFinite(updatedAtSec) && updatedAtSec > 0 ? updatedAtSec * 1000 : undefined,
+    };
+  } catch {
+    return null;
+  }
+};
+
+export const parseMeshstellarSnapshot = (payload: string): MeshstellarNode[] => {
+  const nodes = new Map<string, MeshstellarNode>();
+  const normalized = payload.replaceAll("\r\n", "\n");
+  for (const block of normalized.split("\n\n")) {
+    let eventType = "message";
+    const data: string[] = [];
+    for (const line of block.split("\n")) {
+      if (line.startsWith("event:")) eventType = line.slice(6).trim();
+      if (line.startsWith("data:")) data.push(line.slice(5).replace(/^ /, ""));
+    }
+    if (eventType !== "update-node") continue;
+    const node = nodeFromEventData(data.join("\n"));
+    if (!node) continue;
+    const current = nodes.get(node.nodeId);
+    if (!current || (node.updatedAt ?? 0) >= (current.updatedAt ?? 0)) nodes.set(node.nodeId, node);
+  }
+  return Array.from(nodes.values()).sort((a, b) => a.nodeId.localeCompare(b.nodeId));
+};
+
+export const readMeshstellarSnapshot = async (body: ReadableStream<Uint8Array>): Promise<MeshstellarNode[]> => {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  const startedAt = Date.now();
+  let lastDataAt = startedAt;
+  let payload = "";
+  let bytesRead = 0;
+  try {
+    while (Date.now() - startedAt < SNAPSHOT_MAX_MS) {
+      const waitMs = payload.includes("event: update-node")
+        ? Math.max(1, SNAPSHOT_IDLE_MS - (Date.now() - lastDataAt))
+        : Math.max(1, SNAPSHOT_MAX_MS - (Date.now() - startedAt));
+      const outcome = await Promise.race([
+        reader.read().then((result) => ({ type: "read" as const, result })),
+        new Promise<{ type: "timeout" }>((resolve) => setTimeout(() => resolve({ type: "timeout" }), waitMs)),
+      ]);
+      if (outcome.type === "timeout") break;
+      if (outcome.result.done) {
+        payload += decoder.decode();
+        break;
+      }
+      bytesRead += outcome.result.value.byteLength;
+      if (bytesRead > MAX_STREAM_BYTES) throw new Error("Meshstellar snapshot exceeded the size limit");
+      payload += decoder.decode(outcome.result.value, { stream: true });
+      lastDataAt = Date.now();
+    }
+  } finally {
+    await reader.cancel().catch(() => undefined);
+  }
+  const nodes = parseMeshstellarSnapshot(payload);
+  if (!nodes.length) throw new Error("Meshstellar returned no positioned nodes");
+  return nodes;
+};
+
+const parsePerMinuteLimit = (raw: string | undefined, fallback: number): number => {
+  const parsed = Number(raw ?? "");
+  return Number.isFinite(parsed) ? Math.max(1, Math.floor(parsed)) : fallback;
+};
+
+export const onRequest: PagesFunction<Env> = async ({ request, env }) => {
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return new Response("Method not allowed", { status: 405, headers: { "cache-control": "no-store" } });
+  }
+
+  const cacheKey = new Request(new URL(request.url).origin + "/node-sources/868-no", { method: "GET" });
+  const cache = caches.default;
+  const cached = await cache.match(cacheKey);
+  if (cached) return request.method === "HEAD" ? new Response(null, cached) : cached;
+
+  const limiter = takeRateLimitToken({
+    key: `node-source:868-no:${getClientAddress(request)}`,
+    limit: parsePerMinuteLimit(env.PROXY_RATE_LIMIT_PER_MINUTE, 30),
+  });
+  if (!limiter.allowed) {
+    return new Response("Rate limit reached", {
+      status: 429,
+      headers: { "cache-control": "no-store", "retry-after": String(limiter.retryAfterSec) },
+    });
+  }
+
+  try {
+    const upstream = await fetch(UPSTREAM_URL, {
+      headers: { accept: "text/event-stream" },
+    });
+    if (!upstream.ok || !upstream.body) throw new Error(`Meshstellar snapshot failed (${upstream.status})`);
+    const nodes = await readMeshstellarSnapshot(upstream.body);
+    const response = new Response(request.method === "HEAD" ? null : JSON.stringify(nodes), {
+      status: 200,
+      headers: {
+        "cache-control": `public, max-age=60, s-maxage=${CACHE_TTL_SEC}`,
+        "content-type": "application/json; charset=utf-8",
+      },
+    });
+    await cache.put(cacheKey, new Response(JSON.stringify(nodes), response));
+    return response;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Meshstellar snapshot failed";
+    return new Response(message, { status: 502, headers: { "cache-control": "no-store" } });
+  }
+};

--- a/src/components/MapView.overlayHandoff.test.tsx
+++ b/src/components/MapView.overlayHandoff.test.tsx
@@ -115,7 +115,8 @@ vi.mock("react-map-gl/maplibre", async () => {
   };
 });
 
-vi.mock("../lib/meshtasticMqtt", () => ({
+vi.mock("../lib/meshtasticMqtt", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/meshtasticMqtt")>()),
   fetchMeshmapNodes: vi.fn(async () => ({
     fromCache: false,
     networkError: false,

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -40,7 +40,13 @@ import { useAppStore } from "../store/appStore";
 import { isAutomaticCalculationLocked, useCoverageStore } from "../store/coverageStore";
 import { TERRAIN_DATASET_LABEL } from "../lib/terrainDataset";
 import type { Link, Site } from "../types/radio";
-import { fetchMeshmapNodes, type MeshmapNode } from "../lib/meshtasticMqtt";
+import {
+  fetchMeshmapNodes,
+  mergeMeshmapNodes,
+  NODE_FEED_SOURCES,
+  type MeshmapNode,
+  type NodeFeedSourceId,
+} from "../lib/meshtasticMqtt";
 import { canShowSaveSelectedLinkAction } from "../lib/selectedPairActions";
 import {
   optionsForSelectionCount,
@@ -870,10 +876,14 @@ export function MapView({
   const [isDraggingSite, setIsDraggingSite] = useState(false);
   const [siteDraftStatus, setSiteDraftStatus] = useState<string | null>(null);
   const [showDiscoverySites, setShowDiscoverySites] = useState(false);
-  const [showDiscoveryMqtt, setShowDiscoveryMqtt] = useState(false);
+  const [showMeshmapFeed, setShowMeshmapFeed] = useState(false);
+  const [show868NoFeed, setShow868NoFeed] = useState(false);
   const [visibleSiteSourcesOpen, setVisibleSiteSourcesOpen] = useState(false);
-  const [mqttNodes, setMqttNodes] = useState<MeshmapNode[]>([]);
-  const [mqttLoadStatus, setMqttLoadStatus] = useState<string | null>(null);
+  const [nodeSourceLoads, setNodeSourceLoads] = useState<Partial<Record<NodeFeedSourceId, {
+    status: "loading" | "loaded" | "failed";
+    nodes: MeshmapNode[];
+    message?: string;
+  }>>>({});
   const [overlayHoverInfo, setOverlayHoverInfo] = useState<MapInspectorHoverInfo | null>(null);
   const [panoramaInteraction, setPanoramaInteraction] = useState<PanoramaInteractionState | null>(null);
   const [selectedDiscoveryLibraryEntryId, setSelectedDiscoveryLibraryEntryId] = useState<string | null>(null);
@@ -904,6 +914,23 @@ export function MapView({
     pitch: number;
   } | null>(null);
   const editorDraftAnimationKeyRef = useRef("");
+  const enabledNodeSourceIds = useMemo<NodeFeedSourceId[]>(() => [
+    ...(showMeshmapFeed ? ["meshmap" as const] : []),
+    ...(show868NoFeed ? ["868-no" as const] : []),
+  ], [show868NoFeed, showMeshmapFeed]);
+  const showDiscoveryMqtt = enabledNodeSourceIds.length > 0;
+  const mqttNodes = useMemo(
+    () => mergeMeshmapNodes(enabledNodeSourceIds.map((sourceId) => nodeSourceLoads[sourceId]?.nodes ?? [])),
+    [enabledNodeSourceIds, nodeSourceLoads],
+  );
+  const mqttLoadStatus = useMemo(() => {
+    const enabledLoads = enabledNodeSourceIds.map((sourceId) => nodeSourceLoads[sourceId]);
+    if (enabledLoads.some((load) => load?.status === "loading")) return "Loading node sources...";
+    const failed = enabledLoads.filter((load) => load?.status === "failed");
+    if (failed.length) return `Node source load failed: ${failed.map((load) => load?.message).filter(Boolean).join("; ")}`;
+    const cachedWarnings = enabledLoads.map((load) => load?.message).filter(Boolean);
+    return cachedWarnings.length ? cachedWarnings.join("; ") : null;
+  }, [enabledNodeSourceIds, nodeSourceLoads]);
 
   const stopUserLocation = useCallback(() => {
     if (userLocationWatchIdRef.current !== null && navigator.geolocation) {
@@ -1190,29 +1217,38 @@ export function MapView({
   );
 
   useEffect(() => {
-    if (!showDiscoveryMqtt) return;
-    if (mqttNodes.length) return;
-    let canceled = false;
-    setMqttLoadStatus("Loading MQTT nodes...");
-    void fetchMeshmapNodes({ cacheTtlMs: 30 * 60 * 1000 })
-      .then((result) => {
-        if (canceled) return;
-        setMqttNodes(result.nodes);
-        if (result.fromCache && result.networkError) {
-          const ageMin = Math.max(1, Math.round((result.cacheAgeMs ?? 0) / 60_000));
-          setMqttLoadStatus(`Live fetch failed — showing ${result.nodes.length} cached node(s) from ${ageMin} min ago.`);
-        } else {
-          setMqttLoadStatus(null);
-        }
-      })
-      .catch((error) => {
-        if (canceled) return;
-        setMqttLoadStatus(`MQTT load failed: ${getUiErrorMessage(error)}`);
+    const pendingSourceIds = enabledNodeSourceIds.filter((sourceId) => !nodeSourceLoads[sourceId]);
+    if (!pendingSourceIds.length) return;
+    setNodeSourceLoads((current) => {
+      const next = { ...current };
+      for (const sourceId of pendingSourceIds) next[sourceId] = { status: "loading", nodes: [] };
+      return next;
+    });
+    void Promise.allSettled(pendingSourceIds.map(async (sourceId) => {
+      const source = NODE_FEED_SOURCES[sourceId];
+      const result = await fetchMeshmapNodes({
+        sourceId,
+        sourceUrl: source.sourceUrl,
+        cacheTtlMs: 30 * 60 * 1000,
       });
-    return () => {
-      canceled = true;
-    };
-  }, [showDiscoveryMqtt, mqttNodes.length]);
+      const message = result.fromCache && result.networkError
+        ? `${source.label} live fetch failed — showing ${result.nodes.length} cached node(s) from ${Math.max(1, Math.round((result.cacheAgeMs ?? 0) / 60_000))} min ago.`
+        : undefined;
+      return { sourceId, nodes: result.nodes, message };
+    })).then((results) => {
+      setNodeSourceLoads((current) => {
+        const next = { ...current };
+        results.forEach((result, index) => {
+          const sourceId = pendingSourceIds[index];
+          if (!sourceId) return;
+          next[sourceId] = result.status === "fulfilled"
+            ? { status: "loaded", nodes: result.value.nodes, message: result.value.message }
+            : { status: "failed", nodes: [], message: getUiErrorMessage(result.reason) };
+        });
+        return next;
+      });
+    });
+  }, [enabledNodeSourceIds, nodeSourceLoads]);
   useEffect(() => {
     const previousSelectionCount = previousSelectionCountRef.current;
     previousSelectionCountRef.current = selectionCount;
@@ -3070,7 +3106,7 @@ export function MapView({
         insertIntoSimulation: true,
         sourceMeta: {
           sourceType: "mqtt-feed",
-          sourceUrl: "/meshmap/nodes.json",
+          sourceUrl: node.sourceUrl ?? NODE_FEED_SOURCES.meshmap.sourceUrl,
           nodeId: node.nodeId,
           longName: node.longName,
           shortName: node.shortName,
@@ -3112,7 +3148,7 @@ export function MapView({
         insertIntoSimulation: true,
         sourceMeta: {
           sourceType: "mqtt-feed",
-          sourceUrl: "/meshmap/nodes.json",
+          sourceUrl: node.sourceUrl ?? NODE_FEED_SOURCES.meshmap.sourceUrl,
           nodeId: node.nodeId,
           longName: node.longName,
           shortName: node.shortName,
@@ -3220,20 +3256,25 @@ export function MapView({
     setCoverageVizMode(selectionCount === 1 ? "passfail" : selectionCount === 2 ? "relay" : "heatmap");
   }, [allowedOverlayModes, coverageVizMode, selectionCount, setCoverageVizMode]);
   const simulationOverlaySelectValue = coverageVizMode;
-  const visibleSiteSourceSummary =
-    showDiscoverySites && showDiscoveryMqtt
-      ? "Simulation + Library + MQTT"
-      : showDiscoverySites
-        ? "Simulation + Library"
-        : showDiscoveryMqtt
-          ? "Simulation + MQTT"
-          : "Simulation only";
-  const setVisibleSiteSource = useCallback((source: "library" | "mqtt", visible: boolean) => {
+  const visibleSiteSourceLabels = [
+    "Simulation",
+    ...(showDiscoverySites ? ["Library"] : []),
+    ...(showMeshmapFeed ? [NODE_FEED_SOURCES.meshmap.label] : []),
+    ...(show868NoFeed ? [NODE_FEED_SOURCES["868-no"].label] : []),
+  ];
+  const visibleSiteSourceSummary = visibleSiteSourceLabels.length === 1
+    ? "Simulation only"
+    : visibleSiteSourceLabels.join(" + ");
+  const setVisibleSiteSource = useCallback((source: "library" | NodeFeedSourceId, visible: boolean) => {
     if (source === "library") {
       setShowDiscoverySites(visible);
       return;
     }
-    setShowDiscoveryMqtt(visible);
+    if (source === "meshmap") {
+      setShowMeshmapFeed(visible);
+      return;
+    }
+    setShow868NoFeed(visible);
   }, []);
   const selectedSite = selectedSites[0] ?? null;
   const selectedDiscoveryLibraryEntry =
@@ -3533,7 +3574,7 @@ export function MapView({
           {showDiscoveryMqtt && mqttLoadStatus ? (
             <div className="map-inspector-section">
               <p className="map-inspector-line">{mqttLoadStatus}</p>
-              {mqttLoadStatus === "Loading MQTT nodes..." ? (
+              {mqttLoadStatus.startsWith("Loading") ? (
                 <div className="map-progress-track">
                   <div className="map-progress-fill map-progress-fill-indeterminate" />
                 </div>
@@ -3542,8 +3583,13 @@ export function MapView({
                   <ActionButton
                     aria-label="Retry MQTT load"
                     onClick={() => {
-                      setMqttNodes([]);
-                      setMqttLoadStatus(null);
+                      setNodeSourceLoads((current) => {
+                        const next = { ...current };
+                        for (const sourceId of enabledNodeSourceIds) {
+                          if (next[sourceId]?.status === "failed") delete next[sourceId];
+                        }
+                        return next;
+                      });
                     }}
                   >
                     <RefreshCw aria-hidden="true" size={12} strokeWidth={2} />
@@ -3752,7 +3798,7 @@ export function MapView({
                 </div>
                 <FloatingPopover
                   className="visible-site-sources-popover"
-                  estimatedHeight={120}
+                  estimatedHeight={150}
                   estimatedWidth={240}
                   onClose={() => setVisibleSiteSourcesOpen(false)}
                   open={visibleSiteSourcesOpen}
@@ -3772,11 +3818,19 @@ export function MapView({
                       </label>
                       <label className="checkbox-field visible-site-source-option">
                         <input
-                          checked={showDiscoveryMqtt}
-                          onChange={(event) => setVisibleSiteSource("mqtt", event.currentTarget.checked)}
+                          checked={showMeshmapFeed}
+                          onChange={(event) => setVisibleSiteSource("meshmap", event.currentTarget.checked)}
                           type="checkbox"
                         />
-                        <span>MQTT</span>
+                        <span>{NODE_FEED_SOURCES.meshmap.label}</span>
+                      </label>
+                      <label className="checkbox-field visible-site-source-option">
+                        <input
+                          checked={show868NoFeed}
+                          onChange={(event) => setVisibleSiteSource("868-no", event.currentTarget.checked)}
+                          type="checkbox"
+                        />
+                        <span>{NODE_FEED_SOURCES["868-no"].label}</span>
                       </label>
                     </div>
                   </div>

--- a/src/components/MapView.userLocation.test.tsx
+++ b/src/components/MapView.userLocation.test.tsx
@@ -73,8 +73,9 @@ vi.mock("react-map-gl/maplibre", async () => {
   };
 });
 
-vi.mock("../lib/meshtasticMqtt", () => ({
-  fetchMeshmapNodes: vi.fn(async () => ({
+vi.mock("../lib/meshtasticMqtt", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/meshtasticMqtt")>()),
+  fetchMeshmapNodes: vi.fn(async (options?: { sourceId?: "meshmap" | "868-no"; sourceUrl?: string }) => ({
     fromCache: false,
     networkError: false,
     nodes: [
@@ -86,6 +87,8 @@ vi.mock("../lib/meshtasticMqtt", () => ({
         lat: 60.55,
         lon: 11.55,
         updatedAt: 1,
+        sourceId: options?.sourceId,
+        sourceUrl: options?.sourceUrl,
       },
     ],
   })),
@@ -463,10 +466,11 @@ describe("MapView user location flow", () => {
     expect(surface).toHaveClass("has-pointer-tail");
     expect(surface).toHaveClass("visible-site-sources-popover");
     expect(within(popover).getByLabelText("Library")).not.toBeChecked();
-    expect(within(popover).getByLabelText("MQTT")).not.toBeChecked();
+    expect(within(popover).getByLabelText("MeshMap.net")).not.toBeChecked();
+    expect(within(popover).getByLabelText("868.no")).not.toBeChecked();
   });
 
-  it("keeps Library visible when MQTT is also enabled", async () => {
+  it("keeps Library visible when 868.no is also enabled", async () => {
     useAppStore.setState({
       siteLibrary: [
         {
@@ -494,10 +498,13 @@ describe("MapView user location flow", () => {
     fireEvent.click(within(popover).getByLabelText("Library"));
     expect(screen.getByRole("button", { name: "Library Alpha" })).toBeInTheDocument();
 
-    fireEvent.click(within(popover).getByLabelText("MQTT"));
+    fireEvent.click(within(popover).getByLabelText("868.no"));
 
     expect(screen.getByRole("button", { name: "Library Alpha" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Simulation + Library + MQTT" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Simulation + Library + 868.no" })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText("Loading node sources...")).not.toBeInTheDocument();
+    });
     await waitFor(() => {
       expect(useAppStore.getState().discoveryLibraryVisible).toBe(true);
       expect(useAppStore.getState().discoveryMqttVisible).toBe(true);

--- a/src/lib/meshtasticMqtt.test.ts
+++ b/src/lib/meshtasticMqtt.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { mergeMeshmapNodes, parseMeshmapLikeFeed } from "./meshtasticMqtt";
+
+describe("node feed normalization", () => {
+  it("normalizes legacy MeshMap and normalized adapter payloads", () => {
+    expect(
+      parseMeshmapLikeFeed({
+        "!meshmap": {
+          longName: "MeshMap node",
+          latitude: 601000000,
+          longitude: 102000000,
+          altitude: 123,
+          lastMapReport: 1_800_000_000,
+        },
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        nodeId: "!meshmap",
+        lat: 60.1,
+        lon: 10.2,
+        updatedAt: 1_800_000_000_000,
+      }),
+    ]);
+
+    expect(
+      parseMeshmapLikeFeed([
+        { nodeId: "!norway", longName: "Norway node", lat: 61.2, lon: 11.3, updatedAt: 1_800_000_200_000 },
+      ]),
+    ).toEqual([
+      expect.objectContaining({ nodeId: "!norway", lat: 61.2, lon: 11.3, updatedAt: 1_800_000_200_000 }),
+    ]);
+  });
+
+  it("deduplicates enabled sources by canonical node id and prefers the newest report", () => {
+    expect(
+      mergeMeshmapNodes([
+        [
+          { nodeId: "!ABC123", longName: "Older", lat: 60, lon: 10, updatedAt: 100 },
+        ],
+        [
+          { nodeId: "abc123", longName: "Newer", lat: 61, lon: 11, updatedAt: 200 },
+          { nodeId: "!other", longName: "Other", lat: 62, lon: 12 },
+        ],
+      ]),
+    ).toEqual([
+      expect.objectContaining({ nodeId: "!abc123", longName: "Newer" }),
+      expect.objectContaining({ nodeId: "!other" }),
+    ]);
+  });
+});

--- a/src/lib/meshtasticMqtt.ts
+++ b/src/lib/meshtasticMqtt.ts
@@ -7,6 +7,22 @@ export type MeshmapNode = {
   lat: number;
   lon: number;
   altitudeM?: number;
+  updatedAt?: number;
+  sourceId?: NodeFeedSourceId;
+  sourceUrl?: string;
+};
+
+export type NodeFeedSourceId = "meshmap" | "868-no";
+
+export type NodeFeedSource = {
+  id: NodeFeedSourceId;
+  label: string;
+  sourceUrl: string;
+};
+
+export const NODE_FEED_SOURCES: Record<NodeFeedSourceId, NodeFeedSource> = {
+  meshmap: { id: "meshmap", label: "MeshMap.net", sourceUrl: "/meshmap/nodes.json" },
+  "868-no": { id: "868-no", label: "868.no", sourceUrl: "/node-sources/868-no" },
 };
 
 type MeshmapNodeRaw = {
@@ -17,6 +33,10 @@ type MeshmapNodeRaw = {
   latitude?: unknown;
   longitude?: unknown;
   altitude?: unknown;
+  altitudeM?: unknown;
+  lat?: unknown;
+  lon?: unknown;
+  updatedAt?: unknown;
   precision?: unknown;
   seenBy?: unknown;
   lastMapReport?: unknown;
@@ -32,6 +52,7 @@ type MeshmapCache = {
 
 type MeshmapFetchOptions = {
   sourceUrl?: string;
+  sourceId?: NodeFeedSourceId;
   cacheTtlMs?: number;
 };
 
@@ -45,6 +66,7 @@ export type MeshmapFetchResult = {
 
 const DEFAULT_MESHMAP_FEED_URL = "/meshmap/nodes.json";
 const MESHMAP_CACHE_KEY = "rmw-meshmap-cache-v1";
+const NODE_SOURCE_CACHE_KEY_PREFIX = "rmw-node-source-cache-v1";
 const MESHMAP_SOURCE_URL_KEY = "rmw-meshmap-source-url-v1";
 
 const toNumber = (value: unknown): number | null => {
@@ -55,9 +77,14 @@ const toNumber = (value: unknown): number | null => {
 const toStringOrUndefined = (value: unknown): string | undefined =>
   typeof value === "string" && value.trim().length ? value : undefined;
 
-const readCache = (): MeshmapCache | null => {
+const cacheKeyFor = (sourceUrl: string): string =>
+  sourceUrl === DEFAULT_MESHMAP_FEED_URL
+    ? MESHMAP_CACHE_KEY
+    : `${NODE_SOURCE_CACHE_KEY_PREFIX}:${sourceUrl}`;
+
+const readCache = (sourceUrl: string): MeshmapCache | null => {
   try {
-    const raw = localStorage.getItem(MESHMAP_CACHE_KEY);
+    const raw = localStorage.getItem(cacheKeyFor(sourceUrl));
     if (!raw) return null;
     const parsed = JSON.parse(raw) as MeshmapCache;
     if (!Number.isFinite(parsed.savedAt)) return null;
@@ -76,34 +103,58 @@ const writeCache = (sourceUrl: string, nodes: MeshmapNode[]): void => {
       sourceUrl,
       nodes,
     };
-    localStorage.setItem(MESHMAP_CACHE_KEY, JSON.stringify(payload));
+    localStorage.setItem(cacheKeyFor(sourceUrl), JSON.stringify(payload));
   } catch {
     // Best effort cache.
   }
 };
 
 const parseNode = (nodeId: string, node: MeshmapNodeRaw): MeshmapNode | null => {
-  const latI = toNumber(node.latitude);
-  const lonI = toNumber(node.longitude);
+  const normalizedLat = toNumber(node.lat);
+  const normalizedLon = toNumber(node.lon);
+  const latI = normalizedLat ?? toNumber(node.latitude);
+  const lonI = normalizedLon ?? toNumber(node.longitude);
   if (latI === null || lonI === null) return null;
-  const lat = latI / 10_000_000;
-  const lon = lonI / 10_000_000;
+  const lat = normalizedLat === null ? latI / 10_000_000 : normalizedLat;
+  const lon = normalizedLon === null ? lonI / 10_000_000 : normalizedLon;
   if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
   if (Math.abs(lat) > 90 || Math.abs(lon) > 180) return null;
 
+  const updatedAt = toTimestampMs(node.updatedAt ?? node.lastMapReport);
   return {
-    nodeId,
+    nodeId: canonicalNodeId(nodeId),
     longName: toStringOrUndefined(node.longName),
     shortName: toStringOrUndefined(node.shortName),
     hwModel: toStringOrUndefined(node.hwModel),
     role: toStringOrUndefined(node.role),
     lat,
     lon,
-    altitudeM: toNumber(node.altitude) ?? undefined,
+    altitudeM: toNumber(node.altitudeM ?? node.altitude) ?? undefined,
+    updatedAt: updatedAt ?? undefined,
   };
 };
 
-const parseMeshmapLikeFeed = (payload: unknown): MeshmapNode[] => {
+const canonicalNodeId = (nodeId: string): string => {
+  const normalized = nodeId.trim().toLowerCase();
+  if (normalized.startsWith("!")) return normalized;
+  return /^[a-f0-9]+$/.test(normalized) ? `!${normalized}` : normalized;
+};
+
+const toTimestampMs = (value: unknown): number | null => {
+  if (typeof value === "string" && value.trim()) {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) {
+      const parsed = Date.parse(value);
+      return Number.isFinite(parsed) ? parsed : null;
+    }
+    value = numeric;
+  }
+  const numeric = toNumber(value);
+  if (numeric === null || numeric <= 0) return null;
+  return numeric < 10_000_000_000 ? numeric * 1000 : numeric;
+};
+
+export const parseMeshmapLikeFeed = (payload: unknown): MeshmapNode[] => {
   const out: MeshmapNode[] = [];
   if (payload && typeof payload === "object" && !Array.isArray(payload)) {
     for (const [nodeId, node] of Object.entries(payload as Record<string, MeshmapNodeRaw>)) {
@@ -121,6 +172,21 @@ const parseMeshmapLikeFeed = (payload: unknown): MeshmapNode[] => {
     }
   }
   return out.sort((a, b) => a.nodeId.localeCompare(b.nodeId));
+};
+
+export const mergeMeshmapNodes = (sources: MeshmapNode[][]): MeshmapNode[] => {
+  const merged = new Map<string, MeshmapNode>();
+  for (const nodes of sources) {
+    for (const node of nodes) {
+      const nodeId = canonicalNodeId(node.nodeId);
+      const candidate = { ...node, nodeId };
+      const current = merged.get(nodeId);
+      if (!current || (candidate.updatedAt ?? 0) >= (current.updatedAt ?? 0)) {
+        merged.set(nodeId, candidate);
+      }
+    }
+  }
+  return Array.from(merged.values()).sort((a, b) => a.nodeId.localeCompare(b.nodeId));
 };
 
 export const getDefaultMeshmapFeedUrl = (): string => DEFAULT_MESHMAP_FEED_URL;
@@ -145,7 +211,7 @@ export const savePreferredMeshmapSourceUrl = (sourceUrl: string): void => {
 };
 
 export const getCachedMeshmapSnapshotInfo = (): { sourceUrl: string; savedAt: number; nodeCount: number } | null => {
-  const cache = readCache();
+  const cache = readCache(DEFAULT_MESHMAP_FEED_URL);
   if (!cache) return null;
   return {
     sourceUrl: cache.sourceUrl,
@@ -157,14 +223,18 @@ export const getCachedMeshmapSnapshotInfo = (): { sourceUrl: string; savedAt: nu
 export const fetchMeshmapNodes = async (options: MeshmapFetchOptions = {}): Promise<MeshmapFetchResult> => {
   const sourceUrl = options.sourceUrl?.trim() || readPreferredMeshmapSourceUrl();
   const cacheTtlMs = options.cacheTtlMs ?? 12 * 60 * 60 * 1000;
-  const cached = readCache();
+  const cached = readCache(sourceUrl);
   try {
     const response = await fetch(sourceUrl, { cache: "no-store" });
     if (!response.ok) {
       throw new Error(`Feed error: ${response.status}`);
     }
     const payload = (await response.json()) as unknown;
-    const nodes = parseMeshmapLikeFeed(payload);
+    const nodes = parseMeshmapLikeFeed(payload).map((node) => ({
+      ...node,
+      sourceId: options.sourceId,
+      sourceUrl,
+    }));
     if (!nodes.length) {
       throw new Error("Feed parsed but returned no usable nodes");
     }
@@ -177,7 +247,7 @@ export const fetchMeshmapNodes = async (options: MeshmapFetchOptions = {}): Prom
   } catch (error) {
     if (
       cached &&
-      (cached.sourceUrl === sourceUrl || cached.sourceUrl === DEFAULT_MESHMAP_FEED_URL) &&
+      cached.sourceUrl === sourceUrl &&
       Date.now() - cached.savedAt <= cacheTtlMs &&
       cached.nodes.length
     ) {

--- a/src/lib/migrations.test.ts
+++ b/src/lib/migrations.test.ts
@@ -197,6 +197,7 @@ describe("migrations", () => {
 
     setStoredVersion("0.9.0");
     localStorage.setItem("rmw-meshmap-cache-v1", JSON.stringify({ savedAt: Date.now(), nodes: [] }));
+    localStorage.setItem("rmw-node-source-cache-v1:/node-sources/868-no", JSON.stringify({ savedAt: Date.now(), nodes: [] }));
     localStorage.setItem("rmw-storage-health-v1", JSON.stringify({ ok: true }));
     localStorage.setItem("linksim-copernicus-tilelist-v1", JSON.stringify({ copernicus30: {} }));
     localStorage.setItem("linksim-copernicus-tile-index-v1", JSON.stringify({ copernicus30: {} }));
@@ -207,6 +208,7 @@ describe("migrations", () => {
 
     expect(result.migrated).toBe(true);
     expect(localStorage.getItem("rmw-meshmap-cache-v1")).toBe(null);
+    expect(localStorage.getItem("rmw-node-source-cache-v1:/node-sources/868-no")).toBe(null);
     expect(localStorage.getItem("rmw-storage-health-v1")).toBe(null);
     expect(localStorage.getItem("linksim-copernicus-tilelist-v1")).not.toBe(null);
     expect(localStorage.getItem("linksim-copernicus-tile-index-v1")).not.toBe(null);

--- a/src/lib/migrations.ts
+++ b/src/lib/migrations.ts
@@ -38,6 +38,7 @@ const CLIENT_STORAGE_RULES: ClientStorageRule[] = [
   { scope: "localStorage", policy: "preserve", key: "linksim-basemap-style-preset-v1" },
   { scope: "localStorage", policy: "preserve", key: "linksim-panorama-settings-v1" },
   { scope: "localStorage", policy: "resetOnVersionChange", key: "rmw-meshmap-cache-v1" },
+  { scope: "localStorage", policy: "resetOnVersionChange", prefix: "rmw-node-source-cache-v1:" },
   { scope: "localStorage", policy: "preserve", key: "rmw-meshmap-source-url-v1" },
   { scope: "localStorage", policy: "preserve", key: "linksim-copernicus-tilelist-v1" },
   { scope: "localStorage", policy: "preserve", key: "linksim-copernicus-tile-index-v1" },


### PR DESCRIPTION
## Summary

- add a stateless, cached edge adapter that reads the initial Meshstellar SSE snapshot from map.868.no
- expose 868.no and MeshMap.net independently through the existing Visible Sites source selector
- normalize and merge enabled feeds, deduplicating canonical Meshtastic node IDs by newest report
- keep source-specific client caches and preserve source attribution when opening a node as a Site draft

## Why

868.no publishes the complete Norwegian node database through Meshstellar's initial SSE burst. Reading that burst on demand avoids continuously monitoring the MQTT broker while still exposing all regions as one source.

## Impact

Users can enable 868.no as a separate source and see all positioned nodes available in the shared snapshot. Existing MeshMap.net behavior remains available independently. The edge result is cached for five minutes and requests are rate-limited.

## Verification

- `npm test` — 126 files, 699 tests passed
- `npm run build`
- `npm run lint`
- `git diff --check`
- local edge/browser QA: 455 normalized positioned nodes returned; 100 rendered in the current Oslo-area view; source summary changed to `Simulation + 868.no`
- local dev-server guard confirmed no server left running

Addresses #954