### PR TITLE
Handle catalog-confirmed GLO-30 ocean cells

### DIFF
--- a/src/lib/copernicusTerrainClient.test.ts
+++ b/src/lib/copernicusTerrainClient.test.ts
@@ -16,6 +16,38 @@ import {
   copernicus30PathForTileKey,
   loadCopernicus30TilesByKeys,
 } from "./copernicusTerrainClient";
+import { sampleSrtmElevation } from "./srtm";
+
+const TILE_INDEX_CACHE_KEY = "linksim-copernicus-tile-index-v1";
+
+const storage = new Map<string, string>();
+const localStorageMock = {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => storage.set(key, String(value)),
+  removeItem: (key: string) => storage.delete(key),
+  clear: () => storage.clear(),
+  key: (index: number) => Array.from(storage.keys())[index] ?? null,
+  get length() {
+    return storage.size;
+  },
+};
+
+const catalogEntryFor = (key: string): string => {
+  const match = /^([NS])(\d{2})([EW])(\d{3})$/.exec(key);
+  if (!match) throw new Error(`Unexpected key: ${key}`);
+  const [, ns, lat, ew, lon] = match;
+  return `Copernicus_DSM_COG_10_${ns}${lat}_00_${ew}${lon}_00_DEM`;
+};
+
+const catalogResponse = (keys: string[]): Response =>
+  new Response(keys.map(catalogEntryFor).join("\n"), { status: 200 });
+
+const seedCatalogCache = (keys: string[], fetchedAtMs = Date.now()) => {
+  localStorageMock.setItem(
+    TILE_INDEX_CACHE_KEY,
+    JSON.stringify({ copernicus30: { fetchedAtMs, keys } }),
+  );
+};
 
 const installEmptyCache = () => {
   Object.defineProperty(globalThis, "caches", {
@@ -33,7 +65,9 @@ const installEmptyCache = () => {
 describe("Copernicus GLO-30 tile loading", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    storage.clear();
     installEmptyCache();
+    vi.stubGlobal("localStorage", localStorageMock);
     vi.stubGlobal("Worker", undefined);
   });
 
@@ -51,7 +85,10 @@ describe("Copernicus GLO-30 tile loading", () => {
     let maxActive = 0;
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => {
+      vi.fn(async (url: string) => {
+        if (String(url).endsWith("/tileList.txt")) {
+          return catalogResponse(["N60E009", "N60E010", "N61E009", "N61E010"]);
+        }
         active += 1;
         maxActive = Math.max(maxActive, active);
         await new Promise((resolve) => setTimeout(resolve, 5));
@@ -73,6 +110,7 @@ describe("Copernicus GLO-30 tile loading", () => {
   it("retries one transient response but not a permanent 404", async () => {
     const fetchMock = vi
       .fn()
+      .mockResolvedValueOnce(catalogResponse(["N60E009", "N60E010"]))
       .mockResolvedValueOnce(new Response("", { status: 503 }))
       .mockResolvedValueOnce(new Response(new Uint8Array([1]), { status: 200 }))
       .mockResolvedValueOnce(new Response("", { status: 404 }));
@@ -82,9 +120,91 @@ describe("Copernicus GLO-30 tile loading", () => {
       concurrency: 1,
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
     expect(result.tiles).toHaveLength(1);
     expect(result.failedTiles).toEqual(["N60E010"]);
+    expect(result.seaLevelTiles).toEqual([]);
+  });
+
+  it("creates zero-elevation tiles for catalog-confirmed ocean cells without requesting their TIFFs", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      const requestUrl = String(url);
+      if (requestUrl.endsWith("/tileList.txt")) return catalogResponse(["N70E018"]);
+      if (requestUrl.includes("N70_00_E018_00")) {
+        return new Response(new Uint8Array([1]), { status: 200 });
+      }
+      throw new Error(`Unexpected ocean TIFF request: ${requestUrl}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await loadCopernicus30TilesByKeys(["N70E016", "N70E017", "N70E018"]);
+
+    expect(result.failedTiles).toEqual([]);
+    expect(result.seaLevelTiles).toEqual(["N70E016", "N70E017"]);
+    expect(result.tiles.map((tile) => tile.key).sort()).toEqual(["N70E016", "N70E017", "N70E018"]);
+    expect(sampleSrtmElevation(result.tiles, 70.5, 16.5)).toBe(0);
+    expect(sampleSrtmElevation(result.tiles, 70.5, 17.5)).toBe(0);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses a fresh compact catalog cache without fetching the catalog", async () => {
+    seedCatalogCache(["N70E018"]);
+    const fetchMock = vi.fn(async () => {
+      throw new Error("No request expected");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await loadCopernicus30TilesByKeys(["N70E016"]);
+
+    expect(result.seaLevelTiles).toEqual(["N70E016"]);
+    expect(result.failedTiles).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("uses a stale catalog cache when refreshing the catalog fails", async () => {
+    seedCatalogCache(["N70E018"], 1);
+    const fetchMock = vi.fn(async () => new Response("", { status: 503 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await loadCopernicus30TilesByKeys(["N70E016"]);
+
+    expect(result.seaLevelTiles).toEqual(["N70E016"]);
+    expect(result.failedTiles).toEqual([]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("refetches a corrupt catalog cache", async () => {
+    localStorageMock.setItem(TILE_INDEX_CACHE_KEY, "{bad-json");
+    const fetchMock = vi.fn(async (url: string) => {
+      if (String(url).endsWith("/tileList.txt")) return catalogResponse(["N70E018"]);
+      throw new Error(`Unexpected TIFF request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await loadCopernicus30TilesByKeys(["N70E016"]);
+
+    expect(result.seaLevelTiles).toEqual(["N70E016"]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(localStorageMock.getItem(TILE_INDEX_CACHE_KEY) ?? "null")).toEqual(
+      expect.objectContaining({
+        copernicus30: expect.objectContaining({ keys: ["N70E018"] }),
+      }),
+    );
+  });
+
+  it("does not infer ocean when no catalog is available", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("", { status: 503 }))
+      .mockResolvedValueOnce(new Response("", { status: 404 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await loadCopernicus30TilesByKeys(["N70E016"]);
+
+    expect(result.tiles).toEqual([]);
+    expect(result.seaLevelTiles).toEqual([]);
+    expect(result.failedTiles).toEqual(["N70E016"]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it("aborts active work without reporting cancellation as a failed tile", async () => {
@@ -92,14 +212,16 @@ describe("Copernicus GLO-30 tile loading", () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(
-        (_url: string, init?: RequestInit) =>
-          new Promise<Response>((_resolve, reject) => {
+        (url: string, init?: RequestInit) => {
+          if (String(url).endsWith("/tileList.txt")) return Promise.resolve(catalogResponse(["N60E009"]));
+          return new Promise<Response>((_resolve, reject) => {
             init?.signal?.addEventListener(
               "abort",
               () => reject(new DOMException("Stopped", "AbortError")),
               { once: true },
             );
-          }),
+          });
+        },
       ),
     );
 

--- a/src/lib/copernicusTerrainClient.ts
+++ b/src/lib/copernicusTerrainClient.ts
@@ -17,6 +17,7 @@ export type CopernicusLoadResult = {
   failedTiles: string[];
   fetchedTiles: string[];
   cacheHits: string[];
+  seaLevelTiles: string[];
 };
 
 export type RetryPolicy = {
@@ -48,6 +49,9 @@ type TileParserResponseMessage =
   | { id: number; ok: false; error: string };
 
 const CACHE_NAME = "linksim-copernicus-cog-v1";
+const TILE_INDEX_CACHE_KEY = "linksim-copernicus-tile-index-v1";
+const TILE_INDEX_TTL_MS = 6 * 60 * 60 * 1000;
+const TILE_LIST_PATH = "/copernicus/30m/tileList.txt";
 const RESPONSE_START_TIMEOUT_MS = 15_000;
 const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
 const TILE_RETRY_POLICY: RetryPolicy = {
@@ -155,6 +159,57 @@ type TileResponse = {
 
 class PermanentTileError extends Error {}
 
+type CachedTileIndex = {
+  fetchedAtMs: number;
+  keys: string[];
+};
+
+const COPERNICUS_CATALOG_ENTRY = /Copernicus_DSM_COG_10_([NS])(\d{2})_00_([EW])(\d{3})_00_DEM/;
+const TERRAIN_TILE_KEY = /^([NS])(\d{2})([EW])(\d{3})$/;
+
+const readCachedTileIndex = (): CachedTileIndex | null => {
+  if (typeof localStorage === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(TILE_INDEX_CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const entry = parsed.copernicus30 as Partial<CachedTileIndex> | undefined;
+    if (!entry || !Number.isFinite(entry.fetchedAtMs) || !Array.isArray(entry.keys)) return null;
+    const keys = entry.keys.filter((key): key is string => typeof key === "string" && TERRAIN_TILE_KEY.test(key));
+    return keys.length > 0 ? { fetchedAtMs: Number(entry.fetchedAtMs), keys } : null;
+  } catch {
+    return null;
+  }
+};
+
+const writeCachedTileIndex = (entry: CachedTileIndex): void => {
+  if (typeof localStorage === "undefined") return;
+  let parsed: Record<string, unknown> = {};
+  try {
+    const raw = localStorage.getItem(TILE_INDEX_CACHE_KEY);
+    if (raw) parsed = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    parsed = {};
+  }
+  try {
+    parsed.copernicus30 = entry;
+    localStorage.setItem(TILE_INDEX_CACHE_KEY, JSON.stringify(parsed));
+  } catch {
+    // The catalog remains usable for this load when persistent storage is unavailable.
+  }
+};
+
+const parseCatalogTileKeys = (text: string): string[] => {
+  const keys = new Set<string>();
+  for (const line of text.split(/\r?\n/)) {
+    const match = COPERNICUS_CATALOG_ENTRY.exec(line);
+    if (!match) continue;
+    const [, ns, lat, ew, lon] = match;
+    keys.add(`${ns}${lat}${ew}${lon}`);
+  }
+  return Array.from(keys).sort();
+};
+
 const requestTile = async (url: string, signal?: AbortSignal): Promise<TileResponse> => {
   throwIfAborted(signal);
   const controller = new AbortController();
@@ -175,6 +230,49 @@ const requestTile = async (url: string, signal?: AbortSignal): Promise<TileRespo
     clearTimeout(timeout);
     signal?.removeEventListener("abort", relayAbort);
   }
+};
+
+const loadCopernicus30TileIndex = async (signal?: AbortSignal): Promise<Set<string> | null> => {
+  const cached = readCachedTileIndex();
+  if (cached && Date.now() - cached.fetchedAtMs < TILE_INDEX_TTL_MS) {
+    return new Set(cached.keys);
+  }
+
+  try {
+    const requested = await requestTile(TILE_LIST_PATH, signal);
+    if (!requested.response.ok || !requested.buffer) {
+      throw new Error(`GLO-30 catalog returned HTTP ${requested.response.status}`);
+    }
+    const keys = parseCatalogTileKeys(new TextDecoder().decode(requested.buffer));
+    if (keys.length <= 0) throw new Error("GLO-30 catalog contained no valid tile keys");
+    writeCachedTileIndex({ fetchedAtMs: Date.now(), keys });
+    return new Set(keys);
+  } catch (error) {
+    if (isAbortError(error) || signal?.aborted) throw error;
+    return cached ? new Set(cached.keys) : null;
+  }
+};
+
+const seaLevelTileForKey = (key: string): SrtmTile => {
+  const match = TERRAIN_TILE_KEY.exec(key);
+  if (!match) throw new Error(`Invalid terrain tile key: ${key}`);
+  const [, ns, latRaw, ew, lonRaw] = match;
+  const latStart = Number(latRaw) * (ns === "S" ? -1 : 1);
+  const lonStart = Number(lonRaw) * (ew === "W" ? -1 : 1);
+  return {
+    key,
+    latStart,
+    lonStart,
+    size: 2,
+    width: 2,
+    height: 2,
+    arcSecondSpacing: 3,
+    elevations: new Int16Array([0, 0, 0, 0]),
+    sourceKind: "auto-fetch",
+    sourceId: "copernicus30",
+    sourceLabel: "Copernicus GLO-30 sea level",
+    sourceDetail: "Catalog-confirmed ocean cell",
+  };
 };
 
 const fetchTileBuffer = async (
@@ -310,18 +408,34 @@ export const loadCopernicus30TilesByKeys = async (
   } = {},
 ): Promise<CopernicusLoadResult> => {
   const keys = Array.from(new Set(tileKeys));
+  if (keys.length <= 0) {
+    return { tiles: [], failedTiles: [], fetchedTiles: [], cacheHits: [], seaLevelTiles: [] };
+  }
+  const catalogKeys = await loadCopernicus30TileIndex(options.signal);
+  const seaLevelTiles = catalogKeys ? keys.filter((key) => !catalogKeys.has(key)) : [];
+  const keysToFetch = catalogKeys ? keys.filter((key) => catalogKeys.has(key)) : keys;
   const concurrency = Math.max(1, Math.min(2, Math.floor(options.concurrency ?? 2)));
-  const tiles: SrtmTile[] = [];
+  const tiles: SrtmTile[] = seaLevelTiles.map(seaLevelTileForKey);
   const failedTiles: string[] = [];
   const fetchedTiles: string[] = [];
   const cacheHits: string[] = [];
   let nextIndex = 0;
-  let completedTiles = 0;
+  let completedTiles = seaLevelTiles.length;
+
+  seaLevelTiles.forEach((tileKey, index) => {
+    options.onTileProgress?.({
+      dataset: "copernicus30",
+      tileKey,
+      bytes: 0,
+      completedTiles: index + 1,
+      totalTiles: keys.length,
+    });
+  });
 
   const worker = async () => {
-    while (nextIndex < keys.length) {
+    while (nextIndex < keysToFetch.length) {
       throwIfAborted(options.signal);
-      const tileKey = keys[nextIndex];
+      const tileKey = keysToFetch[nextIndex];
       nextIndex += 1;
       let bytes = 0;
       try {
@@ -348,9 +462,9 @@ export const loadCopernicus30TilesByKeys = async (
     }
   };
 
-  await Promise.all(Array.from({ length: Math.min(concurrency, keys.length) }, () => worker()));
+  await Promise.all(Array.from({ length: Math.min(concurrency, keysToFetch.length) }, () => worker()));
   throwIfAborted(options.signal);
-  return { tiles, failedTiles, fetchedTiles, cacheHits };
+  return { tiles, failedTiles, fetchedTiles, cacheHits, seaLevelTiles };
 };
 
 export const clearCopernicusCache = async (): Promise<void> => {

--- a/src/lib/terrainMerge.test.ts
+++ b/src/lib/terrainMerge.test.ts
@@ -71,4 +71,25 @@ describe("mergeSrtmTiles", () => {
     expect(result[0].latStart).toBe(99);
     expect(result[0].sourceId).toBe("copernicus30");
   });
+
+  it("keeps a manual tile when a catalog-confirmed sea-level tile arrives", () => {
+    const manual = {
+      ...makeTile("N70E016", 70, 16),
+      sourceKind: "manual-upload" as const,
+      elevations: new Int16Array([12]),
+      size: 1,
+      width: 1,
+      height: 1,
+    };
+    const seaLevel = {
+      ...makeTile("N70E016", 70, 16),
+      elevations: new Int16Array([0]),
+      size: 1,
+      width: 1,
+      height: 1,
+      sourceDetail: "Catalog-confirmed ocean cell",
+    };
+
+    expect(mergeSrtmTiles([manual], [seaLevel])).toEqual([manual]);
+  });
 });

--- a/src/store/appStore.terrainLoading.test.ts
+++ b/src/store/appStore.terrainLoading.test.ts
@@ -79,6 +79,7 @@ describe("appStore GLO-30 terrain lifecycle", () => {
       failedTiles: [],
       fetchedTiles: ["N59E009"],
       cacheHits: [],
+      seaLevelTiles: [],
     });
     const recompute = vi.spyOn(useCoverageStore.getState(), "recomputeCoverage").mockImplementation(() => {
       expect(useAppStore.getState().isTerrainFetching).toBe(false);
@@ -101,6 +102,7 @@ describe("appStore GLO-30 terrain lifecycle", () => {
       failedTiles: ["N59E009"],
       fetchedTiles: [],
       cacheHits: [],
+      seaLevelTiles: [],
     });
     const recompute = vi.spyOn(useCoverageStore.getState(), "recomputeCoverage").mockImplementation(() => {
       expect(useAppStore.getState().isTerrainFetching).toBe(false);
@@ -118,6 +120,7 @@ describe("appStore GLO-30 terrain lifecycle", () => {
       failedTiles: ["N60E009"],
       fetchedTiles: ["N59E009"],
       cacheHits: [],
+      seaLevelTiles: [],
     });
     const recompute = vi.spyOn(useCoverageStore.getState(), "recomputeCoverage").mockImplementation(() => {
       expect(useAppStore.getState().isTerrainFetching).toBe(false);
@@ -137,6 +140,7 @@ describe("appStore GLO-30 terrain lifecycle", () => {
       failedTiles: string[];
       fetchedTiles: string[];
       cacheHits: string[];
+      seaLevelTiles: string[];
     }) => void;
     terrainClient.loadCopernicus30TilesByKeys.mockImplementation(
       () =>
@@ -152,11 +156,37 @@ describe("appStore GLO-30 terrain lifecycle", () => {
       failedTiles: [],
       fetchedTiles: ["N59E009"],
       cacheHits: [],
+      seaLevelTiles: [],
     });
     await loading;
 
     expect(useAppStore.getState().isTerrainFetching).toBe(false);
     expect(useAppStore.getState().terrainFetchStatus).toBe("Terrain loading stopped.");
     expect(useAppStore.getState().srtmTiles.some((entry) => entry.key === "N59E009")).toBe(false);
+  });
+
+  it("merges catalog-confirmed sea-level cells without reporting them unavailable", async () => {
+    const seaLevelTile = {
+      ...tile("N59E009"),
+      elevations: new Int16Array([0, 0, 0, 0]),
+      sourceLabel: "Copernicus GLO-30 sea level",
+      sourceDetail: "Catalog-confirmed ocean cell",
+    };
+    terrainClient.loadCopernicus30TilesByKeys.mockResolvedValue({
+      tiles: [seaLevelTile],
+      failedTiles: [],
+      fetchedTiles: [],
+      cacheHits: [],
+      seaLevelTiles: ["N59E009"],
+    });
+    const recompute = vi.spyOn(useCoverageStore.getState(), "recomputeCoverage").mockImplementation(() => {});
+
+    await useAppStore.getState().recommendAndFetchTerrainForCurrentArea(20);
+
+    expect(recompute).toHaveBeenCalledTimes(1);
+    expect(useAppStore.getState().srtmTiles).toContainEqual(seaLevelTile);
+    expect(useAppStore.getState().terrainFetchStatus).toContain("1 sea-level");
+    expect(useAppStore.getState().terrainFetchStatus).not.toContain("unavailable");
+    expect(useAppStore.getState().isHighResTerrainLoaded).toBe(true);
   });
 });

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -3902,6 +3902,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         `Loaded ${result.tiles.length} tile(s)`,
         result.fetchedTiles.length ? `${result.fetchedTiles.length} fetched` : "",
         result.cacheHits.length ? `${result.cacheHits.length} from cache` : "",
+        result.seaLevelTiles.length ? `${result.seaLevelTiles.length} sea-level` : "",
         result.failedTiles.length ? `${result.failedTiles.length} unavailable` : "",
       ].filter(Boolean);
       const missing = result.failedTiles.length

--- a/src/store/coverageStore.test.ts
+++ b/src/store/coverageStore.test.ts
@@ -8,7 +8,7 @@ import {
 import * as coverageLib from "../lib/coverage";
 import { simulationAreaBoundsForSites } from "../lib/simulationArea";
 import { tilesForBounds } from "../lib/terrainTiles";
-import type { CoverageSample, Site } from "../types/radio";
+import type { CoverageSample, Site, SrtmTile } from "../types/radio";
 
 const site: Site = {
   id: "site-1",
@@ -22,7 +22,7 @@ const site: Site = {
   cableLossDb: 1,
 };
 
-const completeTerrainTiles = (radiusKm = 50) => {
+const completeTerrainTiles = (radiusKm = 50): SrtmTile[] => {
   const bounds = simulationAreaBoundsForSites([site], { overlayRadiusKm: radiusKm });
   if (!bounds) return [];
   return tilesForBounds(bounds.minLat, bounds.maxLat, bounds.minLon, bounds.maxLon).map((key) => {
@@ -190,6 +190,26 @@ describe("coverageStore simulation progress phases", () => {
     expect(useCoverageStore.getState().coverageSamples).toEqual([]);
     expect(useCoverageStore.getState().simulationErrorMessage).toContain("50 km");
     expect(useCoverageStore.getState().simulationErrorMessage).toContain("terrain");
+  });
+
+  it("accepts zero-elevation Copernicus ocean cells as complete 100 km terrain", async () => {
+    const buildSpy = vi.spyOn(coverageLib, "buildCoverageAsync").mockResolvedValue([]);
+    const terrainTiles = completeTerrainTiles(100);
+    terrainTiles[0] = {
+      ...terrainTiles[0],
+      elevations: new Int16Array([0, 0, 0, 0]),
+      sourceLabel: "Copernicus GLO-30 sea level",
+      sourceDetail: "Catalog-confirmed ocean cell",
+    };
+    bridgeState.selectedOverlayRadiusOption = "100";
+    bridgeState.srtmTiles = terrainTiles;
+
+    useCoverageStore.getState().startManualCalculation();
+    vi.advanceTimersByTime(220);
+    await flushAsyncTicks();
+
+    expect(buildSpy).toHaveBeenCalledTimes(1);
+    expect(useCoverageStore.getState().simulationErrorMessage).toBe("");
   });
 
   it("identifies the independent 100 km+ and 4x+ automatic opt-out thresholds", () => {


### PR DESCRIPTION
## Summary

- restore a compact six-hour GLO-30 tile-index cache using the existing Copernicus catalog proxy
- represent catalog-confirmed non-published cells as lightweight 0 m sea-level terrain
- keep catalog-listed download failures and no-catalog cases strict
- report sea-level cells separately in the existing terrain status

## Root cause

Selected-radius completeness treated every bounding-grid key as a required published TIFF. Ocean-only keys such as `N70E016` and `N70E017` are legitimately absent from the official catalog, so their upstream 404s incorrectly blocked the whole Simulation.

## Safety

- a bare 404 never implies ocean
- catalog refresh failure uses a stale valid index when available
- without any catalog, LinkSim retains the prior direct-fetch and unavailable-terrain behavior
- manual terrain uploads keep precedence over generated sea-level tiles

## Validation

- focused suite: 4 files / 38 tests passed
- full suite: 133 files / 772 tests passed
- `npm run build` passed
- `git diff --check` passed
- `npm run dev:check` found no LinkSim dev/watch servers

No live browser testing was performed. No production promotion is included.

Refs #993