### PR TITLE
Refine Library modal navigation and actions

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -2317,13 +2317,15 @@ export function AppShell() {
           onClose={closeLibrary}
           suspended={mapEditor?.origin?.kind === "library"}
         >
-          <LibraryPanel
-            initialTab={libraryRequest.tab}
-            isMobile={isMobileViewport}
-            onClose={closeLibrary}
-            onOpenUserProfile={(userId, anchor) => setProfileTarget({ anchor, userId })}
-            readOnly={!canPersistWorkspace}
-          />
+          <div className="library-manager-card settings-panel-wrapper library-panel-wrapper">
+            <LibraryPanel
+              initialTab={libraryRequest.tab}
+              isMobile={isMobileViewport}
+              onClose={closeLibrary}
+              onOpenUserProfile={(userId, anchor) => setProfileTarget({ anchor, userId })}
+              readOnly={!canPersistWorkspace}
+            />
+          </div>
         </ModalOverlay>
       ) : null}
       {showShareModal ? (

--- a/src/components/LibraryPanel.css.test.ts
+++ b/src/components/LibraryPanel.css.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("Library panel responsive styling", () => {
+  const stylesheet = readFileSync(resolve(process.cwd(), "src/index.css"), "utf8");
+
+  it("uses opaque Settings surfaces for the Library shell and results", () => {
+    expect(stylesheet).toMatch(/\.library-panel\s*\{[^}]*background:\s*var\(--surface\)/s);
+    expect(stylesheet).toMatch(/\.library-panel-sidebar\s*\{[^}]*background:\s*var\(--surface-2\)/s);
+    expect(stylesheet).toMatch(/\.library-unified-list\s*\{[^}]*background:\s*var\(--surface-2\)/s);
+  });
+
+  it("sizes desktop Site selection checkboxes to 28 pixels", () => {
+    expect(stylesheet).toMatch(/\.library-site-select\s*\{[^}]*width:\s*28px[^}]*height:\s*28px/s);
+  });
+});

--- a/src/components/LibraryPanel.test.tsx
+++ b/src/components/LibraryPanel.test.tsx
@@ -87,36 +87,91 @@ describe("LibraryPanel", () => {
     });
   });
 
-  it("keeps search visible and remembers separate search state for each tab", async () => {
+  it("keeps search visible and remembers separate search state for each section", async () => {
     const user = userEvent.setup();
     render(<LibraryPanel initialTab="sites" isMobile={false} onClose={vi.fn()} readOnly={false} />);
 
-    const sitesTab = screen.getByRole("tab", { name: "Sites" });
-    const simulationsTab = screen.getByRole("tab", { name: "Simulations" });
-    expect(sitesTab).toHaveAttribute("aria-selected", "true");
+    const sectionNav = screen.getByRole("navigation", { name: "Library sections" });
+    const sitesSection = within(sectionNav).getByRole("button", { name: "Sites" });
+    const simulationsSection = within(sectionNav).getByRole("button", { name: "Simulations" });
+    expect(sitesSection).toHaveAttribute("aria-current", "page");
 
     const search = screen.getByRole("searchbox", { name: "Search Sites" });
     await user.type(search, "ridge");
-    await user.click(simulationsTab);
+    await user.click(simulationsSection);
     const simulationSearch = screen.getByRole("searchbox", { name: "Search Simulations" });
     expect(simulationSearch).toHaveValue("");
     await user.type(simulationSearch, "valley");
 
-    await user.click(sitesTab);
+    await user.click(sitesSection);
     expect(screen.getByRole("searchbox", { name: "Search Sites" })).toHaveValue("ridge");
   });
 
-  it("opens item details from the item body and keeps Add as a separate action", async () => {
+  it("uses the Settings-style mobile section list without losing section state", async () => {
     const user = userEvent.setup();
     render(<LibraryPanel initialTab="sites" isMobile onClose={vi.fn()} readOnly={false} />);
 
-    await user.click(screen.getByRole("button", { name: "Open Site details: Ridge Site" }));
+    const search = screen.getByRole("searchbox", { name: "Search Sites" });
+    await user.type(search, "ridge");
+    await user.click(screen.getByRole("button", { name: "Open Library sections" }));
+
+    expect(screen.queryByRole("searchbox", { name: "Search Sites" })).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /Simulations/i }));
+    expect(screen.getByRole("searchbox", { name: "Search Simulations" })).toBeVisible();
+
+    await user.click(screen.getByRole("button", { name: "Open Library sections" }));
+    await user.click(screen.getByRole("button", { name: /Sites/i }));
+    expect(screen.getByRole("searchbox", { name: "Search Sites" })).toHaveValue("ridge");
+  });
+
+  it("restores each section's results scroll position after using the mobile menu", async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <LibraryPanel initialTab="sites" isMobile onClose={vi.fn()} readOnly={false} />,
+    );
+
+    const sitesList = container.querySelector<HTMLElement>(".library-unified-list");
+    expect(sitesList).not.toBeNull();
+    if (!sitesList) return;
+    sitesList.scrollTop = 120;
+    await user.click(screen.getByRole("button", { name: "Open Library sections" }));
+    await user.click(screen.getByRole("button", { name: /Simulations/i }));
+
+    const simulationsList = container.querySelector<HTMLElement>(".library-unified-list");
+    expect(simulationsList).not.toBeNull();
+    if (!simulationsList) return;
+    simulationsList.scrollTop = 48;
+    await user.click(screen.getByRole("button", { name: "Open Library sections" }));
+    await user.click(screen.getByRole("button", { name: /Sites/i }));
+
+    expect(container.querySelector<HTMLElement>(".library-unified-list")?.scrollTop).toBe(120);
+  });
+
+  it("opens Site details from an explicit button and keeps Add separate", async () => {
+    const user = userEvent.setup();
+    render(<LibraryPanel initialTab="sites" isMobile onClose={vi.fn()} readOnly={false} />);
+
+    expect(screen.queryByRole("button", { name: "Open Site details: Ridge Site" })).not.toBeInTheDocument();
+    expect(screen.getByText("Ridge Site").closest("button")).toBeNull();
+    await user.click(screen.getByRole("button", { name: "Details for Ridge Site" }));
     expect(useAppStore.getState().mapEditor).toMatchObject({
       kind: "site",
       resourceId: "site-library-1",
       origin: { kind: "library", tab: "sites" },
     });
     expect(useAppStore.getState().libraryRequest).toEqual({ tab: "sites" });
+  });
+
+  it("uses explicit Details and Open actions for Simulations", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(<LibraryPanel initialTab="simulations" isMobile onClose={onClose} readOnly={false} />);
+
+    expect(screen.getByRole("button", { name: "Details for Valley Plan" })).toBeVisible();
+    await user.click(screen.getByRole("button", { name: "Open Valley Plan" }));
+
+    expect(useAppStore.getState().selectedScenarioId).toBe("sim-1");
+    expect(onClose).toHaveBeenCalledOnce();
   });
 
   it("preserves Save a copy in the Simulations tab", async () => {
@@ -135,7 +190,8 @@ describe("LibraryPanel", () => {
     });
   });
 
