### PR TITLE
Library icon actions and Simulation soft deletion

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -40,6 +40,16 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Apply staging Simulation lifecycle migration
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          if ! npx wrangler d1 execute linksim_staging --remote --command "SELECT status FROM simulations LIMIT 0;"; then
+            npx wrangler d1 execute linksim_staging --remote --file db/migrations/2026-08-04_simulation_soft_delete.sql --yes
+          fi
+          npx wrangler d1 execute linksim_staging --remote --command "PRAGMA table_info(simulations);"
+
       - name: Deploy staging with guardrails
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/db/migrations/2026-08-04_simulation_soft_delete.sql
+++ b/db/migrations/2026-08-04_simulation_soft_delete.sql
@@ -1,0 +1,4 @@
+ALTER TABLE simulations
+ADD COLUMN status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'deleted'));
+
+CREATE INDEX IF NOT EXISTS idx_simulations_status ON simulations(status);

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -64,6 +64,7 @@ CREATE TABLE IF NOT EXISTS simulations (
   last_edited_at TEXT,
   name TEXT NOT NULL,
   visibility TEXT NOT NULL DEFAULT 'private' CHECK (visibility IN ('private', 'public_read', 'public_write')),
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'deleted')),
   payload_json TEXT NOT NULL,
   updated_at TEXT NOT NULL,
   FOREIGN KEY (owner_user_id) REFERENCES users(id) ON DELETE CASCADE
@@ -96,5 +97,6 @@ CREATE INDEX IF NOT EXISTS idx_sites_visibility ON sites(visibility);
 CREATE INDEX IF NOT EXISTS idx_site_roles_user ON site_roles(user_id);
 CREATE INDEX IF NOT EXISTS idx_simulations_owner ON simulations(owner_user_id);
 CREATE INDEX IF NOT EXISTS idx_simulations_visibility ON simulations(visibility);
+CREATE INDEX IF NOT EXISTS idx_simulations_status ON simulations(status);
 CREATE INDEX IF NOT EXISTS idx_simulation_roles_user ON simulation_roles(user_id);
 CREATE INDEX IF NOT EXISTS idx_resource_changes_lookup ON resource_changes(resource_kind, resource_id, changed_at DESC);

--- a/functions/_lib/db.sharedSimulation.test.ts
+++ b/functions/_lib/db.sharedSimulation.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { fetchPublicSimulationBundle, upsertLibrarySnapshot } from "./db";
+import { fetchLibraryForUser, fetchPublicSimulationBundle, setSimulationLifecycleStatus, upsertLibrarySnapshot } from "./db";
 
 type AnyRow = Record<string, unknown>;
 
@@ -51,6 +51,7 @@ const TABLE_COLUMNS: Record<string, string[]> = {
     "last_edited_at",
     "name",
     "visibility",
+    "status",
     "payload_json",
     "updated_at",
   ],
