### PR TITLE
Documentation and Getting Started refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,24 @@ LinkSim is a web app for terrain-aware radio path planning and simulation.
   <img src="./docs/assets/readme/path-profile-simulation.png" alt="LinkSim path profile simulation" width="49%">
 </p>
 
-## Start Here
+## Use LinkSim
 
 | Need | Document |
 | --- | --- |
-| Use the app | [Getting Started](./docs/onboarding.md) |
-| Understand radio models | [RF models and sampling](./docs/rf-models-and-sampling.md) |
-| Run or maintain the repo | [Repository guide](./docs/repository-guide.md) |
-| Test changes | [Testing plan](./docs/testing-plan.md) |
+| Learn the workflow | [Getting Started](./docs/onboarding.md) |
+| Understand calculations | [RF models and coverage](./docs/rf-models-and-sampling.md) |
+| Share a specific view | [Deep links](./docs/deep-links.md) |
+
+## Build and Operate
+
+| Need | Document |
+| --- | --- |
+| Set up and understand the repository | [Repository guide](./docs/repository-guide.md) |
+| Test a change | [Testing plan](./docs/testing-plan.md) |
+| Work with shared staging | [Staging environment](./docs/staging-environment.md) |
 | Ship a release | [Release flow](./docs/release-flow.md) |
+| Configure authentication | [Cloudflare Access and D1](./docs/cloudflare-auth-setup.md) |
+| Manage Cloudflare with Terraform | [Terraform guide](./docs/terraform-iac.md) |
 | Reuse UI patterns | UI Gallery (`/ui-gallery`) |
 | Review policies | [Security](./SECURITY.md), [Privacy](./docs/legal/PRIVACY.md), [Terms](./docs/legal/TERMS.md) |
 

--- a/docs/cloudflare-auth-setup.md
+++ b/docs/cloudflare-auth-setup.md
@@ -22,11 +22,7 @@ Copy the returned `database_id` into `wrangler.toml`.
 npx wrangler d1 execute linksim --file ./db/schema.sql
 ```
 
-For upgrades from older deployments, apply migrations explicitly (runtime auto-migrations are disabled):
-
-```bash
-npx wrangler d1 execute linksim --file ./db/migrations/2026-03-12_schema_alignment.sql
-```
+For upgrades from older deployments, review [`db/migrations`](../db/migrations) and apply each migration that the target database has not received, in filename order. Runtime auto-migrations are disabled, and deployment preflight stops when a required column is missing.
 
 ## 3) Configure Cloudflare Access (GitHub + OTP)
 
@@ -108,5 +104,7 @@ This is for local testing only.
 
 ## Related docs
 
-- Access policy templates: `docs/access-policy-templates.md`
-- Testing plan: `docs/testing-plan.md`
+- [Access policy templates](./access-policy-templates.md)
+- [Testing plan](./testing-plan.md)
+- [Staging environment](./staging-environment.md)
+- [Release flow](./release-flow.md)

--- a/docs/deep-links.md
+++ b/docs/deep-links.md
@@ -9,23 +9,19 @@ LinkSim supports shareable deep links that link directly to a specific simulatio
 | **Simulation only** | `/<username>/<simulation>` | `/Alice/Blefjell` |
 | **Single site** | `/<username>/<simulation>/<site>` | `/Alice/Blefjell/Fyrisjøen` |
 | **Multi-site** | `/<username>/<simulation>/<site1>+<site2>+<site3>` | `/Alice/Blefjell/Fyrisjøen+HOEG-ROUTER` |
-| **Link** | `/<username>/<simulation>/<site1>~<site2>` | `/Alice/Blefjell/Fyrisjøen~HOEG-ROUTER` |
+| **Path** | `/<username>/<simulation>/<site1>~<site2>` | `/Alice/Blefjell/Fyrisjøen~HOEG-ROUTER` |
 
-## Features
+## Names and matching
 
-### Unicode & Emoji Support
-- Unicode characters are preserved in URLs (e.g., `Høgevarde`, `한국조선`)
-- Emoji are preserved (e.g., `💩`, `🏝️~🌋`)
-- No URL encoding required for special characters
+- Display names are normalized into path segments: surrounding whitespace is removed, internal spaces become hyphens, and reserved delimiter characters are removed.
+- Unicode letters are preserved (for example `Høgevarde` or `한국조선`). Browsers may percent-encode Unicode when copying or displaying the URL; LinkSim safely decodes it when reading the link.
+- Matching is case-insensitive and Unicode-normalized while the generated URL preserves the display-name case.
 
-### Case Handling
-- URLs preserve original case (e.g., `/Alice/Blefjell` not `/alice/blefjell`)
-- Matching is case-insensitive using canonical slug comparison
-- Simulation names are resolved inside the owner username namespace, so different users can use the same Simulation name.
+Simulation names are resolved inside the owner username namespace, so different users can use the same Simulation name.
 
 ### Delimiters
 - **Multi-site selection**: `+` between site names
-- **Link selection**: `~` between the two endpoint sites
+- **Path selection**: `~` between the two endpoint Sites
 
 The `~` delimiter is used instead of `<>` to avoid browser URL encoding issues (`<` and `>` would appear as `%3C` and `%3E` in the address bar).
 
@@ -36,7 +32,14 @@ The following characters are stripped from names when generating URLs:
 - `~` (link delimiter)
 - `/` (path separator)
 
-## Legacy Format Support
+## Access behavior
+
+- A deep link does not bypass Simulation visibility or collaborator permissions.
+- Broadly accessible Simulations can be opened read-only by guests when the deployment enables guest deep-link mode.
+- Private or specifically shared Simulations require a signed-in user with access.
+- The Library is not exposed to anonymous deep-link visitors.
+
+## Legacy format support
 
 Old-style deep links using query parameters are still supported:
 
@@ -44,10 +47,10 @@ Old-style deep links using query parameters are still supported:
 ?dl=1&sim=sim-123&link=lnk-1
 ```
 
