### PR TITLE
Fix panorama label sizing in expanded mode

### DIFF
--- a/src/components/PanoramaChart.css.test.ts
+++ b/src/components/PanoramaChart.css.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("Panorama chart responsive styling", () => {
+  const stylesheet = readFileSync(resolve(process.cwd(), "src/index.css"), "utf8");
+
+  it("keeps expanded chart sizing off panorama label icons", () => {
+    expect(stylesheet).toMatch(/\.chart-svg-wrap\s*>\s*svg\s*\{/);
+    expect(stylesheet).toMatch(/\.chart-panel\.is-expanded\s+\.chart-svg-wrap\s*>\s*svg\s*\{/);
+    expect(stylesheet).toMatch(
+      /\.panorama-label-overlay svg\s*\{[^}]*width:\s*10px[^}]*height:\s*10px[^}]*min-height:\s*unset/s,
+    );
+    expect(stylesheet).not.toMatch(/\.chart-panel\.is-expanded\s+\.chart-svg-wrap\s+svg\s*\{/);
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -2970,7 +2970,7 @@ button {
   letter-spacing: 0.01em;
 }
 
-.chart-svg-wrap svg {
+.chart-svg-wrap > svg {
   display: block;
   width: 100%;
   height: 100%;
@@ -2988,17 +2988,11 @@ button {
   flex-shrink: 0;
 }
 
-.chart-panel.is-expanded .panorama-label-overlay svg {
-  width: 10px;
-  height: 10px;
-  min-height: unset;
-}
-
 .chart-panel.is-expanded .chart-svg-wrap {
   min-height: clamp(280px, 62vh, 760px);
 }
 
-.chart-panel.is-expanded .chart-svg-wrap svg {
+.chart-panel.is-expanded .chart-svg-wrap > svg {
   max-height: none;
   min-height: clamp(280px, 62vh, 760px);
 }


### PR DESCRIPTION
Closes #969.

## What changed
- scope chart SVG sizing rules to the direct chart SVG
- keep panorama label icons at their existing 10 x 10 size in normal and expanded modes
- remove the redundant expanded-label override
- add a regression test for the selector boundary

## Root cause
The expanded `.chart-svg-wrap svg` rule also matched Lucide SVG icons inside panorama labels. Its chart-sized `min-height` won the cascade and made the label pills extremely tall.

## Verification
- `npm run test -- --run src/components/PanoramaChart.css.test.ts`
- `npm test` (131 files, 748 tests)
- `npm run build`
- `npm run dev:check`

After merge and automatic staging deployment, normal and expanded modes will be visually verified with browser control.