@@ -131,6 +132,7 @@ class FakeDb {
   readonly simulations = new Map<string, AnyRow>();
   readonly simulationRoles = new Map<string, string>();
   readonly resourceChanges: AnyRow[] = [];
+  readonly adminUserIds = new Set<string>();
 
   prepare(sql: string): FakeStatement {
     return new FakeStatement(this, sql);
@@ -145,11 +147,43 @@ class FakeDb {
   }
 
   first(sql: string, bound: unknown[]): AnyRow | null {
-    if (sql.includes("FROM simulations t LEFT JOIN simulation_roles")) {
+    if (sql.includes("FROM users WHERE id = ?")) {
+      const id = String(bound[0] ?? "");
+      return {
+        id,
+        username: id,
+        email: `${id}@example.test`,
+        username_set_at: "2026-01-01T00:00:00.000Z",
+        bio: "",
+        access_request_note: "",
+        idp_email: "",
+        idp_email_verified: 0,
+        avatar_url: "",
+        email_public: 1,
+        default_frequency_preset_id: null,
+        simulation_defaults_preference_json: null,
+        avatar_object_key: null,
+        avatar_thumb_key: null,
+        avatar_hash: null,
+        avatar_bytes: null,
+        avatar_content_type: null,
+        is_admin: this.adminUserIds.has(id) ? 1 : 0,
+        is_moderator: 0,
+        is_approved: 1,
+        approved_at: null,
+        approved_by_user_id: null,
+        created_at: "2026-01-01T00:00:00.000Z",
+        updated_at: null,
+      };
+    }
+    if (sql.includes("SELECT id, owner_user_id, status, payload_json FROM simulations")) {
+      return this.simulations.get(String(bound[0] ?? "")) ?? null;
+    }
+    if (sql.includes("FROM simulations t") && sql.includes("LEFT JOIN simulation_roles")) {
       const id = String(bound[1] ?? "");
       return this.simulations.get(id) ?? null;
     }
-    if (sql.includes("FROM sites t LEFT JOIN site_roles")) {
+    if (sql.includes("FROM sites t") && sql.includes("LEFT JOIN site_roles")) {
       const id = String(bound[1] ?? "");
       return this.sites.get(id) ?? null;
     }
@@ -192,6 +226,35 @@ class FakeDb {
     if (sql.includes("SELECT id, payload_json, visibility FROM sites WHERE id IN")) {
       return bound.map((id) => this.sites.get(String(id))).filter((row): row is AnyRow => Boolean(row));
     }
+    if (sql.includes("SELECT s.id") && sql.includes("s.status = 'deleted'")) {
+      const userId = String(bound[1] ?? "");
+      return [...this.simulations.values()]
+        .filter((row) => row.status === "deleted" && (row.owner_user_id === userId || row.visibility !== "private"))
+        .map((row) => ({ id: row.id }));
+    }
+    if (sql.includes("SELECT s.payload_json") && sql.includes("FROM simulations s")) {
+      const userId = String(bound[2] ?? "");
+      const isAdmin = Number(bound[1] ?? 0) === 1;
+      return [...this.simulations.values()]
+        .filter((row) => (isAdmin || row.status === "active") && (isAdmin || row.owner_user_id === userId || row.visibility !== "private"))
+        .map((row) => ({
+          ...row,
+          role: null,
+          owner_name: String(row.owner_user_id),
+          owner_avatar_url: "",
+          created_by_name: null,
+          created_by_avatar_url: null,
+          first_actor_user_id: null,
+          first_actor_name: null,
+          first_actor_avatar_url: null,
+          last_edited_by_name: null,
+          last_edited_by_avatar_url: null,
+          last_actor_user_id: null,
+          last_actor_name: null,
+          last_actor_avatar_url: null,
+        }));
+    }
+    if (sql.includes("SELECT s.payload_json") && sql.includes("FROM sites s")) return [];
     return [];
   }
 
@@ -208,6 +271,7 @@ class FakeDb {
         last_edited_at: lastEditedAt,
         name,
         visibility,
+        status: "active",
         payload_json: payloadJson,
         updated_at: updatedAt,
       });
@@ -242,6 +306,21 @@ class FakeDb {
         details_json: detailsJson,
         snapshot_json: snapshotJson,
       });
+      return;
+    }
+    if (sql.includes("UPDATE simulations") && sql.includes("SET status = ?")) {
+      const [status, payloadJson, updatedAt, lastEditedAt, lastEditedByUserId, id] = bound;
+      const current = this.simulations.get(String(id));
+      if (current) {
+        this.simulations.set(String(id), {
+          ...current,
+          status,
+          payload_json: payloadJson,
+          updated_at: updatedAt,
+          last_edited_at: lastEditedAt,
+          last_edited_by_user_id: lastEditedByUserId,
+        });
+      }
       return;
     }
     if (sql.includes("DELETE FROM site_roles") || sql.includes("DELETE FROM simulation_roles")) {
@@ -352,6 +431,7 @@ describe("upsertLibrarySnapshot shared simulations", () => {
       id: "sim-private",
       owner_user_id: "owner-1",
       visibility: "private",
+      status: "active",
       payload_json: JSON.stringify({
         id: "sim-private",
         visibility: "private",
@@ -412,6 +492,76 @@ describe("upsertLibrarySnapshot shared simulations", () => {
     expect(result.status).toBe("ok");
     if (result.status !== "ok") return;
     expect(result.sites).toEqual([expect.objectContaining({ id: "site-private", visibility: "private" })]);
+  });
+
+  it("soft deletes for owners and restores only for platform admins", async () => {
+    const db = createPrivateBundleDb();
+    const env = { DB: db } as unknown as Parameters<typeof setSimulationLifecycleStatus>[0];
+
+    await expect(
+      setSimulationLifecycleStatus(env, { id: "editor-1", isAdmin: false, isModerator: false }, "sim-private", "deleted"),
+    ).resolves.toEqual({ ok: false, reason: "forbidden" });
+    await expect(
+      setSimulationLifecycleStatus(env, { id: "owner-1", isAdmin: false, isModerator: false }, "sim-private", "deleted"),
+    ).resolves.toEqual({ ok: true, simulationId: "sim-private", status: "deleted" });
+    expect(db.simulations.get("sim-private")?.status).toBe("deleted");
+    expect(db.simulationRoles).toBeDefined();
+    await expect(
+      setSimulationLifecycleStatus(env, { id: "owner-1", isAdmin: false, isModerator: false }, "sim-private", "active"),
+    ).resolves.toEqual({ ok: false, reason: "forbidden" });
+    await expect(
+      setSimulationLifecycleStatus(env, { id: "admin-1", isAdmin: true, isModerator: false }, "sim-private", "active"),
+    ).resolves.toEqual({ ok: true, simulationId: "sim-private", status: "active" });
+    expect(db.simulations.get("sim-private")?.status).toBe("active");
+    expect(db.resourceChanges.map((change) => change.note)).toEqual(["Deleted Simulation", "Restored Simulation"]);
+  });
+
+  it("rejects stale upserts and public loading for deleted Simulations", async () => {
+    const db = createPrivateBundleDb();
+    db.simulations.set("sim-private", { ...db.simulations.get("sim-private"), status: "deleted" });
+    const env = { DB: db } as unknown as Parameters<typeof upsertLibrarySnapshot>[0];
+
+    const upsert = await upsertLibrarySnapshot(
+      env,
+      { id: "owner-1", isAdmin: false, isModerator: false },
+      { siteLibrary: [], simulationPresets: [{ id: "sim-private", name: "Private", visibility: "private" }] },
+    );
+    expect(upsert.conflicts).toContain("simulation_deleted");
+    await expect(
+      fetchPublicSimulationBundle(env, {
+        simulationId: "sim-private",
+        actor: { id: "admin-1", isAdmin: true, isModerator: false },
+      }),
+    ).resolves.toEqual({ status: "missing" });
+  });
+
+  it("returns tombstones to former readers and deleted records only to admins", async () => {
+    const db = createPrivateBundleDb();
+    db.simulations.set("sim-deleted", {
+      id: "sim-deleted",
+      owner_user_id: "owner-1",
+      created_by_user_id: "owner-1",
+      last_edited_by_user_id: "owner-1",
+      created_at: "2026-01-01T00:00:00.000Z",
+      last_edited_at: "2026-01-02T00:00:00.000Z",
+      name: "Deleted",
+      visibility: "public_read",
+      status: "deleted",
+      payload_json: JSON.stringify({ id: "sim-deleted", name: "Deleted", updatedAt: "2026-01-02T00:00:00.000Z" }),
+      updated_at: "2026-01-02T00:00:00.000Z",
+    });
+    db.adminUserIds.add("admin-1");
+    const env = { DB: db } as unknown as Parameters<typeof fetchLibraryForUser>[0];
+
+    const ownerLibrary = await fetchLibraryForUser(env, "owner-1");
+    expect(ownerLibrary.simulationPresets.map((simulation) => simulation.id)).toEqual(["sim-private"]);
+    expect(ownerLibrary.deletedSimulationIds).toEqual(["sim-deleted"]);
+
+    const adminLibrary = await fetchLibraryForUser(env, "admin-1");
+    expect(adminLibrary.deletedSimulationIds).toEqual([]);
+    expect(adminLibrary.simulationPresets).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: "sim-deleted", status: "deleted" })]),
+    );
   });
 
   afterEach(() => {

--- a/functions/_lib/db.ts
+++ b/functions/_lib/db.ts
@@ -7,7 +7,7 @@ const DB_VISIBILITIES: DbVisibility[] = ["private", "public_read", "public_write
 const ROLES: ResourceRole[] = ["viewer", "editor", "admin"];
 
 let schemaReady: Promise<void> | null = null;
-const SCHEMA_VERSION = "2026-05-03a";
+const SCHEMA_VERSION = "2026-08-04a";
 type AccountState = "pending" | "approved" | "revoked";
 
 const dbVisibilityFromVisibility = (value: Visibility): DbVisibility => {
@@ -272,6 +272,7 @@ const REQUIRED_COLUMNS: Record<string, string[]> = {
     "last_edited_at",
     "name",
     "visibility",
+    "status",
     "payload_json",
     "updated_at",
   ],
@@ -410,6 +411,7 @@ const ensureSchema = async (env: Env): Promise<void> => {
             last_edited_at TEXT,
             name TEXT NOT NULL,
             visibility TEXT NOT NULL DEFAULT 'private' CHECK (visibility IN ('private', 'public_read', 'public_write')),
+            status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'deleted')),
             payload_json TEXT NOT NULL,
             updated_at TEXT NOT NULL,
             FOREIGN KEY (owner_user_id) REFERENCES users(id) ON DELETE CASCADE
@@ -480,6 +482,7 @@ const ensureSchema = async (env: Env): Promise<void> => {
         env.DB.prepare("CREATE INDEX IF NOT EXISTS idx_site_roles_user ON site_roles(user_id)"),
         env.DB.prepare("CREATE INDEX IF NOT EXISTS idx_simulations_owner ON simulations(owner_user_id)"),
         env.DB.prepare("CREATE INDEX IF NOT EXISTS idx_simulations_visibility ON simulations(visibility)"),
+        env.DB.prepare("CREATE INDEX IF NOT EXISTS idx_simulations_status ON simulations(status)"),
         env.DB.prepare("CREATE INDEX IF NOT EXISTS idx_simulation_roles_user ON simulation_roles(user_id)"),
         env.DB.prepare("CREATE INDEX IF NOT EXISTS idx_resource_changes_lookup ON resource_changes(resource_kind, resource_id, changed_at DESC)"),
         env.DB.prepare("CREATE INDEX IF NOT EXISTS idx_path_leaderboard_distance ON simulation_path_leaderboard_entries(distance_km DESC)"),
@@ -1263,6 +1266,7 @@ type ResourceRow = {
   name: string;
   visibility: DbVisibility;
   created_at: string | null;
+  status?: "active" | "deleted";
 };
 
 type ActorPolicy = {
@@ -1314,6 +1318,58 @@ const canEditResource = (
   return false;
 };
 
+export const setSimulationLifecycleStatus = async (
+  env: Env,
+  actor: ActorPolicy,
+  simulationId: string,
+  status: "active" | "deleted",
+): Promise<
+  | { ok: true; simulationId: string; status: "active" | "deleted" }
+  | { ok: false; reason: "missing" | "forbidden" }
+> => {
+  await ensureSchema(env);
+  const id = simulationId.trim();
+  if (!id) return { ok: false, reason: "missing" };
+  const existing = await env.DB
+    .prepare("SELECT id, owner_user_id, status, payload_json FROM simulations WHERE id = ? LIMIT 1")
+    .bind(id)
+    .first<{ id: string; owner_user_id: string; status: "active" | "deleted"; payload_json: string }>();
+  if (!existing) return { ok: false, reason: "missing" };
+  if (status === "deleted" && !(actor.isAdmin || existing.owner_user_id === actor.id)) {
+    return { ok: false, reason: "forbidden" };
+  }
+  if (status === "active" && !actor.isAdmin) return { ok: false, reason: "forbidden" };
+  if (existing.status === status) return { ok: true, simulationId: id, status };
+
+  const now = new Date().toISOString();
+  let snapshot: Record<string, unknown> | undefined;
+  let nextPayload = existing.payload_json;
+  try {
+    snapshot = JSON.parse(existing.payload_json) as Record<string, unknown>;
+    nextPayload = JSON.stringify({ ...snapshot, updatedAt: now });
+  } catch {
+    snapshot = undefined;
+  }
+  await env.DB
+    .prepare(
+      `UPDATE simulations
+       SET status = ?, payload_json = ?, updated_at = ?, last_edited_at = ?, last_edited_by_user_id = ?
+       WHERE id = ?`,
+    )
+    .bind(status, nextPayload, now, now, actor.id, id)
+    .run();
+  await createResourceChange(
+    env,
+    "simulation",
+    id,
+    "updated",
+    actor.id,
+    status === "deleted" ? "Deleted Simulation" : "Restored Simulation",
+    { details: { changedFields: ["status"], diff: { status: { before: existing.status, after: status } } }, snapshot },
+  );
+  return { ok: true, simulationId: id, status };
+};
+
 const upsertOwnedResource = async (
   env: Env,
   kind: "site" | "simulation",
@@ -1334,7 +1390,7 @@ const upsertOwnedResource = async (
 
   const existing = await env.DB
     .prepare(
-      `SELECT t.owner_user_id, t.payload_json, t.name, t.visibility, t.created_at, r.role AS actor_role
+      `SELECT t.owner_user_id, t.payload_json, t.name, t.visibility, t.created_at${kind === "simulation" ? ", t.status" : ""}, r.role AS actor_role
        FROM ${table} t
        LEFT JOIN ${rolesTable} r ON r.${kind}_id = t.id AND r.user_id = ?
        WHERE t.id = ?`,
@@ -1343,6 +1399,9 @@ const upsertOwnedResource = async (
     .first<ResourceRow & { actor_role?: string | null }>();
 
   if (existing) {
+    if (kind === "simulation" && existing.status === "deleted") {
+      return { ok: false, reason: "simulation_deleted" };
+    }
     const existingVisibility = visibilityFromDbVisibility(existing.visibility);
     const actorRole = typeof existing.actor_role === "string" ? existing.actor_role : null;
     if (!canEditResource(actor, existing.owner_user_id, existingVisibility, actorRole)) {
@@ -1561,13 +1620,14 @@ type LibraryRow = {
   last_actor_avatar_url: string | null;
   created_at: string | null;
   last_edited_at: string | null;
+  status?: "active" | "deleted";
 };
 
 export const fetchLibraryForUser = async (
   env: Env,
   userId: string,
   opts?: { since?: string },
-): Promise<{ siteLibrary: CloudResourceRecord[]; simulationPresets: CloudResourceRecord[] }> => {
+): Promise<{ siteLibrary: CloudResourceRecord[]; simulationPresets: CloudResourceRecord[]; deletedSimulationIds: string[] }> => {
   await ensureSchema(env);
   const me = await fetchUserProfile(env, userId);
   const canReadAllResources = Boolean(me?.isAdmin);
@@ -1602,9 +1662,24 @@ export const fetchLibraryForUser = async (
     .bind(userId, canReadAllResources ? 1 : 0, userId, ...(opts?.since ? [opts.since] : []))
     .all<LibraryRow>();
 
+  const deletedSimulationRows = canReadAllResources
+    ? { results: [] as Array<{ id: string }> }
+    : await env.DB
+        .prepare(
+          `SELECT s.id
+           FROM simulations s
+           LEFT JOIN simulation_roles r ON r.simulation_id = s.id AND r.user_id = ?
+           WHERE s.status = 'deleted'
+             AND (s.owner_user_id = ?
+               OR s.visibility IN ('public_read', 'public_write')
+               OR (r.user_id IS NOT NULL AND s.visibility != 'private'))${opts?.since ? "\n             AND s.updated_at > ?" : ""}`,
+        )
+        .bind(userId, userId, ...(opts?.since ? [opts.since] : []))
+        .all<{ id: string }>();
+
   const simulationRows = await env.DB
     .prepare(
-      `SELECT s.payload_json, s.owner_user_id, s.visibility, r.role,
+      `SELECT s.payload_json, s.owner_user_id, s.visibility, s.status, r.role,
               owner_u.username AS owner_name,
               owner_u.avatar_url AS owner_avatar_url,
               s.created_by_user_id,
@@ -1624,12 +1699,13 @@ export const fetchLibraryForUser = async (
        FROM simulations s
        LEFT JOIN simulation_roles r ON r.simulation_id = s.id AND r.user_id = ?
        LEFT JOIN users owner_u ON owner_u.id = s.owner_user_id
-       WHERE (? = 1
+       WHERE ((? = 1
           OR s.owner_user_id = ?
           OR s.visibility IN ('public_read', 'public_write')
-          OR (r.user_id IS NOT NULL AND s.visibility != 'private'))${opts?.since ? "\n          AND s.updated_at > ?" : ""}`,
+          OR (r.user_id IS NOT NULL AND s.visibility != 'private'))
+         AND (? = 1 OR s.status = 'active'))${opts?.since ? "\n          AND s.updated_at > ?" : ""}`,
     )
-    .bind(userId, canReadAllResources ? 1 : 0, userId, ...(opts?.since ? [opts.since] : []))
+    .bind(userId, canReadAllResources ? 1 : 0, userId, canReadAllResources ? 1 : 0, ...(opts?.since ? [opts.since] : []))
     .all<LibraryRow>();
 
   const mapRows = (rows: LibraryRow[]) =>
@@ -1664,6 +1740,7 @@ export const fetchLibraryForUser = async (
             lastEditedByName,
             lastEditedByAvatarUrl,
             lastEditedAt: row.last_edited_at,
+            ...(row.status ? { status: row.status } : {}),
             effectiveRole:
               canReadAllResources
                 ? "admin"
@@ -1683,6 +1760,7 @@ export const fetchLibraryForUser = async (
   return {
     siteLibrary: mapRows(siteRows.results),
     simulationPresets: mapRows(simulationRows.results),
+    deletedSimulationIds: deletedSimulationRows.results.map((row) => row.id),
   };
 };
 
@@ -1897,6 +1975,7 @@ export const fetchResourceChanges = async (
   env: Env,
   kind: "site" | "simulation",
   resourceId: string,
+  actor?: { isAdmin: boolean },
 ): Promise<
   Array<{
     id: number;
@@ -1911,6 +1990,13 @@ export const fetchResourceChanges = async (
   }>
 > => {
   await ensureSchema(env);
+  if (kind === "simulation" && !actor?.isAdmin) {
+    const simulation = await env.DB
+      .prepare("SELECT status FROM simulations WHERE id = ? LIMIT 1")
+      .bind(resourceId)
+      .first<{ status: "active" | "deleted" }>();
+    if (simulation?.status === "deleted") return [];
+  }
   const rows = await env.DB
     .prepare(
       `SELECT c.id, c.action, c.changed_at, c.note, c.actor_user_id, c.details_json, c.snapshot_json,
@@ -2011,15 +2097,16 @@ export const resolveSimulationAccessForUser = async (
 
   const row = await env.DB
     .prepare(
-      `SELECT s.owner_user_id, s.visibility, r.role AS actor_role
+      `SELECT s.owner_user_id, s.visibility, s.status, r.role AS actor_role
        FROM simulations s
        LEFT JOIN simulation_roles r ON r.simulation_id = s.id AND r.user_id = ?
        WHERE s.id = ?`,
     )
     .bind(actor.id, id)
-    .first<{ owner_user_id: string; visibility: DbVisibility; actor_role?: string | null }>();
+    .first<{ owner_user_id: string; visibility: DbVisibility; status: "active" | "deleted"; actor_role?: string | null }>();
 
   if (!row) return "missing";
+  if (row.status === "deleted") return "missing";
 
   const canRead = canReadResource(
     {
@@ -2044,7 +2131,7 @@ export const resolveSimulationIdBySlug = async (
   const canonicalKey = canonicalizeSimulationLookupKey(simulationSlug);
   if (!slug && !canonicalKey) return null;
   const rows = await env.DB
-    .prepare("SELECT id, name, payload_json FROM simulations LIMIT 8000")
+    .prepare("SELECT id, name, payload_json FROM simulations WHERE status = 'active' LIMIT 8000")
     .all<{ id: string; name: string; payload_json: string }>();
   for (const row of rows.results) {
     const nameSlug = slugifyName(row.name);
@@ -2094,7 +2181,7 @@ export const resolveSimulationIdByOwnerSlug = async (
   const canonicalKey = canonicalizeSimulationLookupKey(simulationSlug);
   if (!slug && !canonicalKey) return null;
   const rows = await env.DB
-    .prepare("SELECT id, name, payload_json FROM simulations WHERE owner_user_id = ? LIMIT 8000")
+    .prepare("SELECT id, name, payload_json FROM simulations WHERE owner_user_id = ? AND status = 'active' LIMIT 8000")
     .bind(ownerId)
     .all<{ id: string; name: string; payload_json: string }>();
   for (const row of rows.results) {
@@ -2145,10 +2232,11 @@ export const fetchPublicSimulationBundle = async (
   if (!resolvedId) return { status: "missing" };
 
   const simulationRow = await env.DB
-    .prepare("SELECT id, owner_user_id, payload_json, visibility FROM simulations WHERE id = ? LIMIT 1")
+    .prepare("SELECT id, owner_user_id, payload_json, visibility, status FROM simulations WHERE id = ? LIMIT 1")
     .bind(resolvedId)
-    .first<{ id: string; owner_user_id: string; payload_json: string; visibility: DbVisibility }>();
+    .first<{ id: string; owner_user_id: string; payload_json: string; visibility: DbVisibility; status: "active" | "deleted" }>();
   if (!simulationRow) return { status: "missing" };
+  if (simulationRow.status === "deleted") return { status: "missing" };
   const visibility = visibilityFromDbVisibility(simulationRow.visibility);
 
   let actorSimulationRole: string | null = null;

--- a/functions/_lib/pathLeaderboard.ts
+++ b/functions/_lib/pathLeaderboard.ts
@@ -230,7 +230,7 @@ export const submitPathLeaderboardCandidate = async (
       `SELECT s.id, s.owner_user_id, s.name, s.visibility, s.payload_json, r.role AS actor_role
        FROM simulations s
        LEFT JOIN simulation_roles r ON r.simulation_id = s.id AND r.user_id = ?
-       WHERE s.id = ?
+       WHERE s.id = ? AND s.status = 'active'
        LIMIT 1`,
     )
     .bind(actor.id, candidate.simulationId)
@@ -319,6 +319,7 @@ export const submitPathLeaderboardCandidate = async (
          FROM simulation_path_leaderboard_entries e
          JOIN simulations s ON s.id = e.simulation_id
          WHERE s.visibility IN ('public_read', 'public_write')
+           AND s.status = 'active'
            AND json_extract(s.payload_json, '$.updatedAt') = e.simulation_updated_at
          ORDER BY e.distance_km DESC, e.path_label ASC
          LIMIT ?
@@ -341,6 +342,7 @@ export const listStatsPathLeaderboardEntries = async (env: Env): Promise<StatsPa
        JOIN simulations s ON s.id = e.simulation_id
        LEFT JOIN users u ON u.id = e.owner_user_id
        WHERE s.visibility IN ('public_read', 'public_write')
+         AND s.status = 'active'
          AND json_extract(s.payload_json, '$.updatedAt') = e.simulation_updated_at
        ORDER BY e.distance_km DESC, e.path_label ASC
        LIMIT ?`,

--- a/functions/api/changes.test.ts
+++ b/functions/api/changes.test.ts
@@ -23,7 +23,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   verifyAuthMock.mockResolvedValue({ userId: "u1", tokenPayload: {}, source: "headers" });
   ensureUserMock.mockResolvedValue(undefined);
-  assertUserAccessMock.mockResolvedValue(undefined);
+  assertUserAccessMock.mockResolvedValue({ id: "u1", isAdmin: false });
   fetchResourceChangesMock.mockResolvedValue([{ id: 1, action: "updated" }]);
 });
 
@@ -43,6 +43,6 @@ describe("api/changes", () => {
     const res = await onRequestGet(mkCtx(new Request("https://example.test/api/changes?kind=simulation&id=sim-1")));
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toEqual({ changes: [{ id: 1, action: "updated" }] });
-    expect(fetchResourceChangesMock).toHaveBeenCalledWith(env, "simulation", "sim-1");
+    expect(fetchResourceChangesMock).toHaveBeenCalledWith(env, "simulation", "sim-1", { isAdmin: false });
   });
 });

--- a/functions/api/changes.ts
+++ b/functions/api/changes.ts
@@ -11,7 +11,7 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
     if (!auth) return withCors(request, json({ error: "Unauthorized" }, { status: 401 }));
 
     await ensureUser(env, auth.userId, auth.tokenPayload);
-    await assertUserAccess(env, auth.userId);
+    const me = await assertUserAccess(env, auth.userId);
 
     const url = new URL(request.url);
     const kindRaw = url.searchParams.get("kind");
@@ -22,7 +22,7 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
       return withCors(request, json({ error: "Missing kind or id" }, { status: 400 }));
     }
 
-    const changes = await fetchResourceChanges(env, kind, resourceId);
+    const changes = await fetchResourceChanges(env, kind, resourceId, { isAdmin: me.isAdmin });
     return withCors(request, json({ changes }));
   } catch (error) {
     return errorResponse(request, error, 500);

--- a/functions/api/library/simulations/[id].test.ts
+++ b/functions/api/library/simulations/[id].test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { verifyAuthMock, ensureUserMock, assertUserAccessMock, setSimulationLifecycleStatusMock } = vi.hoisted(() => ({
+  verifyAuthMock: vi.fn(),
+  ensureUserMock: vi.fn(),
+  assertUserAccessMock: vi.fn(),
+  setSimulationLifecycleStatusMock: vi.fn(),
+}));
+
+vi.mock("../../../_lib/auth", () => ({ verifyAuth: verifyAuthMock }));
+vi.mock("../../../_lib/db", () => ({
+  ensureUser: ensureUserMock,
+  assertUserAccess: assertUserAccessMock,
+  setSimulationLifecycleStatus: setSimulationLifecycleStatusMock,
+}));
+
+import { onRequestDelete, onRequestPatch } from "./[id]";
+
+const env = { DB: {} } as unknown as { DB: D1Database };
+const mkCtx = (request: Request, id = "sim-1") =>
+  ({ request, env, params: { id } } as unknown as Parameters<typeof onRequestDelete>[0]);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  verifyAuthMock.mockResolvedValue({ userId: "owner-1", tokenPayload: {} });
+  assertUserAccessMock.mockResolvedValue({ id: "owner-1", isAdmin: false, isModerator: false });
+  setSimulationLifecycleStatusMock.mockResolvedValue({ ok: true, simulationId: "sim-1", status: "deleted" });
+});
+
+describe("api/library/simulations/[id]", () => {
+  it("marks an owned Simulation deleted", async () => {
+    const response = await onRequestDelete(mkCtx(new Request("https://example.test/api/library/simulations/sim-1", { method: "DELETE" })));
+
+    expect(response.status).toBe(200);
+    expect(setSimulationLifecycleStatusMock).toHaveBeenCalledWith(
+      env,
+      expect.objectContaining({ id: "owner-1", isAdmin: false }),
+      "sim-1",
+      "deleted",
+    );
+  });
+
+  it("only accepts admin restoration", async () => {
+    const request = new Request("https://example.test/api/library/simulations/sim-1", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ status: "active" }),
+    });
+    const forbidden = await onRequestPatch(mkCtx(request));
+    expect(forbidden.status).toBe(403);
+
+    assertUserAccessMock.mockResolvedValueOnce({ id: "admin-1", isAdmin: true, isModerator: false });
+    setSimulationLifecycleStatusMock.mockResolvedValueOnce({ ok: true, simulationId: "sim-1", status: "active" });
+    const restored = await onRequestPatch(mkCtx(new Request(request)));
+    expect(restored.status).toBe(200);
+    expect(setSimulationLifecycleStatusMock).toHaveBeenLastCalledWith(
+      env,
+      expect.objectContaining({ id: "admin-1", isAdmin: true }),
+      "sim-1",
+      "active",
+    );
+  });
+
+  it("maps lifecycle failures to permission and missing responses", async () => {
+    setSimulationLifecycleStatusMock.mockResolvedValueOnce({ ok: false, reason: "forbidden" });
+    const forbidden = await onRequestDelete(mkCtx(new Request("https://example.test/api/library/simulations/sim-1", { method: "DELETE" })));
+    expect(forbidden.status).toBe(403);
+
+    setSimulationLifecycleStatusMock.mockResolvedValueOnce({ ok: false, reason: "missing" });
+    const missing = await onRequestDelete(mkCtx(new Request("https://example.test/api/library/simulations/sim-1", { method: "DELETE" })));
+    expect(missing.status).toBe(404);
+  });
+});