-When accessed, these links will load the simulation but may not preserve site/link selection (legacy limitation).
+When accessed, these links will load the Simulation but may not preserve Site or Path selection (legacy limitation).
 
 The previous path-only format `/<simulation>` is no longer a valid deep link because path links now require an owner username segment.
 
-## Generating Deep Links
+## Generate a deep link
 
-Deep links are automatically generated when using the Share functionality in the app. The appropriate format is chosen based on current selection state.
+Use the Share action in LinkSim. The generated URL follows the current Simulation and Site or Path selection.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,43 +1,59 @@
 # Getting Started
 
-## Simulations
-- A **simulation** is a complete setup of sites, links, and radio/model settings.
-- Open an existing simulation from the **Simulation Library** or create a new one.
-- Use clear names so teammates can find simulations quickly.
+LinkSim plans terrain-aware radio coverage and Paths between reusable Sites. Work is organized in Simulations, and signed-in users can sync and share their Library resources.
 
-## Sites
-- Sites are physical node locations with coordinates, ground elevation, and antenna height.
-- Manage your reusable site collection in **Site Library**.
-- Add sites by coordinates, map click, search, or Meshtastic MQTT sources.
-- Add sites from the library into the current simulation as needed.
-- Click on the map to create a temporary site pin, drag to refine position, then use **Save to Library** or **Dismiss**.
-- Drag existing sites to test alternative positions instantly, then use **Save Positions** or **Dismiss** to commit or revert.
+## 1. Choose or create a Simulation
 
-## Links and Site Selection
-- **Select multiple sites** on the map or sidebar using **{{MODIFIER}}+Click** to view a link between them.
-- The map overlay automatically adjusts based on your selection:
-  - **No selection** — Heatmap (quality overview)
-  - **One site** — Pass/Fail (threshold + terrain context)
-  - **Two sites** — Relay (best relay-candidate regions)
-- To save a link permanently, select two sites and press **Save** in the map inspector.
+- A **Simulation** contains its Sites, saved Paths, radio settings, map state, and calculation settings.
+- Open an existing Simulation from the **Simulation Library**, or choose **Create New Simulation** from the welcome screen.
+- The Library keeps search visible. Use **Filter and sort** to narrow Simulations by your role or visibility and to sort by name or recent activity.
+- Simulations are private by default. Use a clear name before sharing one with collaborators.
 
