### PR TITLE
Release 0.26.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.26.2] - 2026-08-05
+
+### Fixed
+- Allowed Auto calculate to be deliberately re-enabled after its 100 km or 4x safety opt-out. (#989)
+- Retried partial GLO-30 terrain loads and treated catalog-confirmed ocean cells as sea level without weakening missing-terrain protection. (#990, #993)
+- Kept Link lines visible above completed Simulation overlays. (#991)
+
 ## [0.26.1] - 2026-08-05
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linksim",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linksim",
-      "version": "0.26.1",
+      "version": "0.26.2",
       "license": "GPL-3.0-only",
       "dependencies": {
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "linksim",
   "private": true,
-  "version": "0.26.1",
+  "version": "0.26.2",
   "license": "GPL-3.0-only",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- bump LinkSim from 0.26.1 to 0.26.2
- document the Simulation reliability hotfixes shipped from issues #989, #990, #991, and #993
- preserve the exact verified staging implementation tree apart from release metadata

## Validation

- full suite: 133 files / 772 tests passed
- `npm run build` passed
- `git diff --check` passed
- `npm run dev:check` found no LinkSim dev/watch servers

Refs #989
Refs #990
Refs #991
Refs #993