### PR TITLE
Match Library item action buttons

### DIFF
--- a/src/components/LibraryPanel.test.tsx
+++ b/src/components/LibraryPanel.test.tsx
@@ -153,7 +153,9 @@ describe("LibraryPanel", () => {
 
     expect(screen.queryByRole("button", { name: "Open Site details: Ridge Site" })).not.toBeInTheDocument();
     expect(screen.getByText("Ridge Site").closest("button")).toBeNull();
-    await user.click(screen.getByRole("button", { name: "Details for Ridge Site" }));
+    const detailsButton = screen.getByRole("button", { name: "Details for Ridge Site" });
+    expect(detailsButton.className).toBe(screen.getByRole("button", { name: "Add Ridge Site" }).className);
+    await user.click(detailsButton);
     expect(useAppStore.getState().mapEditor).toMatchObject({
       kind: "site",
       resourceId: "site-library-1",
@@ -167,8 +169,10 @@ describe("LibraryPanel", () => {
     const onClose = vi.fn();
     render(<LibraryPanel initialTab="simulations" isMobile onClose={onClose} readOnly={false} />);
 
-    expect(screen.getByRole("button", { name: "Details for Valley Plan" })).toBeVisible();
-    await user.click(screen.getByRole("button", { name: "Open Valley Plan" }));
+    const detailsButton = screen.getByRole("button", { name: "Details for Valley Plan" });
+    const openButton = screen.getByRole("button", { name: "Open Valley Plan" });
+    expect(detailsButton.className).toBe(openButton.className);
+    await user.click(openButton);
 
     expect(useAppStore.getState().selectedScenarioId).toBe("sim-1");
     expect(onClose).toHaveBeenCalledOnce();

--- a/src/components/LibraryPanel.tsx
+++ b/src/components/LibraryPanel.tsx
@@ -635,7 +635,6 @@ export function LibraryPanel({
                       aria-label={`Details for ${entry.name}`}
                       onClick={(event) => openSiteDetails(entry, event.currentTarget)}
                       type="button"
-                      variant="ghost"
                     >
                       Details
                     </ActionButton>
@@ -686,7 +685,6 @@ export function LibraryPanel({
                       aria-label={`Details for ${preset.name}`}
                       onClick={(event) => openSimulationDetails(preset, event.currentTarget)}
                       type="button"
-                      variant="ghost"
                     >
                       Details
                     </ActionButton>

--- a/src/index.css
+++ b/src/index.css
@@ -5169,8 +5169,7 @@ html.panorama-gesture-lock body {
     height: 20px;
   }
 
-  .library-item-actions .btn,
-  .library-item-actions .btn-ghost {
+  .library-item-actions .btn {
     min-height: 44px;
   }
 
@@ -5188,8 +5187,7 @@ html.panorama-gesture-lock body {
     justify-content: stretch;
   }
 
-  .library-item-actions .btn,
-  .library-item-actions .btn-ghost {
+  .library-item-actions .btn {
     flex: 1 1 0;
   }
 


### PR DESCRIPTION
## Summary
- use the same default shared button appearance for Details and Add/Open
- remove obsolete Library-specific ghost-button selectors
- add regression assertions for Site and Simulation action pairs

## Verification
- focused Library tests: 9 passed
- npm test: 129 files, 728 tests passed
- npm run build
- git diff --check
- npm run dev:check

Issue #965 remains open for staging sign-off.