### PR TITLE
Sharpen adaptive Pass/Fail overlay boundaries

### DIFF
--- a/src/lib/overlayRaster.test.ts
+++ b/src/lib/overlayRaster.test.ts
@@ -217,6 +217,39 @@ describe("overlayRaster async builders", () => {
     expect(matchingPixels / (dimensions.width * dimensions.height)).toBeGreaterThanOrEqual(0.99);
   });
 
+  it("keeps supersampled Pass/Fail boundaries close to the exact display-pixel result", async () => {
+    const dimensions = { width: 312, height: 312 };
+    const ridgeTerrain = (lat: number, lon: number) => {
+      const latOffset = (lat - 59.9) / 0.1;
+      const lonOffset = (lon - 10.7) / 0.1;
+      const ridgeOffset = latOffset - lonOffset * 0.42 - 0.413;
+      return 105 + Math.exp(-(ridgeOffset ** 2) / 0.0014) * 155;
+    };
+    const exact = await buildSourcePassFailOverlayPixelsAsync(
+      bounds, fromSite, link, toSite.antennaHeightM, toSite.rxGainDbi, environment,
+      -118, 0, ridgeTerrain, dimensions, 24, undefined,
+      { phase: "passfail", signature: "supersampled-ridge-reference" }, { adaptive: false },
+    );
+    const adaptive = await buildSourcePassFailOverlayPixelsAsync(
+      bounds, fromSite, link, toSite.antennaHeightM, toSite.rxGainDbi, environment,
+      -118, 0, ridgeTerrain, dimensions, 24, undefined,
+      { phase: "passfail", signature: "supersampled-ridge-adaptive" }, { adaptive: true },
+    );
+
+    let matchingPixels = 0;
+    for (let index = 0; index < dimensions.width * dimensions.height; index += 1) {
+      const offset = index * 4;
+      if (
+        exact!.pixels[offset] === adaptive!.pixels[offset] &&
+        exact!.pixels[offset + 1] === adaptive!.pixels[offset + 1] &&
+        exact!.pixels[offset + 2] === adaptive!.pixels[offset + 2]
+      ) matchingPixels += 1;
+    }
+    const agreement = matchingPixels / (dimensions.width * dimensions.height);
+    expect(agreement).toBeGreaterThanOrEqual(0.9999);
+    expect(adaptive?.analysisStats?.evaluatedPaths).toBeLessThan(dimensions.width * dimensions.height * 0.45);
+  });
+
   it("reuses cached Pass/Fail RF metrics when only the target changes", async () => {
     const dimensions = { width: 96, height: 96 };
     let firstReads = 0;

--- a/src/lib/overlayRaster.ts
+++ b/src/lib/overlayRaster.ts
@@ -107,6 +107,8 @@ export type OverlayTaskContext = {
 
 const DEFAULT_FRAME_BUDGET_MS = 8;
 const DEFAULT_LONG_TASK_MS = 28;
+const PASS_FAIL_BOUNDARY_MARGIN_DB = 5;
+const PASS_FAIL_DENSE_SAMPLE_MIN_SPAN_PX = 9;
 
 type PassFailMetricCache = {
   width: number;
@@ -289,6 +291,25 @@ const sampleIndicesForRasterBlock = (block: RasterBlock, width: number): number[
     yLast * width + block.x0,
     yLast * width + xLast,
     yMid * width + xMid,
+  ]));
+};
+
+const passFailSampleIndicesForRasterBlock = (block: RasterBlock, width: number): number[] => {
+  const baseIndices = sampleIndicesForRasterBlock(block, width);
+  if (
+    block.x1 - block.x0 < PASS_FAIL_DENSE_SAMPLE_MIN_SPAN_PX &&
+    block.y1 - block.y0 < PASS_FAIL_DENSE_SAMPLE_MIN_SPAN_PX
+  ) return baseIndices;
+  const xLast = block.x1 - 1;
+  const yLast = block.y1 - 1;
+  const xMid = Math.floor((block.x0 + xLast) / 2);
+  const yMid = Math.floor((block.y0 + yLast) / 2);
+  return Array.from(new Set([
+    ...baseIndices,
+    block.y0 * width + xMid,
+    yLast * width + xMid,
+    yMid * width + block.x0,
+    yMid * width + xLast,
   ]));
 };
 
@@ -801,14 +822,17 @@ export const buildSourcePassFailOverlayPixelsAsync = async (
       width * height,
       (block) => {
         const area = rasterBlockArea(block);
-        const sampleIndices = sampleIndicesForRasterBlock(block, width);
+        const sampleIndices = passFailSampleIndicesForRasterBlock(block, width);
         const states = sampleIndices.map(evaluate);
         const firstState = states[0] ?? 0;
         const stableState = states.every((state) => state === firstState);
         const safelyAwayFromThreshold =
-          firstState === 0 || sampleIndices.every((index) => Math.abs(marginByPixel[index]) >= 3);
+          firstState === 0 || sampleIndices.every((index) => Math.abs(marginByPixel[index]) >= PASS_FAIL_BOUNDARY_MARGIN_DB);
         const stableUnavailable = firstState === 0 && !pointMask;
-        if (area === 1 || (stableState && safelyAwayFromThreshold && (firstState !== 0 || stableUnavailable))) {
+        if (
+          area === 1 ||
+          (stableState && safelyAwayFromThreshold && (firstState !== 0 || stableUnavailable))
+        ) {
           for (let y = block.y0; y < block.y1; y += 1) {
             for (let x = block.x0; x < block.x1; x += 1) {
               const index = y * width + x;


### PR DESCRIPTION
## What changed

- sample four additional edge points when a Pass/Fail analysis block is visually large
- widen the threshold-focused refinement band from 3 dB to 5 dB
- add a representative 312×312 supersampled narrow-ridge regression fixture

## Why

The adaptive performance work made Pass/Fail substantially faster, but its hard categorical threshold exposed coarse blocks more clearly than smooth Heatmap shading. A global maximum block size recovered detail but recalculated most pixels, so this update concentrates extra work on large blocks and plausible threshold boundaries.

## Accuracy and performance

- representative supersampled ridge fixture improved from 99.843% agreement to at least 99.99% agreement with exact display-pixel output
- adaptive work remains below 45% of exact path evaluations on that fixture
- existing Pass/Fail 3× timing fixture remains green
- Relay and other Simulation layer algorithms are unchanged

## Validation

- `npm test` — 133 files, 780 tests passed
- `npm run build` — passed
- `npm run lint` — passed
- `npx tsc -b config/tsconfig.json --pretty false` — passed
- `npm run dev:check` — no LinkSim dev/watch servers found

Refs #998