### PR TITLE
fix: migrate production Simulation lifecycle schema

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -95,6 +95,17 @@ jobs:
         working-directory: ${{ runner.temp }}/linksim-release
         run: npm ci
 
+      - name: Apply production Simulation lifecycle migration
+        working-directory: ${{ runner.temp }}/linksim-release
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          if ! npx wrangler d1 execute linksim --remote --command "SELECT status FROM simulations LIMIT 0;"; then
+            npx wrangler d1 execute linksim --remote --file db/migrations/2026-08-04_simulation_soft_delete.sql --yes
+          fi
+          npx wrangler d1 execute linksim --remote --command "SELECT status FROM simulations LIMIT 0;"
+
       - name: Validate release gate
         working-directory: ${{ runner.temp }}/linksim-release
         run: node scripts/validate-prod-release.mjs

--- a/functions/_lib/deployPagesWorkflow.test.ts
+++ b/functions/_lib/deployPagesWorkflow.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const workflow = readFileSync(
+  resolve(process.cwd(), ".github/workflows/deploy-pages.yml"),
+  "utf8",
+);
+
+const productionJob = workflow.split("  deploy-prod-main:")[1] ?? "";
+
+describe("Deploy LinkSim Pages workflow", () => {
+  it("applies and verifies the Simulation lifecycle migration before production deployment", () => {
+    const migrationStep = "- name: Apply production Simulation lifecycle migration";
+    const deployStep = "- name: Deploy prod/main with guardrails";
+
+    expect(productionJob).toContain(migrationStep);
+    expect(productionJob).toContain(
+      'npx wrangler d1 execute linksim --remote --command "SELECT status FROM simulations LIMIT 0;"',
+    );
+    expect(productionJob).toContain(
+      "npx wrangler d1 execute linksim --remote --file db/migrations/2026-08-04_simulation_soft_delete.sql --yes",
+    );
+    expect(productionJob.indexOf(migrationStep)).toBeLessThan(
+      productionJob.indexOf(deployStep),
+    );
+  });
+});

--- a/scripts/deploy-pages-safe.mjs
+++ b/scripts/deploy-pages-safe.mjs
@@ -192,8 +192,8 @@ const parseWranglerJsonPayload = (stdout) => {
 
 async function verifyRemoteSchema(targetName, databaseName) {
   if (targetName !== "staging" && targetName !== "prod-main") return;
-  // Skip in CI: schema correctness is enforced by the PR/migration review process.
-  // The check requires D1 API access beyond what the deploy token provides.
+  // CI workflows apply and verify required migrations before invoking this deploy script.
+  // Keep the local preflight for operators with D1 read access.
   if (process.env.GITHUB_ACTIONS === "true") return;
   let resourceChangesResult;
   let simulationsResult;


### PR DESCRIPTION
## Summary
- apply the existing Simulation lifecycle migration to production when `simulations.status` is absent
- re-probe the required column before validation and deployment
- add workflow regression coverage for the production migration gate
- clarify that CI workflows own migration application and verification

Closes #984

## Verification
- failing test first: `functions/_lib/deployPagesWorkflow.test.ts`
- `npm test`: 133 files / 762 tests passed
- `npm run build`: passed
- `git diff --check`: passed
- `npm run dev:check`: no LinkSim dev/watch servers found