-  it("hides Site bulk selection on mobile and keeps it on desktop", () => {
+  it("hides Site bulk selection on mobile and reveals desktop actions after selection", async () => {
+    const user = userEvent.setup();
     const mobile = render(
       <LibraryPanel initialTab="sites" isMobile onClose={vi.fn()} readOnly={false} />,
     );
@@ -144,8 +200,36 @@ describe("LibraryPanel", () => {
     mobile.unmount();
 
     render(<LibraryPanel initialTab="sites" isMobile={false} onClose={vi.fn()} readOnly={false} />);
-    expect(screen.getByRole("checkbox", { name: "Select Ridge Site" })).toBeInTheDocument();
+    const checkbox = screen.getByRole("checkbox", { name: "Select Ridge Site" });
+    expect(checkbox).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Select filtered/i })).not.toBeInTheDocument();
+
+    await user.click(checkbox);
     expect(screen.getByRole("button", { name: /Select filtered/i })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Clear selection" }));
+    expect(screen.queryByRole("button", { name: /Select filtered/i })).not.toBeInTheDocument();
+  });
+
+  it("omits Manual item labels while retaining MQTT badges and source filtering", async () => {
+    const user = userEvent.setup();
+    useAppStore.setState({
+      siteLibrary: [
+        ...useAppStore.getState().siteLibrary,
+        {
+          ...useAppStore.getState().siteLibrary[0],
+          id: "site-library-2",
+          name: "MQTT Ridge",
+          sourceMeta: { sourceType: "mqtt-feed", sourceUrl: "mqtt://feed-1" },
+        },
+      ],
+    });
+    render(<LibraryPanel initialTab="sites" isMobile onClose={vi.fn()} readOnly={false} />);
+
+    expect(screen.queryByText("Manual")).not.toBeInTheDocument();
+    expect(screen.getByText("MQTT")).toBeVisible();
+
+    await user.click(screen.getByRole("button", { name: /Filter and sort Sites/i }));
+    expect(within(screen.getByRole("dialog", { name: "Filter and sort Sites" })).getByText("Manual")).toBeVisible();
   });
 
   it("keeps search outside the advanced filter panel", async () => {

--- a/src/components/LibraryPanel.tsx
+++ b/src/components/LibraryPanel.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useRef, useState } from "react";
-import { Filter } from "lucide-react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { Filter, Menu, X } from "lucide-react";
 import {
   DEFAULT_LIBRARY_FILTER_STATE,
   filterAndSortLibraryItems,
@@ -20,6 +20,7 @@ import { ModalOverlay } from "./ModalOverlay";
 import { Badge } from "./ui/Badge";
 import { FloatingPopover } from "./ui/FloatingPopover";
 import { Surface } from "./ui/Surface";
+import { SettingsNav, type SettingsNavItem } from "./settings/SettingsNav";
 
 const SITE_LIBRARY_FILTERS_KEY = "rmw-site-library-filters-v1";
 const SIMULATION_LIBRARY_FILTERS_KEY = "rmw-simulation-library-filters-v1";
@@ -104,11 +105,17 @@ export function LibraryPanel({
   );
   const [filterDraft, setFilterDraft] = useState<LibraryFilterState | null>(null);
   const [filtersOpen, setFiltersOpen] = useState(false);
+  const [mobileDetailOpen, setMobileDetailOpen] = useState(true);
   const [selectedSiteIds, setSelectedSiteIds] = useState<Set<string>>(new Set());
   const [deleteSelection, setDeleteSelection] = useState<string[] | null>(null);
   const filterTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const listRef = useRef<HTMLDivElement | null>(null);
+  const scrollPositionsRef = useRef<Record<LibraryTab, number>>({ sites: 0, simulations: 0 });
 
-  useEffect(() => setActiveTab(initialTab), [initialTab]);
+  useEffect(() => {
+    setActiveTab(initialTab);
+    setMobileDetailOpen(true);
+  }, [initialTab]);
   useEffect(() => persistLibraryFilterState(SITE_LIBRARY_FILTERS_KEY, siteFilters), [siteFilters]);
   useEffect(
     () => persistLibraryFilterState(SIMULATION_LIBRARY_FILTERS_KEY, simulationFilters),
@@ -117,6 +124,13 @@ export function LibraryPanel({
 
   const currentUserId = currentUser?.id ?? null;
   const activeFilters = activeTab === "sites" ? siteFilters : simulationFilters;
+  const sectionItems = useMemo<SettingsNavItem<LibraryTab>[]>(
+    () => [
+      { id: "sites", label: "Sites", description: "Saved locations and radio details" },
+      { id: "simulations", label: "Simulations", description: "Saved workspaces and scenarios" },
+    ],
+    [],
+  );
   const setActiveFilters = (next: LibraryFilterState) => {
     if (activeTab === "sites") setSiteFilters(next);
     else setSimulationFilters(next);
@@ -167,6 +181,25 @@ export function LibraryPanel({
     setFiltersOpen(false);
     setFilterDraft(null);
   };
+  const rememberScrollPosition = () => {
+    if (listRef.current) scrollPositionsRef.current[activeTab] = listRef.current.scrollTop;
+  };
+  const selectSection = (section: LibraryTab) => {
+    rememberScrollPosition();
+    setActiveTab(section);
+    setMobileDetailOpen(true);
+    closeFilters();
+  };
+  const openSectionList = () => {
+    rememberScrollPosition();
+    setMobileDetailOpen(false);
+    closeFilters();
+  };
+
+  useLayoutEffect(() => {
+    if (!mobileDetailOpen || !listRef.current) return;
+    listRef.current.scrollTop = scrollPositionsRef.current[activeTab];
+  }, [activeTab, mobileDetailOpen]);
   const applyFilters = () => {
     if (filterDraft) setActiveFilters(filterDraft);
     closeFilters();
@@ -376,144 +409,155 @@ export function LibraryPanel({
     avatarUrl: resource.createdByAvatarUrl ?? "",
   });
 
+  const showSectionList = !isMobile || !mobileDetailOpen;
+  const showSectionDetail = !isMobile || mobileDetailOpen;
+  const activeSectionLabel = activeTab === "sites" ? "Sites" : "Simulations";
+
   return (
-    <Surface className="library-unified-card" variant="card">
-      <div className="library-manager-header library-unified-header">
-        <h2>Library</h2>
-        <InlineCloseIconButton onClick={onClose} />
-      </div>
-      <div aria-label="Library sections" className="library-tabs" role="tablist">
-        <button
-          aria-selected={activeTab === "sites"}
-          className={activeTab === "sites" ? "is-active" : ""}
-          onClick={() => {
-            setActiveTab("sites");
-            closeFilters();
-          }}
-          role="tab"
-          type="button"
-        >
-          Sites
-        </button>
-        <button
-          aria-selected={activeTab === "simulations"}
-          className={activeTab === "simulations" ? "is-active" : ""}
-          onClick={() => {
-            setActiveTab("simulations");
-            closeFilters();
-          }}
-          role="tab"
-          type="button"
-        >
-          Simulations
-        </button>
-      </div>
-      <div className="library-search-row">
-        <input
-          aria-label={`Search ${activeTab === "sites" ? "Sites" : "Simulations"}`}
-          onChange={(event) => setActiveFilters({ ...activeFilters, searchQuery: event.target.value })}
-          placeholder={activeTab === "sites" ? "Search by name or coordinates" : "Search Simulations"}
-          role="searchbox"
-          type="search"
-          value={activeFilters.searchQuery}
-        />
-        <ActionButton
-          aria-expanded={filtersOpen}
-          aria-label={`Filter and sort ${activeTab === "sites" ? "Sites" : "Simulations"}${filterCount ? `, active` : ""}`}
-          onClick={filtersOpen ? closeFilters : openFilters}
-          ref={filterTriggerRef}
-          type="button"
-        >
-          <Filter aria-hidden="true" size={16} strokeWidth={1.8} />
-          Filter and sort{filterCount ? " · Active" : ""}
-        </ActionButton>
-      </div>
-      {isMobile ? (
-        filtersOpen ? (
-          <ModalOverlay
-            aria-label={`Filter and sort ${activeTab === "sites" ? "Sites" : "Simulations"}`}
-            className="library-filter-sheet-overlay"
-            onClose={closeFilters}
-            tier="raised"
-          >
-            <Surface className="library-filter-sheet" variant="card">
-              <div className="library-manager-header">
-                <h2>Filter and sort</h2>
-                <InlineCloseIconButton onClick={closeFilters} />
-              </div>
-              {filterPanel}
-            </Surface>
-          </ModalOverlay>
-        ) : null
-      ) : (
-        <FloatingPopover
-          className="library-filter-floating"
-          estimatedHeight={520}
-          estimatedWidth={360}
-          onClose={closeFilters}
-          open={filtersOpen}
-          triggerRef={filterTriggerRef}
-        >
-          {filterPanel}
-        </FloatingPopover>
-      )}
-
-      <div className="library-tab-actions">
-        {activeTab === "sites" ? (
-          <ActionButton onClick={(event) => openNewSite(event.currentTarget)} type="button">New Site</ActionButton>
-        ) : (
-          <>
-            <ActionButton onClick={(event) => openNewSimulation(event.currentTarget)} type="button">
-              New Simulation
-            </ActionButton>
-            <ActionButton onClick={(event) => openSimulationCopy(event.currentTarget)} type="button">
-              Save a copy
-            </ActionButton>
-          </>
-        )}
-      </div>
-
-      {!isOnline ? <p className="field-help library-status">Offline: showing cached Library items.</p> : null}
-      {syncErrorMessage ? <p className="field-help warning-text library-status">{syncErrorMessage}</p> : null}
-
-      {activeTab === "sites" && !isMobile ? (
-        <div className="library-bulk-toolbar">
-          <ActionButton
-            onClick={() => setSelectedSiteIds(new Set(filteredSites.map((entry) => entry.id)))}
-            type="button"
-          >
-            Select filtered ({filteredSites.length})
-          </ActionButton>
-          <ActionButton onClick={() => setSelectedSiteIds(new Set())} type="button">Clear selection</ActionButton>
-          <ActionButton
-            disabled={!selectedSiteIds.size || !canAddToActiveSimulation}
-            onClick={() => {
-              insertSitesFromLibrary(Array.from(selectedSiteIds));
-              setSelectedSiteIds(new Set());
-              onClose();
-            }}
-            type="button"
-          >
-            Add selected ({selectedSiteIds.size})
-          </ActionButton>
-          <ActionButton
-            disabled={
-              !selectedSiteIds.size ||
-              Array.from(selectedSiteIds).some((id) => {
-                const entry = siteLibrary.find((candidate) => candidate.id === id);
-                return !entry || !canEditResource(entry, currentUserId);
-              })
-            }
-            onClick={() => setDeleteSelection(Array.from(selectedSiteIds))}
-            type="button"
-            variant="danger"
-          >
-            Delete selected ({selectedSiteIds.size})
-          </ActionButton>
+    <div className="settings-panel library-panel">
+      <header className="settings-panel-header">
+        <div className="settings-panel-header-lead">
+          {isMobile && mobileDetailOpen ? (
+            <button
+              aria-label="Open Library sections"
+              className="settings-panel-menu"
+              onClick={openSectionList}
+              type="button"
+            >
+              <Menu aria-hidden="true" size={20} strokeWidth={2} />
+            </button>
+          ) : null}
+          <h2 className="settings-panel-title">
+            {isMobile && mobileDetailOpen ? activeSectionLabel : "Library"}
+          </h2>
         </div>
-      ) : null}
+        <button
+          aria-label="Close Library"
+          className="settings-panel-close"
+          onClick={onClose}
+          type="button"
+        >
+          <X aria-hidden="true" size={20} strokeWidth={2} />
+        </button>
+      </header>
 
-      <div className="library-unified-list">
+      <div className="settings-panel-body">
+        {showSectionList ? (
+          <aside className="settings-panel-sidebar library-panel-sidebar">
+            <SettingsNav
+              activeSection={activeTab}
+              ariaLabel="Library sections"
+              items={sectionItems}
+              layout={isMobile ? "list" : "sidebar"}
+              onSelect={selectSection}
+            />
+          </aside>
+        ) : null}
+        {showSectionDetail ? (
+          <main className="settings-panel-content library-panel-content">
+            <div className="library-search-row">
+              <input
+                aria-label={`Search ${activeSectionLabel}`}
+                onChange={(event) => setActiveFilters({ ...activeFilters, searchQuery: event.target.value })}
+                placeholder={activeTab === "sites" ? "Search by name or coordinates" : "Search Simulations"}
+                role="searchbox"
+                type="search"
+                value={activeFilters.searchQuery}
+              />
+              <ActionButton
+                aria-expanded={filtersOpen}
+                aria-label={`Filter and sort ${activeSectionLabel}${filterCount ? `, active` : ""}`}
+                onClick={filtersOpen ? closeFilters : openFilters}
+                ref={filterTriggerRef}
+                type="button"
+              >
+                <Filter aria-hidden="true" size={16} strokeWidth={1.8} />
+                Filter and sort{filterCount ? " · Active" : ""}
+              </ActionButton>
+            </div>
+            {isMobile ? (
+              filtersOpen ? (
+                <ModalOverlay
+                  aria-label={`Filter and sort ${activeSectionLabel}`}
+                  className="library-filter-sheet-overlay"
+                  onClose={closeFilters}
+                  tier="raised"
+                >
+                  <Surface className="library-filter-sheet" variant="card">
+                    <div className="library-manager-header">
+                      <h2>Filter and sort</h2>
+                      <InlineCloseIconButton onClick={closeFilters} />
+                    </div>
+                    {filterPanel}
+                  </Surface>
+                </ModalOverlay>
+              ) : null
+            ) : (
+              <FloatingPopover
+                className="library-filter-floating"
+                estimatedHeight={520}
+                estimatedWidth={360}
+                onClose={closeFilters}
+                open={filtersOpen}
+                triggerRef={filterTriggerRef}
+              >
+                {filterPanel}
+              </FloatingPopover>
+            )}
+
+            <div className="library-tab-actions">
+              {activeTab === "sites" ? (
+                <ActionButton onClick={(event) => openNewSite(event.currentTarget)} type="button">New Site</ActionButton>
+              ) : (
+                <>
+                  <ActionButton onClick={(event) => openNewSimulation(event.currentTarget)} type="button">
+                    New Simulation
+                  </ActionButton>
+                  <ActionButton onClick={(event) => openSimulationCopy(event.currentTarget)} type="button">
+                    Save a copy
+                  </ActionButton>
+                </>
+              )}
+            </div>
+
+            {!isOnline ? <p className="field-help library-status">Offline: showing cached Library items.</p> : null}
+            {syncErrorMessage ? <p className="field-help warning-text library-status">{syncErrorMessage}</p> : null}
+
+            {activeTab === "sites" && !isMobile && selectedSiteIds.size > 0 ? (
+              <div className="library-bulk-toolbar">
+                <ActionButton
+                  onClick={() => setSelectedSiteIds(new Set(filteredSites.map((entry) => entry.id)))}
+                  type="button"
+                >
+                  Select filtered ({filteredSites.length})
+                </ActionButton>
+                <ActionButton onClick={() => setSelectedSiteIds(new Set())} type="button">Clear selection</ActionButton>
+                <ActionButton
+                  disabled={!canAddToActiveSimulation}
+                  onClick={() => {
+                    insertSitesFromLibrary(Array.from(selectedSiteIds));
+                    setSelectedSiteIds(new Set());
+                    onClose();
+                  }}
+                  type="button"
+                >
+                  Add selected ({selectedSiteIds.size})
+                </ActionButton>
+                <ActionButton
+                  disabled={Array.from(selectedSiteIds).some((id) => {
+                    const entry = siteLibrary.find((candidate) => candidate.id === id);
+                    return !entry || !canEditResource(entry, currentUserId);
+                  })}
+                  onClick={() => setDeleteSelection(Array.from(selectedSiteIds))}
+                  type="button"
+                  variant="danger"
+                >
+                  Delete selected ({selectedSiteIds.size})
+                </ActionButton>
+              </div>
+            ) : null}
+
+            <div className="library-unified-list" ref={listRef}>
         {isInitializing && !(activeTab === "sites" ? siteLibrary.length : simulationPresets.length) ? (
           <p className="field-help">Loading Library…</p>
         ) : null}
@@ -527,6 +571,7 @@ export function LibraryPanel({
                     <input
                       aria-label={`Select ${entry.name}`}
                       checked={selectedSiteIds.has(entry.id)}
+                      className="library-site-select"
                       onChange={() =>
                         setSelectedSiteIds((current) => {
                           const next = new Set(current);
@@ -538,22 +583,15 @@ export function LibraryPanel({
                       type="checkbox"
                     />
                   ) : null}
-                  <button
-                    aria-label={`Open Site details: ${entry.name}`}
-                    className="library-item-details"
-                    onClick={(event) => openSiteDetails(entry, event.currentTarget)}
-                    type="button"
+                  <div
+                    className="library-item-copy"
                   >
                     <strong>{entry.name}</strong>
                     <span>{entry.position.lat.toFixed(5)}, {entry.position.lon.toFixed(5)}</span>
-                  </button>
+                  </div>
                   <div className="library-item-meta">
                     <Badge variant={visibility as "private" | "public" | "shared"}>{visibility}</Badge>
-                    {entry.sourceMeta?.sourceType === "mqtt-feed" ? (
-                      <Badge variant="mqtt">MQTT</Badge>
-                    ) : (
-                      <span className="library-source-label">Manual</span>
-                    )}
+                    {entry.sourceMeta?.sourceType === "mqtt-feed" ? <Badge variant="mqtt">MQTT</Badge> : null}
                     {entry.ownerUserId && onOpenUserProfile ? (
                       <button
                         aria-label={`Open owner profile: ${owner.name}`}
@@ -592,14 +630,25 @@ export function LibraryPanel({
                       ),
                     )}
                   </div>
-                  <ActionButton
-                    disabled={!canAddToActiveSimulation}
-                    onClick={() => closeAndAddSite(entry.id)}
-                    title={canAddToActiveSimulation ? "Add to Simulation" : "Open an editable Simulation to add this Site"}
-                    type="button"
-                  >
-                    Add
-                  </ActionButton>
+                  <div className="library-item-actions">
+                    <ActionButton
+                      aria-label={`Details for ${entry.name}`}
+                      onClick={(event) => openSiteDetails(entry, event.currentTarget)}
+                      type="button"
+                      variant="ghost"
+                    >
+                      Details
+                    </ActionButton>
+                    <ActionButton
+                      aria-label={`Add ${entry.name}`}
+                      disabled={!canAddToActiveSimulation}
+                      onClick={() => closeAndAddSite(entry.id)}
+                      title={canAddToActiveSimulation ? "Add to Simulation" : "Open an editable Simulation to add this Site"}
+                      type="button"
+                    >
+                      Add
+                    </ActionButton>
+                  </div>
                 </article>
               );
             })
@@ -608,15 +657,12 @@ export function LibraryPanel({
               const visibility = toAccessVisibility(preset.visibility);
               return (
                 <article className="library-unified-item library-simulation-item" key={preset.id}>
-                  <button
-                    aria-label={`Open Simulation details: ${preset.name}`}
-                    className="library-item-details"
-                    onClick={(event) => openSimulationDetails(preset, event.currentTarget)}
-                    type="button"
+                  <div
+                    className="library-item-copy"
                   >
                     <strong>{preset.name}</strong>
                     <span>Updated {formatDate(preset.updatedAt)}</span>
-                  </button>
+                  </div>
                   <div className="library-item-meta">
                     <Badge variant={visibility as "private" | "public" | "shared"}>{visibility}</Badge>
                     {preset.ownerUserId && onOpenUserProfile ? (
@@ -635,7 +681,23 @@ export function LibraryPanel({
                       </span>
                     )}
                   </div>
-                  <ActionButton onClick={() => closeAndLoadSimulation(preset.id)} type="button">Load</ActionButton>
+                  <div className="library-item-actions">
+                    <ActionButton
+                      aria-label={`Details for ${preset.name}`}
+                      onClick={(event) => openSimulationDetails(preset, event.currentTarget)}
+                      type="button"
+                      variant="ghost"
+                    >
+                      Details
+                    </ActionButton>
+                    <ActionButton
+                      aria-label={`Open ${preset.name}`}
+                      onClick={() => closeAndLoadSimulation(preset.id)}
+                      type="button"
+                    >
+                      Open
+                    </ActionButton>
+                  </div>
                 </article>
               );
             })}
@@ -651,6 +713,9 @@ export function LibraryPanel({
         {!isInitializing && activeTab === "simulations" && simulationPresets.length > 0 && !filteredSimulations.length ? (
           <p className="field-help">No Simulations match the current search and filters.</p>
         ) : null}
+            </div>
+          </main>
+        ) : null}
       </div>
 
       {deleteSelection ? (
@@ -665,6 +730,6 @@ export function LibraryPanel({
           title="Delete Sites"
         />
       ) : null}
-    </Surface>
+    </div>
   );
 }

--- a/src/components/settings/SettingsNav.tsx
+++ b/src/components/settings/SettingsNav.tsx
@@ -1,25 +1,31 @@
 import { ChevronRight, ShieldCheck, SlidersHorizontal, UserRound } from "lucide-react";
-import type { SettingsSectionId } from "../../lib/deepLink";
 
-export type SettingsNavItem = {
-  id: SettingsSectionId;
+export type SettingsNavItem<SectionId extends string = string> = {
+  id: SectionId;
   label: string;
   description: string;
-  icon: typeof UserRound;
+  icon?: typeof UserRound;
 };
 
-type SettingsNavProps = {
-  items: SettingsNavItem[];
-  activeSection: SettingsSectionId;
-  onSelect: (section: SettingsSectionId) => void;
+type SettingsNavProps<SectionId extends string> = {
+  activeSection: SectionId;
+  ariaLabel?: string;
+  items: SettingsNavItem<SectionId>[];
+  onSelect: (section: SectionId) => void;
   layout: "sidebar" | "list";
 };
 
-export function SettingsNav({ items, activeSection, onSelect, layout }: SettingsNavProps) {
+export function SettingsNav<SectionId extends string>({
+  activeSection,
+  ariaLabel = "Settings sections",
+  items,
+  onSelect,
+  layout,
+}: SettingsNavProps<SectionId>) {
   return (
     <nav
       className={`settings-nav settings-nav-${layout}`}
-      aria-label="Settings sections"
+      aria-label={ariaLabel}
     >
       <ul>
         {items.map((item) => {
@@ -33,9 +39,11 @@ export function SettingsNav({ items, activeSection, onSelect, layout }: Settings
                 aria-current={isActive ? "page" : undefined}
                 onClick={() => onSelect(item.id)}
               >
-                <span className="settings-nav-item-icon" aria-hidden="true">
-                  <Icon size={18} strokeWidth={2} />
-                </span>
+                {Icon ? (
+                  <span className="settings-nav-item-icon" aria-hidden="true">
+                    <Icon size={18} strokeWidth={2} />
+                  </span>
+                ) : null}
                 <span className="settings-nav-item-copy">
                   <span className="settings-nav-item-label">{item.label}</span>
                   {layout === "list" ? (

--- a/src/components/settings/SettingsPanel.test.tsx
+++ b/src/components/settings/SettingsPanel.test.tsx
@@ -152,4 +152,21 @@ describe("SettingsPanel", () => {
     expect(screen.getByTestId("preferences-section")).toBeInTheDocument();
     expect(screen.queryByTestId("profile-section")).not.toBeInTheDocument();
   });
+
+  it("uses a hamburger control to return to the mobile section list", () => {
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({
+      matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }));
+
+    render(<SettingsPanel initialSection="preferences" onClose={vi.fn()} />);
+    expect(screen.getByTestId("preferences-section")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Settings sections" }));
+    expect(screen.queryByTestId("preferences-section")).not.toBeInTheDocument();
+    expect(screen.getByRole("navigation", { name: "Settings sections" })).toBeInTheDocument();
+
+    vi.unstubAllGlobals();
+  });
 });

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ArrowLeft, X } from "lucide-react";
+import { Menu, X } from "lucide-react";
 import { buildSettingsPath, matchSettingsPath, type SettingsSectionId } from "../../lib/deepLink";
 import { useAppStore } from "../../store/appStore";
 import { fetchMe, type CloudUser } from "../../lib/cloudUser";
@@ -124,8 +124,8 @@ export function SettingsPanel({ initialSection, onClose }: SettingsPanelProps) {
     window.location.href = "/cdn-cgi/access/logout";
   }, [setAuthState, setCurrentUser]);
 
-  const navItems = useMemo<SettingsNavItem[]>(() => {
-    const items: SettingsNavItem[] = [
+  const navItems = useMemo<SettingsNavItem<SettingsSectionId>[]>(() => {
+    const items: SettingsNavItem<SettingsSectionId>[] = [
       {
         id: "profile",
         label: "Profile",
@@ -165,7 +165,7 @@ export function SettingsPanel({ initialSection, onClose }: SettingsPanelProps) {
     }
   };
 
-  const onBackToList = () => {
+  const openSectionList = () => {
     setMobileDetailOpen(false);
     if (typeof window !== "undefined") {
       window.history.pushState(null, "", buildSettingsPath(null));
@@ -220,12 +220,11 @@ export function SettingsPanel({ initialSection, onClose }: SettingsPanelProps) {
           {isNarrow && mobileDetailOpen ? (
             <button
               type="button"
-              className="settings-panel-back"
-              aria-label="Back to settings"
-              onClick={onBackToList}
+              className="settings-panel-menu"
+              aria-label="Open Settings sections"
+              onClick={openSectionList}
             >
-              <ArrowLeft size={18} strokeWidth={2} aria-hidden="true" />
-              <span>Back</span>
+              <Menu size={20} strokeWidth={2} aria-hidden="true" />
             </button>
           ) : null}
           <h1 id="settings-panel-title" className="settings-panel-title">

--- a/src/index.css
+++ b/src/index.css
@@ -4955,40 +4955,27 @@ html.panorama-gesture-lock body {
   pointer-events: none;
 }
 
-.library-unified-card {
-  width: min(1040px, 96vw);
+.library-panel-wrapper {
+  width: min(1120px, 96vw);
   height: min(86vh, 900px);
   min-height: 0;
-  padding: 14px;
-  display: grid;
-  grid-template-rows: auto auto auto auto auto minmax(0, 1fr);
-  gap: 10px;
+  padding: 0;
   overflow: hidden;
 }
 
-.library-tabs {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 4px;
-  padding: 4px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-card);
-  background: color-mix(in srgb, var(--surface-2) 88%, transparent);
+.library-panel {
+  background: var(--surface);
 }
 
-.library-tabs button {
-  min-height: 40px;
-  border: 1px solid transparent;
-  border-radius: var(--radius-btn);
-  background: transparent;
-  color: var(--muted);
-  cursor: pointer;
+.library-panel-sidebar {
+  background: var(--surface-2);
 }
 
-.library-tabs button.is-active {
-  border-color: color-mix(in srgb, var(--accent) 48%, var(--border));
-  background: color-mix(in srgb, var(--accent-soft) 52%, var(--surface));
-  color: var(--text);
+.library-panel-content {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  overflow: hidden;
 }
 
 .library-search-row {
@@ -5025,7 +5012,7 @@ html.panorama-gesture-lock body {
   padding: 8px;
   border: 1px solid var(--border);
   border-radius: var(--radius-card);
-  background: color-mix(in srgb, var(--surface-2) 88%, transparent);
+  background: var(--surface-2);
 }
 
 .library-status {
@@ -5041,7 +5028,7 @@ html.panorama-gesture-lock body {
   padding: 8px;
   border: 1px solid var(--border);
   border-radius: var(--radius-card);
-  background: color-mix(in srgb, var(--surface-2) 86%, transparent);
+  background: var(--surface-2);
   overscroll-behavior: contain;
 }
 
@@ -5060,25 +5047,16 @@ html.panorama-gesture-lock body {
   grid-template-columns: minmax(0, 1fr) auto auto;
 }
 
-.library-item-details {
+.library-item-copy {
   min-width: 0;
-  border: 0;
-  border-radius: var(--radius-btn);
-  background: transparent;
   color: var(--text);
-  cursor: pointer;
   display: grid;
   gap: 4px;
   padding: 6px;
   text-align: left;
 }
 
-.library-item-details:hover,
-.library-item-details:focus-visible {
-  background: color-mix(in srgb, var(--accent-soft) 34%, transparent);
-}
-
-.library-item-details span {
+.library-item-copy span {
   color: var(--muted);
   font-size: 0.74rem;
 }
@@ -5090,10 +5068,19 @@ html.panorama-gesture-lock body {
   gap: 6px;
 }
 
-.library-source-label {
-  color: var(--text-muted);
-  font-size: 0.72rem;
-  font-weight: 650;
+.library-item-actions {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.library-site-select {
+  width: 28px;
+  height: 28px;
+  margin: 0;
+  accent-color: var(--accent);
+  flex-shrink: 0;
 }
 
 .library-filter-floating {
@@ -5136,11 +5123,14 @@ html.panorama-gesture-lock body {
 }
 
 .library-filter-sheet {
+  --surface-pill-background: var(--surface);
   width: min(620px, 100%);
   max-height: min(82dvh, 720px);
   overflow: auto;
   padding: 14px 14px calc(14px + env(safe-area-inset-bottom));
   border-radius: 18px 18px 0 0;
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
 }
 
 .confirm-action-card {
@@ -5152,21 +5142,14 @@ html.panorama-gesture-lock body {
     padding: 0;
   }
 
-  .library-unified-card {
+  .library-panel-wrapper {
     width: 100%;
-    height: 100dvh;
+    height: 100%;
     max-height: none;
-    padding:
-      calc(10px + env(safe-area-inset-top))
-      10px
-      calc(10px + env(safe-area-inset-bottom));
+    padding: 0;
     border: 0;
     border-radius: 0;
     box-shadow: none;
-  }
-
-  .library-unified-header {
-    min-height: 44px;
   }
 
   .library-search-row {
@@ -5186,26 +5169,28 @@ html.panorama-gesture-lock body {
     height: 20px;
   }
 
-  .library-tabs button,
-  .library-item-details,
-  .library-unified-item > .btn {
+  .library-item-actions .btn,
+  .library-item-actions .btn-ghost {
     min-height: 44px;
   }
 
   .library-unified-item,
   .library-simulation-item {
-    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .library-item-meta {
-    grid-column: 1;
     justify-content: flex-start;
     padding-left: 6px;
   }
 
-  .library-unified-item > .btn {
-    grid-column: 2;
-    grid-row: 1 / span 2;
+  .library-item-actions {
+    justify-content: stretch;
+  }
+
+  .library-item-actions .btn,
+  .library-item-actions .btn-ghost {
+    flex: 1 1 0;
   }
 
   .library-filter-options {
@@ -5890,7 +5875,7 @@ html.panorama-gesture-lock body {
   line-height: 1.2;
 }
 
-.settings-panel-back,
+.settings-panel-menu,
 .settings-panel-close {
   display: inline-flex;
   align-items: center;
@@ -5904,7 +5889,7 @@ html.panorama-gesture-lock body {
   cursor: pointer;
 }
 
-.settings-panel-back:hover,
+.settings-panel-menu:hover,
 .settings-panel-close:hover {
   background: var(--surface-2);
   border-color: var(--border);
@@ -5939,13 +5924,31 @@ html.panorama-gesture-lock body {
 }
 
 @media (max-width: 980px) {
+  .settings-panel-header {
+    padding:
+      calc(14px + env(safe-area-inset-top))
+      calc(20px + env(safe-area-inset-right))
+      14px
+      calc(20px + env(safe-area-inset-left));
+  }
   .settings-panel-sidebar {
     flex: 1 1 auto;
     border-right: none;
-    padding: 8px;
+    padding:
+      8px
+      calc(8px + env(safe-area-inset-right))
+      calc(8px + env(safe-area-inset-bottom))
+      calc(8px + env(safe-area-inset-left));
   }
   .settings-panel-content {
     padding: 16px 16px 36px;
+  }
+  .settings-panel-content.library-panel-content {
+    padding:
+      16px
+      calc(16px + env(safe-area-inset-right))
+      calc(36px + env(safe-area-inset-bottom))
+      calc(16px + env(safe-area-inset-left));
   }
   .settings-panel-wrapper {
     width: 100%;


### PR DESCRIPTION
## Summary
- align Library with the Settings desktop sidebar and mobile list/detail modal behavior
- use hamburger section navigation in both Library and Settings
- expose explicit Details and Add/Open item actions
- enlarge Site checkboxes, remove visible Manual labels, and show bulk actions only after selection
- keep per-section search, filters, sorting, selection, and scroll state

## Verification
- npm test (129 files, 728 tests)
- npm run build
- focused Library and Settings suite (21 tests)
- git diff --check
- npm run dev:check

Closes no issue; #965 remains open for shared-staging sign-off.