--- a/functions/api/library/simulations/[id].ts
+++ b/functions/api/library/simulations/[id].ts
@@ -1,0 +1,49 @@
+import { verifyAuth } from "../../../_lib/auth";
+import { assertUserAccess, ensureUser, setSimulationLifecycleStatus } from "../../../_lib/db";
+import { errorResponse, handleOptions, json, withCors } from "../../../_lib/http";
+import type { Env } from "../../../_lib/types";
+
+export const onRequestOptions: PagesFunction<Env> = async ({ request }) => handleOptions(request);
+
+const actorPolicy = (user: { id: string; isAdmin: boolean; isModerator?: boolean }) => ({
+  id: user.id,
+  isAdmin: user.isAdmin,
+  isModerator: Boolean(user.isModerator),
+});
+
+const lifecycleResponse = (request: Request, result: Awaited<ReturnType<typeof setSimulationLifecycleStatus>>) => {
+  if (result.ok) return withCors(request, json(result));
+  if (result.reason === "missing") return withCors(request, json({ error: "Simulation not found" }, { status: 404 }));
+  return withCors(request, json({ error: "Forbidden" }, { status: 403 }));
+};
+
+export const onRequestDelete: PagesFunction<Env> = async ({ request, env, params }) => {
+  try {
+    const auth = await verifyAuth(request, env);
+    if (!auth) return withCors(request, json({ error: "Unauthorized" }, { status: 401 }));
+    await ensureUser(env, auth.userId, auth.tokenPayload);
+    const me = await assertUserAccess(env, auth.userId);
+    const simulationId = typeof params.id === "string" ? params.id.trim() : "";
+    if (!simulationId) return withCors(request, json({ error: "Missing simulation id" }, { status: 400 }));
+    return lifecycleResponse(request, await setSimulationLifecycleStatus(env, actorPolicy(me), simulationId, "deleted"));
+  } catch (error) {
+    return errorResponse(request, error, 500);
+  }
+};
+
+export const onRequestPatch: PagesFunction<Env> = async ({ request, env, params }) => {
+  try {
+    const auth = await verifyAuth(request, env);
+    if (!auth) return withCors(request, json({ error: "Unauthorized" }, { status: 401 }));
+    await ensureUser(env, auth.userId, auth.tokenPayload);
+    const me = await assertUserAccess(env, auth.userId);
+    if (!me.isAdmin) return withCors(request, json({ error: "Forbidden" }, { status: 403 }));
+    const simulationId = typeof params.id === "string" ? params.id.trim() : "";
+    if (!simulationId) return withCors(request, json({ error: "Missing simulation id" }, { status: 400 }));
+    const body = (await request.json()) as { status?: unknown };
+    if (body.status !== "active") return withCors(request, json({ error: "Invalid Simulation status" }, { status: 400 }));
+    return lifecycleResponse(request, await setSimulationLifecycleStatus(env, actorPolicy(me), simulationId, "active"));
+  } catch (error) {
+    return errorResponse(request, error, 500);
+  }
+};

