### PR TITLE
Improve Simulation layer performance with adaptive analysis

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1999,6 +1999,26 @@ export function MapView({
       selectedSiteRadioDigest,
       meshExtensionFrequencyMHz,
     ].join("|");
+    const directAnalysisCacheKey = [
+      mode,
+      overlayBounds.minLat.toFixed(5),
+      overlayBounds.maxLat.toFixed(5),
+      overlayBounds.minLon.toFixed(5),
+      overlayBounds.maxLon.toFixed(5),
+      overlayDimensions.width,
+      overlayDimensions.height,
+      srtmTiles.length,
+      terrainLoadEpoch,
+      effectiveGridSize,
+      activeSelectionLink?.id ?? "",
+      activeSelectionLink?.frequencyMHz ?? "",
+      activeSelectionLink?.txPowerDbm ?? "",
+      activeSelectionLink?.txGainDbi ?? "",
+      activeSelectionLink?.rxGainDbi ?? "",
+      activeSelectionLink?.cableLossDb ?? "",
+      selectedSiteRadioDigest,
+      propagationEnvironmentDigest,
+    ].join("|");
     if (
       shouldDeferOverlayRasterization({
         isTerrainFetching,
@@ -2140,6 +2160,7 @@ export function MapView({
               effectiveGridSize,
               overlayPointMask,
               context,
+              { adaptive: true, analysisCacheKey: directAnalysisCacheKey },
             );
           } else if (mode === "relay") {
             rasterPixels = await buildRelayCandidateOverlayPixelsAsync(
@@ -2154,6 +2175,7 @@ export function MapView({
               effectiveGridSize,
               overlayPointMask,
               context,
+              { adaptive: true, analysisCacheKey: directAnalysisCacheKey },
             );
           } else if (mode === "mesh-extension") {
             rasterPixels = await buildMeshExtensionOverlayPixelsAsync({
@@ -2212,6 +2234,8 @@ export function MapView({
             pixelCount: rasterPixels.width * rasterPixels.height,
             gridSize: effectiveGridSize,
             effectiveRadiusKm: overlayRadiusKm,
+            evaluatedPaths: rasterPixels.analysisStats?.evaluatedPaths,
+            refinedBlocks: rasterPixels.analysisStats?.refinedBlocks,
           });
           const overlayValue = raster ? { ...raster } : null;
           if (overlayValue) {

--- a/src/lib/coverage.ts
+++ b/src/lib/coverage.ts
@@ -220,6 +220,57 @@ const evalRx = (
   return eirp + txSystem.rxGainDbi - (loss + terrainLoss);
 };
 
+type ResolvedCoverageMembership = { site: Site; system: RadioSystem };
+
+const resolveCoverageMemberships = (
+  network: Network,
+  sites: Site[],
+  systems: RadioSystem[],
+): ResolvedCoverageMembership[] => {
+  const sitesById = new Map(sites.map((site) => [site.id, site]));
+  const systemsById = new Map(systems.map((system) => [system.id, system]));
+  const resolved = network.memberships.flatMap((member) => {
+    const site = sitesById.get(member.siteId);
+    const system = systemsById.get(member.systemId);
+    return site && system ? [{ site, system }] : [];
+  });
+  if (resolved.length) return resolved;
+  const fallbackSystem = systems[0];
+  return fallbackSystem ? sites.map((site) => ({ site, system: fallbackSystem })) : [];
+};
+
+const evaluateCoveragePoint = (
+  sample: CoverageGridPoint,
+  memberships: ResolvedCoverageMembership[],
+  frequencyMHz: number,
+  terrainSamples: number,
+  environment: PropagationEnvironment,
+  terrainSampler?: (coordinates: Coordinates) => number | null,
+  terrainCacheKey?: string,
+): Pick<CoverageSample, "valueDbm" | "weakestDbm"> => {
+  let strongestDbm = Number.NEGATIVE_INFINITY;
+  let weakestDbm = Number.POSITIVE_INFINITY;
+  for (const { site, system } of memberships) {
+    const valueDbm = evalRx(
+      sample.lat,
+      sample.lon,
+      site,
+      system,
+      frequencyMHz,
+      terrainSamples,
+      environment,
+      terrainSampler,
+      terrainCacheKey,
+    );
+    strongestDbm = Math.max(strongestDbm, valueDbm);
+    weakestDbm = Math.min(weakestDbm, valueDbm);
+  }
+  return {
+    valueDbm: Number.isFinite(strongestDbm) ? strongestDbm : -140,
+    weakestDbm: Number.isFinite(weakestDbm) ? weakestDbm : -140,
+  };
+};
+
 
 export const buildCoverage = (
   gridSize: number,
@@ -240,19 +291,7 @@ export const buildCoverage = (
       : terrainSampler;
   const onProgress = options?.onProgress;
   const shouldCancel = options?.shouldCancel;
-  const fallbackSystemId = systems[0]?.id ?? "";
-  const effectiveMemberships =
-    network.memberships
-      .filter(
-        (member) =>
-          sites.some((site) => site.id === member.siteId) &&
-          systems.some((system) => system.id === member.systemId),
-      )
-      .map((member) => ({ siteId: member.siteId, systemId: member.systemId })) || [];
-  const membershipsToUse =
-    effectiveMemberships.length > 0
-      ? effectiveMemberships
-      : sites.map((site) => ({ siteId: site.id, systemId: fallbackSystemId }));
+  const membershipsToUse = resolveCoverageMemberships(network, sites, systems);
 
   const bounds = simulationAreaBoundsForSites(sites, {
     overlayRadiusKm: options?.overlayRadiusKm,
@@ -268,29 +307,16 @@ export const buildCoverage = (
   for (let i = 0; i < samples.length; i += 1) {
     if (shouldCancel?.()) throw new CoverageBuildCancelledError();
     const sample = samples[i];
-    const rxLevels = membershipsToUse
-      .map((m) => {
-        const site = sites.find((s) => s.id === m.siteId);
-        const system = systems.find((sys) => sys.id === m.systemId);
-        if (!site || !system) return null;
-        return evalRx(
-          sample.lat,
-          sample.lon,
-          site,
-          system,
-          effectiveFrequencyMHz,
-          terrainSamples,
-          environment,
-          effectiveTerrainSampler,
-          options?.terrainCacheKey,
-        );
-      })
-      .filter((v): v is number => v !== null);
-
-    const valueDbm = rxLevels.length ? Math.max(...rxLevels) : -140;
-    const weakestDbm = rxLevels.length ? Math.min(...rxLevels) : -140;
-
-    results.push({ ...sample, valueDbm, weakestDbm });
+    const levels = evaluateCoveragePoint(
+      sample,
+      membershipsToUse,
+      effectiveFrequencyMHz,
+      terrainSamples,
+      environment,
+      effectiveTerrainSampler,
+      options?.terrainCacheKey,
+    );
+    results.push({ ...sample, ...levels });
     if ((i + 1) % notifyEvery === 0 || i === samples.length - 1) {
       onProgress?.((i + 1) / total);
     }
@@ -317,19 +343,7 @@ export const buildCoverageAsync = async (
       : terrainSampler;
   const onProgress = options?.onProgress;
   const shouldCancel = options?.shouldCancel;
-  const fallbackSystemId = systems[0]?.id ?? "";
-  const effectiveMemberships =
-    network.memberships
-      .filter(
-        (member) =>
-          sites.some((site) => site.id === member.siteId) &&
-          systems.some((system) => system.id === member.systemId),
-      )
-      .map((member) => ({ siteId: member.siteId, systemId: member.systemId })) || [];
-  const membershipsToUse =
-    effectiveMemberships.length > 0
-      ? effectiveMemberships
-      : sites.map((site) => ({ siteId: site.id, systemId: fallbackSystemId }));
+  const membershipsToUse = resolveCoverageMemberships(network, sites, systems);
 
   const bounds = simulationAreaBoundsForSites(sites, {
     overlayRadiusKm: options?.overlayRadiusKm,
@@ -348,29 +362,16 @@ export const buildCoverageAsync = async (
   for (let i = 0; i < samples.length; i += 1) {
     if (shouldCancel?.()) throw new CoverageBuildCancelledError();
     const sample = samples[i];
-    const rxLevels = membershipsToUse
-      .map((m) => {
-        const site = sites.find((s) => s.id === m.siteId);
-        const system = systems.find((sys) => sys.id === m.systemId);
-        if (!site || !system) return null;
-        return evalRx(
-          sample.lat,
-          sample.lon,
-          site,
-          system,
-          effectiveFrequencyMHz,
-          terrainSamples,
-          environment,
-          effectiveTerrainSampler,
-          options?.terrainCacheKey,
-        );
-      })
-      .filter((v): v is number => v !== null);
-
-    const valueDbm = rxLevels.length ? Math.max(...rxLevels) : -140;
-    const weakestDbm = rxLevels.length ? Math.min(...rxLevels) : -140;
-
-    results.push({ ...sample, valueDbm, weakestDbm });
+    const levels = evaluateCoveragePoint(
+      sample,
+      membershipsToUse,
+      effectiveFrequencyMHz,
+      terrainSamples,
+      environment,
+      effectiveTerrainSampler,
+      options?.terrainCacheKey,
+    );
+    results.push({ ...sample, ...levels });
     if ((i + 1) % notifyEvery === 0 || i === samples.length - 1) {
       onProgress?.((i + 1) / total);
     }

--- a/src/lib/overlayRaster.test.ts
+++ b/src/lib/overlayRaster.test.ts
@@ -77,6 +77,194 @@ const environment: PropagationEnvironment = {
 const terrainSampler = () => 135;
 
 describe("overlayRaster async builders", () => {
+  it("keeps adaptive Pass/Fail within the accuracy gate while reducing terrain work", async () => {
+    const dimensions = { width: 120, height: 120 };
+    let exactTerrainReads = 0;
+    let adaptiveTerrainReads = 0;
+    const exact = await buildSourcePassFailOverlayPixelsAsync(
+      bounds,
+      fromSite,
+      link,
+      toSite.antennaHeightM,
+      toSite.rxGainDbi,
+      environment,
+      -118,
+      0,
+      () => {
+        exactTerrainReads += 1;
+        return 135;
+      },
+      dimensions,
+      24,
+      undefined,
+      { phase: "passfail", signature: "passfail-reference" },
+      { adaptive: false },
+    );
+    const adaptive = await buildSourcePassFailOverlayPixelsAsync(
+      bounds,
+      fromSite,
+      link,
+      toSite.antennaHeightM,
+      toSite.rxGainDbi,
+      environment,
+      -118,
+      0,
+      () => {
+        adaptiveTerrainReads += 1;
+        return 135;
+      },
+      dimensions,
+      24,
+      undefined,
+      { phase: "passfail", signature: "passfail-adaptive" },
+      { adaptive: true },
+    );
+
+    expect(exact).not.toBeNull();
+    expect(adaptive).not.toBeNull();
+    let matchingPixels = 0;
+    for (let index = 0; index < dimensions.width * dimensions.height; index += 1) {
+      const offset = index * 4;
+      const exactState = Array.from(exact!.pixels.slice(offset, offset + 4)).join(",");
+      const adaptiveState = Array.from(adaptive!.pixels.slice(offset, offset + 4)).join(",");
+      if (exactState === adaptiveState) matchingPixels += 1;
+    }
+    expect(matchingPixels / (dimensions.width * dimensions.height)).toBeGreaterThanOrEqual(0.99);
+    expect(adaptiveTerrainReads).toBeLessThan(exactTerrainReads * 0.3);
+    expect(adaptive?.analysisStats?.evaluatedPaths).toBeLessThan(dimensions.width * dimensions.height * 0.3);
+  });
+
+  it("keeps adaptive Relay signal within the error gate while reducing terrain work", async () => {
+    const dimensions = { width: 120, height: 120 };
+    let exactTerrainReads = 0;
+    let adaptiveTerrainReads = 0;
+    const exact = await buildRelayCandidateOverlayPixelsAsync(
+      bounds,
+      fromSite,
+      toSite,
+      link,
+      environment,
+      0,
+      () => {
+        exactTerrainReads += 1;
+        return 135;
+      },
+      dimensions,
+      24,
+      undefined,
+      { phase: "relay", signature: "relay-reference" },
+      { adaptive: false },
+    );
+    const adaptive = await buildRelayCandidateOverlayPixelsAsync(
+      bounds,
+      fromSite,
+      toSite,
+      link,
+      environment,
+      0,
+      () => {
+        adaptiveTerrainReads += 1;
+        return 135;
+      },
+      dimensions,
+      24,
+      undefined,
+      { phase: "relay", signature: "relay-adaptive" },
+      { adaptive: true },
+    );
+
+    expect(exact).not.toBeNull();
+    expect(adaptive).not.toBeNull();
+    const signalErrors: number[] = [];
+    for (let index = 0; index < dimensions.width * dimensions.height; index += 1) {
+      signalErrors.push(Math.abs(exact!.signalValuesDbm![index] - adaptive!.signalValuesDbm![index]));
+    }
+    signalErrors.sort((left, right) => left - right);
+    const medianError = signalErrors[Math.floor(signalErrors.length * 0.5)];
+    expect(medianError).toBeLessThanOrEqual(0.5);
+    expect(signalErrors[Math.floor(signalErrors.length * 0.99)]).toBeLessThanOrEqual(2);
+    expect(adaptiveTerrainReads).toBeLessThan(exactTerrainReads * 0.3);
+    expect(adaptive?.analysisStats?.evaluatedPaths).toBeLessThan(dimensions.width * dimensions.height * 0.3);
+  });
+
+  it("keeps adaptive Pass/Fail accurate across a narrow terrain ridge", async () => {
+    const dimensions = { width: 96, height: 96 };
+    const ridgeTerrain = (lat: number, lon: number) => {
+      const latOffset = (lat - 59.9) / 0.1;
+      const lonOffset = (lon - 10.7) / 0.1;
+      return 105 + Math.exp(-((latOffset - lonOffset * 0.35 - 0.45) ** 2) / 0.0025) * 140;
+    };
+    const exact = await buildSourcePassFailOverlayPixelsAsync(
+      bounds, fromSite, link, toSite.antennaHeightM, toSite.rxGainDbi, environment,
+      -118, 0, ridgeTerrain, dimensions, 24, undefined,
+      { phase: "passfail", signature: "ridge-reference" }, { adaptive: false },
+    );
+    const adaptive = await buildSourcePassFailOverlayPixelsAsync(
+      bounds, fromSite, link, toSite.antennaHeightM, toSite.rxGainDbi, environment,
+      -118, 0, ridgeTerrain, dimensions, 24, undefined,
+      { phase: "passfail", signature: "ridge-adaptive" }, { adaptive: true },
+    );
+
+    let matchingPixels = 0;
+    for (let index = 0; index < dimensions.width * dimensions.height; index += 1) {
+      const offset = index * 4;
+      if (
+        exact!.pixels[offset] === adaptive!.pixels[offset] &&
+        exact!.pixels[offset + 1] === adaptive!.pixels[offset + 1] &&
+        exact!.pixels[offset + 2] === adaptive!.pixels[offset + 2]
+      ) matchingPixels += 1;
+    }
+    expect(matchingPixels / (dimensions.width * dimensions.height)).toBeGreaterThanOrEqual(0.99);
+  });
+
+  it("reuses cached Pass/Fail RF metrics when only the target changes", async () => {
+    const dimensions = { width: 96, height: 96 };
+    let firstReads = 0;
+    let secondReads = 0;
+    const common = [
+      bounds, fromSite, link, toSite.antennaHeightM, toSite.rxGainDbi, environment,
+    ] as const;
+    await buildSourcePassFailOverlayPixelsAsync(
+      ...common, -118, 0, () => { firstReads += 1; return 135; }, dimensions, 24, undefined,
+      { phase: "passfail", signature: "cache-first" },
+      { adaptive: true, analysisCacheKey: "passfail-target-cache" },
+    );
+    await buildSourcePassFailOverlayPixelsAsync(
+      ...common, -112, 0, () => { secondReads += 1; return 135; }, dimensions, 24, undefined,
+      { phase: "passfail", signature: "cache-second" },
+      { adaptive: true, analysisCacheKey: "passfail-target-cache" },
+    );
+
+    expect(firstReads).toBeGreaterThan(0);
+    expect(secondReads).toBeLessThan(firstReads * 0.2);
+  });
+
+  it("builds adaptive Pass/Fail at least three times faster than the exact reference fixture", async () => {
+    const dimensions = { width: 120, height: 120 };
+    const measure = async (adaptive: boolean): Promise<number> => {
+      const startedAt = performance.now();
+      await buildSourcePassFailOverlayPixelsAsync(
+        bounds, fromSite, link, toSite.antennaHeightM, toSite.rxGainDbi, environment,
+        -118, 0, terrainSampler, dimensions, 24, undefined,
+        { phase: "passfail", signature: adaptive ? "timing-adaptive" : "timing-reference" },
+        { adaptive },
+      );
+      return performance.now() - startedAt;
+    };
+
+    await measure(true);
+    await measure(false);
+    const exactDurations: number[] = [];
+    const adaptiveDurations: number[] = [];
+    for (let run = 0; run < 3; run += 1) {
+      exactDurations.push(await measure(false));
+      adaptiveDurations.push(await measure(true));
+    }
+    exactDurations.sort((left, right) => left - right);
+    adaptiveDurations.sort((left, right) => left - right);
+    expect(adaptiveDurations[1] * 3).toBeLessThan(exactDurations[1]);
+  });
+
   it("derives a representative mesh-extension profile from selected-site medians", () => {
     const profile = deriveMeshExtensionCandidateProfile([
       { ...fromSite, antennaHeightM: 4, txPowerDbm: 18, txGainDbi: 1, rxGainDbi: 2, cableLossDb: 0.5 },

--- a/src/lib/overlayRaster.ts
+++ b/src/lib/overlayRaster.ts
@@ -5,6 +5,7 @@ import { haversineDistanceKm } from "./geo";
 import { getPathLossDb } from "./rfModels";
 import type { Link, PropagationEnvironment, Site } from "../types/radio";
 import { interpolateHeatmapColor } from "../themes/heatmapColors";
+import { createLruCache } from "./lruCache";
 
 export type TerrainBounds = {
   minLat: number;
@@ -28,6 +29,20 @@ export type OverlayRasterPixels = {
   maxDbm?: number;
   minAreaKm2?: number;
   maxAreaKm2?: number;
+  analysisStats?: OverlayAnalysisStats;
+  signalValuesDbm?: Float32Array;
+};
+
+export type OverlayAnalysisStats = {
+  evaluatedPaths: number;
+  refinedBlocks: number;
+  filledPixels: number;
+  totalPixels: number;
+};
+
+export type AdaptiveOverlayOptions = {
+  adaptive?: boolean;
+  analysisCacheKey?: string;
 };
 
 export type OverlayRasterDataUrl = {
@@ -92,6 +107,24 @@ export type OverlayTaskContext = {
 
 const DEFAULT_FRAME_BUDGET_MS = 8;
 const DEFAULT_LONG_TASK_MS = 28;
+
+type PassFailMetricCache = {
+  width: number;
+  height: number;
+  rxDbm: Float64Array;
+  obstruction: Int8Array;
+  evaluated: Uint8Array;
+};
+
+type RelayMetricCache = {
+  width: number;
+  height: number;
+  baseDbm: Float64Array;
+  evaluated: Uint8Array;
+};
+
+const passFailMetricCache = createLruCache<PassFailMetricCache>(2);
+const relayMetricCache = createLruCache<RelayMetricCache>(2);
 
 const nowMs = (): number =>
   typeof performance !== "undefined" && typeof performance.now === "function"
@@ -204,6 +237,116 @@ const runCooperativeLoop = async (
       percent: 100,
     });
   }
+};
+
+type RasterBlock = { x0: number; x1: number; y0: number; y1: number };
+
+const rasterBlockArea = (block: RasterBlock): number =>
+  Math.max(0, block.x1 - block.x0) * Math.max(0, block.y1 - block.y0);
+
+const partitionRasterBlocks = (
+  width: number,
+  height: number,
+  gridSize: number,
+  bounds: TerrainBounds,
+): RasterBlock[] => {
+  const dimensions = computeCoverageGridDimensions(gridSize, bounds);
+  const rowPartitions = Math.max(1, Math.min(height, dimensions.rows));
+  const colPartitions = Math.max(1, Math.min(width, dimensions.cols));
+  const blocks: RasterBlock[] = [];
+  for (let row = 0; row < rowPartitions; row += 1) {
+    const y0 = Math.floor((row * height) / rowPartitions);
+    const y1 = Math.floor(((row + 1) * height) / rowPartitions);
+    for (let col = 0; col < colPartitions; col += 1) {
+      const x0 = Math.floor((col * width) / colPartitions);
+      const x1 = Math.floor(((col + 1) * width) / colPartitions);
+      if (x1 > x0 && y1 > y0) blocks.push({ x0, x1, y0, y1 });
+    }
+  }
+  return blocks;
+};
+
+const splitRasterBlock = (block: RasterBlock): RasterBlock[] => {
+  const xMid = block.x0 + Math.ceil((block.x1 - block.x0) / 2);
+  const yMid = block.y0 + Math.ceil((block.y1 - block.y0) / 2);
+  const xRanges: Array<[number, number]> = xMid < block.x1
+    ? [[block.x0, xMid], [xMid, block.x1]]
+    : [[block.x0, block.x1]];
+  const yRanges: Array<[number, number]> = yMid < block.y1
+    ? [[block.y0, yMid], [yMid, block.y1]]
+    : [[block.y0, block.y1]];
+  return yRanges.flatMap(([y0, y1]) => xRanges.map(([x0, x1]) => ({ x0, x1, y0, y1 })));
+};
+
+const sampleIndicesForRasterBlock = (block: RasterBlock, width: number): number[] => {
+  const xLast = block.x1 - 1;
+  const yLast = block.y1 - 1;
+  const xMid = Math.floor((block.x0 + xLast) / 2);
+  const yMid = Math.floor((block.y0 + yLast) / 2);
+  return Array.from(new Set([
+    block.y0 * width + block.x0,
+    block.y0 * width + xLast,
+    yLast * width + block.x0,
+    yLast * width + xLast,
+    yMid * width + xMid,
+  ]));
+};
+
+const runAdaptiveBlockQueue = async (
+  blocks: RasterBlock[],
+  totalPixels: number,
+  process: (block: RasterBlock) => RasterBlock[] | null,
+  context?: OverlayTaskContext,
+): Promise<{ refinedBlocks: number; filledPixels: number }> => {
+  const queue = blocks.slice().reverse();
+  let refinedBlocks = 0;
+  let filledPixels = 0;
+  const frameBudgetMs = Math.max(1, context?.frameBudgetMs ?? DEFAULT_FRAME_BUDGET_MS);
+  const longTaskMs = Math.max(frameBudgetMs, context?.longTaskMs ?? DEFAULT_LONG_TASK_MS);
+  let chunkStartedAt = nowMs();
+
+  while (queue.length) {
+    throwIfCancelled(context);
+    const block = queue.pop()!;
+    const children = process(block);
+    if (children?.length) {
+      refinedBlocks += 1;
+      for (let index = children.length - 1; index >= 0; index -= 1) queue.push(children[index]);
+    } else {
+      filledPixels += rasterBlockArea(block);
+    }
+
+    const durationMs = nowMs() - chunkStartedAt;
+    if (durationMs >= frameBudgetMs && queue.length) {
+      if (durationMs >= longTaskMs) {
+        context?.onLongTask?.({
+          phase: context.phase,
+          signature: context.signature,
+          durationMs,
+          processed: filledPixels,
+          total: totalPixels,
+        });
+      }
+      context?.onProgress?.({
+        phase: context.phase,
+        signature: context.signature,
+        processed: filledPixels,
+        total: totalPixels,
+        percent: Math.round((filledPixels / Math.max(1, totalPixels)) * 100),
+      });
+      await nextFrame();
+      chunkStartedAt = nowMs();
+    }
+  }
+
+  context?.onProgress?.({
+    phase: context.phase,
+    signature: context.signature,
+    processed: totalPixels,
+    total: totalPixels,
+    percent: 100,
+  });
+  return { refinedBlocks, filledPixels };
 };
 
 const precomputeGridAxes = (
@@ -557,65 +700,139 @@ export const buildSourcePassFailOverlayPixelsAsync = async (
   terrainSamples: number,
   pointMask?: (lat: number, lon: number) => boolean,
   context?: OverlayTaskContext,
+  options?: AdaptiveOverlayOptions,
 ): Promise<OverlayRasterPixels | null> => {
   const width = dimensions.width;
   const height = dimensions.height;
   const { latByRow, lonByCol } = precomputeGridAxes(bounds, dimensions);
   const pixels = new Uint8ClampedArray(width * height * 4);
+  const stateByPixel = new Int8Array(width * height).fill(-1);
+  const marginByPixel = new Float64Array(width * height).fill(Number.NaN);
+  const metricCacheKey = options?.analysisCacheKey
+    ? `${options.analysisCacheKey}|${width}x${height}`
+    : "";
+  const cachedMetrics = metricCacheKey ? passFailMetricCache.get(metricCacheKey) : undefined;
+  const metricCache =
+    cachedMetrics?.width === width && cachedMetrics.height === height
+      ? cachedMetrics
+      : {
+          width,
+          height,
+          rxDbm: new Float64Array(width * height),
+          obstruction: new Int8Array(width * height),
+          evaluated: new Uint8Array(width * height),
+        };
+  let evaluatedPaths = 0;
 
-  await runCooperativeLoop(
-    width * height,
-    (index) => {
+  const writeState = (index: number, stateCode: number): void => {
+    if (stateCode <= 0) return;
+    const px = index * 4;
+    if (stateCode === 1) {
+      pixels[px] = 82;
+      pixels[px + 1] = 181;
+      pixels[px + 2] = 96;
+    } else if (stateCode === 2) {
+      pixels[px] = 232;
+      pixels[px + 1] = 170;
+      pixels[px + 2] = 72;
+    } else if (stateCode === 3) {
+      pixels[px] = 235;
+      pixels[px + 1] = 120;
+      pixels[px + 2] = 70;
+    } else {
+      pixels[px] = 205;
+      pixels[px + 1] = 87;
+      pixels[px + 2] = 79;
+    }
+    pixels[px + 3] = 162;
+  };
+
+  const evaluate = (index: number): number => {
+    const cached = stateByPixel[index];
+    if (cached >= 0) return cached;
+    if (!metricCache.evaluated[index]) {
       const y = Math.floor(index / width);
       const x = index - y * width;
       const lat = latByRow[y];
       const lon = lonByCol[x];
-      if (pointMask && !pointMask(lat, lon)) return;
-      if (terrainSampler(lat, lon) === null) return;
-
-      const metrics = computeSourceCentricRxMetrics(
-        lat,
-        lon,
-        fromSite,
-        effectiveLink,
-        receiverAntennaHeightM,
-        receiverRxGainDbi,
-        terrainSampler,
-        terrainSamples,
-        propagationEnvironment,
-      );
-      const pass = metrics.rxDbm - environmentLossDb >= rxTargetDbm;
-      const losBlocked = metrics.terrainObstructed;
-      const state = classifyPassFailState(pass, losBlocked);
-
-      const px = index * 4;
-      if (state === "pass_clear") {
-        pixels[px] = 82;
-        pixels[px + 1] = 181;
-        pixels[px + 2] = 96;
-      } else if (state === "pass_blocked") {
-        pixels[px] = 232;
-        pixels[px + 1] = 170;
-        pixels[px + 2] = 72;
-      } else if (state === "fail_clear") {
-        pixels[px] = 235;
-        pixels[px + 1] = 120;
-        pixels[px + 2] = 70;
+      metricCache.evaluated[index] = 1;
+      if ((pointMask && !pointMask(lat, lon)) || terrainSampler(lat, lon) === null) {
+        metricCache.obstruction[index] = -1;
       } else {
-        pixels[px] = 205;
-        pixels[px + 1] = 87;
-        pixels[px + 2] = 79;
+        const metrics = computeSourceCentricRxMetrics(
+          lat,
+          lon,
+          fromSite,
+          effectiveLink,
+          receiverAntennaHeightM,
+          receiverRxGainDbi,
+          terrainSampler,
+          terrainSamples,
+          propagationEnvironment,
+        );
+        metricCache.rxDbm[index] = metrics.rxDbm;
+        metricCache.obstruction[index] = metrics.terrainObstructed ? 1 : 0;
+        evaluatedPaths += 1;
       }
-      pixels[px + 3] = 162;
-    },
-    context,
-  );
+    }
+    if (metricCache.obstruction[index] < 0) {
+      stateByPixel[index] = 0;
+      return 0;
+    }
+    const marginDb = metricCache.rxDbm[index] - environmentLossDb - rxTargetDbm;
+    marginByPixel[index] = marginDb;
+    const state = classifyPassFailState(marginDb >= 0, metricCache.obstruction[index] === 1);
+    const stateCode = state === "pass_clear" ? 1 : state === "pass_blocked" ? 2 : state === "fail_clear" ? 3 : 4;
+    stateByPixel[index] = stateCode;
+    return stateCode;
+  };
+
+  let refinedBlocks = 0;
+  let filledPixels = width * height;
+  if (options?.adaptive === false) {
+    await runCooperativeLoop(
+      width * height,
+      (index) => writeState(index, evaluate(index)),
+      context,
+    );
+  } else {
+    const result = await runAdaptiveBlockQueue(
+      partitionRasterBlocks(width, height, terrainSamples, bounds),
+      width * height,
+      (block) => {
+        const area = rasterBlockArea(block);
+        const sampleIndices = sampleIndicesForRasterBlock(block, width);
+        const states = sampleIndices.map(evaluate);
+        const firstState = states[0] ?? 0;
+        const stableState = states.every((state) => state === firstState);
+        const safelyAwayFromThreshold =
+          firstState === 0 || sampleIndices.every((index) => Math.abs(marginByPixel[index]) >= 3);
+        const stableUnavailable = firstState === 0 && !pointMask;
+        if (area === 1 || (stableState && safelyAwayFromThreshold && (firstState !== 0 || stableUnavailable))) {
+          for (let y = block.y0; y < block.y1; y += 1) {
+            for (let x = block.x0; x < block.x1; x += 1) {
+              const index = y * width + x;
+              stateByPixel[index] = firstState;
+              writeState(index, firstState);
+            }
+          }
+          return null;
+        }
+        return splitRasterBlock(block);
+      },
+      context,
+    );
+    refinedBlocks = result.refinedBlocks;
+    filledPixels = result.filledPixels;
+  }
+  if (metricCacheKey) passFailMetricCache.set(metricCacheKey, metricCache);
 
   return {
     width,
     height,
     pixels,
     coordinates: overlayCoordinates(bounds),
+    analysisStats: { evaluatedPaths, refinedBlocks, filledPixels, totalPixels: width * height },
   };
 };
 
@@ -631,6 +848,7 @@ export const buildRelayCandidateOverlayPixelsAsync = async (
   terrainSamples: number,
   pointMask?: (lat: number, lon: number) => boolean,
   context?: OverlayTaskContext,
+  options?: AdaptiveOverlayOptions,
 ): Promise<OverlayRasterPixels | null> => {
   const width = dimensions.width;
   const height = dimensions.height;
@@ -639,6 +857,19 @@ export const buildRelayCandidateOverlayPixelsAsync = async (
   const fallbackRelayGround = (fromSite.groundElevationM + toSite.groundElevationM) / 2;
   const pixels = new Uint8ClampedArray(width * height * 4);
   const bottleneck = new Float32Array(width * height).fill(-Infinity);
+  const metricCacheKey = options?.analysisCacheKey
+    ? `${options.analysisCacheKey}|${width}x${height}`
+    : "";
+  const cachedMetrics = metricCacheKey ? relayMetricCache.get(metricCacheKey) : undefined;
+  const metricCache =
+    cachedMetrics?.width === width && cachedMetrics.height === height
+      ? cachedMetrics
+      : {
+          width,
+          height,
+          baseDbm: new Float64Array(width * height).fill(Number.NEGATIVE_INFINITY),
+          evaluated: new Uint8Array(width * height),
+        };
   const relaySite: Site = {
     id: "__relay_candidate__",
     name: "Relay candidate",
@@ -650,55 +881,118 @@ export const buildRelayCandidateOverlayPixelsAsync = async (
     rxGainDbi: STANDARD_SITE_RADIO.rxGainDbi,
     cableLossDb: STANDARD_SITE_RADIO.cableLossDb,
   };
-  let minDbm = Number.POSITIVE_INFINITY;
-  let maxDbm = Number.NEGATIVE_INFINITY;
-
-  await runCooperativeLoop(
-    width * height,
-    (index) => {
+  let evaluatedPaths = 0;
+  const evaluate = (index: number): number => {
+    if (!metricCache.evaluated[index]) {
+      metricCache.evaluated[index] = 1;
       const y = Math.floor(index / width);
       const x = index - y * width;
       const lat = latByRow[y];
       const lon = lonByCol[x];
-      if (pointMask && !pointMask(lat, lon)) return;
+      if (!pointMask || pointMask(lat, lon)) {
+        const sampledGround = terrainSampler(lat, lon);
+        if (sampledGround !== null) {
+          relaySite.position.lat = lat;
+          relaySite.position.lon = lon;
+          relaySite.groundElevationM = sampledGround ?? fallbackRelayGround;
+          const fromToRelayRx = computeSourceCentricRxDbm(
+            lat,
+            lon,
+            fromSite,
+            effectiveLink,
+            relayAntennaHeightM,
+            relaySite.rxGainDbi,
+            terrainSampler,
+            terrainSamples,
+            propagationEnvironment,
+          );
+          const relayToTargetRx = computeSourceCentricRxDbm(
+            toSite.position.lat,
+            toSite.position.lon,
+            relaySite,
+            effectiveLink,
+            toSite.antennaHeightM,
+            toSite.rxGainDbi,
+            terrainSampler,
+            terrainSamples,
+            propagationEnvironment,
+          );
+          metricCache.baseDbm[index] = Math.min(fromToRelayRx, relayToTargetRx);
+          evaluatedPaths += 1;
+        }
+      }
+    }
+    const value = metricCache.baseDbm[index] - environmentLossDb;
+    bottleneck[index] = value;
+    return value;
+  };
 
-      const sampledGround = terrainSampler(lat, lon);
-      if (sampledGround === null) return;
-      const relayGround = sampledGround ?? fallbackRelayGround;
-      relaySite.position.lat = lat;
-      relaySite.position.lon = lon;
-      relaySite.groundElevationM = relayGround;
+  let refinedBlocks = 0;
+  let filledPixels = width * height;
+  if (options?.adaptive === false) {
+    await runCooperativeLoop(width * height, evaluate, context);
+  } else {
+    const result = await runAdaptiveBlockQueue(
+      partitionRasterBlocks(width, height, terrainSamples, bounds),
+      width * height,
+      (block) => {
+        const area = rasterBlockArea(block);
+        const indices = sampleIndicesForRasterBlock(block, width);
+        const values = indices.map(evaluate);
+        const finiteValues = values.filter(Number.isFinite);
+        const allUnavailable = finiteValues.length === 0;
+        const mixedAvailability = finiteValues.length !== 0 && finiteValues.length !== values.length;
+        const xLast = block.x1 - 1;
+        const yLast = block.y1 - 1;
+        const cornerValues = [
+          evaluate(block.y0 * width + block.x0),
+          evaluate(block.y0 * width + xLast),
+          evaluate(yLast * width + block.x0),
+          evaluate(yLast * width + xLast),
+        ];
+        const centerValue = evaluate(
+          Math.floor((block.y0 + yLast) / 2) * width + Math.floor((block.x0 + xLast) / 2),
+        );
+        const range = finiteValues.length
+          ? Math.max(...finiteValues) - Math.min(...finiteValues)
+          : 0;
+        const predictedCenter = cornerValues.every(Number.isFinite)
+          ? cornerValues.reduce((sum, value) => sum + value, 0) / 4
+          : Number.NaN;
+        const stable =
+          (allUnavailable && !pointMask) ||
+          (!mixedAvailability && range <= 6 && Number.isFinite(centerValue) && Math.abs(centerValue - predictedCenter) <= 0.75);
+        if (area === 1 || stable) {
+          if (!allUnavailable) {
+            const [q00, q10, q01, q11] = cornerValues;
+            for (let y = block.y0; y < block.y1; y += 1) {
+              const ty = yLast === block.y0 ? 0 : (y - block.y0) / (yLast - block.y0);
+              for (let x = block.x0; x < block.x1; x += 1) {
+                const tx = xLast === block.x0 ? 0 : (x - block.x0) / (xLast - block.x0);
+                const top = q00 + (q10 - q00) * tx;
+                const bottom = q01 + (q11 - q01) * tx;
+                bottleneck[y * width + x] = top + (bottom - top) * ty;
+              }
+            }
+          }
+          return null;
+        }
+        return splitRasterBlock(block);
+      },
+      context,
+    );
+    refinedBlocks = result.refinedBlocks;
+    filledPixels = result.filledPixels;
+  }
+  if (metricCacheKey) relayMetricCache.set(metricCacheKey, metricCache);
 
-      const fromToRelayRx = computeSourceCentricRxDbm(
-        lat,
-        lon,
-        fromSite,
-        effectiveLink,
-        relayAntennaHeightM,
-        relaySite.rxGainDbi,
-        terrainSampler,
-        terrainSamples,
-        propagationEnvironment,
-      );
-      const relayToTargetRx = computeSourceCentricRxDbm(
-        toSite.position.lat,
-        toSite.position.lon,
-        relaySite,
-        effectiveLink,
-        toSite.antennaHeightM,
-        toSite.rxGainDbi,
-        terrainSampler,
-        terrainSamples,
-        propagationEnvironment,
-      );
-      const bottleneckDbm = Math.min(fromToRelayRx, relayToTargetRx) - environmentLossDb;
-
-      bottleneck[index] = bottleneckDbm;
-      minDbm = Math.min(minDbm, bottleneckDbm);
-      maxDbm = Math.max(maxDbm, bottleneckDbm);
-    },
-    context,
-  );
+  let minDbm = Number.POSITIVE_INFINITY;
+  let maxDbm = Number.NEGATIVE_INFINITY;
+  for (const value of bottleneck) {
+    if (!Number.isFinite(value)) continue;
+    minDbm = Math.min(minDbm, value);
+    maxDbm = Math.max(maxDbm, value);
+  }
 
   if (!Number.isFinite(minDbm) || !Number.isFinite(maxDbm)) return null;
   const dynamicRange = Math.max(6, maxDbm - minDbm);
@@ -726,6 +1020,8 @@ export const buildRelayCandidateOverlayPixelsAsync = async (
     coordinates: overlayCoordinates(bounds),
     minDbm,
     maxDbm,
+    signalValuesDbm: bottleneck,
+    analysisStats: { evaluatedPaths, refinedBlocks, filledPixels, totalPixels: width * height },
   };
 };
 

--- a/src/lib/simulationPerf.ts
+++ b/src/lib/simulationPerf.ts
@@ -17,6 +17,8 @@ type OverlayPerfRecord = {
   pixelCount: number;
   gridSize: number;
   effectiveRadiusKm: number;
+  evaluatedPaths?: number;
+  refinedBlocks?: number;
 };
 
 type PendingRunPerf = {
@@ -92,6 +94,8 @@ const maybeLogRun = (runId: string): void => {
     overlayGridSize: pending.overlay.gridSize,
     effectiveRadiusKm: pending.coverage.effectiveRadiusKm,
     overlayRadiusKm: pending.overlay.effectiveRadiusKm,
+    evaluatedPaths: pending.overlay.evaluatedPaths,
+    refinedBlocks: pending.overlay.refinedBlocks,
   });
 
   pendingByRun.delete(runId);

--- a/src/lib/srtm.ts
+++ b/src/lib/srtm.ts
@@ -164,6 +164,15 @@ const pickTileForCoordinate = (
   lat: number,
   lon: number,
 ): SrtmTile | null => {
+  const latFloor = Math.floor(lat);
+  const lonFloor = Math.floor(lon);
+  const onLatBoundary = Math.abs(lat - latFloor) <= NEAR_INTEGER_EPSILON;
+  const onLonBoundary = Math.abs(lon - lonFloor) <= NEAR_INTEGER_EPSILON;
+  if (!onLatBoundary && !onLonBoundary) {
+    const candidate = lookup.get(tileKeyForStart(latFloor, lonFloor));
+    return candidate && inTile(candidate, lat, lon) ? candidate : null;
+  }
+
   let chosen: SrtmTile | null = null;
 
   for (const key of candidateTileKeysForCoordinate(lat, lon)) {

--- a/src/store/appStore.selectionRecompute.test.ts
+++ b/src/store/appStore.selectionRecompute.test.ts
@@ -162,4 +162,23 @@ describe("appStore selection recompute triggers", () => {
     useAppStore.getState().clearActiveSelection();
     expect(recomputeCoverage).toHaveBeenCalledTimes(1);
   });
+
+  it("triggers recompute when the Simulation overlay mode changes", async () => {
+    const recomputeCoverage = vi.fn();
+    vi.doMock("./coverageStore", () => ({
+      useCoverageStore: {
+        getState: () => ({ recomputeCoverage }),
+      },
+      setAppStoreBridge: vi.fn(),
+    }));
+
+    const { useAppStore } = await import("./appStore");
+    seedSelectionState(useAppStore);
+
+    useAppStore.getState().setMapOverlayMode("heatmap");
+    expect(recomputeCoverage).toHaveBeenCalledTimes(1);
+
+    useAppStore.getState().setMapOverlayMode("heatmap");
+    expect(recomputeCoverage).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -3597,11 +3597,15 @@ export const useAppStore = create<AppState>((set, get) => ({
       pendingSiteLibraryOpenEntryId: entryId.trim() ? entryId : null,
     }),
   clearOpenSiteLibraryEntryRequest: () => set({ pendingSiteLibraryOpenEntryId: null }),
-  setMapOverlayMode: (mode) =>
+  setMapOverlayMode: (mode) => {
+    let changed = false;
     set((state) => {
       if (state.mapOverlayMode === mode) return state;
+      changed = true;
       return { mapOverlayMode: mode };
-    }),
+    });
+    if (changed) useCoverageStore.getState().recomputeCoverage();
+  },
   setDiscoveryVisibility: ({ libraryVisible, mqttVisible }) =>
     set((state) => {
       if (

--- a/src/store/coverageStore.test.ts
+++ b/src/store/coverageStore.test.ts
@@ -68,6 +68,7 @@ const makeBridgeState = () => ({
   selectedSiteIds: ["site-1"],
   isTerrainFetching: false,
   selectedOverlayRadiusOption: "50",
+  mapOverlayMode: "heatmap",
 });
 
 let bridgeState = makeBridgeState();
@@ -173,6 +174,23 @@ describe("coverageStore simulation progress phases", () => {
     expect(useCoverageStore.getState().autoCalculateEnabled).toBe(false);
     expect(useCoverageStore.getState().calculationCycleSource).toBe("manual");
     expect(buildSpy.mock.calls[0]?.[6]).toEqual(expect.objectContaining({ overlayRadiusKm: 50 }));
+  });
+
+  it("skips the generic coverage grid for direct-analysis overlay modes", async () => {
+    const buildSpy = vi.spyOn(coverageLib, "buildCoverageAsync").mockResolvedValue([]);
+    bridgeState.mapOverlayMode = "passfail";
+    useCoverageStore.setState({
+      coverageSamples: [{ lat: site.position.lat, lon: site.position.lon, valueDbm: -88 }],
+    });
+
+    useCoverageStore.getState().startManualCalculation();
+    vi.advanceTimersByTime(220);
+    await flushAsyncTicks();
+
+    expect(buildSpy).not.toHaveBeenCalled();
+    expect(useCoverageStore.getState().isSimulationRecomputing).toBe(false);
+    expect(useCoverageStore.getState().completedCoverageRunToken).not.toBe("");
+    expect(useCoverageStore.getState().coverageSamples[0]?.valueDbm).toBe(-88);
   });
 
   it("does not calculate or retain results when required terrain tiles remain unavailable", async () => {

--- a/src/store/coverageStore.ts
+++ b/src/store/coverageStore.ts
@@ -141,6 +141,7 @@ type CoverageInputs = {
   selectedSiteIds: string[];
   isTerrainFetching: boolean;
   selectedOverlayRadiusOptionRaw: unknown;
+  mapOverlayMode: string;
 };
 
 const normalizeCoverageResolution = (raw: unknown): "24" | "42" | "84" | "168" => {
@@ -171,6 +172,7 @@ const readCoverageInputs = (appState: Record<string, unknown>): CoverageInputs =
     selectedSiteIds: ((appState.selectedSiteIds as string[]) ?? []).filter((id) => typeof id === "string"),
     isTerrainFetching,
     selectedOverlayRadiusOptionRaw: appState.selectedOverlayRadiusOption,
+    mapOverlayMode: String(appState.mapOverlayMode ?? "heatmap"),
   };
 };
 
@@ -234,6 +236,7 @@ const coverageInputSignature = (inputs: CoverageInputs): string => {
     `selectedSites=${inputs.selectedSiteIds.join(",")}`,
     `terrainFetching=${inputs.isTerrainFetching ? 1 : 0}`,
     `overlayRadius=${String(inputs.selectedOverlayRadiusOptionRaw ?? "")}`,
+    `overlayMode=${inputs.mapOverlayMode}`,
   ].join("|");
 };
 
@@ -395,6 +398,24 @@ const runCoverageComputation = async (
     );
     const targetRadiusKm = resolveTargetOverlayRadiusKm(selectionCount, selectedOverlayRadiusOption);
     const effectiveOverlayRadiusKm = targetRadiusKm;
+
+    const requiresCoverageSamples =
+      inputs.mapOverlayMode === "heatmap" ||
+      inputs.mapOverlayMode === "weakest" ||
+      inputs.mapOverlayMode === "contours";
+    if (!requiresCoverageSamples) {
+      set({
+        simulationProgressMode: "indeterminate",
+        simulationStepLabel: "Preparing Simulation overlay...",
+      });
+      if (get().simulationRunToken !== runId) {
+        markCancelled("token-mismatch-before-mode-finalize");
+        return;
+      }
+      finalizeRunComplete(set, get, runId, get().coverageSamples);
+      lastAppliedCoverageSignature = runSignature;
+      return;
+    }
 
     const boundsForCount = simulationAreaBoundsForSites(inputs.sites, { overlayRadiusKm: effectiveOverlayRadiusKm });
     const sampleCount = boundsForCount


### PR DESCRIPTION
## What changed

- adaptively evaluates Pass/Fail and Relay overlays, filling stable areas and refining uncertain boundaries
- caches terrain-aware RF metrics so target/loss changes can be reclassified without repeating path analysis
- skips the generic coverage calculation for layers that perform their own direct analysis
- removes repeated allocation and lookup work from coverage and SRTM hot paths
- records evaluated-path and refinement counts in existing performance diagnostics

## Why

Pass/Fail and Relay previously ran full terrain-aware RF calculations for every display pixel, while Heatmap reused a coarser grid. That made layers with the same visible resolution and radius have very different calculation times.

## Accuracy contract

- Pass/Fail: at least 99% pixel-state agreement with the exact reference fixtures, including a narrow terrain ridge
- Relay: median signal error no more than 0.5 dB and p99 no more than 2 dB
- uncertain regions recursively refine to individual pixels
- terrain completeness behavior remains strict
- Heatmap, Weakest, Target Line, and Mesh Extension algorithms are unchanged

## Validation

- `npm test` — 133 files, 779 tests passed
- `npm run build` — passed
- `npm run lint` — passed
- `npx tsc -b config/tsconfig.json --pretty false` — passed
- `npm run dev:check` — no LinkSim dev/watch servers found
- differential tests verify accuracy and reduce evaluated terrain paths below 30% of the exact fixture
- adaptive Pass/Fail benchmark fixture exceeds the 3x target

Refs #998