### PR TITLE
Align Library row metadata and actions

### DIFF
--- a/src/components/LibraryPanel.css.test.ts
+++ b/src/components/LibraryPanel.css.test.ts
@@ -14,4 +14,11 @@ describe("Library panel responsive styling", () => {
   it("sizes desktop Site selection checkboxes to 28 pixels", () => {
     expect(stylesheet).toMatch(/\.library-site-select\s*\{[^}]*width:\s*28px[^}]*height:\s*28px/s);
   });
+
+  it("keeps metadata left aligned and centers row actions in the right column", () => {
+    expect(stylesheet).toMatch(/\.library-unified-item\s*\{[^}]*grid-template-columns:\s*auto minmax\(0, 1fr\) auto[^}]*align-items:\s*center/s);
+    expect(stylesheet).toMatch(/\.library-simulation-item\s*\{[^}]*grid-template-columns:\s*minmax\(0, 1fr\) auto/s);
+    expect(stylesheet).toMatch(/\.library-item-meta\s*\{[^}]*justify-content:\s*flex-start/s);
+    expect(stylesheet).toMatch(/\.library-item-actions\s*\{[^}]*align-self:\s*center/s);
+  });
 });

--- a/src/components/LibraryPanel.test.tsx
+++ b/src/components/LibraryPanel.test.tsx
@@ -159,7 +159,8 @@ describe("LibraryPanel", () => {
     expect(addButton).toHaveClass("btn-icon");
     expect(detailsButton.querySelector("svg")).toBeInTheDocument();
     expect(addButton.querySelector("svg")).toBeInTheDocument();
-    expect(detailsButton.closest(".library-item-header-actions")).toBeInTheDocument();
+    const item = detailsButton.closest(".library-unified-item");
+    expect(detailsButton.closest(".library-item-actions")?.parentElement).toBe(item);
     expect(screen.queryByText("Details")).not.toBeInTheDocument();
     expect(screen.queryByText("Add")).not.toBeInTheDocument();
     await user.click(detailsButton);
@@ -180,7 +181,8 @@ describe("LibraryPanel", () => {
     const openButton = screen.getByRole("button", { name: "Open Simulation: Valley Plan" });
     expect(detailsButton).toHaveClass("btn-icon");
     expect(openButton).toHaveClass("btn-icon");
-    expect(detailsButton.closest(".library-item-header-actions")).toBeInTheDocument();
+    const item = detailsButton.closest(".library-unified-item");
+    expect(detailsButton.closest(".library-item-actions")?.parentElement).toBe(item);
     expect(screen.queryByText("Details")).not.toBeInTheDocument();
     expect(screen.queryByText("Open")).not.toBeInTheDocument();
     await user.click(openButton);

--- a/src/components/LibraryPanel.tsx
+++ b/src/components/LibraryPanel.tsx
@@ -567,7 +567,7 @@ export function LibraryPanel({
               const visibility = toAccessVisibility(entry.visibility);
               const canEdit = canEditResource(entry, currentUserId);
               return (
-                <article className="library-unified-item" key={entry.id}>
+                <article className="library-unified-item library-site-item" key={entry.id}>
                   {!isMobile ? (
                     <input
                       aria-label={`Select ${entry.name}`}
@@ -585,30 +585,9 @@ export function LibraryPanel({
                     />
                   ) : null}
                   <div className="library-item-body">
-                    <div className="library-item-header">
-                      <div className="library-item-copy">
-                        <strong>{entry.name}</strong>
-                        <span>{entry.position.lat.toFixed(5)}, {entry.position.lon.toFixed(5)}</span>
-                      </div>
-                      <div className="library-item-header-actions">
-                        <ActionButton
-                          aria-label={`${canEdit ? "Edit" : "View"} Site details: ${entry.name}`}
-                          onClick={(event) => openSiteDetails(entry, event.currentTarget)}
-                          size="icon"
-                          title={`${canEdit ? "Edit" : "View"} Site details: ${entry.name}`}
-                        >
-                          {canEdit ? <Pencil aria-hidden="true" strokeWidth={1.8} /> : <Info aria-hidden="true" strokeWidth={1.8} />}
-                        </ActionButton>
-                        <ActionButton
-                          aria-label={`Add Site to Simulation: ${entry.name}`}
-                          disabled={!canAddToActiveSimulation}
-                          onClick={() => closeAndAddSite(entry.id)}
-                          size="icon"
-                          title={canAddToActiveSimulation ? `Add Site to Simulation: ${entry.name}` : "Open an editable Simulation to add this Site"}
-                        >
-                          <MapPlus aria-hidden="true" strokeWidth={1.8} />
-                        </ActionButton>
-                      </div>
+                    <div className="library-item-copy">
+                      <strong>{entry.name}</strong>
+                      <span>{entry.position.lat.toFixed(5)}, {entry.position.lon.toFixed(5)}</span>
                     </div>
                     <div className="library-item-meta">
                     <Badge variant={visibility as "private" | "public" | "shared"}>{visibility}</Badge>
@@ -652,6 +631,25 @@ export function LibraryPanel({
                     )}
                     </div>
                   </div>
+                  <div className="library-item-actions row-actions">
+                    <ActionButton
+                      aria-label={`${canEdit ? "Edit" : "View"} Site details: ${entry.name}`}
+                      onClick={(event) => openSiteDetails(entry, event.currentTarget)}
+                      size="icon"
+                      title={`${canEdit ? "Edit" : "View"} Site details: ${entry.name}`}
+                    >
+                      {canEdit ? <Pencil aria-hidden="true" strokeWidth={1.8} /> : <Info aria-hidden="true" strokeWidth={1.8} />}
+                    </ActionButton>
+                    <ActionButton
+                      aria-label={`Add Site to Simulation: ${entry.name}`}
+                      disabled={!canAddToActiveSimulation}
+                      onClick={() => closeAndAddSite(entry.id)}
+                      size="icon"
+                      title={canAddToActiveSimulation ? `Add Site to Simulation: ${entry.name}` : "Open an editable Simulation to add this Site"}
+                    >
+                      <MapPlus aria-hidden="true" strokeWidth={1.8} />
+                    </ActionButton>
+                  </div>
                 </article>
               );
             })
@@ -663,30 +661,9 @@ export function LibraryPanel({
               return (
                 <article className="library-unified-item library-simulation-item" key={preset.id}>
                   <div className="library-item-body">
-                    <div className="library-item-header">
-                      <div className="library-item-copy">
-                        <strong>{preset.name}</strong>
-                        <span>Updated {formatDate(preset.updatedAt)}</span>
-                      </div>
-                      <div className="library-item-header-actions">
-                        <ActionButton
-                          aria-label={`${canEdit ? "Edit" : "View"} Simulation details: ${preset.name}`}
-                          onClick={(event) => openSimulationDetails(preset, event.currentTarget)}
-                          size="icon"
-                          title={`${canEdit ? "Edit" : "View"} Simulation details: ${preset.name}`}
-                        >
-                          {canEdit ? <Pencil aria-hidden="true" strokeWidth={1.8} /> : <Info aria-hidden="true" strokeWidth={1.8} />}
-                        </ActionButton>
-                        <ActionButton
-                          aria-label={`Open Simulation: ${preset.name}`}
-                          disabled={isDeleted}
-                          onClick={() => closeAndLoadSimulation(preset.id)}
-                          size="icon"
-                          title={isDeleted ? "Deleted Simulations cannot be opened" : `Open Simulation: ${preset.name}`}
-                        >
-                          <ExternalLink aria-hidden="true" strokeWidth={1.8} />
-                        </ActionButton>
-                      </div>
+                    <div className="library-item-copy">
+                      <strong>{preset.name}</strong>
+                      <span>Updated {formatDate(preset.updatedAt)}</span>
                     </div>
                     <div className="library-item-meta">
                     {isDeleted ? <Badge variant="deleted">Deleted</Badge> : null}
@@ -707,6 +684,25 @@ export function LibraryPanel({
                       </span>
                     )}
                     </div>
+                  </div>
+                  <div className="library-item-actions row-actions">
+                    <ActionButton
+                      aria-label={`${canEdit ? "Edit" : "View"} Simulation details: ${preset.name}`}
+                      onClick={(event) => openSimulationDetails(preset, event.currentTarget)}
+                      size="icon"
+                      title={`${canEdit ? "Edit" : "View"} Simulation details: ${preset.name}`}
+                    >
+                      {canEdit ? <Pencil aria-hidden="true" strokeWidth={1.8} /> : <Info aria-hidden="true" strokeWidth={1.8} />}
+                    </ActionButton>
+                    <ActionButton
+                      aria-label={`Open Simulation: ${preset.name}`}
+                      disabled={isDeleted}
+                      onClick={() => closeAndLoadSimulation(preset.id)}
+                      size="icon"
+                      title={isDeleted ? "Deleted Simulations cannot be opened" : `Open Simulation: ${preset.name}`}
+                    >
+                      <ExternalLink aria-hidden="true" strokeWidth={1.8} />
+                    </ActionButton>
                   </div>
                 </article>
               );

--- a/src/index.css
+++ b/src/index.css
@@ -5034,7 +5034,7 @@ html.panorama-gesture-lock body {
 
 .library-unified-item {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
+  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
   gap: 10px;
   padding: 8px;
@@ -5044,21 +5044,13 @@ html.panorama-gesture-lock body {
 }
 
 .library-simulation-item {
-  grid-template-columns: minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr) auto;
 }
 
 .library-item-body {
   min-width: 0;
   display: grid;
   gap: 6px;
-}
-
-.library-item-header {
-  min-width: 0;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
 }
 
 .library-item-copy {
@@ -5078,16 +5070,13 @@ html.panorama-gesture-lock body {
 .library-item-meta {
   display: inline-flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: flex-start;
   gap: 6px;
+  padding-left: 6px;
 }
 
-.library-item-header-actions {
-  display: inline-flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 2px;
-  flex-shrink: 0;
+.library-item-actions {
+  align-self: center;
 }
 
 .deleted-resource-badge {
@@ -5189,14 +5178,9 @@ html.panorama-gesture-lock body {
     height: 20px;
   }
 
-  .library-unified-item,
+  .library-site-item,
   .library-simulation-item {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .library-item-meta {
-    justify-content: flex-start;
-    padding-left: 6px;
+    grid-template-columns: minmax(0, 1fr) auto;
   }
 
   .library-filter-options {


### PR DESCRIPTION
## Summary
- left-align Library access and owner metadata on desktop to match mobile
- place Site and Simulation icon actions in a dedicated right column centered across the full row
- preserve the desktop Site checkbox column and responsive mobile action layout
- add structural and CSS regression coverage

## Verification
- `npm test` (130 files, 744 tests)
- `npm run build`
- focused Library tests (13 tests)
- `npm run dev:check`

Refs #966