### PR TITLE
chore: release 0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.26.0] - 2026-08-05
+
+### Added
+- Added per-Simulation colors for Links and Site icons. (#958)
+- Added 868.no as a second MQTT source, including position-precision bounds for MQTT nodes. (#954, #968)
+- Added a shared compact user profile popover. (#891)
+- Added safe deletion for owned Simulations from the unified Library. (#966)
+
+### Changed
+- Redesigned the Library as a unified, mobile-first Sites and Simulations experience with consistent row actions. (#965)
+- Refreshed the documentation and Getting Started guidance for the 0.26 workflow. (#970, #971)
+
+### Fixed
+- Prevented panorama labels from changing size when the panel is expanded. (#969)
+- Required complete terrain for the selected Simulation radius and reported unavailable terrain instead of presenting partial results. (#972)
+
 ## [0.25.0] - 2026-08-01
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linksim",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linksim",
-      "version": "0.25.0",
+      "version": "0.26.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "linksim",
   "private": true,
-  "version": "0.25.0",
+  "version": "0.26.0",
   "license": "GPL-3.0-only",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump LinkSim to 0.26.0
- add the 0.26.0 milestone changelog
- preserve the verified staging release scope

## Verification
- npm test (132 files, 761 tests)
- npm run build
- git diff --check
- npm run dev:check