-## Channel and Model Settings
-- **Channel**: frequency, bandwidth, SF, coding rate, TX power, gains, cable loss, environment loss.
-- **Propagation model**: FSPL, TwoRay, or ITM (terrain-aware approximation).
-- **Terrain**: fetch and refresh terrain before relying on pass/fail decisions.
-- **RX target**: your decision threshold; pass/fail is based on this target.
+## 2. Add Sites
 
-## Map Overlays
-- The map can display several overlay modes:
+- A **Site** is a physical node location with coordinates, ground elevation, antenna height, and radio values.
+- Browse reusable Sites in the **Site Library**. Search and filters work independently in the Sites and Simulations sections.
+- Add one or several Library Sites to the current Simulation. On desktop, bulk selection applies to the filtered Site results.
+- You can also add a Site from coordinates, map search, a map click, or a visible Meshtastic MQTT source.
+- A map click creates a temporary Site pin. Drag it to refine the location, then choose **Save to Library** or **Dismiss**.
+- Drag existing Simulation Sites to compare positions, then choose **Save Positions** or **Dismiss** to commit or revert the move.
+
+## 3. Select Sites and inspect a Path
+
+- Select multiple Sites on the map or in the sidebar with **{{MODIFIER}}+Click**.
+- One selected Site makes single-Site analysis such as Pass/Fail and Panorama available. Two selected Sites make their Path, Path profile, and Relay analysis available.
+- Select two Sites and choose **Save** in the Inspector to keep the Path in the Simulation.
+- The browser address follows the active Simulation and Site selection, so the Share action can copy a deep link to the same view.
+
+## 4. Set the Channel and calculation area
+
+- Channel settings include the frequency plan, bandwidth, spreading factor, coding rate, TX power, antenna gains, cable loss, and environment loss.
+- LinkSim uses ITM for terrain-aware propagation. FSPL may appear in results as a reference value; it is not a selectable propagation model.
+- The **RX target** is the signal threshold used by Pass/Fail and target-line displays.
+- Choose the Simulation Resolution and Radius deliberately. Larger areas and higher resolutions require more terrain and calculation time.
+- LinkSim fetches Copernicus GLO-30 terrain for the selected area. A Simulation result is not calculated from a partial terrain set: if required terrain is unavailable, LinkSim clears the stale overlay and reports the problem.
+- Automatic calculation is convenient for normal work. For expensive settings, use **Start** for a deliberate one-shot run or **Stop** to cancel current terrain and calculation work.
+
+## 5. Choose an overlay or detailed view
+
+The available Simulation Overlay follows the current Site selection. You can switch among the compatible modes in the Inspector.
 
 | Overlay | What it shows | What to use it for |
 | --- | --- | --- |
-| Heatmap | Continuous RX strength estimate (dBm) across sampled area | Quick quality overview and hotspot discovery |
-| Contours | Stepped strength zones (grouped levels) | Fast threshold-oriented planning and area segmentation |
-| Pass/Fail | Four-state check: green (clear+pass), yellow (blocked+pass), orange (clear+fail), red (blocked+fail) | Clear threshold + terrain context in one view |
-| Relay | Best relay-candidate regions for selected From/To pair | Find where a third node could bridge weak links |
-| Terrain overlay | Terrain raster used by simulation in current area | Confirm what elevation input the model is actually using |
-| Path profile | Elevation profile + link geometry between selected endpoints | Validate LOS/Fresnel context and understand obstructions |
+| Heatmap | Strongest predicted Site signal across the selected area | Get a general coverage overview |
+| Weakest Site | Weakest signal from each point to any applicable Site | Find locations that must reach every Site |
+| Heatmap + Target Line | Heatmap plus the boundary where signal crosses the RX target | See coverage shape and the pass/fail edge together |
+| Pass/Fail | Clear/blocked and above/below-target states for one selected Site | Make a terrain-aware go/no-go check |
+| Relay | Candidate quality between two selected Sites | Find where a third node could bridge a weak Path |
+| Mesh Extension | Bidirectionally connected candidate areas that add terrain coverage | Place a new node that extends the existing mesh |
+| Terrain | Copernicus terrain shading for the current area | Confirm the terrain used by the Simulation |
 
