### PR TITLE
release: 0.26.1

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -95,6 +95,17 @@ jobs:
         working-directory: ${{ runner.temp }}/linksim-release
         run: npm ci
 
+      - name: Apply production Simulation lifecycle migration
+        working-directory: ${{ runner.temp }}/linksim-release
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          if ! npx wrangler d1 execute linksim --remote --command "SELECT status FROM simulations LIMIT 0;"; then
+            npx wrangler d1 execute linksim --remote --file db/migrations/2026-08-04_simulation_soft_delete.sql --yes
+          fi
+          npx wrangler d1 execute linksim --remote --command "SELECT status FROM simulations LIMIT 0;"
+
       - name: Validate release gate
         working-directory: ${{ runner.temp }}/linksim-release
         run: node scripts/validate-prod-release.mjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.26.1] - 2026-08-05
+
+### Fixed
+- Restored production access after the Simulation lifecycle rollout by applying and verifying its required D1 migration before production deployment. (#984)
+
 ## [0.26.0] - 2026-08-05
 
 ### Added

--- a/functions/_lib/deployPagesWorkflow.test.ts
+++ b/functions/_lib/deployPagesWorkflow.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const workflow = readFileSync(
+  resolve(process.cwd(), ".github/workflows/deploy-pages.yml"),
+  "utf8",
+);
+
+const productionJob = workflow.split("  deploy-prod-main:")[1] ?? "";
+
+describe("Deploy LinkSim Pages workflow", () => {
+  it("applies and verifies the Simulation lifecycle migration before production deployment", () => {
+    const migrationStep = "- name: Apply production Simulation lifecycle migration";
+    const deployStep = "- name: Deploy prod/main with guardrails";
+
+    expect(productionJob).toContain(migrationStep);
+    expect(productionJob).toContain(
+      'npx wrangler d1 execute linksim --remote --command "SELECT status FROM simulations LIMIT 0;"',
+    );
+    expect(productionJob).toContain(
+      "npx wrangler d1 execute linksim --remote --file db/migrations/2026-08-04_simulation_soft_delete.sql --yes",
+    );
+    expect(productionJob.indexOf(migrationStep)).toBeLessThan(
+      productionJob.indexOf(deployStep),
+    );
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linksim",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linksim",
-      "version": "0.26.0",
+      "version": "0.26.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "linksim",
   "private": true,
-  "version": "0.26.0",
+  "version": "0.26.1",
   "license": "GPL-3.0-only",
   "type": "module",
   "scripts": {

--- a/scripts/deploy-pages-safe.mjs
+++ b/scripts/deploy-pages-safe.mjs
@@ -192,8 +192,8 @@ const parseWranglerJsonPayload = (stdout) => {
 
 async function verifyRemoteSchema(targetName, databaseName) {
   if (targetName !== "staging" && targetName !== "prod-main") return;
-  // Skip in CI: schema correctness is enforced by the PR/migration review process.
-  // The check requires D1 API access beyond what the deploy token provides.
+  // CI workflows apply and verify required migrations before invoking this deploy script.
+  // Keep the local preflight for operators with D1 read access.
   if (process.env.GITHUB_ACTIONS === "true") return;
   let resourceChangesResult;
   let simulationsResult;


### PR DESCRIPTION
## Hotfix release
Promote the verified LinkSim 0.26.1 tree using the documented squash-history fallback.

- Incident: #984
- Tag: v0.26.1
- Verified staging commit: 7c8eb7760c0b00bdd54d4edf7dd32b5520160280
- Fallback commit: 12f8095
- Exact tree: 444e749163424754d79fc7535a37135419a9086f
- Staging deployment: https://github.com/wilhel1812/LinkSim/actions/runs/30991270605
- Emergency production migration recovery: https://github.com/wilhel1812/LinkSim/actions/runs/30990754680
- Replaces conflicting direct promotion PR #987.

- [x] Milestone release checklist completed: docs/milestone-release-checklist.md