### PR TITLE
chore: release 0.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.26.1] - 2026-08-05
+
+### Fixed
+- Restored production access after the Simulation lifecycle rollout by applying and verifying its required D1 migration before production deployment. (#984)
+
 ## [0.26.0] - 2026-08-05
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linksim",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linksim",
-      "version": "0.26.0",
+      "version": "0.26.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "linksim",
   "private": true,
-  "version": "0.26.0",
+  "version": "0.26.1",
   "license": "GPL-3.0-only",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump LinkSim to 0.26.1
- document the production D1 migration incident fix from #984
- preserve the verified hotfix-only staging scope

## Verification
- npm test (133 files, 762 tests)
- npm run build
- git diff --check
- npm run dev:check