-## Sharing and Permissions
-- Everything is **private by default**. Share simulations and sites with specific users when you're ready to collaborate.
+Use the **Path profile** for terrain, line-of-sight, and Fresnel context between two Sites. Use **Panorama** for a terrain-clipped 360-degree view from one Site.
+
+## 6. Save, share, and collaborate
+
+- Simulations and Sites are private by default. Their access settings are independent: a private Site can remain private when referenced by a shared Simulation.
+- Share with specific users as viewer or editor, or use the broader visibility options when the resource is intended for wider access.
+- Viewers can inspect shared work without editing it. Owners and editors can save permitted changes.
+- Library visibility and roles are collaboration controls, not a place to store secrets.
+- Cloud sync runs in the background while signed in. The account toolbar shows pending, syncing, offline, and current states.

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -62,7 +62,7 @@
 
 ## Versioning Policy
 - SemVer is mandatory (`MAJOR.MINOR.PATCH`).
-- Current baseline: `0.24.0`.
+- The current version is defined by `package.json`; do not duplicate it in release documentation.
 - Bump level decision rules:
   - `PATCH` (`0.9.x`): bug fixes, polish, performance tuning, and non-breaking UX behavior fixes.
   - `MINOR` (`0.x.0`): new user-facing features or meaningful workflow additions that are backward-compatible.

--- a/docs/repository-guide.md
+++ b/docs/repository-guide.md
@@ -36,34 +36,27 @@ Operational rule:
 
 ## Quick Start (Local)
 
-Install dependencies:
+CI uses Node.js 22. Install dependencies from the lockfile:
 
 ```bash
-npm install
+npm ci
 ```
 
-Run local edge-parity stack:
-
-```bash
-docker compose up --build edge
-```
-
-Open:
-- `http://localhost:8788`
-
-Other local runtime options (legacy/optional):
+Start the Vite development server for normal frontend work:
 
 ```bash
 npm run dev
-npm run dev:edge
-docker compose up --build web
-docker compose up --build dev
 ```
 
-Default ports:
-- `edge`: `http://localhost:8788`
-- `web`: `http://localhost:8080`
-- `dev`: `http://localhost:5173`
+Vite reports the local URL, normally `http://localhost:5173`.
+
+Use the local edge stack when Pages Functions, D1, or R2 behavior is part of the change:
+
+```bash
+npm run dev:edge
+```
+
+It serves the built app and local Cloudflare bindings at `http://localhost:8788`. Docker Compose provides equivalent `dev`, `edge`, and production-style `web` services when a container workflow is preferred.
 
 ## Build, Test, Smoke
 
@@ -124,15 +117,7 @@ deployment and release operations. Normal staging and production deploys run
 from CI after PRs merge to `staging` or `main`; do not run deploy scripts
 locally for the standard release flow.
 
-Production deploys are guarded and require:
-- `HEAD` is tagged `v<package.json version>`
-- Version is bumped in `HEAD` compared to `HEAD^`
-
-Build label rules:
-- Local: `vX.Y.Z-alpha+<commit>`
-- Staging: `vX.Y.Z-beta+<commit>`
-- Production: `vX.Y.Z`
-- Same commit always keeps the same base version (`X.Y.Z`) across all environments.
+Do not duplicate release commands or version requirements here. The release-flow document owns the branch, tag, SemVer, build-label, deployment, and promotion rules.
 
 ## Cloudflare Setup Overview
 
@@ -192,6 +177,6 @@ npm run refresh:staging:r2
 
 ## Contributor Notes
 
-- Keep working tree clean before deploy commands, except expected generated build metadata in `.tmp/buildInfo.ts`.
+- Keep the working tree clean before release operations. Build metadata under `.tmp/` is generated and untracked.
 - Follow [docs/release-flow.md](./release-flow.md) for production promotion.
 - When changing auth/permissions, add or update tests in the same pass.

--- a/docs/rf-models-and-sampling.md
+++ b/docs/rf-models-and-sampling.md
@@ -1,15 +1,18 @@
-# RF Models and Coverage Sampling
+# RF Model and Coverage Calculation
 
