### PR TITLE
Require complete terrain for simulations

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -50,14 +50,11 @@ import {
 import { canShowSaveSelectedLinkAction } from "../lib/selectedPairActions";
 import {
   optionsForSelectionCount,
-  resolveEffectiveOverlayRadiusKm,
-  resolveLoadedOverlayRadiusCapKm,
+  resolveRequiredOverlayTerrainTileKeys,
   resolveOverlayRadiusOptionForSelectionTransition,
   resolveTargetOverlayRadiusKm,
   type SimulationOverlayRadiusOption,
 } from "../lib/simulationOverlayRadius";
-import { simulationAreaBoundsForSites } from "../lib/simulationArea";
-import { tilesForBounds } from "../lib/terrainTiles";
 import {
   buildCoverageOverlayPixelsAsync,
   buildMeshExtensionOverlayPixelsAsync,
@@ -808,6 +805,7 @@ export function MapView({
   const simulationStepLabel = useCoverageStore((state) => state.simulationStepLabel);
   const simulationRunToken = useCoverageStore((state) => state.simulationRunToken);
   const completedCoverageRunToken = useCoverageStore((state) => state.completedCoverageRunToken);
+  const simulationErrorMessage = useCoverageStore((state) => state.simulationErrorMessage);
   const autoCalculateEnabled = useCoverageStore((state) => state.autoCalculateEnabled);
   const automaticLockNoticeShown = useCoverageStore((state) => state.automaticLockNoticeShown);
   const calculationCycleSource = useCoverageStore((state) => state.calculationCycleSource);
@@ -1330,59 +1328,28 @@ export function MapView({
     onPublishNotice,
     setAutoCalculateEnabled,
   ]);
+  useEffect(() => {
+    if (!simulationErrorMessage) return;
+    onPublishNotice?.({
+      id: "simulation-terrain-unavailable",
+      message: simulationErrorMessage,
+      tone: "error",
+      persistent: false,
+    });
+  }, [onPublishNotice, simulationErrorMessage]);
   const targetRadiusKm = useMemo(
     () => resolveTargetOverlayRadiusKm(selectionCount, normalizedOverlayRadiusOption),
     [selectionCount, normalizedOverlayRadiusOption],
   );
-  const loadedRadiusCapKm = useMemo(
-    () => resolveLoadedOverlayRadiusCapKm(analysisTargetSites, targetRadiusKm, srtmTiles, 20),
-    [analysisTargetSites, targetRadiusKm, srtmTiles],
-  );
-  const overlayRadiusKm = useMemo(
-    () =>
-      Math.min(
-        targetRadiusKm,
-        Math.min(
-          loadedRadiusCapKm,
-          resolveEffectiveOverlayRadiusKm({
-            selectionCount,
-            option: normalizedOverlayRadiusOption,
-            selectedSingleSite: selectionCount === 1 ? selectedSites[0] ?? null : null,
-            srtmTiles,
-            isTerrainFetching,
-          }),
-        ),
-      ),
-    [
-      targetRadiusKm,
-      normalizedOverlayRadiusOption,
-      loadedRadiusCapKm,
-      selectionCount,
-      selectedSites,
-      srtmTiles,
-      isTerrainFetching,
-    ],
-  );
+  const overlayRadiusKm = targetRadiusKm;
   const overlayRadiusOptions = optionsForSelectionCount(selectionCount);
   const loaded30mTileKeys = useMemo(
     () => new Set(srtmTiles.filter((tile) => tile.sourceId === "copernicus30").map((tile) => tile.key)),
     [srtmTiles],
   );
-  const targetRadiusBounds = useMemo(
-    () => simulationAreaBoundsForSites(analysisTargetSites, { overlayRadiusKm: targetRadiusKm }),
-    [analysisTargetSites, targetRadiusKm],
-  );
   const requiredTargetRadiusTileKeys = useMemo(
-    () =>
-      targetRadiusBounds
-        ? tilesForBounds(
-            targetRadiusBounds.minLat,
-            targetRadiusBounds.maxLat,
-            targetRadiusBounds.minLon,
-            targetRadiusBounds.maxLon,
-          )
-        : [],
-    [targetRadiusBounds],
+    () => resolveRequiredOverlayTerrainTileKeys(analysisTargetSites, targetRadiusKm),
+    [analysisTargetSites, targetRadiusKm],
   );
   const missingTargetRadiusTileCount = useMemo(
     () => requiredTargetRadiusTileKeys.filter((key) => !loaded30mTileKeys.has(key)).length,

--- a/src/components/MapView.userLocation.test.tsx
+++ b/src/components/MapView.userLocation.test.tsx
@@ -177,6 +177,7 @@ describe("MapView user location flow", () => {
       autoCalculateEnabled: true,
       automaticLockNoticeShown: false,
       calculationCycleSource: null,
+      simulationErrorMessage: "",
     });
   });
 
@@ -234,6 +235,28 @@ describe("MapView user location flow", () => {
     act(() => useAppStore.setState({ selectedOverlayRadiusOption: "100" }));
     await waitFor(() => expect(screen.getByRole("button", { name: "Start calculation" })).toBeInTheDocument());
     expect(onPublishNotice).toHaveBeenCalledTimes(1);
+  });
+
+  it("publishes an explicit terrain-unavailable calculation error", async () => {
+    const onPublishNotice = vi.fn();
+    renderMapView({ onPublishNotice });
+
+    act(() => {
+      useCoverageStore.setState({
+        simulationErrorMessage:
+          "The 50 km Simulation could not be completed because required GLO-30 terrain is unavailable.",
+      });
+    });
+
+    await waitFor(() =>
+      expect(onPublishNotice).toHaveBeenCalledWith({
+        id: "simulation-terrain-unavailable",
+        message:
+          "The 50 km Simulation could not be completed because required GLO-30 terrain is unavailable.",
+        tone: "error",
+        persistent: false,
+      }),
+    );
   });
 
   it("starts and stops live geolocation from the map control", () => {

--- a/src/lib/coverage.test.ts
+++ b/src/lib/coverage.test.ts
@@ -107,6 +107,20 @@ describe("buildCoverage", () => {
     ).rejects.toBeInstanceOf(CoverageBuildCancelledError);
   });
 
+  it("rejects a terrain-backed build when any required terrain sample is unavailable", async () => {
+    await expect(
+      buildCoverageAsync(
+        NORMAL_GRID,
+        network,
+        [sites[0]],
+        systems,
+        defaultPropagationEnvironment(),
+        () => null,
+        { overlayRadiusKm: 50, requireCompleteTerrain: true },
+      ),
+    ).rejects.toThrow("Terrain data is unavailable");
+  });
+
   it("uses single-site radius override for sampling bounds", () => {
     const singleSite = [sites[0]];
     const base = buildCoverage(NORMAL_GRID, network, singleSite, systems, defaultPropagationEnvironment());

--- a/src/lib/coverage.ts
+++ b/src/lib/coverage.ts
@@ -19,6 +19,7 @@ export type BuildCoverageOptions = {
   overlayRadiusKm?: number;
   singleSiteRadiusKm?: number;
   shouldCancel?: () => boolean;
+  requireCompleteTerrain?: boolean;
 };
 
 export class CoverageBuildCancelledError extends Error {
@@ -27,6 +28,24 @@ export class CoverageBuildCancelledError extends Error {
     this.name = "CoverageBuildCancelledError";
   }
 }
+
+export class CoverageTerrainUnavailableError extends Error {
+  constructor(coordinates: Coordinates) {
+    super(
+      `Terrain data is unavailable at ${coordinates.lat.toFixed(5)}, ${coordinates.lon.toFixed(5)}`,
+    );
+    this.name = "CoverageTerrainUnavailableError";
+  }
+}
+
+const requireTerrainSample = (
+  terrainSampler: (coordinates: Coordinates) => number | null,
+): ((coordinates: Coordinates) => number) =>
+  (coordinates) => {
+    const elevationM = terrainSampler(coordinates);
+    if (elevationM === null) throw new CoverageTerrainUnavailableError(coordinates);
+    return elevationM;
+  };
 
 export type CoverageGridBounds = {
   minLat: number;
@@ -215,6 +234,10 @@ export const buildCoverage = (
   const effectiveFrequencyMHz = network.frequencyOverrideMHz ?? network.frequencyMHz;
   const sampleMultiplier = Math.max(1, options?.sampleMultiplier ?? 1);
   const terrainSamples = Math.max(16, Math.round(options?.terrainSamples ?? 20));
+  const effectiveTerrainSampler =
+    terrainSampler && options?.requireCompleteTerrain
+      ? requireTerrainSample(terrainSampler)
+      : terrainSampler;
   const onProgress = options?.onProgress;
   const shouldCancel = options?.shouldCancel;
   const fallbackSystemId = systems[0]?.id ?? "";
@@ -258,7 +281,7 @@ export const buildCoverage = (
           effectiveFrequencyMHz,
           terrainSamples,
           environment,
-          terrainSampler,
+          effectiveTerrainSampler,
           options?.terrainCacheKey,
         );
       })
@@ -288,6 +311,10 @@ export const buildCoverageAsync = async (
   const effectiveFrequencyMHz = network.frequencyOverrideMHz ?? network.frequencyMHz;
   const sampleMultiplier = Math.max(1, options?.sampleMultiplier ?? 1);
   const terrainSamples = Math.max(16, Math.round(options?.terrainSamples ?? 20));
+  const effectiveTerrainSampler =
+    terrainSampler && options?.requireCompleteTerrain
+      ? requireTerrainSample(terrainSampler)
+      : terrainSampler;
   const onProgress = options?.onProgress;
   const shouldCancel = options?.shouldCancel;
   const fallbackSystemId = systems[0]?.id ?? "";
@@ -334,7 +361,7 @@ export const buildCoverageAsync = async (
           effectiveFrequencyMHz,
           terrainSamples,
           environment,
-          terrainSampler,
+          effectiveTerrainSampler,
           options?.terrainCacheKey,
         );
       })

--- a/src/lib/simulationOverlayRadius.test.ts
+++ b/src/lib/simulationOverlayRadius.test.ts
@@ -3,8 +3,7 @@ import {
   defaultOptionForSelectionCount,
   normalizeOverlayRadiusOptionForSelectionCount,
   optionsForSelectionCount,
-  resolveEffectiveOverlayRadiusKm,
-  resolveLoadedOverlayRadiusCapKm,
+  resolveMissingOverlayTerrainTileKeys,
   resolveOverlayRadiusOptionForSelectionTransition,
   resolveTargetOverlayRadiusKm,
 } from "./simulationOverlayRadius";
@@ -52,36 +51,16 @@ describe("simulationOverlayRadius", () => {
     ).toBe("50");
   });
 
-  it("uses fixed values in single-site mode", () => {
-    const radius = resolveEffectiveOverlayRadiusKm({
-      selectionCount: 1,
-      option: "100",
-      selectedSingleSite: site,
-      srtmTiles: [mkTile("N59E010")],
-      isTerrainFetching: false,
-    });
-    expect(radius).toBe(100);
-  });
-
-  it("uses fixed values outside single-site mode", () => {
-    const radius = resolveEffectiveOverlayRadiusKm({
-      selectionCount: 2,
-      option: "100",
-      selectedSingleSite: null,
-      srtmTiles: [],
-      isTerrainFetching: false,
-    });
-    expect(radius).toBe(100);
-  });
-
   it("resolves target radius by context and option", () => {
     expect(resolveTargetOverlayRadiusKm(1, "20")).toBe(20);
     expect(resolveTargetOverlayRadiusKm(1, "200")).toBe(200);
     expect(resolveTargetOverlayRadiusKm(3, "100")).toBe(100);
   });
 
-  it("caps loaded radius conservatively to available 30m tiles", () => {
-    const capped = resolveLoadedOverlayRadiusCapKm([site], 200, [mkTile("N59E010")], 20);
-    expect(capped).toBe(20);
+  it("reports every missing GLO-30 tile for the full selected radius", () => {
+    const missing = resolveMissingOverlayTerrainTileKeys([site], 200, [mkTile("N59E010")]);
+
+    expect(missing.length).toBeGreaterThan(1);
+    expect(missing).not.toContain("N59E010");
   });
 });

--- a/src/lib/simulationOverlayRadius.ts
+++ b/src/lib/simulationOverlayRadius.ts
@@ -40,18 +40,6 @@ export const isOverlayRadiusOption = (value: unknown): value is SimulationOverla
   typeof value === "string" &&
   (["20", "50", "100", "200"] as const).includes(value as SimulationOverlayRadiusOption);
 
-export const resolveEffectiveOverlayRadiusKm = (params: {
-  selectionCount: number;
-  option: SimulationOverlayRadiusOption;
-  selectedSingleSite: Pick<Site, "position"> | null;
-  srtmTiles: ReadonlyArray<SrtmTile>;
-  isTerrainFetching: boolean;
-}): number => {
-  const { option } = params;
-  const fixed = option === "20" || option === "50" || option === "100" || option === "200" ? Number(option) : 20;
-  return fixed;
-};
-
 export const resolveTargetOverlayRadiusKm = (
   selectionCount: number,
   option: SimulationOverlayRadiusOption,
@@ -60,36 +48,23 @@ export const resolveTargetOverlayRadiusKm = (
     ? Number(option)
     : 20;
 
-export const resolveLoadedOverlayRadiusCapKm = (
+export const resolveRequiredOverlayTerrainTileKeys = (
+  sites: Pick<Site, "position">[],
+  targetRadiusKm: number,
+): string[] => {
+  const bounds = simulationAreaBoundsForSites(sites, { overlayRadiusKm: targetRadiusKm });
+  return bounds ? tilesForBounds(bounds.minLat, bounds.maxLat, bounds.minLon, bounds.maxLon) : [];
+};
+
+export const resolveMissingOverlayTerrainTileKeys = (
   sites: Pick<Site, "position">[],
   targetRadiusKm: number,
   srtmTiles: ReadonlyArray<SrtmTile>,
-  minimumRadiusKm = 20,
-): number => {
-  if (!sites.length) return minimumRadiusKm;
-  const loaded30m = new Set(srtmTiles.filter((tile) => tile.sourceId === "copernicus30").map((tile) => tile.key));
-  if (!loaded30m.size) return minimumRadiusKm;
-
-  const minRadiusKm = Math.max(1, minimumRadiusKm);
-  const maxRadiusKm = Math.max(minRadiusKm, Math.round(targetRadiusKm));
-  const hasCoverageForRadius = (radiusKm: number): boolean => {
-    const bounds = simulationAreaBoundsForSites(sites, { overlayRadiusKm: radiusKm });
-    if (!bounds) return false;
-    const needed = tilesForBounds(bounds.minLat, bounds.maxLat, bounds.minLon, bounds.maxLon);
-    if (!needed.length) return false;
-    return needed.every((key) => loaded30m.has(key));
-  };
-
-  if (!hasCoverageForRadius(minRadiusKm)) return minRadiusKm;
-  let low = minRadiusKm;
-  let high = maxRadiusKm;
-  while (low < high) {
-    const mid = Math.ceil((low + high + 1) / 2);
-    if (hasCoverageForRadius(mid)) {
-      low = mid;
-    } else {
-      high = mid - 1;
-    }
-  }
-  return low;
+): string[] => {
+  const loaded30m = new Set(
+    srtmTiles.filter((tile) => tile.sourceId === "copernicus30").map((tile) => tile.key),
+  );
+  return resolveRequiredOverlayTerrainTileKeys(sites, targetRadiusKm).filter(
+    (key) => !loaded30m.has(key),
+  );
 };

--- a/src/store/appStore.terrainLoading.test.ts
+++ b/src/store/appStore.terrainLoading.test.ts
@@ -112,6 +112,25 @@ describe("appStore GLO-30 terrain lifecycle", () => {
     expect(useAppStore.getState().terrainFetchStatus).toContain("1 unavailable");
   });
 
+  it("retains successful tiles and recomputes once after a partial load has settled", async () => {
+    terrainClient.loadCopernicus30TilesByKeys.mockResolvedValue({
+      tiles: [tile("N59E009")],
+      failedTiles: ["N60E009"],
+      fetchedTiles: ["N59E009"],
+      cacheHits: [],
+    });
+    const recompute = vi.spyOn(useCoverageStore.getState(), "recomputeCoverage").mockImplementation(() => {
+      expect(useAppStore.getState().isTerrainFetching).toBe(false);
+    });
+
+    await useAppStore.getState().recommendAndFetchTerrainForCurrentArea(20);
+
+    expect(recompute).toHaveBeenCalledTimes(1);
+    expect(useAppStore.getState().srtmTiles.some((entry) => entry.key === "N59E009")).toBe(true);
+    expect(useAppStore.getState().isHighResTerrainLoaded).toBe(false);
+    expect(useAppStore.getState().terrainFetchStatus).toContain("1 unavailable");
+  });
+
   it("cancels the active load and ignores its late result", async () => {
     let resolveLoad!: (value: {
       tiles: SrtmTile[];

--- a/src/store/coverageStore.test.ts
+++ b/src/store/coverageStore.test.ts
@@ -6,6 +6,8 @@ import {
   useCoverageStore,
 } from "./coverageStore";
 import * as coverageLib from "../lib/coverage";
+import { simulationAreaBoundsForSites } from "../lib/simulationArea";
+import { tilesForBounds } from "../lib/terrainTiles";
 import type { CoverageSample, Site } from "../types/radio";
 
 const site: Site = {
@@ -20,6 +22,28 @@ const site: Site = {
   cableLossDb: 1,
 };
 
+const completeTerrainTiles = (radiusKm = 50) => {
+  const bounds = simulationAreaBoundsForSites([site], { overlayRadiusKm: radiusKm });
+  if (!bounds) return [];
+  return tilesForBounds(bounds.minLat, bounds.maxLat, bounds.minLon, bounds.maxLon).map((key) => {
+    const match = /^([NS])(\d{2})([EW])(\d{3})$/.exec(key);
+    if (!match) throw new Error(`Unexpected tile key: ${key}`);
+    const latStart = Number(match[2]) * (match[1] === "S" ? -1 : 1);
+    const lonStart = Number(match[4]) * (match[3] === "W" ? -1 : 1);
+    return {
+      key,
+      latStart,
+      lonStart,
+      size: 2,
+      width: 2,
+      height: 2,
+      arcSecondSpacing: 1 as const,
+      elevations: new Int16Array([100, 100, 100, 100]),
+      sourceId: "copernicus30",
+    };
+  });
+};
+
 const makeBridgeState = () => ({
   selectedCoverageResolution: "24",
   networks: [{ id: "net-1", memberships: [], frequencyMHz: 869.5 }],
@@ -27,7 +51,7 @@ const makeBridgeState = () => ({
   sites: [site],
   systems: [],
   propagationModel: "ITM",
-  srtmTiles: [],
+  srtmTiles: completeTerrainTiles(),
   links: [],
   selectedLinkId: "",
   autoPropagationEnvironment: false,
@@ -79,6 +103,7 @@ describe("coverageStore simulation progress phases", () => {
       completedCoverageRunToken: "",
       autoCalculateEnabled: true,
       calculationCycleSource: null,
+      simulationErrorMessage: "",
     });
     resetCoverageSchedulerForTests();
     setAppStoreBridge({
@@ -147,6 +172,24 @@ describe("coverageStore simulation progress phases", () => {
     expect(buildSpy).toHaveBeenCalledTimes(1);
     expect(useCoverageStore.getState().autoCalculateEnabled).toBe(false);
     expect(useCoverageStore.getState().calculationCycleSource).toBe("manual");
+    expect(buildSpy.mock.calls[0]?.[6]).toEqual(expect.objectContaining({ overlayRadiusKm: 50 }));
+  });
+
+  it("does not calculate or retain results when required terrain tiles remain unavailable", async () => {
+    const buildSpy = vi.spyOn(coverageLib, "buildCoverageAsync").mockResolvedValue([]);
+    bridgeState.srtmTiles = completeTerrainTiles().slice(0, 1);
+    useCoverageStore.setState({
+      coverageSamples: [{ lat: site.position.lat, lon: site.position.lon, valueDbm: -80 }],
+    });
+
+    useCoverageStore.getState().startManualCalculation();
+    vi.advanceTimersByTime(220);
+    await flushAsyncTicks();
+
+    expect(buildSpy).not.toHaveBeenCalled();
+    expect(useCoverageStore.getState().coverageSamples).toEqual([]);
+    expect(useCoverageStore.getState().simulationErrorMessage).toContain("50 km");
+    expect(useCoverageStore.getState().simulationErrorMessage).toContain("terrain");
   });
 
   it("locks automatic calculation for 100 km+ or 4x+ settings", () => {
@@ -196,6 +239,30 @@ describe("coverageStore simulation progress phases", () => {
 
     expect(buildSpy).not.toHaveBeenCalled();
     expect(useCoverageStore.getState().isSimulationRecomputing).toBe(false);
+
+    bridgeState.isTerrainFetching = false;
+    bridgeState.terrainLoadEpoch += 1;
+    useCoverageStore.getState().recomputeCoverage();
+    vi.advanceTimersByTime(220);
+    await flushAsyncTicks();
+    vi.advanceTimersByTime(700);
+    await flushAsyncTicks();
+
+    expect(buildSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a manual Start waiting without committing coverage while terrain loads", async () => {
+    const buildSpy = vi.spyOn(coverageLib, "buildCoverageAsync").mockResolvedValue([]);
+    bridgeState.isTerrainFetching = true;
+    useCoverageStore.setState({ coverageSamples: [] });
+
+    useCoverageStore.getState().startManualCalculation();
+    vi.advanceTimersByTime(220);
+    await flushAsyncTicks();
+
+    expect(buildSpy).not.toHaveBeenCalled();
+    expect(useCoverageStore.getState().coverageSamples).toEqual([]);
+    expect(useCoverageStore.getState().calculationCycleSource).toBe("manual");
 
     bridgeState.isTerrainFetching = false;
     bridgeState.terrainLoadEpoch += 1;

--- a/src/store/coverageStore.ts
+++ b/src/store/coverageStore.ts
@@ -3,6 +3,7 @@ import {
   buildCoverageAsync,
   computeCoverageGridDimensions,
   CoverageBuildCancelledError,
+  CoverageTerrainUnavailableError,
 } from "../lib/coverage";
 import { simulationAreaBoundsForSites } from "../lib/simulationArea";
 import {
@@ -10,8 +11,7 @@ import {
 } from "../lib/propagationEnvironment";
 import {
   normalizeOverlayRadiusOptionForSelectionCount,
-  resolveLoadedOverlayRadiusCapKm,
-  resolveEffectiveOverlayRadiusKm,
+  resolveMissingOverlayTerrainTileKeys,
   resolveTargetOverlayRadiusKm,
 } from "../lib/simulationOverlayRadius";
 import {
@@ -87,6 +87,7 @@ export type CoverageState = {
   autoCalculateEnabled: boolean;
   automaticLockNoticeShown: boolean;
   calculationCycleSource: "auto" | "manual" | null;
+  simulationErrorMessage: string;
   recomputeCoverage: () => void;
   markAutomaticLockNoticeShown: () => void;
   setAutoCalculateEnabled: (enabled: boolean) => void;
@@ -385,29 +386,12 @@ const runCoverageComputation = async (
     }
 
     const selectionCount = inputs.selectedSiteIds.length;
-    const selectedSingleSite =
-      selectionCount === 1
-        ? inputs.sites.find((site) => site.id === inputs.selectedSiteIds[0]) ?? null
-        : null;
     const selectedOverlayRadiusOption = normalizeOverlayRadiusOptionForSelectionCount(
       selectionCount,
       inputs.selectedOverlayRadiusOptionRaw,
     );
-    const overlayRadiusKm = resolveEffectiveOverlayRadiusKm({
-      selectionCount,
-      option: selectedOverlayRadiusOption,
-      selectedSingleSite,
-      srtmTiles: inputs.srtmTiles,
-      isTerrainFetching: inputs.isTerrainFetching,
-    });
     const targetRadiusKm = resolveTargetOverlayRadiusKm(selectionCount, selectedOverlayRadiusOption);
-    const loadedRadiusCapKm = resolveLoadedOverlayRadiusCapKm(
-      selectionCount === 1 && selectedSingleSite ? [selectedSingleSite] : inputs.sites,
-      targetRadiusKm,
-      inputs.srtmTiles,
-      20,
-    );
-    const effectiveOverlayRadiusKm = Math.min(targetRadiusKm, overlayRadiusKm, loadedRadiusCapKm);
+    const effectiveOverlayRadiusKm = targetRadiusKm;
 
     const boundsForCount = simulationAreaBoundsForSites(inputs.sites, { overlayRadiusKm: effectiveOverlayRadiusKm });
     const sampleCount = boundsForCount
@@ -443,6 +427,7 @@ const runCoverageComputation = async (
           }
         },
         shouldCancel: () => get().simulationRunToken !== runId,
+        requireCompleteTerrain: true,
         terrainCacheKey: `${inputs.effectiveCoverageResolution}|${inputs.selectedNetworkId}|${inputs.propagationModel}|${inputs.terrainLoadEpoch}`,
       },
     );
@@ -498,6 +483,27 @@ const runCoverageComputation = async (
       markCancelled("coverage-build-cancelled");
       return;
     }
+    if (error instanceof CoverageTerrainUnavailableError) {
+      const message =
+        "Simulation could not be completed because required terrain samples are unavailable.";
+      if (get().simulationRunToken === runId) {
+        set({
+          coverageSamples: [],
+          isSimulationRecomputing: false,
+          simulationProgress: 0,
+          simulationProgressMode: "indeterminate",
+          simulationStepLabel: "",
+          simulationSamplesDone: 0,
+          simulationSamplesTotal: 0,
+          simulationRunToken: "",
+          completedCoverageRunToken: "",
+          calculationCycleSource: null,
+          simulationErrorMessage: message,
+        });
+        appStoreBridge?.setState({ terrainFetchStatus: message });
+      }
+      return;
+    }
     console.error("Coverage recompute failed", error);
     if (get().simulationRunToken === runId) {
       set({
@@ -535,6 +541,40 @@ const flushCoverageRunQueue = async (): Promise<void> => {
       simulationSamplesTotal: 0,
       simulationRunToken: "",
     });
+    return;
+  }
+  const selectionCount = inputs.selectedSiteIds.length;
+  const selectedTerrainSites =
+    selectionCount === 1
+      ? inputs.sites.filter((site) => site.id === inputs.selectedSiteIds[0])
+      : inputs.sites;
+  const selectedOverlayRadiusOption = normalizeOverlayRadiusOptionForSelectionCount(
+    selectionCount,
+    inputs.selectedOverlayRadiusOptionRaw,
+  );
+  const targetRadiusKm = resolveTargetOverlayRadiusKm(selectionCount, selectedOverlayRadiusOption);
+  const missingTerrainTileKeys = resolveMissingOverlayTerrainTileKeys(
+    selectedTerrainSites,
+    targetRadiusKm,
+    inputs.srtmTiles,
+  );
+  if (missingTerrainTileKeys.length > 0) {
+    coverageRerunQueued = false;
+    const message = `The ${targetRadiusKm} km Simulation could not be completed because ${missingTerrainTileKeys.length} required GLO-30 terrain tile${missingTerrainTileKeys.length === 1 ? " is" : "s are"} unavailable.`;
+    useCoverageStore.setState({
+      coverageSamples: [],
+      isSimulationRecomputing: false,
+      simulationProgress: 0,
+      simulationProgressMode: "indeterminate",
+      simulationStepLabel: "",
+      simulationSamplesDone: 0,
+      simulationSamplesTotal: 0,
+      simulationRunToken: "",
+      completedCoverageRunToken: "",
+      calculationCycleSource: null,
+      simulationErrorMessage: message,
+    });
+    appStoreBridge.setState({ terrainFetchStatus: message });
     return;
   }
   const runSignature = coverageInputSignature(inputs);
@@ -575,6 +615,7 @@ export const useCoverageStore = create<CoverageState>((set, get) => ({
   autoCalculateEnabled: true,
   automaticLockNoticeShown: false,
   calculationCycleSource: null,
+  simulationErrorMessage: "",
   recomputeCoverage: () => {
     if (!appStoreBridge) return;
     const appState = appStoreBridge.getState();
@@ -594,6 +635,7 @@ export const useCoverageStore = create<CoverageState>((set, get) => ({
     if (get().isSimulationRecomputing) return;
     set({
       calculationCycleSource: manualRun ? "manual" : "auto",
+      simulationErrorMessage: "",
       isSimulationRecomputing: true,
       simulationProgress: 0,
       simulationProgressMode: "indeterminate",
@@ -640,6 +682,7 @@ export const useCoverageStore = create<CoverageState>((set, get) => ({
     if (coverageRunInFlight || get().isSimulationRecomputing) return;
     set({
       isSimulationRecomputing: true,
+      simulationErrorMessage: "",
       simulationProgress: 0,
       simulationProgressMode: "indeterminate",
       simulationStepLabel: "Preparing simulation bounds...",


### PR DESCRIPTION
## Summary

- remove the loaded-terrain radius cap from calculation and display bounds
- wait for complete GLO-30 coverage before calculating the selected radius
- abort terrain-backed calculations when a required tile or sample remains unavailable
- clear stale coverage and publish an explicit error through the existing notice system
- preserve manual waiting, retry, cancellation, and automatic-calculation behavior

## Root cause

The calculation and map pipelines independently reduced the selected radius to the continuously loaded tile area. After partial or failed downloads, recomputation therefore produced a smaller result, while missing samples could still fall through to zero terrain loss.

## Impact

A 20, 50, 100, or 200 km Simulation now either completes for its selected radius with complete terrain or reports that it could not be completed. Partial results are not committed as successful coverage.

## Validation

- `npm test` — 130 files, 747 tests passed
- `npm run build` — passed
- focused terrain, coverage-store, radius, and MapView tests — 49 passed
- `npm run dev:check` — no LinkSim dev/watch servers found

Addresses #972