### PR TITLE
Show MQTT position precision bounds

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -42,6 +42,8 @@ import { TERRAIN_DATASET_LABEL } from "../lib/terrainDataset";
 import type { Link, Site } from "../types/radio";
 import {
   fetchMeshmapNodes,
+  formatPositionPrecision,
+  getPositionPrecisionBounds,
   mergeMeshmapNodes,
   NODE_FEED_SOURCES,
   type MeshmapNode,
@@ -261,8 +263,8 @@ const terrainRasterPaint = {
   "raster-saturation": -0.06,
 };
 
-const userLocationAccuracyLayer = (color: string): LayerProps => ({
-  id: "user-location-accuracy-layer",
+const positionAreaLayer = (id: string, color: string): LayerProps => ({
+  id,
   type: "fill",
   paint: {
     "fill-color": color,
@@ -662,6 +664,7 @@ type PendingSiteMove = {
 type MapInspectorHoverInfo = {
   text: string;
   libraryEntryId?: string;
+  mqttNode?: MeshmapNode;
 };
 
 type PanoramaInteractionState = {
@@ -721,6 +724,35 @@ const buildUserLocationAccuracyGeoJson = (fix: UserLocationFix | null) => {
         geometry: {
           type: "Polygon" as const,
           coordinates: [coordinates],
+        },
+      },
+    ],
+  };
+};
+
+const buildMqttPositionPrecisionGeoJson = (node: MeshmapNode | undefined) => {
+  const bounds = node ? getPositionPrecisionBounds(node) : null;
+  if (!bounds) {
+    return {
+      type: "FeatureCollection" as const,
+      features: [],
+    };
+  }
+  return {
+    type: "FeatureCollection" as const,
+    features: [
+      {
+        type: "Feature" as const,
+        properties: {},
+        geometry: {
+          type: "Polygon" as const,
+          coordinates: [[
+            [bounds.minLon, bounds.minLat],
+            [bounds.maxLon, bounds.minLat],
+            [bounds.maxLon, bounds.maxLat],
+            [bounds.minLon, bounds.maxLat],
+            [bounds.minLon, bounds.minLat],
+          ]],
         },
       },
     ],
@@ -1039,6 +1071,7 @@ export function MapView({
   useEffect(() => {
     if (showDiscoveryMqtt) return;
     setMqttDuplicatePrompt(null);
+    setOverlayHoverInfo((current) => (current?.mqttNode ? null : current));
   }, [showDiscoveryMqtt]);
 
   useEffect(() => {
@@ -3150,6 +3183,7 @@ export function MapView({
     () => buildUserLocationAccuracyGeoJson(userLocationFix),
     [userLocationFix],
   );
+  const mqttPositionPrecisionGeoJson = buildMqttPositionPrecisionGeoJson(overlayHoverInfo?.mqttNode);
   const userLocationSelectionColor = variant.cssVars["--selection"] ?? selectedLinkColor;
   // Track the selected category in local state; initialize from the current style's category.
   const [selectedCategory, setSelectedCategory] = useState<BasemapCategory>(
@@ -4204,7 +4238,18 @@ export function MapView({
 
         {userLocationFix ? (
           <Source data={userLocationAccuracyGeoJson} id="user-location-accuracy" type="geojson">
-            <Layer {...userLocationAccuracyLayer(userLocationSelectionColor)} />
+            <Layer {...positionAreaLayer("user-location-accuracy-layer", userLocationSelectionColor)} />
+          </Source>
+        ) : null}
+
+        {mqttPositionPrecisionGeoJson.features.length ? (
+          <Source data={mqttPositionPrecisionGeoJson} id="mqtt-position-precision" type="geojson">
+            <Layer
+              {...positionAreaLayer(
+                "mqtt-position-precision-layer",
+                variant.cssVars["--temporary"] ?? userLocationSelectionColor,
+              )}
+            />
           </Source>
         ) : null}
 
@@ -4327,7 +4372,8 @@ export function MapView({
                     setOverlayHoverInfo({
                       text: `${node.longName ?? node.shortName ?? node.nodeId} · ${node.nodeId}${
                         node.shortName ? ` · ${node.shortName}` : ""
-                      }${node.hwModel ? ` · ${node.hwModel}` : ""}`,
+                      }${node.hwModel ? ` · ${node.hwModel}` : ""} · ${formatPositionPrecision(node.positionPrecisionBits)}`,
+                      mqttNode: node,
                     })
                   }
                   onMouseLeave={() => setOverlayHoverInfo(null)}

--- a/src/components/MapView.userLocation.test.tsx
+++ b/src/components/MapView.userLocation.test.tsx
@@ -86,6 +86,7 @@ vi.mock("../lib/meshtasticMqtt", async (importOriginal) => ({
         hwModel: "T-Beam",
         lat: 60.55,
         lon: 11.55,
+        positionPrecisionBits: options?.sourceId === "meshmap" ? 16 : undefined,
         updatedAt: 1,
         sourceId: options?.sourceId,
         sourceUrl: options?.sourceUrl,
@@ -532,6 +533,65 @@ describe("MapView user location flow", () => {
       expect(useAppStore.getState().discoveryLibraryVisible).toBe(true);
       expect(useAppStore.getState().discoveryMqttVisible).toBe(true);
     });
+  });
+
+  it("shows the exact MQTT position precision rectangle only while hovering", async () => {
+    useAppStore.setState({ mapViewport: { center: { lat: 60.55, lon: 11.55 }, zoom: 12 } });
+    renderMapView({ showInspector: true });
+
+    fireEvent.click(screen.getByText("Map"));
+    const popover = await openVisibleSiteSources();
+    fireEvent.click(within(popover).getByLabelText("MeshMap.net"));
+    const marker = await screen.findByRole("button", { name: "MQTT Alpha" });
+
+    fireEvent.mouseEnter(marker);
+
+    expect(await screen.findByText(/Position precision: 16 bits · ≈364 m/)).toBeVisible();
+    await waitFor(() => {
+      const source = [...mapMock.sourceProps]
+        .reverse()
+        .find((props) => props.id === "mqtt-position-precision");
+      expect(source?.data).toEqual({
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            properties: {},
+            geometry: {
+              type: "Polygon",
+              coordinates: [[
+                [11.5467232, 60.5467232],
+                [11.5532768, 60.5467232],
+                [11.5532768, 60.5532768],
+                [11.5467232, 60.5532768],
+                [11.5467232, 60.5467232],
+              ]],
+            },
+          },
+        ],
+      });
+    });
+
+    fireEvent.mouseLeave(marker);
+    expect(screen.queryByText(/Position precision: 16 bits/)).not.toBeInTheDocument();
+  });
+
+  it("reports unavailable MQTT precision without rendering a rectangle and preserves marker activation", async () => {
+    useAppStore.setState({ mapViewport: { center: { lat: 60.55, lon: 11.55 }, zoom: 12 } });
+    renderMapView({ showInspector: true });
+
+    fireEvent.click(screen.getByText("Map"));
+    const popover = await openVisibleSiteSources();
+    fireEvent.click(within(popover).getByLabelText("868.no"));
+    const marker = await screen.findByRole("button", { name: "MQTT Alpha" });
+
+    fireEvent.mouseEnter(marker);
+
+    expect(await screen.findByText(/Position precision unavailable/)).toBeVisible();
+    expect(mapMock.sourceProps.some((props) => props.id === "mqtt-position-precision")).toBe(false);
+
+    fireEvent.click(marker);
+    expect(await screen.findByText(/Opened MQTT node in the site editor/)).toBeVisible();
   });
 
   it("clears selected library discovery actions when Library is disabled", async () => {

--- a/src/lib/meshtasticMqtt.test.ts
+++ b/src/lib/meshtasticMqtt.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { mergeMeshmapNodes, parseMeshmapLikeFeed } from "./meshtasticMqtt";
+import {
+  formatPositionPrecision,
+  getPositionPrecisionBounds,
+  mergeMeshmapNodes,
+  parseMeshmapLikeFeed,
+} from "./meshtasticMqtt";
 
 describe("node feed normalization", () => {
   it("normalizes legacy MeshMap and normalized adapter payloads", () => {
@@ -30,6 +35,63 @@ describe("node feed normalization", () => {
     ).toEqual([
       expect.objectContaining({ nodeId: "!norway", lat: 61.2, lon: 11.3, updatedAt: 1_800_000_200_000 }),
     ]);
+  });
+
+  it("normalizes integer position precision bits from numeric and string feed values", () => {
+    expect(
+      parseMeshmapLikeFeed({
+        "!numeric": { lat: 60.1, lon: 10.2, precision: 16 },
+        "!string": { lat: 61.2, lon: 11.3, precision: "32" },
+      }),
+    ).toEqual([
+      expect.objectContaining({ nodeId: "!numeric", positionPrecisionBits: 16 }),
+      expect.objectContaining({ nodeId: "!string", positionPrecisionBits: 32 }),
+    ]);
+  });
+
+  it.each([undefined, 0, -1, 1.5, 33, "invalid"])(
+    "treats invalid position precision %s as unavailable",
+    (precision) => {
+      expect(
+        parseMeshmapLikeFeed({
+          "!node": { lat: 60.1, lon: 10.2, precision },
+        }),
+      ).toEqual([
+        expect.not.objectContaining({ positionPrecisionBits: expect.anything() }),
+      ]);
+    },
+  );
+
+  it("calculates the exact coordinate quantization bounds", () => {
+    expect(getPositionPrecisionBounds({ lat: 60.55, lon: 11.55, positionPrecisionBits: 16 })).toEqual({
+      minLat: 60.5467232,
+      maxLat: 60.5532768,
+      minLon: 11.5467232,
+      maxLon: 11.5532768,
+    });
+
+    expect(getPositionPrecisionBounds({ lat: -33.9, lon: -151.2, positionPrecisionBits: 32 })).toEqual({
+      minLat: -33.90000005,
+      maxLat: -33.89999995,
+      minLon: -151.20000005,
+      maxLon: -151.19999995,
+    });
+
+    expect(getPositionPrecisionBounds({ lat: 78.2, lon: 15.6, positionPrecisionBits: 16 })).toEqual({
+      minLat: 78.1967232,
+      maxLat: 78.2032768,
+      minLon: 15.5967232,
+      maxLon: 15.6032768,
+    });
+
+    expect(getPositionPrecisionBounds({ lat: 78.2, lon: 15.6 })).toBeNull();
+  });
+
+  it("formats approximate precision and full or unavailable states", () => {
+    expect(formatPositionPrecision(10)).toBe("Position precision: 10 bits · ≈23.3 km");
+    expect(formatPositionPrecision(16)).toBe("Position precision: 16 bits · ≈364 m");
+    expect(formatPositionPrecision(32)).toBe("Position precision: full (32 bits)");
+    expect(formatPositionPrecision(undefined)).toBe("Position precision unavailable");
   });
 
   it("deduplicates enabled sources by canonical node id and prefers the newest report", () => {

--- a/src/lib/meshtasticMqtt.ts
+++ b/src/lib/meshtasticMqtt.ts
@@ -7,6 +7,7 @@ export type MeshmapNode = {
   lat: number;
   lon: number;
   altitudeM?: number;
+  positionPrecisionBits?: number;
   updatedAt?: number;
   sourceId?: NodeFeedSourceId;
   sourceUrl?: string;
@@ -77,6 +78,41 @@ const toNumber = (value: unknown): number | null => {
 const toStringOrUndefined = (value: unknown): string | undefined =>
   typeof value === "string" && value.trim().length ? value : undefined;
 
+const toPositionPrecisionBits = (value: unknown): number | undefined => {
+  const precision = toNumber(value);
+  return precision !== null && Number.isInteger(precision) && precision >= 1 && precision <= 32
+    ? precision
+    : undefined;
+};
+
+export const getPositionPrecisionBounds = (
+  node: Pick<MeshmapNode, "lat" | "lon" | "positionPrecisionBits">,
+): { minLat: number; maxLat: number; minLon: number; maxLon: number } | null => {
+  const precisionBits = node.positionPrecisionBits;
+  if (precisionBits === undefined) return null;
+  const halfSpanDegrees = 2 ** (31 - precisionBits) * 1e-7;
+  const stableCoordinate = (value: number): number => Number(value.toFixed(12));
+  return {
+    minLat: stableCoordinate(node.lat - halfSpanDegrees),
+    maxLat: stableCoordinate(node.lat + halfSpanDegrees),
+    minLon: stableCoordinate(node.lon - halfSpanDegrees),
+    maxLon: stableCoordinate(node.lon + halfSpanDegrees),
+  };
+};
+
+export const formatPositionPrecision = (precisionBits: number | undefined): string => {
+  if (precisionBits === undefined) return "Position precision unavailable";
+  if (precisionBits === 32) return "Position precision: full (32 bits)";
+  const halfSpanM = 2 ** (31 - precisionBits) * 1e-7 * 111_195;
+  const formattedSpan =
+    halfSpanM >= 1_000
+      ? `${(halfSpanM / 1_000).toFixed(1)} km`
+      : halfSpanM >= 1
+        ? `${Math.round(halfSpanM)} m`
+        : "<1 m";
+  return `Position precision: ${precisionBits} bits · ≈${formattedSpan}`;
+};
+
 const cacheKeyFor = (sourceUrl: string): string =>
   sourceUrl === DEFAULT_MESHMAP_FEED_URL
     ? MESHMAP_CACHE_KEY
@@ -130,6 +166,7 @@ const parseNode = (nodeId: string, node: MeshmapNodeRaw): MeshmapNode | null => 
     lat,
     lon,
     altitudeM: toNumber(node.altitudeM ?? node.altitude) ?? undefined,
+    positionPrecisionBits: toPositionPrecisionBits(node.precision),
     updatedAt: updatedAt ?? undefined,
   };
 };


### PR DESCRIPTION
Closes #968 after staging verification and user sign-off.

## What changed

- Parse valid Meshtastic MQTT position-precision bits while preserving compatibility with existing cached nodes.
- Render the exact latitude/longitude quantization rectangle only while an MQTT discovery marker is hovered.
- Add position-precision details to the existing map inspector, including full and unavailable states.
- Keep precision as live feed metadata; saved Sites and the 868.no adapter remain unchanged.

## Why

Meshtastic reduces latitude and longitude precision independently. A rectangular quantization cell represents the encoded uncertainty more accurately than a radial accuracy ring.

## Validation

- `npm run test -- --run src/lib/meshtasticMqtt.test.ts src/components/MapView.userLocation.test.tsx` — 32 tests passed
- `npm test` — 131 files, 759 tests passed
- `npm run build` — passed
- `npm run dev:check` — no LinkSim dev/watch servers running

Repository-wide `npm run lint` remains blocked by the existing lint backlog, including an unrelated nested `.claude/worktrees` checkout; no lint cleanup is included in this issue.