-## Propagation models
-- `FSPL`: free-space path loss only. Fast and optimistic. No terrain blocking.
-- `TwoRay`: direct plus ground reflection. Useful on flatter/open terrain. No terrain profile blocking.
-- `ITM` (default): terrain-aware approximation in LinkSim. Uses loaded terrain elevation for diffraction/excess-loss estimation.
+## Propagation model
 
-## Coverage map sampling modes
-- `BestSite`: each sample point takes strongest predicted site signal.
-- `Polar`: radial sampling around selected `From` site.
-- `Cartesian`: regular grid across analysis bounds.
-- `Route`: samples along a path corridor.
+- LinkSim uses `ITM` for terrain-aware propagation. It applies the loaded terrain profile, atmospheric environment, and radio values when estimating excess loss and obstruction.
+- `FSPL` is retained as a reference metric in Path results. It is not a selectable propagation model.
+- `TwoRay` is not an available LinkSim propagation model.
+
+## Coverage calculation
+
+- Coverage samples use the strongest applicable Site signal by default.
+- **Weakest Site** instead shows the weakest signal to any applicable Simulation Site.
+- Simulation Resolution controls the map sample density. Higher settings improve spatial detail but require more work.
+- Simulation Radius selects the required analysis area. LinkSim determines the complete Copernicus GLO-30 tile set for that radius before calculating.
+- If any required terrain tile is unavailable, the calculation stops and stale coverage is cleared instead of presenting a partial-terrain result.
 
 ## Pass/Fail interpretation
 - Pass/Fail compares predicted calibrated RX dBm to RX target dBm.
@@ -21,4 +24,11 @@
   - `yellow`: blocked path but still meets target
   - `orange`: clear path but below target
   - `red`: blocked path and below target
-- Terrain influences this result when `ITM` is selected and terrain tiles are loaded.
+- Terrain is part of the ITM result and must be complete for the selected analysis area.
+
+## Other overlays
+
+- **Heatmap + Target Line** draws the RX target boundary over the signal heatmap.
+- **Relay** scores candidate positions by the weaker direction through a representative third node between two selected Sites.
+- **Mesh Extension** requires bidirectional signal at or above the RX target and scores how much previously uncovered terrain a representative new node would add.
+- **Terrain** is a separate visual layer showing the elevation raster used by the Simulation.

--- a/docs/staging-environment.md
+++ b/docs/staging-environment.md
@@ -4,13 +4,13 @@ This project supports a separate staging stack with production-like data.
 
 ## What is configured
 
-- Staging Worker environment in [`wrangler.staging.toml`](/Users/wilhelmfrancke/Applications/CodexSandboxGeneric/LinkSim/wrangler.staging.toml)
+- Staging Worker environment in [`wrangler.staging.toml`](../wrangler.staging.toml)
 - Staging avatar fallback to production origin while staging R2 catches up
-- Staging scripts in [`package.json`](/Users/wilhelmfrancke/Applications/CodexSandboxGeneric/LinkSim/package.json)
+- Staging scripts in [`package.json`](../package.json)
 - Custom domain: https://staging.linksim.link
 - Refresh scripts:
-  - [`scripts/refresh-staging-d1.sh`](/Users/wilhelmfrancke/Applications/CodexSandboxGeneric/LinkSim/scripts/refresh-staging-d1.sh)
-  - [`scripts/refresh-staging-r2.sh`](/Users/wilhelmfrancke/Applications/CodexSandboxGeneric/LinkSim/scripts/refresh-staging-r2.sh)
+  - [`scripts/refresh-staging-d1.sh`](../scripts/refresh-staging-d1.sh)
+  - [`scripts/refresh-staging-r2.sh`](../scripts/refresh-staging-r2.sh)
 
 ## Routine workflows
 
