### PR TITLE
Stabilize simulation calculation and layer ordering

### DIFF
--- a/src/components/MapView.overlayHandoff.test.tsx
+++ b/src/components/MapView.overlayHandoff.test.tsx
@@ -2,7 +2,8 @@
 import React from "react";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { Site } from "../types/radio";
+import type { Site, SrtmTile } from "../types/radio";
+import { resolveRequiredOverlayTerrainTileKeys } from "../lib/simulationOverlayRadius";
 
 const overlayMock = vi.hoisted(() => {
   const requests: Array<{
@@ -33,6 +34,7 @@ const loadingOverlayMock = vi.hoisted(() => ({
 
 const layerMock = vi.hoisted(() => ({
   coveragePaint: null as null | Record<string, unknown>,
+  props: [] as Array<{ beforeId?: string; id?: string }>,
 }));
 
 vi.hoisted(() => {
@@ -91,7 +93,8 @@ vi.mock("react-map-gl/maplibre", async () => {
         return <div>{props.children}</div>;
       },
     ),
-    Layer: (props: { id?: string; paint?: Record<string, unknown> }) => {
+    Layer: (props: { beforeId?: string; id?: string; paint?: Record<string, unknown> }) => {
+      layerMock.props.push(props);
       if (props.id === "coverage-overlay-layer") {
         layerMock.coveragePaint = props.paint ?? null;
       }
@@ -162,6 +165,7 @@ describe("MapView overlay handoff", () => {
     overlayMock.encodedRasterCount = 0;
     loadingOverlayMock.props = null;
     layerMock.coveragePaint = null;
+    layerMock.props = [];
     Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
       configurable: true,
       value: vi.fn(() => ({})),
@@ -219,6 +223,13 @@ describe("MapView overlay handoff", () => {
         "data:image/mock-1",
       ),
     );
+    expect(layerMock.props.find((props) => props.id === "coverage-overlay-layer")?.beforeId).toBe(
+      "link-lines-casing",
+    );
+    expect(
+      screen.getByTestId("links").compareDocumentPosition(screen.getByTestId("coverage-overlay-source")) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
     act(() => loadingOverlayMock.props?.onCloudExited?.(firstKey!));
 
     act(() => useAppStore.getState().setMapOverlayMode("contours"));
@@ -319,7 +330,53 @@ describe("MapView overlay handoff", () => {
     );
   });
 
-  it("does not auto-start a manually locked initial calculation", async () => {
+  it("retries only the remaining terrain after a partial load and stops after no progress", async () => {
+    const requiredKeys = resolveRequiredOverlayTerrainTileKeys([site], 20);
+    expect(requiredKeys.length).toBeGreaterThan(1);
+    const tileForKey = (key: string): SrtmTile => ({
+      key,
+      latStart: 0,
+      lonStart: 0,
+      size: 2,
+      width: 2,
+      height: 2,
+      arcSecondSpacing: 1,
+      elevations: new Int16Array([0, 0, 0, 0]),
+      sourceId: "copernicus30",
+    });
+    const recommendAndFetchTerrainForCurrentArea = vi.fn(async () => {
+      const currentEpoch = useAppStore.getState().terrainLoadEpoch;
+      useAppStore.setState({
+        isTerrainFetching: true,
+        terrainLoadEpoch: currentEpoch + 1,
+      });
+    });
+    useAppStore.setState({ recommendAndFetchTerrainForCurrentArea });
+
+    render(
+      <MapView
+        canPersist
+        isMapExpanded={false}
+        onToggleMapExpanded={() => undefined}
+        showInspector={false}
+      />,
+    );
+
+    await waitFor(() => expect(recommendAndFetchTerrainForCurrentArea).toHaveBeenCalledTimes(1));
+    act(() => {
+      useAppStore.setState({
+        isTerrainFetching: false,
+        srtmTiles: [tileForKey(requiredKeys[0])],
+      });
+    });
+    await waitFor(() => expect(recommendAndFetchTerrainForCurrentArea).toHaveBeenCalledTimes(2));
+
+    act(() => useAppStore.setState({ isTerrainFetching: false }));
+    await act(async () => undefined);
+    expect(recommendAndFetchTerrainForCurrentArea).toHaveBeenCalledTimes(2);
+  });
+
+  it("opts out before an expensive initial automatic calculation starts", async () => {
     const recomputeCoverage = vi.fn();
     useAppStore.setState({ selectedCoverageResolution: "84" });
     useCoverageStore.setState({
@@ -340,6 +397,7 @@ describe("MapView overlay handoff", () => {
 
     await act(async () => undefined);
     expect(recomputeCoverage).not.toHaveBeenCalled();
+    expect(useCoverageStore.getState().autoCalculateEnabled).toBe(false);
   });
 
   it("does not replay clouds when a completed signature is observed again", async () => {

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -37,7 +37,7 @@ import {
 } from "../lib/profileDraftEvent";
 import { subscribePanoramaInteraction, type PanoramaFocusPoint, type PanoramaInteractionEvent } from "../lib/panoramaEvents";
 import { useAppStore } from "../store/appStore";
-import { isAutomaticCalculationLocked, useCoverageStore } from "../store/coverageStore";
+import { resolveAutomaticCalculationThresholds, useCoverageStore } from "../store/coverageStore";
 import { TERRAIN_DATASET_LABEL } from "../lib/terrainDataset";
 import type { Link, Site } from "../types/radio";
 import {
@@ -145,8 +145,10 @@ const WORLD_POLYGON_GEOJSON = {
   properties: {},
 };
 
+const LINK_LAYER_ANCHOR_ID = "link-lines-casing";
+
 const mapLineCasingLayer = (color: string): LayerProps => ({
-  id: "link-lines-casing",
+  id: LINK_LAYER_ANCHOR_ID,
   type: "line",
   paint: {
     "line-color": color,
@@ -218,6 +220,7 @@ const panoramaRayLayer = (color: string): LayerProps => ({
 const coverageRasterLayer = (fadedForCloud: boolean, hidden: boolean): LayerProps => {
   const transition = resolveSimulationOverlayTransition(fadedForCloud);
   return {
+    beforeId: LINK_LAYER_ANCHOR_ID,
     id: "coverage-overlay-layer",
     type: "raster",
     paint: {
@@ -232,6 +235,7 @@ const coverageRasterLayer = (fadedForCloud: boolean, hidden: boolean): LayerProp
 };
 
 const targetContourHaloLayer = (color: string, fadedForCloud: boolean, hidden: boolean): LayerProps => ({
+  beforeId: LINK_LAYER_ANCHOR_ID,
   id: "coverage-target-contour-halo-layer",
   type: "line",
   paint: {
@@ -245,6 +249,7 @@ const targetContourHaloLayer = (color: string, fadedForCloud: boolean, hidden: b
 });
 
 const targetContourLineLayer = (color: string, fadedForCloud: boolean, hidden: boolean): LayerProps => ({
+  beforeId: LINK_LAYER_ANCHOR_ID,
   id: "coverage-target-contour-line-layer",
   type: "line",
   paint: {
@@ -839,9 +844,9 @@ export function MapView({
   const completedCoverageRunToken = useCoverageStore((state) => state.completedCoverageRunToken);
   const simulationErrorMessage = useCoverageStore((state) => state.simulationErrorMessage);
   const autoCalculateEnabled = useCoverageStore((state) => state.autoCalculateEnabled);
-  const automaticLockNoticeShown = useCoverageStore((state) => state.automaticLockNoticeShown);
+  const automaticOptOutNoticeShown = useCoverageStore((state) => state.automaticOptOutNoticeShown);
   const calculationCycleSource = useCoverageStore((state) => state.calculationCycleSource);
-  const markAutomaticLockNoticeShown = useCoverageStore((state) => state.markAutomaticLockNoticeShown);
+  const markAutomaticOptOutNoticeShown = useCoverageStore((state) => state.markAutomaticOptOutNoticeShown);
   const recomputeCoverage = useCoverageStore((state) => state.recomputeCoverage);
   const setAutoCalculateEnabled = useCoverageStore((state) => state.setAutoCalculateEnabled);
   const startManualCalculation = useCoverageStore((state) => state.startManualCalculation);
@@ -1302,19 +1307,31 @@ export function MapView({
     selectionCount,
     option: selectedOverlayRadiusOption,
   });
-  const automaticCalculationLocked = isAutomaticCalculationLocked(
-    selectedCoverageResolution,
-    normalizedOverlayRadiusOption,
+  const automaticCalculationThresholds = useMemo(
+    () =>
+      resolveAutomaticCalculationThresholds(
+        selectedCoverageResolution,
+        normalizedOverlayRadiusOption,
+      ),
+    [normalizedOverlayRadiusOption, selectedCoverageResolution],
   );
-  const previousAutomaticCalculationLockedRef = useRef(automaticCalculationLocked);
+  const previousAutomaticCalculationThresholdsRef = useRef({
+    highResolution: false,
+    largeRadius: false,
+  });
+  const automaticCalculationThresholdCrossed =
+    (automaticCalculationThresholds.highResolution &&
+      !previousAutomaticCalculationThresholdsRef.current.highResolution) ||
+    (automaticCalculationThresholds.largeRadius &&
+      !previousAutomaticCalculationThresholdsRef.current.largeRadius);
   const calculationWorkAllowed =
-    (autoCalculateEnabled && !automaticCalculationLocked) || calculationCycleSource === "manual";
+    (autoCalculateEnabled && !automaticCalculationThresholdCrossed) || calculationCycleSource === "manual";
   const initialAutomaticCalculationRequestedRef = useRef(false);
   useEffect(() => {
     if (initialAutomaticCalculationRequestedRef.current) return;
     if (
       !autoCalculateEnabled ||
-      automaticCalculationLocked ||
+      automaticCalculationThresholdCrossed ||
       coverageVizMode === "none" ||
       analysisTargetSites.length === 0
     ) {
@@ -1333,7 +1350,7 @@ export function MapView({
   }, [
     analysisTargetSites.length,
     autoCalculateEnabled,
-    automaticCalculationLocked,
+    automaticCalculationThresholdCrossed,
     completedCoverageRunToken,
     coverageSamples.length,
     coverageVizMode,
@@ -1341,23 +1358,23 @@ export function MapView({
     recomputeCoverage,
   ]);
   useEffect(() => {
-    const becameLocked = automaticCalculationLocked && !previousAutomaticCalculationLockedRef.current;
-    previousAutomaticCalculationLockedRef.current = automaticCalculationLocked;
-    if (!automaticCalculationLocked) return;
-    if (autoCalculateEnabled) setAutoCalculateEnabled(false);
-    if (!becameLocked || automaticLockNoticeShown) return;
-    markAutomaticLockNoticeShown();
+    previousAutomaticCalculationThresholdsRef.current = automaticCalculationThresholds;
+    if (!automaticCalculationThresholdCrossed || !autoCalculateEnabled) return;
+    setAutoCalculateEnabled(false);
+    if (automaticOptOutNoticeShown) return;
+    markAutomaticOptOutNoticeShown();
     onPublishNotice?.({
-      id: "automatic-calculation-locked",
+      id: "automatic-calculation-opt-out",
       message: "Auto calculate was turned off for 100 km or 4x and above. Press Start to calculate.",
       tone: "info",
       persistent: false,
     });
   }, [
-    automaticCalculationLocked,
-    automaticLockNoticeShown,
+    automaticCalculationThresholdCrossed,
+    automaticCalculationThresholds,
+    automaticOptOutNoticeShown,
     autoCalculateEnabled,
-    markAutomaticLockNoticeShown,
+    markAutomaticOptOutNoticeShown,
     onPublishNotice,
     setAutoCalculateEnabled,
   ]);
@@ -1384,11 +1401,11 @@ export function MapView({
     () => resolveRequiredOverlayTerrainTileKeys(analysisTargetSites, targetRadiusKm),
     [analysisTargetSites, targetRadiusKm],
   );
-  const missingTargetRadiusTileCount = useMemo(
-    () => requiredTargetRadiusTileKeys.filter((key) => !loaded30mTileKeys.has(key)).length,
+  const missingTargetRadiusTileKeys = useMemo(
+    () => requiredTargetRadiusTileKeys.filter((key) => !loaded30mTileKeys.has(key)).sort(),
     [requiredTargetRadiusTileKeys, loaded30mTileKeys],
   );
-  const targetRadiusTerrainSignature = `${targetRadiusKm}|${requiredTargetRadiusTileKeys.join(",")}`;
+  const targetRadiusTerrainSignature = `${targetRadiusKm}|${missingTargetRadiusTileKeys.join(",")}`;
   const targetRadiusFetchAttemptRef = useRef<{
     signature: string;
     terrainLoadEpoch: number;
@@ -1408,7 +1425,7 @@ export function MapView({
       };
       return;
     }
-    if (!analysisTargetSites.length || missingTargetRadiusTileCount <= 0) {
+    if (!analysisTargetSites.length || missingTargetRadiusTileKeys.length <= 0) {
       targetRadiusFetchAttemptRef.current = {
         signature: "",
         terrainLoadEpoch: -1,
@@ -1431,7 +1448,7 @@ export function MapView({
   }, [
     coverageVizMode,
     analysisTargetSites.length,
-    missingTargetRadiusTileCount,
+    missingTargetRadiusTileKeys.length,
     isTerrainFetching,
     isTerrainRecommending,
     normalizedOverlayRadiusOption,
@@ -3414,22 +3431,17 @@ export function MapView({
             <div className="map-calculation-controls">
               <ActionButton
                 aria-label={
-                  automaticCalculationLocked
-                    ? "Automatic calculation unavailable at 100 km or 4x and above"
-                    : autoCalculateEnabled
-                      ? "Turn off automatic calculation"
-                      : "Turn on automatic calculation"
+                  autoCalculateEnabled
+                    ? "Turn off automatic calculation"
+                    : "Turn on automatic calculation"
                 }
                 aria-pressed={autoCalculateEnabled}
                 className={`map-calculation-control map-calculation-toggle ${autoCalculateEnabled ? "is-on" : "is-off"}`}
-                disabled={automaticCalculationLocked}
                 onClick={() => setAutoCalculateEnabled(!autoCalculateEnabled)}
                 title={
-                  automaticCalculationLocked
-                    ? "Automatic calculation unavailable at 100 km or 4x and above"
-                    : autoCalculateEnabled
-                      ? "Turn off automatic calculation"
-                      : "Turn on automatic calculation"
+                  autoCalculateEnabled
+                    ? "Turn off automatic calculation"
+                    : "Turn on automatic calculation"
                 }
                 variant="ghost"
               >
@@ -4158,6 +4170,12 @@ export function MapView({
           </Source>
         ) : null}
 
+        <Source data={lineFeatures} id="links" type="geojson">
+          <Layer {...mapLineCasingLayer(linkCasingColor)} />
+          <Layer {...mapLineLayer(linkColor)} />
+          <Layer {...mapLineSelectedLayer(linkColor)} />
+        </Source>
+
         {showTerrainOverlay && simulationTerrainOverlay ? (
           <Source
             coordinates={simulationTerrainOverlay.coordinates}
@@ -4166,6 +4184,7 @@ export function MapView({
             url={simulationTerrainOverlay.url}
           >
             <Layer
+              beforeId={LINK_LAYER_ANCHOR_ID}
               id="terrain-overlay-layer"
               type="raster"
               paint={{
@@ -4207,7 +4226,7 @@ export function MapView({
         ) : null}
 
         <SimulationLoadingOverlay
-          beforeLayerId="link-lines-casing"
+          beforeLayerId={LINK_LAYER_ANCHOR_ID}
           bounds={analysisBounds}
           handoffKey={overlayHandoff.requestKey}
           loading={simulationLoadingOverlayActive}
@@ -4252,12 +4271,6 @@ export function MapView({
             />
           </Source>
         ) : null}
-
-        <Source data={lineFeatures} id="links" type="geojson">
-          <Layer {...mapLineCasingLayer(linkCasingColor)} />
-          <Layer {...mapLineLayer(linkColor)} />
-          <Layer {...mapLineSelectedLayer(linkColor)} />
-        </Source>
 
         {sites.map((site) => {
           const isEditedSiteInSimulation =

--- a/src/components/MapView.userLocation.test.tsx
+++ b/src/components/MapView.userLocation.test.tsx
@@ -176,7 +176,7 @@ describe("MapView user location flow", () => {
       simulationRunToken: "",
       completedCoverageRunToken: "",
       autoCalculateEnabled: true,
-      automaticLockNoticeShown: false,
+      automaticOptOutNoticeShown: false,
       calculationCycleSource: null,
       simulationErrorMessage: "",
     });
@@ -213,29 +213,38 @@ describe("MapView user location flow", () => {
     expect(cancelTerrainLoad).toHaveBeenCalledTimes(1);
   });
 
-  it("locks automatic calculation at 4x while preserving manual Start", async () => {
+  it("opts out at each expensive threshold while allowing a deliberate override", async () => {
     const onPublishNotice = vi.fn();
     renderMapView({ showInspector: true, onPublishNotice });
 
     act(() => useAppStore.setState({ selectedCoverageResolution: "84" }));
 
-    const lockedToggle = await screen.findByRole("button", {
-      name: "Automatic calculation unavailable at 100 km or 4x and above",
+    const optedOutToggle = await screen.findByRole("button", {
+      name: "Turn on automatic calculation",
     });
-    expect(lockedToggle).toBeDisabled();
-    expect(lockedToggle).toHaveClass("is-off");
+    expect(optedOutToggle).toBeEnabled();
+    expect(optedOutToggle).toHaveClass("is-off");
     expect(screen.getByRole("button", { name: "Start calculation" })).toBeInTheDocument();
     expect(onPublishNotice).toHaveBeenCalledWith({
-      id: "automatic-calculation-locked",
+      id: "automatic-calculation-opt-out",
       message: "Auto calculate was turned off for 100 km or 4x and above. Press Start to calculate.",
       tone: "info",
       persistent: false,
     });
 
-    act(() => useAppStore.setState({ selectedCoverageResolution: "24" }));
+    fireEvent.click(optedOutToggle);
+    expect(screen.getByRole("button", { name: "Turn off automatic calculation" })).toHaveClass("is-on");
+
+    act(() => useAppStore.setState({ selectedCoverageResolution: "168" }));
+    expect(screen.getByRole("button", { name: "Turn off automatic calculation" })).toHaveClass("is-on");
+
     act(() => useAppStore.setState({ selectedOverlayRadiusOption: "100" }));
     await waitFor(() => expect(screen.getByRole("button", { name: "Start calculation" })).toBeInTheDocument());
     expect(onPublishNotice).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Turn on automatic calculation" }));
+    act(() => useAppStore.setState({ selectedOverlayRadiusOption: "200" }));
+    expect(screen.getByRole("button", { name: "Turn off automatic calculation" })).toHaveClass("is-on");
   });
 
   it("publishes an explicit terrain-unavailable calculation error", async () => {

--- a/src/store/coverageStore.test.ts
+++ b/src/store/coverageStore.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  isAutomaticCalculationLocked,
+  resolveAutomaticCalculationThresholds,
   resetCoverageSchedulerForTests,
   setAppStoreBridge,
   useCoverageStore,
@@ -192,17 +192,29 @@ describe("coverageStore simulation progress phases", () => {
     expect(useCoverageStore.getState().simulationErrorMessage).toContain("terrain");
   });
 
-  it("locks automatic calculation for 100 km+ or 4x+ settings", () => {
-    expect(isAutomaticCalculationLocked("24", "50")).toBe(false);
-    expect(isAutomaticCalculationLocked("24", "100")).toBe(true);
-    expect(isAutomaticCalculationLocked("84", "20")).toBe(true);
+  it("identifies the independent 100 km+ and 4x+ automatic opt-out thresholds", () => {
+    expect(resolveAutomaticCalculationThresholds("24", "50")).toEqual({
+      highResolution: false,
+      largeRadius: false,
+    });
+    expect(resolveAutomaticCalculationThresholds("24", "100")).toEqual({
+      highResolution: false,
+      largeRadius: true,
+    });
+    expect(resolveAutomaticCalculationThresholds("84", "20")).toEqual({
+      highResolution: true,
+      largeRadius: false,
+    });
+  });
 
+  it("allows the user to enable automatic calculation at an expensive setting", () => {
     bridgeState.selectedCoverageResolution = "84";
-    useCoverageStore.getState().recomputeCoverage();
-    vi.advanceTimersByTime(220);
+    useCoverageStore.getState().setAutoCalculateEnabled(false);
+    useCoverageStore.getState().setAutoCalculateEnabled(true);
 
-    expect(useCoverageStore.getState().autoCalculateEnabled).toBe(false);
-    expect(useCoverageStore.getState().isSimulationRecomputing).toBe(false);
+    expect(useCoverageStore.getState().autoCalculateEnabled).toBe(true);
+    expect(useCoverageStore.getState().isSimulationRecomputing).toBe(true);
+    expect(useCoverageStore.getState().calculationCycleSource).toBe("auto");
   });
 
   it("stops active coverage work and clears queued reruns", async () => {

--- a/src/store/coverageStore.ts
+++ b/src/store/coverageStore.ts
@@ -85,24 +85,27 @@ export type CoverageState = {
   simulationRunToken: string;
   completedCoverageRunToken: string;
   autoCalculateEnabled: boolean;
-  automaticLockNoticeShown: boolean;
+  automaticOptOutNoticeShown: boolean;
   calculationCycleSource: "auto" | "manual" | null;
   simulationErrorMessage: string;
   recomputeCoverage: () => void;
-  markAutomaticLockNoticeShown: () => void;
+  markAutomaticOptOutNoticeShown: () => void;
   setAutoCalculateEnabled: (enabled: boolean) => void;
   startManualCalculation: () => void;
   stopCalculation: () => void;
   finishCalculationCycle: () => void;
 };
 
-export const isAutomaticCalculationLocked = (
+export const resolveAutomaticCalculationThresholds = (
   resolution: unknown,
   radiusOption: unknown,
-): boolean => {
+): { highResolution: boolean; largeRadius: boolean } => {
   const gridSize = Number(resolution);
   const radiusKm = Number(radiusOption);
-  return (Number.isFinite(gridSize) && gridSize >= 84) || (Number.isFinite(radiusKm) && radiusKm >= 100);
+  return {
+    highResolution: Number.isFinite(gridSize) && gridSize >= 84,
+    largeRadius: Number.isFinite(radiusKm) && radiusKm >= 100,
+  };
 };
 
 type NetworkLike = {
@@ -613,22 +616,14 @@ export const useCoverageStore = create<CoverageState>((set, get) => ({
   simulationRunToken: "",
   completedCoverageRunToken: "",
   autoCalculateEnabled: true,
-  automaticLockNoticeShown: false,
+  automaticOptOutNoticeShown: false,
   calculationCycleSource: null,
   simulationErrorMessage: "",
   recomputeCoverage: () => {
     if (!appStoreBridge) return;
-    const appState = appStoreBridge.getState();
-    const locked = isAutomaticCalculationLocked(
-      appState.selectedCoverageResolution,
-      appState.selectedOverlayRadiusOption,
-    );
     const state = get();
-    if (locked && state.autoCalculateEnabled) {
-      set({ autoCalculateEnabled: false });
-    }
     const manualRun = state.calculationCycleSource === "manual";
-    if (!manualRun && (!state.autoCalculateEnabled || locked)) return;
+    if (!manualRun && !state.autoCalculateEnabled) return;
     coverageRerunQueued = true;
     queueCoverageRunFlush(COVERAGE_RECOMPUTE_DEBOUNCE_MS);
     if (coverageRunInFlight) return;
@@ -644,7 +639,7 @@ export const useCoverageStore = create<CoverageState>((set, get) => ({
       simulationSamplesTotal: 0,
     });
   },
-  markAutomaticLockNoticeShown: () => set({ automaticLockNoticeShown: true }),
+  markAutomaticOptOutNoticeShown: () => set({ automaticOptOutNoticeShown: true }),
   setAutoCalculateEnabled: (enabled) => {
     if (!enabled) {
       const hadPendingRun = coverageRecomputeTimer !== null;
@@ -667,11 +662,6 @@ export const useCoverageStore = create<CoverageState>((set, get) => ({
       return;
     }
     if (!appStoreBridge) return;
-    const appState = appStoreBridge.getState();
-    if (isAutomaticCalculationLocked(appState.selectedCoverageResolution, appState.selectedOverlayRadiusOption)) {
-      set({ autoCalculateEnabled: false });
-      return;
-    }
     set({ autoCalculateEnabled: true, calculationCycleSource: "auto" });
     get().recomputeCoverage();
   },


### PR DESCRIPTION
## Summary

- keep the automatic safety opt-out at 100 km and 4x, while allowing an explicit manual re-enable
- retry terrain loading when a request makes partial progress, and stop only after a no-progress attempt
- anchor Simulation overlays below link-line layers so links remain visible above them

## Root causes addressed

- the expensive-setting guard was enforced again inside the store, making the UI toggle permanently unavailable
- terrain request deduplication keyed attempts by the full required tile set, so partial success could not schedule the remaining tiles
- Simulation overlays were added after the link layers without a stable `beforeId`, allowing MapLibre insertion order to cover the links

## Validation

- focused regression suite: 5 files / 52 tests passed
- full test suite: 133 files / 764 tests passed
- `npm run build` passed
- `git diff --check` passed
- `npm run dev:check` found no LinkSim dev/watch servers

No live browser testing was performed in this pass. No production promotion is included.

Refs #989
Refs #990
Refs #991