### PR TITLE
Release 0.26.2 to production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.26.2] - 2026-08-05
+
+### Fixed
+- Allowed Auto calculate to be deliberately re-enabled after its 100 km or 4x safety opt-out. (#989)
+- Retried partial GLO-30 terrain loads and treated catalog-confirmed ocean cells as sea level without weakening missing-terrain protection. (#990, #993)
+- Kept Link lines visible above completed Simulation overlays. (#991)
+
 ## [0.26.1] - 2026-08-05
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linksim",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linksim",
-      "version": "0.26.1",
+      "version": "0.26.2",
       "license": "GPL-3.0-only",
       "dependencies": {
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "linksim",
   "private": true,
-  "version": "0.26.1",
+  "version": "0.26.2",
   "license": "GPL-3.0-only",
   "type": "module",
   "scripts": {

--- a/src/components/MapView.overlayHandoff.test.tsx
+++ b/src/components/MapView.overlayHandoff.test.tsx
@@ -2,7 +2,8 @@
 import React from "react";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { Site } from "../types/radio";
+import type { Site, SrtmTile } from "../types/radio";
+import { resolveRequiredOverlayTerrainTileKeys } from "../lib/simulationOverlayRadius";
 
 const overlayMock = vi.hoisted(() => {
   const requests: Array<{
@@ -33,6 +34,7 @@ const loadingOverlayMock = vi.hoisted(() => ({
 
 const layerMock = vi.hoisted(() => ({
   coveragePaint: null as null | Record<string, unknown>,
+  props: [] as Array<{ beforeId?: string; id?: string }>,
 }));
 
 vi.hoisted(() => {
@@ -91,7 +93,8 @@ vi.mock("react-map-gl/maplibre", async () => {
         return <div>{props.children}</div>;
       },
     ),
-    Layer: (props: { id?: string; paint?: Record<string, unknown> }) => {
+    Layer: (props: { beforeId?: string; id?: string; paint?: Record<string, unknown> }) => {
+      layerMock.props.push(props);
       if (props.id === "coverage-overlay-layer") {
         layerMock.coveragePaint = props.paint ?? null;
       }
@@ -162,6 +165,7 @@ describe("MapView overlay handoff", () => {
     overlayMock.encodedRasterCount = 0;
     loadingOverlayMock.props = null;
     layerMock.coveragePaint = null;
+    layerMock.props = [];
     Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
       configurable: true,
       value: vi.fn(() => ({})),
@@ -219,6 +223,13 @@ describe("MapView overlay handoff", () => {
         "data:image/mock-1",
       ),
     );
+    expect(layerMock.props.find((props) => props.id === "coverage-overlay-layer")?.beforeId).toBe(
+      "link-lines-casing",
+    );
+    expect(
+      screen.getByTestId("links").compareDocumentPosition(screen.getByTestId("coverage-overlay-source")) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
     act(() => loadingOverlayMock.props?.onCloudExited?.(firstKey!));
 
     act(() => useAppStore.getState().setMapOverlayMode("contours"));
@@ -319,7 +330,53 @@ describe("MapView overlay handoff", () => {
     );
   });
 
-  it("does not auto-start a manually locked initial calculation", async () => {
+  it("retries only the remaining terrain after a partial load and stops after no progress", async () => {
+    const requiredKeys = resolveRequiredOverlayTerrainTileKeys([site], 20);
+    expect(requiredKeys.length).toBeGreaterThan(1);
+    const tileForKey = (key: string): SrtmTile => ({
+      key,
+      latStart: 0,
+      lonStart: 0,
+      size: 2,
+      width: 2,
+      height: 2,
+      arcSecondSpacing: 1,
+      elevations: new Int16Array([0, 0, 0, 0]),
+      sourceId: "copernicus30",
+    });
+    const recommendAndFetchTerrainForCurrentArea = vi.fn(async () => {
+      const currentEpoch = useAppStore.getState().terrainLoadEpoch;
+      useAppStore.setState({
+        isTerrainFetching: true,
+        terrainLoadEpoch: currentEpoch + 1,
+      });
+    });
+    useAppStore.setState({ recommendAndFetchTerrainForCurrentArea });
+
+    render(
+      <MapView
+        canPersist
+        isMapExpanded={false}
+        onToggleMapExpanded={() => undefined}
+        showInspector={false}
+      />,
+    );
+
+    await waitFor(() => expect(recommendAndFetchTerrainForCurrentArea).toHaveBeenCalledTimes(1));
+    act(() => {
+      useAppStore.setState({
+        isTerrainFetching: false,
+        srtmTiles: [tileForKey(requiredKeys[0])],
+      });
+    });
+    await waitFor(() => expect(recommendAndFetchTerrainForCurrentArea).toHaveBeenCalledTimes(2));
+
+    act(() => useAppStore.setState({ isTerrainFetching: false }));
+    await act(async () => undefined);
+    expect(recommendAndFetchTerrainForCurrentArea).toHaveBeenCalledTimes(2);
+  });
+
+  it("opts out before an expensive initial automatic calculation starts", async () => {
     const recomputeCoverage = vi.fn();
     useAppStore.setState({ selectedCoverageResolution: "84" });
     useCoverageStore.setState({
@@ -340,6 +397,7 @@ describe("MapView overlay handoff", () => {
 
     await act(async () => undefined);
     expect(recomputeCoverage).not.toHaveBeenCalled();
+    expect(useCoverageStore.getState().autoCalculateEnabled).toBe(false);
   });
 
   it("does not replay clouds when a completed signature is observed again", async () => {

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -37,7 +37,7 @@ import {
 } from "../lib/profileDraftEvent";
 import { subscribePanoramaInteraction, type PanoramaFocusPoint, type PanoramaInteractionEvent } from "../lib/panoramaEvents";
 import { useAppStore } from "../store/appStore";
-import { isAutomaticCalculationLocked, useCoverageStore } from "../store/coverageStore";
+import { resolveAutomaticCalculationThresholds, useCoverageStore } from "../store/coverageStore";
 import { TERRAIN_DATASET_LABEL } from "../lib/terrainDataset";
 import type { Link, Site } from "../types/radio";
 import {
@@ -145,8 +145,10 @@ const WORLD_POLYGON_GEOJSON = {
   properties: {},
 };
 
+const LINK_LAYER_ANCHOR_ID = "link-lines-casing";
+
 const mapLineCasingLayer = (color: string): LayerProps => ({
-  id: "link-lines-casing",
+  id: LINK_LAYER_ANCHOR_ID,
   type: "line",
   paint: {
     "line-color": color,
@@ -218,6 +220,7 @@ const panoramaRayLayer = (color: string): LayerProps => ({
 const coverageRasterLayer = (fadedForCloud: boolean, hidden: boolean): LayerProps => {
   const transition = resolveSimulationOverlayTransition(fadedForCloud);
   return {
+    beforeId: LINK_LAYER_ANCHOR_ID,
     id: "coverage-overlay-layer",
     type: "raster",
     paint: {
@@ -232,6 +235,7 @@ const coverageRasterLayer = (fadedForCloud: boolean, hidden: boolean): LayerProp
 };
 
 const targetContourHaloLayer = (color: string, fadedForCloud: boolean, hidden: boolean): LayerProps => ({
+  beforeId: LINK_LAYER_ANCHOR_ID,
   id: "coverage-target-contour-halo-layer",
   type: "line",
   paint: {
@@ -245,6 +249,7 @@ const targetContourHaloLayer = (color: string, fadedForCloud: boolean, hidden: b
 });
 
 const targetContourLineLayer = (color: string, fadedForCloud: boolean, hidden: boolean): LayerProps => ({
+  beforeId: LINK_LAYER_ANCHOR_ID,
   id: "coverage-target-contour-line-layer",
   type: "line",
   paint: {
@@ -839,9 +844,9 @@ export function MapView({
   const completedCoverageRunToken = useCoverageStore((state) => state.completedCoverageRunToken);
   const simulationErrorMessage = useCoverageStore((state) => state.simulationErrorMessage);
   const autoCalculateEnabled = useCoverageStore((state) => state.autoCalculateEnabled);
-  const automaticLockNoticeShown = useCoverageStore((state) => state.automaticLockNoticeShown);
+  const automaticOptOutNoticeShown = useCoverageStore((state) => state.automaticOptOutNoticeShown);
   const calculationCycleSource = useCoverageStore((state) => state.calculationCycleSource);
-  const markAutomaticLockNoticeShown = useCoverageStore((state) => state.markAutomaticLockNoticeShown);
+  const markAutomaticOptOutNoticeShown = useCoverageStore((state) => state.markAutomaticOptOutNoticeShown);
   const recomputeCoverage = useCoverageStore((state) => state.recomputeCoverage);
   const setAutoCalculateEnabled = useCoverageStore((state) => state.setAutoCalculateEnabled);
   const startManualCalculation = useCoverageStore((state) => state.startManualCalculation);
@@ -1302,19 +1307,31 @@ export function MapView({
     selectionCount,
     option: selectedOverlayRadiusOption,
   });
-  const automaticCalculationLocked = isAutomaticCalculationLocked(
-    selectedCoverageResolution,
-    normalizedOverlayRadiusOption,
+  const automaticCalculationThresholds = useMemo(
+    () =>
+      resolveAutomaticCalculationThresholds(
+        selectedCoverageResolution,
+        normalizedOverlayRadiusOption,
+      ),
+    [normalizedOverlayRadiusOption, selectedCoverageResolution],
   );
-  const previousAutomaticCalculationLockedRef = useRef(automaticCalculationLocked);
+  const previousAutomaticCalculationThresholdsRef = useRef({
+    highResolution: false,
+    largeRadius: false,
+  });
+  const automaticCalculationThresholdCrossed =
+    (automaticCalculationThresholds.highResolution &&
+      !previousAutomaticCalculationThresholdsRef.current.highResolution) ||
+    (automaticCalculationThresholds.largeRadius &&
+      !previousAutomaticCalculationThresholdsRef.current.largeRadius);
   const calculationWorkAllowed =
-    (autoCalculateEnabled && !automaticCalculationLocked) || calculationCycleSource === "manual";
+    (autoCalculateEnabled && !automaticCalculationThresholdCrossed) || calculationCycleSource === "manual";
   const initialAutomaticCalculationRequestedRef = useRef(false);
   useEffect(() => {
     if (initialAutomaticCalculationRequestedRef.current) return;
     if (
       !autoCalculateEnabled ||
-      automaticCalculationLocked ||
+      automaticCalculationThresholdCrossed ||
       coverageVizMode === "none" ||
       analysisTargetSites.length === 0
     ) {
@@ -1333,7 +1350,7 @@ export function MapView({
   }, [
     analysisTargetSites.length,
     autoCalculateEnabled,
-    automaticCalculationLocked,
+    automaticCalculationThresholdCrossed,
     completedCoverageRunToken,
     coverageSamples.length,
     coverageVizMode,
@@ -1341,23 +1358,23 @@ export function MapView({
     recomputeCoverage,
   ]);
   useEffect(() => {
-    const becameLocked = automaticCalculationLocked && !previousAutomaticCalculationLockedRef.current;
-    previousAutomaticCalculationLockedRef.current = automaticCalculationLocked;
-    if (!automaticCalculationLocked) return;
-    if (autoCalculateEnabled) setAutoCalculateEnabled(false);
-    if (!becameLocked || automaticLockNoticeShown) return;
-    markAutomaticLockNoticeShown();
+    previousAutomaticCalculationThresholdsRef.current = automaticCalculationThresholds;
+    if (!automaticCalculationThresholdCrossed || !autoCalculateEnabled) return;
+    setAutoCalculateEnabled(false);
+    if (automaticOptOutNoticeShown) return;
+    markAutomaticOptOutNoticeShown();
     onPublishNotice?.({
-      id: "automatic-calculation-locked",
+      id: "automatic-calculation-opt-out",
       message: "Auto calculate was turned off for 100 km or 4x and above. Press Start to calculate.",
       tone: "info",
       persistent: false,
     });
   }, [
-    automaticCalculationLocked,
-    automaticLockNoticeShown,
+    automaticCalculationThresholdCrossed,
+    automaticCalculationThresholds,
+    automaticOptOutNoticeShown,
     autoCalculateEnabled,
-    markAutomaticLockNoticeShown,
+    markAutomaticOptOutNoticeShown,
     onPublishNotice,
     setAutoCalculateEnabled,
   ]);
@@ -1384,11 +1401,11 @@ export function MapView({
     () => resolveRequiredOverlayTerrainTileKeys(analysisTargetSites, targetRadiusKm),
     [analysisTargetSites, targetRadiusKm],
   );
-  const missingTargetRadiusTileCount = useMemo(
-    () => requiredTargetRadiusTileKeys.filter((key) => !loaded30mTileKeys.has(key)).length,
+  const missingTargetRadiusTileKeys = useMemo(
+    () => requiredTargetRadiusTileKeys.filter((key) => !loaded30mTileKeys.has(key)).sort(),
     [requiredTargetRadiusTileKeys, loaded30mTileKeys],
   );
-  const targetRadiusTerrainSignature = `${targetRadiusKm}|${requiredTargetRadiusTileKeys.join(",")}`;
+  const targetRadiusTerrainSignature = `${targetRadiusKm}|${missingTargetRadiusTileKeys.join(",")}`;
   const targetRadiusFetchAttemptRef = useRef<{
     signature: string;
     terrainLoadEpoch: number;
@@ -1408,7 +1425,7 @@ export function MapView({
       };
       return;
     }
-    if (!analysisTargetSites.length || missingTargetRadiusTileCount <= 0) {
+    if (!analysisTargetSites.length || missingTargetRadiusTileKeys.length <= 0) {
       targetRadiusFetchAttemptRef.current = {
         signature: "",
         terrainLoadEpoch: -1,
@@ -1431,7 +1448,7 @@ export function MapView({
   }, [
     coverageVizMode,
     analysisTargetSites.length,
-    missingTargetRadiusTileCount,
+    missingTargetRadiusTileKeys.length,
     isTerrainFetching,
     isTerrainRecommending,
     normalizedOverlayRadiusOption,
@@ -3414,22 +3431,17 @@ export function MapView({
             <div className="map-calculation-controls">
               <ActionButton
                 aria-label={
-                  automaticCalculationLocked
-                    ? "Automatic calculation unavailable at 100 km or 4x and above"
-                    : autoCalculateEnabled
-                      ? "Turn off automatic calculation"
-                      : "Turn on automatic calculation"
+                  autoCalculateEnabled
+                    ? "Turn off automatic calculation"
+                    : "Turn on automatic calculation"
                 }
                 aria-pressed={autoCalculateEnabled}
                 className={`map-calculation-control map-calculation-toggle ${autoCalculateEnabled ? "is-on" : "is-off"}`}
-                disabled={automaticCalculationLocked}
                 onClick={() => setAutoCalculateEnabled(!autoCalculateEnabled)}
                 title={
-                  automaticCalculationLocked
-                    ? "Automatic calculation unavailable at 100 km or 4x and above"
-                    : autoCalculateEnabled
-                      ? "Turn off automatic calculation"
-                      : "Turn on automatic calculation"
+                  autoCalculateEnabled
+                    ? "Turn off automatic calculation"
+                    : "Turn on automatic calculation"
                 }
                 variant="ghost"
               >
@@ -4158,6 +4170,12 @@ export function MapView({
           </Source>
         ) : null}
 
+        <Source data={lineFeatures} id="links" type="geojson">
+          <Layer {...mapLineCasingLayer(linkCasingColor)} />
+          <Layer {...mapLineLayer(linkColor)} />
+          <Layer {...mapLineSelectedLayer(linkColor)} />
+        </Source>
+
         {showTerrainOverlay && simulationTerrainOverlay ? (
           <Source
             coordinates={simulationTerrainOverlay.coordinates}
@@ -4166,6 +4184,7 @@ export function MapView({
             url={simulationTerrainOverlay.url}
           >
             <Layer
+              beforeId={LINK_LAYER_ANCHOR_ID}
               id="terrain-overlay-layer"
               type="raster"
               paint={{
@@ -4207,7 +4226,7 @@ export function MapView({
         ) : null}
 
         <SimulationLoadingOverlay
-          beforeLayerId="link-lines-casing"
+          beforeLayerId={LINK_LAYER_ANCHOR_ID}
           bounds={analysisBounds}
           handoffKey={overlayHandoff.requestKey}
           loading={simulationLoadingOverlayActive}
@@ -4252,12 +4271,6 @@ export function MapView({
             />
           </Source>
         ) : null}
-
-        <Source data={lineFeatures} id="links" type="geojson">
-          <Layer {...mapLineCasingLayer(linkCasingColor)} />
-          <Layer {...mapLineLayer(linkColor)} />
-          <Layer {...mapLineSelectedLayer(linkColor)} />
-        </Source>
 
         {sites.map((site) => {
           const isEditedSiteInSimulation =

--- a/src/components/MapView.userLocation.test.tsx
+++ b/src/components/MapView.userLocation.test.tsx
@@ -176,7 +176,7 @@ describe("MapView user location flow", () => {
       simulationRunToken: "",
       completedCoverageRunToken: "",
       autoCalculateEnabled: true,
-      automaticLockNoticeShown: false,
+      automaticOptOutNoticeShown: false,
       calculationCycleSource: null,
       simulationErrorMessage: "",
     });
@@ -213,29 +213,38 @@ describe("MapView user location flow", () => {
     expect(cancelTerrainLoad).toHaveBeenCalledTimes(1);
   });
 
-  it("locks automatic calculation at 4x while preserving manual Start", async () => {
+  it("opts out at each expensive threshold while allowing a deliberate override", async () => {
     const onPublishNotice = vi.fn();
     renderMapView({ showInspector: true, onPublishNotice });
 
     act(() => useAppStore.setState({ selectedCoverageResolution: "84" }));
 
-    const lockedToggle = await screen.findByRole("button", {
-      name: "Automatic calculation unavailable at 100 km or 4x and above",
+    const optedOutToggle = await screen.findByRole("button", {
+      name: "Turn on automatic calculation",
     });
-    expect(lockedToggle).toBeDisabled();
-    expect(lockedToggle).toHaveClass("is-off");
+    expect(optedOutToggle).toBeEnabled();
+    expect(optedOutToggle).toHaveClass("is-off");
     expect(screen.getByRole("button", { name: "Start calculation" })).toBeInTheDocument();
     expect(onPublishNotice).toHaveBeenCalledWith({
-      id: "automatic-calculation-locked",
+      id: "automatic-calculation-opt-out",
       message: "Auto calculate was turned off for 100 km or 4x and above. Press Start to calculate.",
       tone: "info",
       persistent: false,
     });
 
-    act(() => useAppStore.setState({ selectedCoverageResolution: "24" }));
+    fireEvent.click(optedOutToggle);
+    expect(screen.getByRole("button", { name: "Turn off automatic calculation" })).toHaveClass("is-on");
+
+    act(() => useAppStore.setState({ selectedCoverageResolution: "168" }));
+    expect(screen.getByRole("button", { name: "Turn off automatic calculation" })).toHaveClass("is-on");
+
     act(() => useAppStore.setState({ selectedOverlayRadiusOption: "100" }));
     await waitFor(() => expect(screen.getByRole("button", { name: "Start calculation" })).toBeInTheDocument());
     expect(onPublishNotice).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Turn on automatic calculation" }));
+    act(() => useAppStore.setState({ selectedOverlayRadiusOption: "200" }));
+    expect(screen.getByRole("button", { name: "Turn off automatic calculation" })).toHaveClass("is-on");
   });
 
   it("publishes an explicit terrain-unavailable calculation error", async () => {

--- a/src/lib/copernicusTerrainClient.test.ts
+++ b/src/lib/copernicusTerrainClient.test.ts
@@ -16,6 +16,38 @@ import {
   copernicus30PathForTileKey,
   loadCopernicus30TilesByKeys,
 } from "./copernicusTerrainClient";
+import { sampleSrtmElevation } from "./srtm";
+
+const TILE_INDEX_CACHE_KEY = "linksim-copernicus-tile-index-v1";
+
+const storage = new Map<string, string>();
+const localStorageMock = {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => storage.set(key, String(value)),
+  removeItem: (key: string) => storage.delete(key),
+  clear: () => storage.clear(),
+  key: (index: number) => Array.from(storage.keys())[index] ?? null,
+  get length() {
+    return storage.size;
+  },
+};
+
+const catalogEntryFor = (key: string): string => {
+  const match = /^([NS])(\d{2})([EW])(\d{3})$/.exec(key);
+  if (!match) throw new Error(`Unexpected key: ${key}`);
+  const [, ns, lat, ew, lon] = match;
+  return `Copernicus_DSM_COG_10_${ns}${lat}_00_${ew}${lon}_00_DEM`;
+};
+
+const catalogResponse = (keys: string[]): Response =>
+  new Response(keys.map(catalogEntryFor).join("\n"), { status: 200 });
+
+const seedCatalogCache = (keys: string[], fetchedAtMs = Date.now()) => {
+  localStorageMock.setItem(
+    TILE_INDEX_CACHE_KEY,
+    JSON.stringify({ copernicus30: { fetchedAtMs, keys } }),
+  );
+};
 
 const installEmptyCache = () => {
   Object.defineProperty(globalThis, "caches", {
@@ -33,7 +65,9 @@ const installEmptyCache = () => {
 describe("Copernicus GLO-30 tile loading", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    storage.clear();
     installEmptyCache();
+    vi.stubGlobal("localStorage", localStorageMock);
     vi.stubGlobal("Worker", undefined);
   });
 
@@ -51,7 +85,10 @@ describe("Copernicus GLO-30 tile loading", () => {
     let maxActive = 0;
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => {
+      vi.fn(async (url: string) => {
+        if (String(url).endsWith("/tileList.txt")) {
+          return catalogResponse(["N60E009", "N60E010", "N61E009", "N61E010"]);
+        }
         active += 1;
         maxActive = Math.max(maxActive, active);
         await new Promise((resolve) => setTimeout(resolve, 5));
@@ -73,6 +110,7 @@ describe("Copernicus GLO-30 tile loading", () => {
   it("retries one transient response but not a permanent 404", async () => {
     const fetchMock = vi
       .fn()
+      .mockResolvedValueOnce(catalogResponse(["N60E009", "N60E010"]))
       .mockResolvedValueOnce(new Response("", { status: 503 }))
       .mockResolvedValueOnce(new Response(new Uint8Array([1]), { status: 200 }))
       .mockResolvedValueOnce(new Response("", { status: 404 }));
@@ -82,9 +120,91 @@ describe("Copernicus GLO-30 tile loading", () => {
       concurrency: 1,
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
     expect(result.tiles).toHaveLength(1);
     expect(result.failedTiles).toEqual(["N60E010"]);
+    expect(result.seaLevelTiles).toEqual([]);
+  });
+
+  it("creates zero-elevation tiles for catalog-confirmed ocean cells without requesting their TIFFs", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      const requestUrl = String(url);
+      if (requestUrl.endsWith("/tileList.txt")) return catalogResponse(["N70E018"]);
+      if (requestUrl.includes("N70_00_E018_00")) {
+        return new Response(new Uint8Array([1]), { status: 200 });
+      }
+      throw new Error(`Unexpected ocean TIFF request: ${requestUrl}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await loadCopernicus30TilesByKeys(["N70E016", "N70E017", "N70E018"]);
+
+    expect(result.failedTiles).toEqual([]);
+    expect(result.seaLevelTiles).toEqual(["N70E016", "N70E017"]);
+    expect(result.tiles.map((tile) => tile.key).sort()).toEqual(["N70E016", "N70E017", "N70E018"]);
+    expect(sampleSrtmElevation(result.tiles, 70.5, 16.5)).toBe(0);
+    expect(sampleSrtmElevation(result.tiles, 70.5, 17.5)).toBe(0);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses a fresh compact catalog cache without fetching the catalog", async () => {
+    seedCatalogCache(["N70E018"]);
+    const fetchMock = vi.fn(async () => {
+      throw new Error("No request expected");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await loadCopernicus30TilesByKeys(["N70E016"]);
+
+    expect(result.seaLevelTiles).toEqual(["N70E016"]);
+    expect(result.failedTiles).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("uses a stale catalog cache when refreshing the catalog fails", async () => {
+    seedCatalogCache(["N70E018"], 1);
+    const fetchMock = vi.fn(async () => new Response("", { status: 503 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await loadCopernicus30TilesByKeys(["N70E016"]);
+
+    expect(result.seaLevelTiles).toEqual(["N70E016"]);
+    expect(result.failedTiles).toEqual([]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("refetches a corrupt catalog cache", async () => {
+    localStorageMock.setItem(TILE_INDEX_CACHE_KEY, "{bad-json");
+    const fetchMock = vi.fn(async (url: string) => {
+      if (String(url).endsWith("/tileList.txt")) return catalogResponse(["N70E018"]);
+      throw new Error(`Unexpected TIFF request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await loadCopernicus30TilesByKeys(["N70E016"]);
+
+    expect(result.seaLevelTiles).toEqual(["N70E016"]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(localStorageMock.getItem(TILE_INDEX_CACHE_KEY) ?? "null")).toEqual(
+      expect.objectContaining({
+        copernicus30: expect.objectContaining({ keys: ["N70E018"] }),
+      }),
+    );
+  });
+
+  it("does not infer ocean when no catalog is available", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("", { status: 503 }))
+      .mockResolvedValueOnce(new Response("", { status: 404 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await loadCopernicus30TilesByKeys(["N70E016"]);
+
+    expect(result.tiles).toEqual([]);
+    expect(result.seaLevelTiles).toEqual([]);
+    expect(result.failedTiles).toEqual(["N70E016"]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it("aborts active work without reporting cancellation as a failed tile", async () => {
@@ -92,14 +212,16 @@ describe("Copernicus GLO-30 tile loading", () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(
-        (_url: string, init?: RequestInit) =>
-          new Promise<Response>((_resolve, reject) => {
+        (url: string, init?: RequestInit) => {
+          if (String(url).endsWith("/tileList.txt")) return Promise.resolve(catalogResponse(["N60E009"]));
+          return new Promise<Response>((_resolve, reject) => {
             init?.signal?.addEventListener(
               "abort",
               () => reject(new DOMException("Stopped", "AbortError")),
               { once: true },
             );
-          }),
+          });
+        },
       ),
     );
 

--- a/src/lib/copernicusTerrainClient.ts
+++ b/src/lib/copernicusTerrainClient.ts
@@ -17,6 +17,7 @@ export type CopernicusLoadResult = {
   failedTiles: string[];
   fetchedTiles: string[];
   cacheHits: string[];
+  seaLevelTiles: string[];
 };
 
 export type RetryPolicy = {
@@ -48,6 +49,9 @@ type TileParserResponseMessage =
   | { id: number; ok: false; error: string };
 
 const CACHE_NAME = "linksim-copernicus-cog-v1";
+const TILE_INDEX_CACHE_KEY = "linksim-copernicus-tile-index-v1";
+const TILE_INDEX_TTL_MS = 6 * 60 * 60 * 1000;
+const TILE_LIST_PATH = "/copernicus/30m/tileList.txt";
 const RESPONSE_START_TIMEOUT_MS = 15_000;
 const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
 const TILE_RETRY_POLICY: RetryPolicy = {
@@ -155,6 +159,57 @@ type TileResponse = {
 
 class PermanentTileError extends Error {}
 
+type CachedTileIndex = {
+  fetchedAtMs: number;
+  keys: string[];
+};
+
+const COPERNICUS_CATALOG_ENTRY = /Copernicus_DSM_COG_10_([NS])(\d{2})_00_([EW])(\d{3})_00_DEM/;
+const TERRAIN_TILE_KEY = /^([NS])(\d{2})([EW])(\d{3})$/;
+
+const readCachedTileIndex = (): CachedTileIndex | null => {
+  if (typeof localStorage === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(TILE_INDEX_CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const entry = parsed.copernicus30 as Partial<CachedTileIndex> | undefined;
+    if (!entry || !Number.isFinite(entry.fetchedAtMs) || !Array.isArray(entry.keys)) return null;
+    const keys = entry.keys.filter((key): key is string => typeof key === "string" && TERRAIN_TILE_KEY.test(key));
+    return keys.length > 0 ? { fetchedAtMs: Number(entry.fetchedAtMs), keys } : null;
+  } catch {
+    return null;
+  }
+};
+
+const writeCachedTileIndex = (entry: CachedTileIndex): void => {
+  if (typeof localStorage === "undefined") return;
+  let parsed: Record<string, unknown> = {};
+  try {
+    const raw = localStorage.getItem(TILE_INDEX_CACHE_KEY);
+    if (raw) parsed = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    parsed = {};
+  }
+  try {
+    parsed.copernicus30 = entry;
+    localStorage.setItem(TILE_INDEX_CACHE_KEY, JSON.stringify(parsed));
+  } catch {
+    // The catalog remains usable for this load when persistent storage is unavailable.
+  }
+};
+
+const parseCatalogTileKeys = (text: string): string[] => {
+  const keys = new Set<string>();
+  for (const line of text.split(/\r?\n/)) {
+    const match = COPERNICUS_CATALOG_ENTRY.exec(line);
+    if (!match) continue;
+    const [, ns, lat, ew, lon] = match;
+    keys.add(`${ns}${lat}${ew}${lon}`);
+  }
+  return Array.from(keys).sort();
+};
+
 const requestTile = async (url: string, signal?: AbortSignal): Promise<TileResponse> => {
   throwIfAborted(signal);
   const controller = new AbortController();
@@ -175,6 +230,49 @@ const requestTile = async (url: string, signal?: AbortSignal): Promise<TileRespo
     clearTimeout(timeout);
     signal?.removeEventListener("abort", relayAbort);
   }
+};
+
+const loadCopernicus30TileIndex = async (signal?: AbortSignal): Promise<Set<string> | null> => {
+  const cached = readCachedTileIndex();
+  if (cached && Date.now() - cached.fetchedAtMs < TILE_INDEX_TTL_MS) {
+    return new Set(cached.keys);
+  }
+
+  try {
+    const requested = await requestTile(TILE_LIST_PATH, signal);
+    if (!requested.response.ok || !requested.buffer) {
+      throw new Error(`GLO-30 catalog returned HTTP ${requested.response.status}`);
+    }
+    const keys = parseCatalogTileKeys(new TextDecoder().decode(requested.buffer));
+    if (keys.length <= 0) throw new Error("GLO-30 catalog contained no valid tile keys");
+    writeCachedTileIndex({ fetchedAtMs: Date.now(), keys });
+    return new Set(keys);
+  } catch (error) {
+    if (isAbortError(error) || signal?.aborted) throw error;
+    return cached ? new Set(cached.keys) : null;
+  }
+};
+
+const seaLevelTileForKey = (key: string): SrtmTile => {
+  const match = TERRAIN_TILE_KEY.exec(key);
+  if (!match) throw new Error(`Invalid terrain tile key: ${key}`);
+  const [, ns, latRaw, ew, lonRaw] = match;
+  const latStart = Number(latRaw) * (ns === "S" ? -1 : 1);
+  const lonStart = Number(lonRaw) * (ew === "W" ? -1 : 1);
+  return {
+    key,
+    latStart,
+    lonStart,
+    size: 2,
+    width: 2,
+    height: 2,
+    arcSecondSpacing: 3,
+    elevations: new Int16Array([0, 0, 0, 0]),
+    sourceKind: "auto-fetch",
+    sourceId: "copernicus30",
+    sourceLabel: "Copernicus GLO-30 sea level",
+    sourceDetail: "Catalog-confirmed ocean cell",
+  };
 };
 
 const fetchTileBuffer = async (
@@ -310,18 +408,34 @@ export const loadCopernicus30TilesByKeys = async (
   } = {},
 ): Promise<CopernicusLoadResult> => {
   const keys = Array.from(new Set(tileKeys));
+  if (keys.length <= 0) {
+    return { tiles: [], failedTiles: [], fetchedTiles: [], cacheHits: [], seaLevelTiles: [] };
+  }
+  const catalogKeys = await loadCopernicus30TileIndex(options.signal);
+  const seaLevelTiles = catalogKeys ? keys.filter((key) => !catalogKeys.has(key)) : [];
+  const keysToFetch = catalogKeys ? keys.filter((key) => catalogKeys.has(key)) : keys;
   const concurrency = Math.max(1, Math.min(2, Math.floor(options.concurrency ?? 2)));
-  const tiles: SrtmTile[] = [];
+  const tiles: SrtmTile[] = seaLevelTiles.map(seaLevelTileForKey);
   const failedTiles: string[] = [];
   const fetchedTiles: string[] = [];
   const cacheHits: string[] = [];
   let nextIndex = 0;
-  let completedTiles = 0;
+  let completedTiles = seaLevelTiles.length;
+
+  seaLevelTiles.forEach((tileKey, index) => {
+    options.onTileProgress?.({
+      dataset: "copernicus30",
+      tileKey,
+      bytes: 0,
+      completedTiles: index + 1,
+      totalTiles: keys.length,
+    });
+  });
 
   const worker = async () => {
-    while (nextIndex < keys.length) {
+    while (nextIndex < keysToFetch.length) {
       throwIfAborted(options.signal);
-      const tileKey = keys[nextIndex];
+      const tileKey = keysToFetch[nextIndex];
       nextIndex += 1;
       let bytes = 0;
       try {
@@ -348,9 +462,9 @@ export const loadCopernicus30TilesByKeys = async (
     }
   };
 
-  await Promise.all(Array.from({ length: Math.min(concurrency, keys.length) }, () => worker()));
+  await Promise.all(Array.from({ length: Math.min(concurrency, keysToFetch.length) }, () => worker()));
   throwIfAborted(options.signal);
-  return { tiles, failedTiles, fetchedTiles, cacheHits };
+  return { tiles, failedTiles, fetchedTiles, cacheHits, seaLevelTiles };
 };
 
 export const clearCopernicusCache = async (): Promise<void> => {

--- a/src/lib/terrainMerge.test.ts
+++ b/src/lib/terrainMerge.test.ts
@@ -71,4 +71,25 @@ describe("mergeSrtmTiles", () => {
     expect(result[0].latStart).toBe(99);
     expect(result[0].sourceId).toBe("copernicus30");
   });
+
+  it("keeps a manual tile when a catalog-confirmed sea-level tile arrives", () => {
+    const manual = {
+      ...makeTile("N70E016", 70, 16),
+      sourceKind: "manual-upload" as const,
+      elevations: new Int16Array([12]),
+      size: 1,
+      width: 1,
+      height: 1,
+    };
+    const seaLevel = {
+      ...makeTile("N70E016", 70, 16),
+      elevations: new Int16Array([0]),
+      size: 1,
+      width: 1,
+      height: 1,
+      sourceDetail: "Catalog-confirmed ocean cell",
+    };
+
+    expect(mergeSrtmTiles([manual], [seaLevel])).toEqual([manual]);
+  });
 });

--- a/src/store/appStore.terrainLoading.test.ts
+++ b/src/store/appStore.terrainLoading.test.ts
@@ -79,6 +79,7 @@ describe("appStore GLO-30 terrain lifecycle", () => {
       failedTiles: [],
       fetchedTiles: ["N59E009"],
       cacheHits: [],
+      seaLevelTiles: [],
     });
     const recompute = vi.spyOn(useCoverageStore.getState(), "recomputeCoverage").mockImplementation(() => {
       expect(useAppStore.getState().isTerrainFetching).toBe(false);
@@ -101,6 +102,7 @@ describe("appStore GLO-30 terrain lifecycle", () => {
       failedTiles: ["N59E009"],
       fetchedTiles: [],
       cacheHits: [],
+      seaLevelTiles: [],
     });
     const recompute = vi.spyOn(useCoverageStore.getState(), "recomputeCoverage").mockImplementation(() => {
       expect(useAppStore.getState().isTerrainFetching).toBe(false);
@@ -118,6 +120,7 @@ describe("appStore GLO-30 terrain lifecycle", () => {
       failedTiles: ["N60E009"],
       fetchedTiles: ["N59E009"],
       cacheHits: [],
+      seaLevelTiles: [],
     });
     const recompute = vi.spyOn(useCoverageStore.getState(), "recomputeCoverage").mockImplementation(() => {
       expect(useAppStore.getState().isTerrainFetching).toBe(false);
@@ -137,6 +140,7 @@ describe("appStore GLO-30 terrain lifecycle", () => {
       failedTiles: string[];
       fetchedTiles: string[];
       cacheHits: string[];
+      seaLevelTiles: string[];
     }) => void;
     terrainClient.loadCopernicus30TilesByKeys.mockImplementation(
       () =>
@@ -152,11 +156,37 @@ describe("appStore GLO-30 terrain lifecycle", () => {
       failedTiles: [],
       fetchedTiles: ["N59E009"],
       cacheHits: [],
+      seaLevelTiles: [],
     });
     await loading;
 
     expect(useAppStore.getState().isTerrainFetching).toBe(false);
     expect(useAppStore.getState().terrainFetchStatus).toBe("Terrain loading stopped.");
     expect(useAppStore.getState().srtmTiles.some((entry) => entry.key === "N59E009")).toBe(false);
+  });
+
+  it("merges catalog-confirmed sea-level cells without reporting them unavailable", async () => {
+    const seaLevelTile = {
+      ...tile("N59E009"),
+      elevations: new Int16Array([0, 0, 0, 0]),
+      sourceLabel: "Copernicus GLO-30 sea level",
+      sourceDetail: "Catalog-confirmed ocean cell",
+    };
+    terrainClient.loadCopernicus30TilesByKeys.mockResolvedValue({
+      tiles: [seaLevelTile],
+      failedTiles: [],
+      fetchedTiles: [],
+      cacheHits: [],
+      seaLevelTiles: ["N59E009"],
+    });
+    const recompute = vi.spyOn(useCoverageStore.getState(), "recomputeCoverage").mockImplementation(() => {});
+
+    await useAppStore.getState().recommendAndFetchTerrainForCurrentArea(20);
+
+    expect(recompute).toHaveBeenCalledTimes(1);
+    expect(useAppStore.getState().srtmTiles).toContainEqual(seaLevelTile);
+    expect(useAppStore.getState().terrainFetchStatus).toContain("1 sea-level");
+    expect(useAppStore.getState().terrainFetchStatus).not.toContain("unavailable");
+    expect(useAppStore.getState().isHighResTerrainLoaded).toBe(true);
   });
 });

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -3902,6 +3902,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         `Loaded ${result.tiles.length} tile(s)`,
         result.fetchedTiles.length ? `${result.fetchedTiles.length} fetched` : "",
         result.cacheHits.length ? `${result.cacheHits.length} from cache` : "",
+        result.seaLevelTiles.length ? `${result.seaLevelTiles.length} sea-level` : "",
         result.failedTiles.length ? `${result.failedTiles.length} unavailable` : "",
       ].filter(Boolean);
       const missing = result.failedTiles.length

--- a/src/store/coverageStore.test.ts
+++ b/src/store/coverageStore.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  isAutomaticCalculationLocked,
+  resolveAutomaticCalculationThresholds,
   resetCoverageSchedulerForTests,
   setAppStoreBridge,
   useCoverageStore,
@@ -8,7 +8,7 @@ import {
 import * as coverageLib from "../lib/coverage";
 import { simulationAreaBoundsForSites } from "../lib/simulationArea";
 import { tilesForBounds } from "../lib/terrainTiles";
-import type { CoverageSample, Site } from "../types/radio";
+import type { CoverageSample, Site, SrtmTile } from "../types/radio";
 
 const site: Site = {
   id: "site-1",
@@ -22,7 +22,7 @@ const site: Site = {
   cableLossDb: 1,
 };
 
-const completeTerrainTiles = (radiusKm = 50) => {
+const completeTerrainTiles = (radiusKm = 50): SrtmTile[] => {
   const bounds = simulationAreaBoundsForSites([site], { overlayRadiusKm: radiusKm });
   if (!bounds) return [];
   return tilesForBounds(bounds.minLat, bounds.maxLat, bounds.minLon, bounds.maxLon).map((key) => {
@@ -192,17 +192,49 @@ describe("coverageStore simulation progress phases", () => {
     expect(useCoverageStore.getState().simulationErrorMessage).toContain("terrain");
   });
 
-  it("locks automatic calculation for 100 km+ or 4x+ settings", () => {
-    expect(isAutomaticCalculationLocked("24", "50")).toBe(false);
-    expect(isAutomaticCalculationLocked("24", "100")).toBe(true);
-    expect(isAutomaticCalculationLocked("84", "20")).toBe(true);
+  it("accepts zero-elevation Copernicus ocean cells as complete 100 km terrain", async () => {
+    const buildSpy = vi.spyOn(coverageLib, "buildCoverageAsync").mockResolvedValue([]);
+    const terrainTiles = completeTerrainTiles(100);
+    terrainTiles[0] = {
+      ...terrainTiles[0],
+      elevations: new Int16Array([0, 0, 0, 0]),
+      sourceLabel: "Copernicus GLO-30 sea level",
+      sourceDetail: "Catalog-confirmed ocean cell",
+    };
+    bridgeState.selectedOverlayRadiusOption = "100";
+    bridgeState.srtmTiles = terrainTiles;
 
-    bridgeState.selectedCoverageResolution = "84";
-    useCoverageStore.getState().recomputeCoverage();
+    useCoverageStore.getState().startManualCalculation();
     vi.advanceTimersByTime(220);
+    await flushAsyncTicks();
 
-    expect(useCoverageStore.getState().autoCalculateEnabled).toBe(false);
-    expect(useCoverageStore.getState().isSimulationRecomputing).toBe(false);
+    expect(buildSpy).toHaveBeenCalledTimes(1);
+    expect(useCoverageStore.getState().simulationErrorMessage).toBe("");
+  });
+
+  it("identifies the independent 100 km+ and 4x+ automatic opt-out thresholds", () => {
+    expect(resolveAutomaticCalculationThresholds("24", "50")).toEqual({
+      highResolution: false,
+      largeRadius: false,
+    });
+    expect(resolveAutomaticCalculationThresholds("24", "100")).toEqual({
+      highResolution: false,
+      largeRadius: true,
+    });
+    expect(resolveAutomaticCalculationThresholds("84", "20")).toEqual({
+      highResolution: true,
+      largeRadius: false,
+    });
+  });
+
+  it("allows the user to enable automatic calculation at an expensive setting", () => {
+    bridgeState.selectedCoverageResolution = "84";
+    useCoverageStore.getState().setAutoCalculateEnabled(false);
+    useCoverageStore.getState().setAutoCalculateEnabled(true);
+
+    expect(useCoverageStore.getState().autoCalculateEnabled).toBe(true);
+    expect(useCoverageStore.getState().isSimulationRecomputing).toBe(true);
+    expect(useCoverageStore.getState().calculationCycleSource).toBe("auto");
   });
 
   it("stops active coverage work and clears queued reruns", async () => {

--- a/src/store/coverageStore.ts
+++ b/src/store/coverageStore.ts
@@ -85,24 +85,27 @@ export type CoverageState = {
   simulationRunToken: string;
   completedCoverageRunToken: string;
   autoCalculateEnabled: boolean;
-  automaticLockNoticeShown: boolean;
+  automaticOptOutNoticeShown: boolean;
   calculationCycleSource: "auto" | "manual" | null;
   simulationErrorMessage: string;
   recomputeCoverage: () => void;
-  markAutomaticLockNoticeShown: () => void;
+  markAutomaticOptOutNoticeShown: () => void;
   setAutoCalculateEnabled: (enabled: boolean) => void;
   startManualCalculation: () => void;
   stopCalculation: () => void;
   finishCalculationCycle: () => void;
 };
 
-export const isAutomaticCalculationLocked = (
+export const resolveAutomaticCalculationThresholds = (
   resolution: unknown,
   radiusOption: unknown,
-): boolean => {
+): { highResolution: boolean; largeRadius: boolean } => {
   const gridSize = Number(resolution);
   const radiusKm = Number(radiusOption);
-  return (Number.isFinite(gridSize) && gridSize >= 84) || (Number.isFinite(radiusKm) && radiusKm >= 100);
+  return {
+    highResolution: Number.isFinite(gridSize) && gridSize >= 84,
+    largeRadius: Number.isFinite(radiusKm) && radiusKm >= 100,
+  };
 };
 
 type NetworkLike = {
@@ -613,22 +616,14 @@ export const useCoverageStore = create<CoverageState>((set, get) => ({
   simulationRunToken: "",
   completedCoverageRunToken: "",
   autoCalculateEnabled: true,
-  automaticLockNoticeShown: false,
+  automaticOptOutNoticeShown: false,
   calculationCycleSource: null,
   simulationErrorMessage: "",
   recomputeCoverage: () => {
     if (!appStoreBridge) return;
-    const appState = appStoreBridge.getState();
-    const locked = isAutomaticCalculationLocked(
-      appState.selectedCoverageResolution,
-      appState.selectedOverlayRadiusOption,
-    );
     const state = get();
-    if (locked && state.autoCalculateEnabled) {
-      set({ autoCalculateEnabled: false });
-    }
     const manualRun = state.calculationCycleSource === "manual";
-    if (!manualRun && (!state.autoCalculateEnabled || locked)) return;
+    if (!manualRun && !state.autoCalculateEnabled) return;
     coverageRerunQueued = true;
     queueCoverageRunFlush(COVERAGE_RECOMPUTE_DEBOUNCE_MS);
     if (coverageRunInFlight) return;
@@ -644,7 +639,7 @@ export const useCoverageStore = create<CoverageState>((set, get) => ({
       simulationSamplesTotal: 0,
     });
   },
-  markAutomaticLockNoticeShown: () => set({ automaticLockNoticeShown: true }),
+  markAutomaticOptOutNoticeShown: () => set({ automaticOptOutNoticeShown: true }),
   setAutoCalculateEnabled: (enabled) => {
     if (!enabled) {
       const hadPendingRun = coverageRecomputeTimer !== null;
@@ -667,11 +662,6 @@ export const useCoverageStore = create<CoverageState>((set, get) => ({
       return;
     }
     if (!appStoreBridge) return;
-    const appState = appStoreBridge.getState();
-    if (isAutomaticCalculationLocked(appState.selectedCoverageResolution, appState.selectedOverlayRadiusOption)) {
-      set({ autoCalculateEnabled: false });
-      return;
-    }
     set({ autoCalculateEnabled: true, calculationCycleSource: "auto" });
     get().recomputeCoverage();
   },


### PR DESCRIPTION
## LinkSim 0.26.2

### Fixed

- Auto calculate can be deliberately re-enabled after the 100 km or 4x safety opt-out. (#989)
- Partial GLO-30 terrain loads retry, while catalog-confirmed ocean cells use sea level without weakening missing-terrain protection. (#990, #993)
- Link lines remain visible above completed Simulation overlays. (#991)

## Exact-tree fallback

Direct PR #996 was non-mergeable because of squash-history drift. This release branch is based on `origin/main` and has been reconciled to the exact verified staging/tag tree.

- release head: `c26b1c5`
- verified staging commit: `7ff3e7a5aff1052d6ce6a8e77300ff0ed2e3aecd`
- release, staging, and `v0.26.2` tree: `53e728e19ff4347fdc15ec943963097f0234ea9f`
- staging deployment: https://github.com/wilhel1812/LinkSim/actions/runs/31028240201
- local suite: 133 files / 772 tests passed
- production build passed

- [x] Milestone release checklist completed: docs/milestone-release-checklist.md

Refs #989
Refs #990
Refs #991
Refs #993