@@ -26,7 +26,7 @@ Do not run `npm run deploy:staging` locally for routine verification; Cloudflare
 npm run deploy:staging:preview
 ```
 
-This creates a separate preview URL for side-by-side comparisons.
+This creates a separate preview URL for an explicitly requested side-by-side comparison. It is not part of routine issue verification.
 
 ### Refresh staging DB from production D1
 

--- a/docs/tdd-workflow.md
+++ b/docs/tdd-workflow.md
@@ -20,8 +20,9 @@ Before pushing a branch:
 
 1. `npm test`
 2. `npm run build`
+3. `git diff --check`
 
-For pull requests, CI also runs coverage mode (`npm run test:ci`) and build.
+For pull requests, CI also runs the security scan, coverage mode (`npm run test:ci`), and the production build.
 
 ## Practical Rules
 

--- a/docs/testing-plan.md
+++ b/docs/testing-plan.md
@@ -32,7 +32,7 @@
   - Modal stack behavior
   - User settings open/save/logout
 
-### 4) Deployment checks (preview/prod)
+### 4) Deployment checks (staging/production)
 - Cloudflare Access gate active.
 - D1 migration applied.
 - Diagnostics endpoints for admins:
@@ -42,7 +42,8 @@
 ## Required checks before push
 1. `npm test`
 2. `npm run build`
-3. Manual quick pass:
+3. `git diff --check`
+4. Manual quick pass when the change affects interactive behavior:
   - open app
   - open/close nested modals
   - load simulation library + site library
@@ -58,7 +59,8 @@
 
 ## CI Quality Gates
 - Workflow: `.github/workflows/ci-quality-gates.yml`
-- Triggered on pull requests to `main` and pushes to non-main branches.
+- Triggered on pull requests to `main` or `staging`, and on pushes to branches other than `main` and `staging`.
 - Runs:
-  1. `npm run test:ci`
-  2. `npm run build`
+  1. `npm run security:scan`
+  2. `npm run test:ci`
+  3. `npm run build`

--- a/src/components/OnboardingTutorialModal.test.tsx
+++ b/src/components/OnboardingTutorialModal.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import OnboardingTutorialModal from "./OnboardingTutorialModal";
+
+describe("OnboardingTutorialModal", () => {
+  it("renders the current Getting Started workflow accessibly", () => {
+    render(
+      <OnboardingTutorialModal
+        onClose={vi.fn()}
+        onOpenLibrary={vi.fn()}
+        onOpenSiteLibrary={vi.fn()}
+        open
+      />,
+    );
+
+    expect(screen.getByRole("dialog", { name: "Onboarding Tutorial" })).toBeVisible();
+    expect(screen.getByRole("heading", { name: "Getting Started", level: 2 })).toBeVisible();
+    expect(screen.getByText(/LinkSim uses ITM for terrain-aware propagation/)).toBeVisible();
+    expect(screen.getByText(/Cmd\+Click|Ctrl\+Click/)).toBeVisible();
+    expect(screen.getByText("Weakest Site")).toBeVisible();
+    expect(screen.getByText("Mesh Extension")).toBeVisible();
+  });
+
+  it("opens the existing Simulation and Site Library actions", async () => {
+    const user = userEvent.setup();
+    const onOpenLibrary = vi.fn();
+    const onOpenSiteLibrary = vi.fn();
+    render(
+      <OnboardingTutorialModal
+        onClose={vi.fn()}
+        onOpenLibrary={onOpenLibrary}
+        onOpenSiteLibrary={onOpenSiteLibrary}
+        open
+      />,
+    );
+
+    await user.click(screen.getByRole("link", { name: "Simulation Library" }));
+    await user.click(screen.getByRole("link", { name: "Site Library" }));
+
+    expect(onOpenLibrary).toHaveBeenCalledOnce();
+    expect(onOpenSiteLibrary).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

- rewrite the shared Getting Started guide around the current Library, Site, Path, terrain, calculation, overlay, and collaboration workflows
- correct RF, deep-link, contributor, testing, staging, authentication, and release documentation drift
- keep the README concise while separating user and operator navigation
- add rendered onboarding coverage for current content, platform modifier substitution, accessibility, and existing Library actions

## Impact

This changes documentation and test coverage only. It adds no UI elements, public APIs, data changes, version bump, or production deployment.

Refs #970
Refs #971

## Validation

- `npm run test -- --run src/components/OnboardingTutorialModal.test.tsx`
- `npm test` — 132 files, 761 tests passed
- `npm run build`
- `npm run security:scan`
- `git diff --check`
- local Markdown links validated across 23 tracked documentation files
- obsolete terminology and machine-specific path scan passed
- `npm run dev:check` — no LinkSim dev/watch servers found