--- a/functions/api/stats.ts
+++ b/functions/api/stats.ts
@@ -355,7 +355,7 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
     const [usersResult, sitesResult, simulationsResult, longestPassingPaths] = await Promise.all([
       env.DB.prepare("SELECT id, username, avatar_url, created_at FROM users").all<UserRow>(),
       env.DB.prepare("SELECT id, owner_user_id, created_at, visibility, payload_json FROM sites").all<ResourceRow>(),
-      env.DB.prepare("SELECT id, owner_user_id, created_at, name, visibility, payload_json FROM simulations").all<ResourceRow>(),
+      env.DB.prepare("SELECT id, owner_user_id, created_at, name, visibility, payload_json FROM simulations WHERE status = 'active'").all<ResourceRow>(),
       listStatsPathLeaderboardEntries(env),
     ]);
 

--- a/scripts/deploy-pages-safe.mjs
+++ b/scripts/deploy-pages-safe.mjs
@@ -195,11 +195,17 @@ async function verifyRemoteSchema(targetName, databaseName) {
   // Skip in CI: schema correctness is enforced by the PR/migration review process.
   // The check requires D1 API access beyond what the deploy token provides.
   if (process.env.GITHUB_ACTIONS === "true") return;
-  let d1Result;
+  let resourceChangesResult;
+  let simulationsResult;
   try {
-    d1Result = await run(
+    resourceChangesResult = await run(
       wrangler,
       ["d1", "execute", databaseName, "--remote", "--command", "PRAGMA table_info(resource_changes);"],
+      { capture: true },
+    );
+    simulationsResult = await run(
+      wrangler,
+      ["d1", "execute", databaseName, "--remote", "--command", "PRAGMA table_info(simulations);"],
       { capture: true },
     );
   } catch (err) {
@@ -213,8 +219,7 @@ async function verifyRemoteSchema(targetName, databaseName) {
     }
     throw err;
   }
-  const { stdout } = d1Result;
-  const parsed = parseWranglerJsonPayload(stdout);
+  const parsed = parseWranglerJsonPayload(resourceChangesResult.stdout);
   assert(Array.isArray(parsed) && parsed.length > 0, "Preflight failed: unable to parse D1 schema output.");
   const first = parsed[0];
   const rows = Array.isArray(first?.results) ? first.results : [];
@@ -226,6 +231,15 @@ async function verifyRemoteSchema(targetName, databaseName) {
     `Preflight failed: D1 schema missing columns in resource_changes: ${missing.join(
       ", ",
     )}. Apply migration db/migrations/2026-03-15_changelog_details.sql before deploy.`,
+  );
+
+  const simulationsParsed = parseWranglerJsonPayload(simulationsResult.stdout);
+  assert(Array.isArray(simulationsParsed) && simulationsParsed.length > 0, "Preflight failed: unable to parse simulations schema output.");
+  const simulationRows = Array.isArray(simulationsParsed[0]?.results) ? simulationsParsed[0].results : [];
+  const simulationColumns = new Set(simulationRows.map((row) => String(row?.name ?? "")).filter(Boolean));
+  assert(
+    simulationColumns.has("status"),
+    "Preflight failed: D1 schema missing simulations.status. Apply migration db/migrations/2026-08-04_simulation_soft_delete.sql before deploy.",
   );
 }
 

--- a/src/components/ConfirmActionModal.tsx
+++ b/src/components/ConfirmActionModal.tsx
@@ -6,6 +6,8 @@ type ConfirmActionModalProps = {
   title: string;
   message: string;
   confirmLabel?: string;
+  busy?: boolean;
+  error?: string;
   onCancel: () => void;
   onConfirm: () => void;
 };
@@ -14,23 +16,26 @@ export function ConfirmActionModal({
   title,
   message,
   confirmLabel = "Delete",
+  busy = false,
+  error = "",
   onCancel,
   onConfirm,
 }: ConfirmActionModalProps) {
   return (
-    <ModalOverlay aria-label={title} onClose={onCancel} tier="raised">
+    <ModalOverlay aria-label={title} onClose={busy ? () => undefined : onCancel} tier="raised">
       <div className="library-manager-card confirm-action-card">
         <div className="library-manager-header">
           <h2>{title}</h2>
-          <InlineCloseIconButton onClick={onCancel} />
+          <InlineCloseIconButton disabled={busy} onClick={onCancel} />
         </div>
         <p className="field-help">{message}</p>
+        {error ? <p className="field-help field-help-error">{error}</p> : null}
         <div className="chip-group">
-          <ActionButton onClick={onCancel} type="button">
+          <ActionButton disabled={busy} onClick={onCancel} type="button">
             Cancel
           </ActionButton>
-          <ActionButton onClick={onConfirm} type="button" variant="danger">
-            {confirmLabel}
+          <ActionButton disabled={busy} onClick={onConfirm} type="button" variant="danger">
+            {busy ? "Deleting..." : confirmLabel}
           </ActionButton>
         </div>
       </div>

--- a/src/components/InlineCloseIconButton.tsx
+++ b/src/components/InlineCloseIconButton.tsx
@@ -2,12 +2,13 @@ import { CircleX } from "lucide-react";
 import { Button } from "./ui/Button";
 
 type InlineCloseIconButtonProps = {
+  disabled?: boolean;
   onClick: () => void;
 };
 
-export function InlineCloseIconButton({ onClick }: InlineCloseIconButtonProps) {
+export function InlineCloseIconButton({ disabled = false, onClick }: InlineCloseIconButtonProps) {
   return (
-    <Button aria-label="Close" size="icon" onClick={onClick} title="Close">
+    <Button aria-label="Close" disabled={disabled} size="icon" onClick={onClick} title="Close">
       <CircleX aria-hidden="true" strokeWidth={1.8} />
     </Button>
   );

--- a/src/components/LibraryPanel.test.tsx
+++ b/src/components/LibraryPanel.test.tsx
@@ -147,14 +147,21 @@ describe("LibraryPanel", () => {
     expect(container.querySelector<HTMLElement>(".library-unified-list")?.scrollTop).toBe(120);
   });
 
-  it("opens Site details from an explicit button and keeps Add separate", async () => {
+  it("uses side-panel icon actions for Site details and adding", async () => {
     const user = userEvent.setup();
     render(<LibraryPanel initialTab="sites" isMobile onClose={vi.fn()} readOnly={false} />);
 
     expect(screen.queryByRole("button", { name: "Open Site details: Ridge Site" })).not.toBeInTheDocument();
     expect(screen.getByText("Ridge Site").closest("button")).toBeNull();
-    const detailsButton = screen.getByRole("button", { name: "Details for Ridge Site" });
-    expect(detailsButton.className).toBe(screen.getByRole("button", { name: "Add Ridge Site" }).className);
+    const detailsButton = screen.getByRole("button", { name: "Edit Site details: Ridge Site" });
+    const addButton = screen.getByRole("button", { name: "Add Site to Simulation: Ridge Site" });
+    expect(detailsButton).toHaveClass("btn-icon");
+    expect(addButton).toHaveClass("btn-icon");
+    expect(detailsButton.querySelector("svg")).toBeInTheDocument();
+    expect(addButton.querySelector("svg")).toBeInTheDocument();
+    expect(detailsButton.closest(".library-item-header-actions")).toBeInTheDocument();
+    expect(screen.queryByText("Details")).not.toBeInTheDocument();
+    expect(screen.queryByText("Add")).not.toBeInTheDocument();
     await user.click(detailsButton);
     expect(useAppStore.getState().mapEditor).toMatchObject({
       kind: "site",
@@ -164,18 +171,39 @@ describe("LibraryPanel", () => {
     expect(useAppStore.getState().libraryRequest).toEqual({ tab: "sites" });
   });
 
-  it("uses explicit Details and Open actions for Simulations", async () => {
+  it("uses side-panel icon actions for Simulation details and opening", async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
     render(<LibraryPanel initialTab="simulations" isMobile onClose={onClose} readOnly={false} />);
 
-    const detailsButton = screen.getByRole("button", { name: "Details for Valley Plan" });
-    const openButton = screen.getByRole("button", { name: "Open Valley Plan" });
-    expect(detailsButton.className).toBe(openButton.className);
+    const detailsButton = screen.getByRole("button", { name: "Edit Simulation details: Valley Plan" });
+    const openButton = screen.getByRole("button", { name: "Open Simulation: Valley Plan" });
+    expect(detailsButton).toHaveClass("btn-icon");
+    expect(openButton).toHaveClass("btn-icon");
+    expect(detailsButton.closest(".library-item-header-actions")).toBeInTheDocument();
+    expect(screen.queryByText("Details")).not.toBeInTheDocument();
+    expect(screen.queryByText("Open")).not.toBeInTheDocument();
     await user.click(openButton);
 
     expect(useAppStore.getState().selectedScenarioId).toBe("sim-1");
     expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("uses Info for read-only details and keeps deleted Simulations inspect-only for admins", () => {
+    useAppStore.setState({
+      currentUser: { ...currentUser, isAdmin: true },
+      simulationPresets: [
+        {
+          ...useAppStore.getState().simulationPresets[0],
+          status: "deleted",
+        },
+      ],
+    });
+    render(<LibraryPanel initialTab="simulations" isMobile onClose={vi.fn()} readOnly={false} />);
+
+    expect(screen.getByText("Deleted")).toBeVisible();
+    expect(screen.getByRole("button", { name: "View Simulation details: Valley Plan" })).toHaveClass("btn-icon");
+    expect(screen.getByRole("button", { name: "Open Simulation: Valley Plan" })).toBeDisabled();
   });
 
   it("preserves Save a copy in the Simulations tab", async () => {

--- a/src/components/LibraryPanel.tsx
+++ b/src/components/LibraryPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { Filter, Menu, X } from "lucide-react";
+import { ExternalLink, Filter, Info, MapPlus, Menu, Pencil, X } from "lucide-react";
 import {
   DEFAULT_LIBRARY_FILTER_STATE,
   filterAndSortLibraryItems,
@@ -236,7 +236,7 @@ export function LibraryPanel({
       isNew: false,
       label: preset.name,
       anchorRect: anchor.getBoundingClientRect(),
-      readOnly: !canEditResource(preset, currentUserId),
+      readOnly: preset.status === "deleted" || !canEditResource(preset, currentUserId),
       origin: { kind: "library", tab: "simulations" },
     });
   };
@@ -565,6 +565,7 @@ export function LibraryPanel({
           ? filteredSites.map((entry) => {
               const owner = ownerDisplay(entry);
               const visibility = toAccessVisibility(entry.visibility);
+              const canEdit = canEditResource(entry, currentUserId);
               return (
                 <article className="library-unified-item" key={entry.id}>
                   {!isMobile ? (
@@ -583,13 +584,33 @@ export function LibraryPanel({
                       type="checkbox"
                     />
                   ) : null}
-                  <div
-                    className="library-item-copy"
-                  >
-                    <strong>{entry.name}</strong>
-                    <span>{entry.position.lat.toFixed(5)}, {entry.position.lon.toFixed(5)}</span>
-                  </div>
-                  <div className="library-item-meta">
+                  <div className="library-item-body">
+                    <div className="library-item-header">
+                      <div className="library-item-copy">
+                        <strong>{entry.name}</strong>
+                        <span>{entry.position.lat.toFixed(5)}, {entry.position.lon.toFixed(5)}</span>
+                      </div>
+                      <div className="library-item-header-actions">
+                        <ActionButton
+                          aria-label={`${canEdit ? "Edit" : "View"} Site details: ${entry.name}`}
+                          onClick={(event) => openSiteDetails(entry, event.currentTarget)}
+                          size="icon"
+                          title={`${canEdit ? "Edit" : "View"} Site details: ${entry.name}`}
+                        >
+                          {canEdit ? <Pencil aria-hidden="true" strokeWidth={1.8} /> : <Info aria-hidden="true" strokeWidth={1.8} />}
+                        </ActionButton>
+                        <ActionButton
+                          aria-label={`Add Site to Simulation: ${entry.name}`}
+                          disabled={!canAddToActiveSimulation}
+                          onClick={() => closeAndAddSite(entry.id)}
+                          size="icon"
+                          title={canAddToActiveSimulation ? `Add Site to Simulation: ${entry.name}` : "Open an editable Simulation to add this Site"}
+                        >
+                          <MapPlus aria-hidden="true" strokeWidth={1.8} />
+                        </ActionButton>
+                      </div>
+                    </div>
+                    <div className="library-item-meta">
                     <Badge variant={visibility as "private" | "public" | "shared"}>{visibility}</Badge>
                     {entry.sourceMeta?.sourceType === "mqtt-feed" ? <Badge variant="mqtt">MQTT</Badge> : null}
                     {entry.ownerUserId && onOpenUserProfile ? (
@@ -629,24 +650,7 @@ export function LibraryPanel({
                         </span>
                       ),
                     )}
-                  </div>
-                  <div className="library-item-actions">
-                    <ActionButton
-                      aria-label={`Details for ${entry.name}`}
-                      onClick={(event) => openSiteDetails(entry, event.currentTarget)}
-                      type="button"
-                    >
-                      Details
-                    </ActionButton>
-                    <ActionButton
-                      aria-label={`Add ${entry.name}`}
-                      disabled={!canAddToActiveSimulation}
-                      onClick={() => closeAndAddSite(entry.id)}
-                      title={canAddToActiveSimulation ? "Add to Simulation" : "Open an editable Simulation to add this Site"}
-                      type="button"
-                    >
-                      Add
-                    </ActionButton>
+                    </div>
                   </div>
                 </article>
               );
@@ -654,15 +658,38 @@ export function LibraryPanel({
           : filteredSimulations.map((preset) => {
               const owner = ownerDisplay(preset);
               const visibility = toAccessVisibility(preset.visibility);
+              const isDeleted = preset.status === "deleted";
+              const canEdit = !isDeleted && canEditResource(preset, currentUserId);
               return (
                 <article className="library-unified-item library-simulation-item" key={preset.id}>
-                  <div
-                    className="library-item-copy"
-                  >
-                    <strong>{preset.name}</strong>
-                    <span>Updated {formatDate(preset.updatedAt)}</span>
-                  </div>
-                  <div className="library-item-meta">
+                  <div className="library-item-body">
+                    <div className="library-item-header">
+                      <div className="library-item-copy">
+                        <strong>{preset.name}</strong>
+                        <span>Updated {formatDate(preset.updatedAt)}</span>
+                      </div>
+                      <div className="library-item-header-actions">
+                        <ActionButton
+                          aria-label={`${canEdit ? "Edit" : "View"} Simulation details: ${preset.name}`}
+                          onClick={(event) => openSimulationDetails(preset, event.currentTarget)}
+                          size="icon"
+                          title={`${canEdit ? "Edit" : "View"} Simulation details: ${preset.name}`}
+                        >
+                          {canEdit ? <Pencil aria-hidden="true" strokeWidth={1.8} /> : <Info aria-hidden="true" strokeWidth={1.8} />}
+                        </ActionButton>
+                        <ActionButton
+                          aria-label={`Open Simulation: ${preset.name}`}
+                          disabled={isDeleted}
+                          onClick={() => closeAndLoadSimulation(preset.id)}
+                          size="icon"
+                          title={isDeleted ? "Deleted Simulations cannot be opened" : `Open Simulation: ${preset.name}`}
+                        >
+                          <ExternalLink aria-hidden="true" strokeWidth={1.8} />
+                        </ActionButton>
+                      </div>
+                    </div>
+                    <div className="library-item-meta">
+                    {isDeleted ? <Badge variant="deleted">Deleted</Badge> : null}
                     <Badge variant={visibility as "private" | "public" | "shared"}>{visibility}</Badge>
                     {preset.ownerUserId && onOpenUserProfile ? (
                       <button
@@ -679,22 +706,7 @@ export function LibraryPanel({
                         <AvatarBadge avatarUrl={owner.avatarUrl} fallbackRawText imageClassName="row-avatar-image" name={owner.name} />
                       </span>
                     )}
-                  </div>
-                  <div className="library-item-actions">
-                    <ActionButton
-                      aria-label={`Details for ${preset.name}`}
-                      onClick={(event) => openSimulationDetails(preset, event.currentTarget)}
-                      type="button"
-                    >
-                      Details
-                    </ActionButton>
-                    <ActionButton
-                      aria-label={`Open ${preset.name}`}
-                      onClick={() => closeAndLoadSimulation(preset.id)}
-                      type="button"
-                    >
-                      Open
-                    </ActionButton>
+                    </div>
                   </div>
                 </article>
               );

--- a/src/components/map/MapEditorPanel.test.tsx
+++ b/src/components/map/MapEditorPanel.test.tsx
@@ -276,6 +276,94 @@ describe("MapEditorPanel", () => {
     ).toBeInTheDocument();
   });
 
+  it("confirms Simulation deletion and preserves the editor when deletion fails", async () => {
+    const deleteSimulationPreset = vi.fn(async () => {
+      throw new Error("Cloud unavailable");
+    });
+    useAppStore.setState({
+      deleteSimulationPreset,
+      simulationPresets: [
+        {
+          id: "sim-delete",
+          name: "Delete Plan",
+          visibility: "private",
+          ownerUserId: "owner-1",
+          effectiveRole: "owner",
+          updatedAt: "2026-01-02T00:00:00.000Z",
+          snapshot: {
+            sites: [], links: [], systems: [], networks: [], selectedSiteId: "", selectedLinkId: "", selectedNetworkId: "",
+            propagationModel: "ITM", selectedFrequencyPresetId: "custom", rxSensitivityTargetDbm: -120,
+            environmentLossDb: 0, propagationEnvironment: useAppStore.getState().propagationEnvironment,
+            autoPropagationEnvironment: true, terrainDataset: "copernicus30",
+          },
+        },
+      ],
+      mapEditor: { kind: "simulation", resourceId: "sim-delete", isNew: false, label: "Delete Plan", anchorRect },
+    });
+    render(<MapEditorPanel isMobile={false} />);
+
+    await userEvent.click(await screen.findByRole("button", { name: "Delete Simulation" }));
+    const dialog = await screen.findByRole("dialog", { name: "Delete Simulation" });
+    expect(within(dialog).getByText(/Delete Delete Plan from the Library/)).toBeInTheDocument();
+    await userEvent.click(within(dialog).getByRole("button", { name: "Delete" }));
+
+    expect(await within(dialog).findByText("Delete failed: Cloud unavailable")).toBeInTheDocument();
+    expect(useAppStore.getState().mapEditor?.resourceId).toBe("sim-delete");
+  });
+
+  it("does not offer Simulation deletion to resource collaborators", async () => {
+    useAppStore.setState({
+      simulationPresets: [
+        {
+          id: "sim-editor", name: "Editor Plan", visibility: "shared", ownerUserId: "other-owner",
+          effectiveRole: "editor", updatedAt: "2026-01-02T00:00:00.000Z",
+          snapshot: {
+            sites: [], links: [], systems: [], networks: [], selectedSiteId: "", selectedLinkId: "", selectedNetworkId: "",
+            propagationModel: "ITM", selectedFrequencyPresetId: "custom", rxSensitivityTargetDbm: -120,
+            environmentLossDb: 0, propagationEnvironment: useAppStore.getState().propagationEnvironment,
+            autoPropagationEnvironment: true, terrainDataset: "copernicus30",
+          },
+        },
+      ],
+      mapEditor: { kind: "simulation", resourceId: "sim-editor", isNew: false, label: "Editor Plan", anchorRect },
+    });
+    render(<MapEditorPanel isMobile={false} />);
+
+    expect(await screen.findByRole("button", { name: "Save" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Delete Simulation" })).not.toBeInTheDocument();
+  });
+
+  it("shows Restore in read-only deleted Simulation details for platform admins", async () => {
+    const restoreSimulationPreset = vi.fn(async () => undefined);
+    useAppStore.setState({
+      currentUser: { ...currentUser, isAdmin: true },
+      restoreSimulationPreset,
+      simulationPresets: [
+        {
+          id: "sim-deleted", name: "Deleted Plan", status: "deleted", visibility: "private", ownerUserId: "owner-1",
+          effectiveRole: "admin", updatedAt: "2026-01-02T00:00:00.000Z",
+          snapshot: {
+            sites: [], links: [], systems: [], networks: [], selectedSiteId: "", selectedLinkId: "", selectedNetworkId: "",
+            propagationModel: "ITM", selectedFrequencyPresetId: "custom", rxSensitivityTargetDbm: -120,
+            environmentLossDb: 0, propagationEnvironment: useAppStore.getState().propagationEnvironment,
+            autoPropagationEnvironment: true, terrainDataset: "copernicus30",
+          },
+        },
+      ],
+      mapEditor: {
+        kind: "simulation", resourceId: "sim-deleted", isNew: false, label: "Deleted Plan", anchorRect, readOnly: true,
+        origin: { kind: "library", tab: "simulations" },
+      },
+    });
+    render(<MapEditorPanel isMobile={false} />);
+
+    expect(await screen.findByText(/available to platform admins for inspection/)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Delete Simulation" })).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Restore Simulation" }));
+    await waitFor(() => expect(restoreSimulationPreset).toHaveBeenCalledWith("sim-deleted"));
+    expect(useAppStore.getState().mapEditor).toBeNull();
+  });
+
   it("shows Simulation settings summary and enables override editing from the edit action", async () => {
     useAppStore.setState({
       selectedFrequencyPresetId: "custom",

--- a/src/components/map/MapEditorPanel.tsx
+++ b/src/components/map/MapEditorPanel.tsx
@@ -844,6 +844,11 @@ function SimulationEditorCard({
   onOpenChangeLog,
   onOpenUserProfile,
   onRequestDelete,
+  canDelete,
+  isDeleted,
+  lifecycleBusy,
+  lifecycleError,
+  onRestore,
 }: {
   isNew: boolean;
   form: ReturnType<typeof useMapEditorFormState>;
@@ -851,6 +856,11 @@ function SimulationEditorCard({
   onOpenChangeLog: (kind: ResourceKindWithChanges, resourceId: string, label: string) => void;
   onOpenUserProfile: (userId: string, anchor: HTMLElement) => void;
   onRequestDelete: () => void;
+  canDelete: boolean;
+  isDeleted: boolean;
+  lifecycleBusy: boolean;
+  lifecycleError: string;
+  onRestore: () => void;
 }) {
   const mapEditor = useAppStore((state) => state.mapEditor);
   const isReadOnly = Boolean(mapEditor?.readOnly && !isNew) || (!form.canWrite && !isNew);
@@ -876,7 +886,9 @@ function SimulationEditorCard({
       </div>
 
       {isReadOnly && (
-        <p className="field-help warning-text">Read-only: you can view this simulation but cannot edit it.</p>
+        <p className="field-help warning-text">
+          {isDeleted ? "Deleted: this Simulation is available to platform admins for inspection and restoration only." : "Read-only: you can view this simulation but cannot edit it."}
+        </p>
       )}
 
       {isReadOnly ? (
@@ -1028,6 +1040,7 @@ function SimulationEditorCard({
 
       {form.simulationNameError ? <p className="field-help field-help-error">{form.simulationNameError}</p> : null}
       {form.status ? <p className="field-help">{form.status}</p> : null}
+      {lifecycleError ? <p className="field-help field-help-error">{lifecycleError}</p> : null}
 
       <div className="chip-group">
         {!isReadOnly ? (
@@ -1035,7 +1048,12 @@ function SimulationEditorCard({
             {isNew ? (isCopySimulation ? "Save a copy" : "Create Simulation") : "Save"}
           </ActionButton>
         ) : null}
-        {!isNew && !isReadOnly ? (
+        {!isNew && isDeleted ? (
+          <ActionButton disabled={lifecycleBusy} onClick={onRestore} type="button">
+            {lifecycleBusy ? "Restoring..." : "Restore Simulation"}
+          </ActionButton>
+        ) : null}
+        {!isNew && !isReadOnly && canDelete ? (
           <ActionButton onClick={onRequestDelete} type="button" variant="danger">
             Delete Simulation
           </ActionButton>
@@ -1067,6 +1085,9 @@ export function MapEditorPanel({ isMobile }: MapEditorPanelProps) {
   const closeMapEditor = useAppStore((state) => state.closeMapEditor);
   const deleteSiteLibraryEntry = useAppStore((state) => state.deleteSiteLibraryEntry);
   const deleteSimulationPreset = useAppStore((state) => state.deleteSimulationPreset);
+  const restoreSimulationPreset = useAppStore((state) => state.restoreSimulationPreset);
+  const simulationPresets = useAppStore((state) => state.simulationPresets);
+  const currentUser = useAppStore((state) => state.currentUser);
   const form = useMapEditorFormState();
 
   const panelRef = useRef<HTMLDivElement | null>(null);
@@ -1085,6 +1106,13 @@ export function MapEditorPanel({ isMobile }: MapEditorPanelProps) {
     resourceId: string;
     label: string;
   } | null>(null);
+  const [lifecycleBusy, setLifecycleBusy] = useState(false);
+  const [lifecycleError, setLifecycleError] = useState("");
+
+  useEffect(() => {
+    setLifecycleBusy(false);
+    setLifecycleError("");
+  }, [mapEditor?.kind, mapEditor?.resourceId]);
 
   const openUserProfilePopup = (userId: string, anchor: HTMLElement) => {
     if (userId) setProfileTarget({ anchor, userId });
@@ -1185,6 +1213,16 @@ export function MapEditorPanel({ isMobile }: MapEditorPanelProps) {
       return <LinkEditorCard form={form} isNew={mapEditor.isNew} onClose={closeMapEditor} />;
     }
     if (mapEditor.kind === "simulation") {
+      const simulation = mapEditor.resourceId
+        ? simulationPresets.find((preset) => preset.id === mapEditor.resourceId)
+        : undefined;
+      const isDeleted = simulation?.status === "deleted";
+      const canDelete = Boolean(
+        simulation &&
+          !isDeleted &&
+          currentUser?.id &&
+          (currentUser.isAdmin || simulation.ownerUserId === currentUser.id || simulation.effectiveRole === "owner"),
+      );
       return (
         <SimulationEditorCard
           form={form}
@@ -1192,10 +1230,23 @@ export function MapEditorPanel({ isMobile }: MapEditorPanelProps) {
           onClose={closeMapEditor}
           onOpenChangeLog={openChangeLogPopup}
           onOpenUserProfile={openUserProfilePopup}
+          canDelete={canDelete}
+          isDeleted={isDeleted}
+          lifecycleBusy={lifecycleBusy}
+          lifecycleError={lifecycleError}
           onRequestDelete={() => {
             if (mapEditor.resourceId) {
               setDeleteTarget({ kind: "simulation", resourceId: mapEditor.resourceId, label: mapEditor.label });
             }
+          }}
+          onRestore={() => {
+            if (!mapEditor.resourceId || lifecycleBusy) return;
+            setLifecycleBusy(true);
+            setLifecycleError("");
+            void restoreSimulationPreset(mapEditor.resourceId)
+              .then(() => closeMapEditor())
+              .catch((error) => setLifecycleError(`Restore failed: ${getUiErrorMessage(error)}`))
+              .finally(() => setLifecycleBusy(false));
           }}
         />
       );
@@ -1205,17 +1256,36 @@ export function MapEditorPanel({ isMobile }: MapEditorPanelProps) {
 
   const deleteConfirmation = deleteTarget ? (
     <ConfirmActionModal
+      busy={lifecycleBusy}
+      error={lifecycleError}
       message={
         deleteTarget.kind === "site"
           ? `Delete ${deleteTarget.label} from the Library? Referenced Simulation data will be detached but preserved.`
           : `Delete ${deleteTarget.label} from the Library?${deleteTarget.resourceId === useAppStore.getState().selectedScenarioId ? " The active workspace will be cleared." : ""}`
       }
-      onCancel={() => setDeleteTarget(null)}
+      onCancel={() => {
+        if (!lifecycleBusy) {
+          setLifecycleError("");
+          setDeleteTarget(null);
+        }
+      }}
       onConfirm={() => {
-        if (deleteTarget.kind === "site") deleteSiteLibraryEntry(deleteTarget.resourceId);
-        else deleteSimulationPreset(deleteTarget.resourceId);
-        setDeleteTarget(null);
-        closeMapEditor();
+        if (deleteTarget.kind === "site") {
+          deleteSiteLibraryEntry(deleteTarget.resourceId);
+          setDeleteTarget(null);
+          closeMapEditor();
+          return;
+        }
+        if (lifecycleBusy) return;
+        setLifecycleBusy(true);
+        setLifecycleError("");
+        void deleteSimulationPreset(deleteTarget.resourceId)
+          .then(() => {
+            setDeleteTarget(null);
+            closeMapEditor();
+          })
+          .catch((error) => setLifecycleError(`Delete failed: ${getUiErrorMessage(error)}`))
+          .finally(() => setLifecycleBusy(false));
       }}
       title={deleteTarget.kind === "site" ? "Delete Site" : "Delete Simulation"}
     />

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -1,7 +1,7 @@
-import { Globe, Lock, EthernetPort, Globe2, GlobeOff, FlaskConical } from 'lucide-react';
+import { CircleMinus, Globe, Lock, EthernetPort, Globe2, GlobeOff, FlaskConical } from 'lucide-react';
 import type { HTMLAttributes } from 'react';
 
-type BadgeVariant = 'private' | 'public' | 'shared' | 'mqtt' | 'local' | 'staging';
+type BadgeVariant = 'private' | 'public' | 'shared' | 'mqtt' | 'local' | 'staging' | 'deleted';
 type BadgeTone = 'subtle' | 'prominent';
 
 type BadgeProps = {
@@ -18,6 +18,7 @@ const variantIcon = {
   mqtt: EthernetPort,
   local: GlobeOff,
   staging: FlaskConical,
+  deleted: CircleMinus,
 };
 
 const defaultTone: Record<BadgeVariant, BadgeTone> = {
@@ -27,6 +28,7 @@ const defaultTone: Record<BadgeVariant, BadgeTone> = {
   mqtt: 'subtle',
   local: 'prominent',
   staging: 'prominent',
+  deleted: 'prominent',
 };
 
 export function Badge({ variant, tone, className, children, ...rest }: BadgeProps) {
@@ -34,7 +36,7 @@ export function Badge({ variant, tone, className, children, ...rest }: BadgeProp
   const effectiveTone = tone ?? defaultTone[variant];
   const isMqtt = variant === 'mqtt';
   return (
-    <span className={`ui-badge ${effectiveTone === 'prominent' ? 'prominent' : ''} ${isMqtt ? 'mqtt-source-badge' : ''} ${className ?? ''}`} {...rest}>
+    <span className={`ui-badge ${effectiveTone === 'prominent' ? 'prominent' : ''} ${isMqtt ? 'mqtt-source-badge' : ''} ${variant === 'deleted' ? 'deleted-resource-badge' : ''} ${className ?? ''}`} {...rest}>
       <Icon aria-hidden size={10} strokeWidth={2.2} style={{ marginRight: 4 }} />
       {children}
     </span>

--- a/src/index.css
+++ b/src/index.css
@@ -5034,7 +5034,7 @@ html.panorama-gesture-lock body {
 
 .library-unified-item {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  grid-template-columns: auto minmax(0, 1fr);
   align-items: center;
   gap: 10px;
   padding: 8px;
@@ -5044,7 +5044,21 @@ html.panorama-gesture-lock body {
 }
 
 .library-simulation-item {
-  grid-template-columns: minmax(0, 1fr) auto auto;
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.library-item-body {
+  min-width: 0;
+  display: grid;
+  gap: 6px;
+}
+
+.library-item-header {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
 }
 
 .library-item-copy {
@@ -5068,11 +5082,17 @@ html.panorama-gesture-lock body {
   gap: 6px;
 }
 
-.library-item-actions {
+.library-item-header-actions {
   display: inline-flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 8px;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.deleted-resource-badge {
+  background: var(--danger);
+  color: var(--danger-on);
 }
 
 .library-site-select {
@@ -5169,10 +5189,6 @@ html.panorama-gesture-lock body {
     height: 20px;
   }
 
-  .library-item-actions .btn {
-    min-height: 44px;
-  }
-
   .library-unified-item,
   .library-simulation-item {
     grid-template-columns: minmax(0, 1fr);
@@ -5181,14 +5197,6 @@ html.panorama-gesture-lock body {
   .library-item-meta {
     justify-content: flex-start;
     padding-left: 6px;
-  }
-
-  .library-item-actions {
-    justify-content: stretch;
-  }
-
-  .library-item-actions .btn {
-    flex: 1 1 0;
   }
 
   .library-filter-options {

--- a/src/lib/cloudLibrary.test.ts
+++ b/src/lib/cloudLibrary.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fetchCloudLibrary, pushCloudLibrary } from "./cloudLibrary";
+import {
+  deleteCloudSimulation,
+  fetchCloudLibrary,
+  pushCloudLibrary,
+  restoreCloudSimulation,
+} from "./cloudLibrary";
 
 beforeEach(() => {
   vi.restoreAllMocks();
@@ -52,7 +57,38 @@ describe("cloudLibrary client", () => {
     );
 
     const result = await fetchCloudLibrary();
-    expect(result).toEqual({ siteLibrary: [{ id: "s1" }], simulationPresets: [] });
+    expect(result).toEqual({ siteLibrary: [{ id: "s1" }], simulationPresets: [], deletedSimulationIds: [] });
+  });
+
+  it("normalizes deletion tombstones from Library responses", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ siteLibrary: [], simulationPresets: [], deletedSimulationIds: ["sim-1", 42] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    await expect(fetchCloudLibrary()).resolves.toMatchObject({ deletedSimulationIds: ["sim-1"] });
+  });
+
+  it("uses dedicated lifecycle requests for delete and restore", async () => {
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, simulationId: "sim-1", status: "deleted" }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, simulationId: "sim-1", status: "active" }), { status: 200 }));
+
+    await deleteCloudSimulation("sim-1");
+    await restoreCloudSimulation("sim-1");
+
+    expect(vi.mocked(globalThis.fetch)).toHaveBeenNthCalledWith(
+      1,
+      "/api/library/simulations/sim-1",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+    expect(vi.mocked(globalThis.fetch)).toHaveBeenNthCalledWith(
+      2,
+      "/api/library/simulations/sim-1",
+      expect.objectContaining({ method: "PATCH", body: JSON.stringify({ status: "active" }) }),
+    );
   });
 
   it("includes simulation names for simulation_name_taken conflicts", async () => {

--- a/src/lib/cloudLibrary.ts
+++ b/src/lib/cloudLibrary.ts
@@ -3,6 +3,7 @@ import { parseApiErrorMessage } from "./apiError";
 export type CloudLibraryPayload = {
   siteLibrary: unknown[];
   simulationPresets: unknown[];
+  deletedSimulationIds?: string[];
 };
 
 type CloudPushResult = {
@@ -34,16 +35,30 @@ const apiCall = async <T>(path: string, init?: RequestInit): Promise<T> => {
   return (await response.json()) as T;
 };
 
-export const fetchCloudLibrary = async (opts?: { since?: string }): Promise<CloudLibraryPayload & { isDelta?: boolean }> => {
+export const fetchCloudLibrary = async (opts?: { since?: string }): Promise<CloudLibraryPayload & { deletedSimulationIds: string[]; isDelta?: boolean }> => {
   const url = opts?.since ? `/api/library?since=${encodeURIComponent(opts.since)}` : "/api/library";
-  const data = await apiCall<{ siteLibrary?: unknown[]; simulationPresets?: unknown[]; isDelta?: boolean }>(url, {
+  const data = await apiCall<{ siteLibrary?: unknown[]; simulationPresets?: unknown[]; deletedSimulationIds?: unknown[]; isDelta?: boolean }>(url, {
     method: "GET",
   });
   return {
     siteLibrary: Array.isArray(data.siteLibrary) ? data.siteLibrary : [],
     simulationPresets: Array.isArray(data.simulationPresets) ? data.simulationPresets : [],
+    deletedSimulationIds: Array.isArray(data.deletedSimulationIds)
+      ? data.deletedSimulationIds.filter((id): id is string => typeof id === "string" && id.trim().length > 0)
+      : [],
     isDelta: data.isDelta,
   };
+};
+
+export const deleteCloudSimulation = async (simulationId: string): Promise<void> => {
+  await apiCall(`/api/library/simulations/${encodeURIComponent(simulationId)}`, { method: "DELETE" });
+};
+
+export const restoreCloudSimulation = async (simulationId: string): Promise<void> => {
+  await apiCall(`/api/library/simulations/${encodeURIComponent(simulationId)}`, {
+    method: "PATCH",
+    body: JSON.stringify({ status: "active" }),
+  });
 };
 
 export const fetchPublicSimulationLibrary = async (params: {

--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -36,8 +36,18 @@ vi.mock("../lib/elevationService", () => ({
   fetchElevations: vi.fn(async () => [123]),
 }));
 
+vi.mock("../lib/cloudLibrary", async () => {
+  const actual = await vi.importActual<typeof import("../lib/cloudLibrary")>("../lib/cloudLibrary");
+  return {
+    ...actual,
+    deleteCloudSimulation: vi.fn(async () => undefined),
+    restoreCloudSimulation: vi.fn(async () => undefined),
+  };
+});
+
 import { useAppStore } from "./appStore";
 import { fetchElevations } from "../lib/elevationService";
+import { deleteCloudSimulation, restoreCloudSimulation } from "../lib/cloudLibrary";
 
 describe("appStore auth session state", () => {
   beforeEach(() => {
@@ -237,7 +247,7 @@ describe("appStore auth guards", () => {
     expect(warnSpy).toHaveBeenCalled();
   });
 
-  it("blocks Library deletion when the current user only has view access", () => {
+  it("blocks Library deletion when the current user only has view access", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     useAppStore.getState().setCurrentUser({
       id: "user-2",
@@ -258,11 +268,13 @@ describe("appStore auth guards", () => {
     });
 
     useAppStore.getState().deleteSiteLibraryEntry("lib-1");
-    useAppStore.getState().deleteSimulationPreset("sim-1");
+    await expect(useAppStore.getState().deleteSimulationPreset("sim-1")).rejects.toThrow(
+      "Only the Simulation owner or a platform admin",
+    );
 
     expect(useAppStore.getState().siteLibrary.some((entry) => entry.id === "lib-1")).toBe(true);
     expect(useAppStore.getState().simulationPresets.some((preset) => preset.id === "sim-1")).toBe(true);
-    expect(warnSpy).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenCalledOnce();
   });
 
   it("does not auto-sync online elevations when adding a site", async () => {
@@ -688,7 +700,7 @@ describe("appStore unified Library state", () => {
     );
   });
 
-  it("clears the workspace and persisted active references when deleting the active Simulation", () => {
+  it("clears the workspace and persisted active references when deleting the active Simulation", async () => {
     const createdId = useAppStore
       .getState()
       .createBlankSimulationPreset("Delete me", { visibility: "private", ownerUserId: "owner-1" });
@@ -696,7 +708,7 @@ describe("appStore unified Library state", () => {
     useAppStore.getState().loadSimulationPreset(createdId as string);
     storage.mock.setItem("rmw-last-simulation-ref-v1", `saved:${createdId}`);
 
-    useAppStore.getState().deleteSimulationPreset(createdId as string);
+    await useAppStore.getState().deleteSimulationPreset(createdId as string);
 
     const state = useAppStore.getState();
     expect(state.selectedScenarioId).toBe("");
@@ -704,6 +716,48 @@ describe("appStore unified Library state", () => {
     expect(state.links).toEqual([]);
     expect(storage.mock.getItem("linksim-last-session-v1")).toBeNull();
     expect(storage.mock.getItem("rmw-last-simulation-ref-v1")).toBeNull();
+  });
+
+  it("keeps the Simulation and active workspace when backend deletion fails", async () => {
+    const createdId = useAppStore
+      .getState()
+      .createBlankSimulationPreset("Keep me", { visibility: "private", ownerUserId: "owner-1" });
+    useAppStore.getState().loadSimulationPreset(createdId as string);
+    vi.mocked(deleteCloudSimulation).mockRejectedValueOnce(new Error("Network unavailable"));
+
+    await expect(useAppStore.getState().deleteSimulationPreset(createdId as string)).rejects.toThrow("Network unavailable");
+
+    expect(useAppStore.getState().simulationPresets.some((preset) => preset.id === createdId)).toBe(true);
+    expect(useAppStore.getState().selectedScenarioId).toBe(createdId);
+  });
+
+  it("keeps deleted Simulations inspectable for admins and restores them", async () => {
+    const createdId = useAppStore
+      .getState()
+      .createBlankSimulationPreset("Admin lifecycle", { visibility: "private", ownerUserId: "owner-1" });
+    useAppStore.setState({
+      currentUser: { ...useAppStore.getState().currentUser!, isAdmin: true, role: "admin" },
+    });
+
+    await useAppStore.getState().deleteSimulationPreset(createdId as string);
+    expect(useAppStore.getState().simulationPresets.find((preset) => preset.id === createdId)?.status).toBe("deleted");
+    await useAppStore.getState().restoreSimulationPreset(createdId as string);
+
+    expect(restoreCloudSimulation).toHaveBeenCalledWith(createdId);
+    expect(useAppStore.getState().simulationPresets.find((preset) => preset.id === createdId)?.status).toBe("active");
+  });
+
+  it("applies remote deletion tombstones and clears a stale active workspace", () => {
+    const createdId = useAppStore
+      .getState()
+      .createBlankSimulationPreset("Remote delete", { visibility: "shared", ownerUserId: "owner-1" });
+    useAppStore.getState().loadSimulationPreset(createdId as string);
+
+    useAppStore.getState().applyDeletedSimulationTombstones([createdId as string]);
+
+    expect(useAppStore.getState().simulationPresets.some((preset) => preset.id === createdId)).toBe(false);
+    expect(useAppStore.getState().selectedScenarioId).toBe("");
+    expect(useAppStore.getState().sites).toEqual([]);
   });
 });
 

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -11,7 +11,12 @@ import {
 } from "../lib/simulationDefaults";
 import { haversineDistanceKm } from "../lib/geo";
 import { getUiErrorMessage } from "../lib/uiError";
-import { fetchCloudLibrary, pushCloudLibrary } from "../lib/cloudLibrary";
+import {
+  deleteCloudSimulation,
+  fetchCloudLibrary,
+  pushCloudLibrary,
+  restoreCloudSimulation,
+} from "../lib/cloudLibrary";
 import {
   migrateSitesAndLinksToSiteRadioDefaults,
   resolveLinkRadio,
@@ -311,6 +316,7 @@ type SimulationPreset = {
   sharedWith?: Array<{ userId: string; role: "viewer" | "editor" | "admin" }>;
   ownerUserId?: string;
   effectiveRole?: "owner" | "admin" | "editor" | "viewer";
+  status?: "active" | "deleted";
   createdByUserId?: string;
   createdByName?: string;
   createdByAvatarUrl?: string;
@@ -369,7 +375,7 @@ const buildEditableSyncPayloadInfo = (
   currentUser: CloudUser | null,
 ): EditableSyncPayloadInfo => {
   const editableSites = siteLibrary.filter((site) => canEditLibraryItem(site, currentUser));
-  const editableSims = simulationPresets.filter((sim) => canEditLibraryItem(sim, currentUser));
+  const editableSims = simulationPresets.filter((sim) => sim.status !== "deleted" && canEditLibraryItem(sim, currentUser));
   const payload = { siteLibrary: editableSites, simulationPresets: editableSims };
   return {
     payload,
@@ -384,7 +390,9 @@ const buildDeltaSyncPayloadInfo = (
   currentUser: CloudUser | null,
 ): EditableSyncPayloadInfo => {
   const editableSites = siteLibrary.filter((site) => canEditLibraryItem(site, currentUser) && dirtySiteIds.has(site.id));
-  const editableSims = simulationPresets.filter((sim) => canEditLibraryItem(sim, currentUser) && dirtySimIds.has(sim.id));
+  const editableSims = simulationPresets.filter(
+    (sim) => sim.status !== "deleted" && canEditLibraryItem(sim, currentUser) && dirtySimIds.has(sim.id),
+  );
   const payload = { siteLibrary: editableSites, simulationPresets: editableSims };
   return {
     payload,
@@ -643,7 +651,9 @@ type AppState = {
       siteIconColors?: Record<string, string>;
     },
   ) => void;
-  deleteSimulationPreset: (presetId: string) => void;
+  deleteSimulationPreset: (presetId: string) => Promise<void>;
+  restoreSimulationPreset: (presetId: string) => Promise<void>;
+  applyDeletedSimulationTombstones: (presetIds: string[]) => void;
   importLibraryData: (
     bundle: { siteLibrary?: SiteLibraryEntry[]; simulationPresets?: SimulationPreset[] },
     mode: "merge" | "replace",
@@ -1457,6 +1467,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 
       // Delta fetch: merge server items by ID (server wins), keep local items not returned
       if (cloud.isDelta) {
+        get().applyDeletedSimulationTombstones(cloud.deletedSimulationIds);
         const deltaSites = cloud.siteLibrary as SiteLibraryEntry[];
         const deltaSims = cloud.simulationPresets as SimulationPreset[];
         set((state) => {
@@ -1495,6 +1506,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 
       const cloudSites = Array.isArray(cloud.siteLibrary) ? cloud.siteLibrary as SiteLibraryEntry[] : [];
       const cloudSims = Array.isArray(cloud.simulationPresets) ? cloud.simulationPresets as SimulationPreset[] : [];
+      get().applyDeletedSimulationTombstones(cloud.deletedSimulationIds);
 
       if (currentUser?.id) {
         const fixedCloudSites = adoptOrphanedEntries(
@@ -1876,7 +1888,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     try {
       const { siteLibrary, simulationPresets, currentUser, importLibraryData } = get();
       const editableSites = siteLibrary.filter((site) => canEditLibraryItem(site, currentUser));
-      const editableSims = simulationPresets.filter((sim) => canEditLibraryItem(sim, currentUser));
+      const editableSims = simulationPresets.filter((sim) => sim.status !== "deleted" && canEditLibraryItem(sim, currentUser));
       const skippedCount = siteLibrary.length - editableSites.length + simulationPresets.length - editableSims.length;
       const payload = { siteLibrary: editableSites, simulationPresets: editableSims };
       const payloadSignature = computeSyncPayloadSignature(payload);
@@ -1896,6 +1908,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       });
       const cloudPresets =
         (cloud.simulationPresets as Parameters<typeof importLibraryData>[0]["simulationPresets"] | undefined) ?? [];
+      get().applyDeletedSimulationTombstones(cloud.deletedSimulationIds);
       console.log("[appStore] Merging cloud data with local...");
       const result = importLibraryData(
         {
@@ -3099,7 +3112,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   },
   loadSimulationPreset: (presetId) => {
     const preset = get().simulationPresets.find((candidate) => candidate.id === presetId);
-    if (!preset) return;
+    if (!preset || preset.status === "deleted") return;
     get().cancelTerrainLoad();
     const snap = preset.snapshot;
     const rawSites = Array.isArray(snap.sites) ? snap.sites : [];
@@ -3414,24 +3427,71 @@ export const useAppStore = create<AppState>((set, get) => ({
       return { simulationPresets: next, ...activeAppearance };
     });
   },
-  deleteSimulationPreset: (presetId) => {
+  applyDeletedSimulationTombstones: (presetIds) => {
+    const deletedIds = new Set((presetIds ?? []).filter(Boolean));
+    if (!deletedIds.size) return;
+    const deletingActiveSimulation = deletedIds.has(get().selectedScenarioId);
+    set((state) => {
+      const next = state.simulationPresets.filter((preset) => !deletedIds.has(preset.id));
+      writeStorage(SIM_PRESETS_KEY, next);
+      return { simulationPresets: next };
+    });
+    if (deletingActiveSimulation) get().clearSimulationWorkspace();
+  },
+  deleteSimulationPreset: async (presetId) => {
     const { currentUser } = get();
     const user = requireAuth(currentUser, "deleteSimulationPreset");
-    if (!user) return;
+    if (!user) throw new Error("Sign in to delete a Simulation.");
     const existing = get().simulationPresets.find((preset) => preset.id === presetId);
-    if (existing && !canEditItem(existing, user)) {
-      console.warn(`[appStore] deleteSimulationPreset: User ${user.id} cannot delete simulation ${presetId}`);
-      return;
+    if (!existing) throw new Error("Simulation not found.");
+    const ownsSimulation = existing.ownerUserId === user.id || existing.effectiveRole === "owner";
+    if (!user.isAdmin && !ownsSimulation) {
+      throw new Error("Only the Simulation owner or a platform admin can delete it.");
     }
     const deletingActiveSimulation = get().selectedScenarioId === presetId;
+    await deleteCloudSimulation(presetId);
     set((state) => {
-      const next = state.simulationPresets.filter((preset) => preset.id !== presetId);
+      const next = user.isAdmin
+        ? state.simulationPresets.map((preset) =>
+            preset.id === presetId ? { ...preset, status: "deleted" as const, updatedAt: new Date().toISOString() } : preset,
+          )
+        : state.simulationPresets.filter((preset) => preset.id !== presetId);
       writeStorage(SIM_PRESETS_KEY, next);
       return { simulationPresets: next };
     });
     if (deletingActiveSimulation) {
       get().clearSimulationWorkspace();
     }
+    const state = get();
+    lastSyncedPayloadSignature = buildEditableSyncPayloadInfo(
+      state.siteLibrary,
+      state.simulationPresets,
+      state.currentUser,
+    ).signature;
+    writeStorage(SYNC_SIGNATURE_KEY, lastSyncedPayloadSignature);
+  },
+  restoreSimulationPreset: async (presetId) => {
+    const { currentUser } = get();
+    const user = requireAuth(currentUser, "restoreSimulationPreset");
+    if (!user) throw new Error("Sign in to restore a Simulation.");
+    if (!user.isAdmin) throw new Error("Only a platform admin can restore a Simulation.");
+    const existing = get().simulationPresets.find((preset) => preset.id === presetId);
+    if (!existing) throw new Error("Simulation not found.");
+    await restoreCloudSimulation(presetId);
+    set((state) => {
+      const next = state.simulationPresets.map((preset) =>
+        preset.id === presetId ? { ...preset, status: "active" as const, updatedAt: new Date().toISOString() } : preset,
+      );
+      writeStorage(SIM_PRESETS_KEY, next);
+      return { simulationPresets: next };
+    });
+    const state = get();
+    lastSyncedPayloadSignature = buildEditableSyncPayloadInfo(
+      state.siteLibrary,
+      state.simulationPresets,
+      state.currentUser,
+    ).signature;
+    writeStorage(SYNC_SIGNATURE_KEY, lastSyncedPayloadSignature);
   },
   importLibraryData: (bundle, mode) => {
     const incomingSites = normalizeSiteLibrary(Array.isArray(bundle.siteLibrary) ? bundle.siteLibrary : []);


### PR DESCRIPTION
## Summary
- replace Library text actions with the side-panel icon-button treatment
- add owner/admin pessimistic Simulation soft deletion and admin-only restore
- synchronize deletion tombstones and exclude deleted Simulations from non-admin/public reads
- apply and verify the additive staging D1 migration before the staging deploy

## Verification
- `npm test` — 130 files, 743 tests passed
- `npm run build`
- `npm run test -- --run src/lib/deepLink.test.ts`
- `npm run test -- --run functions/api/v1/calculate.test.ts`
- `npm run test -- --run src/store/appStore.test.ts`
- workflow YAML validation
- `npm run dev:check` — no LinkSim dev/watch servers running

Refs #966