### PR TITLE
Unify simulation overlay sampling grid

### DIFF
--- a/src/components/MapView.overlayHandoff.test.tsx
+++ b/src/components/MapView.overlayHandoff.test.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { Site, SrtmTile } from "../types/radio";
+import type { Network, RadioSystem, Site, SrtmTile } from "../types/radio";
 import { resolveRequiredOverlayTerrainTileKeys } from "../lib/simulationOverlayRadius";
 
 const overlayMock = vi.hoisted(() => {
@@ -52,6 +52,7 @@ vi.hoisted(() => {
 });
 
 vi.mock("../lib/overlayRaster", () => ({
+  buildAdaptiveCoverageOverlayPixelsAsync: overlayMock.buildCoverage,
   buildCoverageOverlayPixelsAsync: overlayMock.buildCoverage,
   buildMeshExtensionOverlayPixelsAsync: vi.fn(),
   buildRelayCandidateOverlayPixelsAsync: vi.fn(),
@@ -145,6 +146,26 @@ const site: Site = {
   cableLossDb: 1,
 };
 
+const system: RadioSystem = {
+  id: "system-a",
+  name: "System A",
+  txPowerDbm: 30,
+  txGainDbi: 2,
+  rxGainDbi: 2,
+  cableLossDb: 1,
+  antennaHeightM: 8,
+};
+
+const network: Network = {
+  id: "network-a",
+  name: "Network A",
+  frequencyMHz: 869.618,
+  bandwidthKhz: 250,
+  spreadFactor: 11,
+  codingRate: 5,
+  memberships: [{ siteId: site.id, systemId: system.id }],
+};
+
 const resolveNextRaster = async () => {
   await waitFor(() => expect(overlayMock.requests.length).toBeGreaterThan(0));
   const request = overlayMock.requests.shift();
@@ -172,6 +193,9 @@ describe("MapView overlay handoff", () => {
     });
     useAppStore.setState({
       sites: [site],
+      systems: [system],
+      networks: [network],
+      selectedNetworkId: network.id,
       links: [],
       selectedSiteId: site.id,
       selectedSiteIds: [site.id],

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -14,8 +14,11 @@ import Map, {
   type ViewStateChangeEvent,
 } from "react-map-gl/maplibre";
 import type { LayerProps } from "react-map-gl/maplibre";
-import { computeCoverageGridDimensions } from "../lib/coverage";
-import { buildCoverageTargetContourFeatures } from "../lib/coverageContour";
+import {
+  computeCanonicalOverlayGridDimensions,
+  createCoveragePointEvaluator,
+  resolveCanonicalOverlayResolutionScale,
+} from "../lib/coverage";
 import { STANDARD_SITE_RADIO } from "../lib/linkRadio";
 import { sampleSrtmElevation } from "../lib/srtm";
 import { getUiErrorMessage } from "../lib/uiError";
@@ -58,7 +61,7 @@ import {
   type SimulationOverlayRadiusOption,
 } from "../lib/simulationOverlayRadius";
 import {
-  buildCoverageOverlayPixelsAsync,
+  buildAdaptiveCoverageOverlayPixelsAsync,
   buildMeshExtensionOverlayPixelsAsync,
   buildRelayCandidateOverlayPixelsAsync,
   buildSourcePassFailOverlayPixelsAsync,
@@ -123,17 +126,6 @@ const readSectionBool = (key: string, fallback: boolean): boolean => {
 const writeSectionBool = (key: string, value: boolean): void => {
   try { localStorage.setItem(key, String(value)); } catch {}
 };
-
-const FNV_OFFSET_BASIS = 2166136261;
-const FNV_PRIME = 16777619;
-
-const updateFvnHash = (hash: number, value: number): number => {
-  const next = hash ^ (value & 0xff_ff_ff_ff);
-  return Math.imul(next, FNV_PRIME) >>> 0;
-};
-
-const roundHashValue = (value: number, factor = 10_000): number =>
-  Number.isFinite(value) ? Math.round(value * factor) : 0;
 
 // Full-world polygon used for the themed basemap color overlay.
 const WORLD_POLYGON_GEOJSON = {
@@ -233,34 +225,6 @@ const coverageRasterLayer = (fadedForCloud: boolean, hidden: boolean): LayerProp
     },
   };
 };
-
-const targetContourHaloLayer = (color: string, fadedForCloud: boolean, hidden: boolean): LayerProps => ({
-  beforeId: LINK_LAYER_ANCHOR_ID,
-  id: "coverage-target-contour-halo-layer",
-  type: "line",
-  paint: {
-    "line-color": color,
-    "line-width": 2.5,
-    "line-opacity": fadedForCloud || hidden ? 0 : 0.82,
-    "line-opacity-transition": {
-      duration: resolveSimulationOverlayTransition(fadedForCloud).durationMs,
-    },
-  },
-});
-
-const targetContourLineLayer = (color: string, fadedForCloud: boolean, hidden: boolean): LayerProps => ({
-  beforeId: LINK_LAYER_ANCHOR_ID,
-  id: "coverage-target-contour-line-layer",
-  type: "line",
-  paint: {
-    "line-color": color,
-    "line-width": 1.2,
-    "line-opacity": fadedForCloud || hidden ? 0 : 0.96,
-    "line-opacity-transition": {
-      duration: resolveSimulationOverlayTransition(fadedForCloud).durationMs,
-    },
-  },
-});
 
 const terrainRasterPaint = {
   "raster-opacity": 0.62,
@@ -523,17 +487,8 @@ const computeOverlayDimensions = (
   targetGridSize: number,
   resolutionScale = 1,
 ): { width: number; height: number } => {
-  const { rows, cols } = computeCoverageGridDimensions(targetGridSize, bounds, 1);
-  // Match the historical visual baseline (~100k display pixels at 24x24 samples)
-  // while keeping display density proportional to simulation sample density.
-  const targetDisplayPixelsPerSample = 174;
-  const displaySupersample = Math.sqrt(targetDisplayPixelsPerSample);
-  const scaledWidth = Math.round(cols * resolutionScale * displaySupersample);
-  const scaledHeight = Math.round(rows * resolutionScale * displaySupersample);
-  return {
-    width: clamp(scaledWidth, 8, 1400),
-    height: clamp(scaledHeight, 8, 1400),
-  };
+  const dimensions = computeCanonicalOverlayGridDimensions(targetGridSize, bounds, resolutionScale);
+  return { width: dimensions.width, height: dimensions.height };
 };
 
 const kmToLatDegrees = (km: number): number => km / 111.32;
@@ -831,6 +786,7 @@ export function MapView({
   const propagationModel = useAppStore((state) => state.propagationModel);
   const selectedNetworkId = useAppStore((state) => state.selectedNetworkId);
   const networks = useAppStore((state) => state.networks);
+  const systems = useAppStore((state) => state.systems);
   const terrainDataset = useAppStore((state) => state.terrainDataset);
   const rxSensitivityTargetDbm = useAppStore((state) => state.rxSensitivityTargetDbm);
   const environmentLossDb = useAppStore((state) => state.environmentLossDb);
@@ -1657,11 +1613,9 @@ export function MapView({
   );
 
   const overlayResolutionScale = useMemo(() => {
-    if (analysisBoundsDiagonalKm > 600) return 0.52;
-    if (analysisBoundsDiagonalKm > 400) return 0.64;
-    if (analysisBoundsDiagonalKm > 250) return 0.76;
-    return 1;
-  }, [analysisBoundsDiagonalKm]);
+    if (!analysisBounds) return 1;
+    return resolveCanonicalOverlayResolutionScale(analysisBounds);
+  }, [analysisBounds]);
   const largeAreaOptimizationActive = overlayResolutionScale < 1;
 
   // During a site drag, force low-res (24) to keep overlay recomputations cheap.
@@ -1698,16 +1652,17 @@ export function MapView({
       { gridSize: 168, name: "8x" },
     ] as const;
     return options.map(({ gridSize, name }) => {
-      const fallback = { rows: gridSize, cols: gridSize, totalSamples: gridSize * gridSize };
-      const dims = overlayBounds ? computeCoverageGridDimensions(gridSize, overlayBounds, 1) : fallback;
+      const fallback = { width: gridSize, height: gridSize, totalSamples: gridSize * gridSize };
+      const dims = overlayBounds
+        ? computeCanonicalOverlayGridDimensions(gridSize, overlayBounds, overlayResolutionScale)
+        : fallback;
       const isDefault = gridSize === 24;
       return {
         value: String(gridSize) as "24" | "42" | "84" | "168",
-        label: `${name} (${dims.rows}x${dims.cols}, ${dims.totalSamples} samples)${isDefault ? " - Default" : ""}`,
+        label: `${name} (${dims.height}x${dims.width}, ${dims.totalSamples} samples)${isDefault ? " - Default" : ""}`,
       };
     });
-  }, [overlayBounds]);
-  const effectiveBandStepDb = 5;
+  }, [overlayBounds, overlayResolutionScale]);
   const overlayLongTaskWarnedRef = useRef<Set<string>>(new Set());
   const showOverlayDiagnostics =
     import.meta.env.DEV || (typeof window !== "undefined" && window.location.hostname === "localhost");
@@ -1911,15 +1866,6 @@ export function MapView({
     };
   }, []);
 
-  const overlaySampleDigest = useMemo(() => {
-    let hash = FNV_OFFSET_BASIS;
-    for (const sample of samplesForOverlay) {
-      hash = updateFvnHash(hash, roundHashValue(sample.lat, 100_000));
-      hash = updateFvnHash(hash, roundHashValue(sample.lon, 100_000));
-      hash = updateFvnHash(hash, roundHashValue(sample.valueDbm, 10));
-    }
-    return hash.toString(16);
-  }, [samplesForOverlay]);
   const propagationEnvironmentDigest = useMemo(
     () =>
       [
@@ -1936,6 +1882,39 @@ export function MapView({
   );
   const selectedSiteDigest = useMemo(() => selectedSiteIds.join(","), [selectedSiteIds]);
   const selectedSiteRadioDigest = useMemo(() => meshExtensionSiteDigest(meshExtensionSites), [meshExtensionSites]);
+  const coverageAnalysisInputDigest = useMemo(
+    () =>
+      [
+        selectedNetwork?.id ?? "",
+        selectedNetwork?.frequencyMHz ?? "",
+        selectedNetwork?.frequencyOverrideMHz ?? "",
+        ...(selectedNetwork?.memberships ?? []).map((membership) => `${membership.siteId}:${membership.systemId}`),
+        ...sites.map((site) =>
+          [
+            site.id,
+            site.position.lat,
+            site.position.lon,
+            site.groundElevationM,
+            site.antennaHeightM,
+            site.txPowerDbm,
+            site.txGainDbi,
+            site.rxGainDbi,
+            site.cableLossDb,
+          ].join(":"),
+        ),
+        ...systems.map((system) =>
+          [
+            system.id,
+            system.txPowerDbm,
+            system.txGainDbi,
+            system.rxGainDbi,
+            system.cableLossDb,
+            system.antennaHeightM,
+          ].join(":"),
+        ),
+      ].join("|"),
+    [selectedNetwork, sites, systems],
+  );
   const meshExtensionFrequencyMHz =
     selectedNetwork?.frequencyOverrideMHz ?? selectedNetwork?.frequencyMHz ?? activeSelectionLink?.frequencyMHz ?? 869.618;
 
@@ -1961,6 +1940,13 @@ export function MapView({
     }
 
     const mode = coverageVizMode;
+    if (
+      (mode === "heatmap" || mode === "contours" || mode === "weakest") &&
+      (!selectedNetwork || !sites.length || !systems.length)
+    ) {
+      cancelCoveragePipeline();
+      return;
+    }
     if (mode === "passfail" && (!activeSelectionLink || !selectedFromSite || !hasPassFailTopology)) {
       cancelCoveragePipeline();
       return;
@@ -1982,9 +1968,6 @@ export function MapView({
       overlayBounds.maxLon.toFixed(5),
       overlayDimensions.width,
       overlayDimensions.height,
-      effectiveBandStepDb,
-      samplesForOverlay.length,
-      overlaySampleDigest,
       srtmTiles.length,
       terrainLoadEpoch,
       effectiveGridSize,
@@ -2017,6 +2000,20 @@ export function MapView({
       activeSelectionLink?.rxGainDbi ?? "",
       activeSelectionLink?.cableLossDb ?? "",
       selectedSiteRadioDigest,
+      propagationEnvironmentDigest,
+    ].join("|");
+    const coverageAnalysisCacheKey = [
+      "coverage",
+      overlayBounds.minLat.toFixed(5),
+      overlayBounds.maxLat.toFixed(5),
+      overlayBounds.minLon.toFixed(5),
+      overlayBounds.maxLon.toFixed(5),
+      overlayDimensions.width,
+      overlayDimensions.height,
+      srtmTiles.length,
+      terrainLoadEpoch,
+      effectiveGridSize,
+      coverageAnalysisInputDigest,
       propagationEnvironmentDigest,
     ].join("|");
     if (
@@ -2124,24 +2121,30 @@ export function MapView({
           } as const;
           let rasterPixels: OverlayRasterPixels | null = null;
           if (mode === "heatmap" || mode === "contours" || mode === "weakest") {
-            const overlaySamples =
-              mode === "weakest"
-                ? samplesForOverlay.map((sample) => ({
-                    ...sample,
-                    valueDbm: sample.weakestDbm ?? sample.valueDbm,
-                  }))
-                : samplesForOverlay;
-            rasterPixels = await buildCoverageOverlayPixelsAsync(
-              overlayBounds,
-              overlaySamples,
-              mode === "contours" || mode === "weakest" ? "heatmap" : mode,
-              effectiveBandStepDb,
-              overlayDimensions,
-              overlayPointMask,
-              terrainSampler,
-              context,
-              { rxTargetDbm: rxSensitivityTargetDbm },
+            const evaluateCoveragePoint = createCoveragePointEvaluator(
+              selectedNetwork!,
+              sites,
+              systems,
+              propagationEnvironment,
+              ({ lat, lon }) => terrainSampler(lat, lon),
+              {
+                terrainSamples: 20,
+                terrainCacheKey: coverageAnalysisCacheKey,
+                requireCompleteTerrain: true,
+              },
             );
+            rasterPixels = await buildAdaptiveCoverageOverlayPixelsAsync({
+              bounds: overlayBounds,
+              dimensions: overlayDimensions,
+              initialGridSize: effectiveGridSize,
+              mode,
+              rxTargetDbm: rxSensitivityTargetDbm,
+              evaluatePoint: evaluateCoveragePoint,
+              pointMask: overlayPointMask,
+              context,
+              adaptive: true,
+              analysisCacheKey: coverageAnalysisCacheKey,
+            });
           } else if (mode === "passfail") {
             const receiverAntennaHeightM = selectedToSite?.antennaHeightM ?? selectedFromSite!.antennaHeightM ?? 2;
             const receiverRxGainDbi =
@@ -2283,9 +2286,6 @@ export function MapView({
     overlayPointMask,
     srtmTiles,
     terrainLoadEpoch,
-    effectiveBandStepDb,
-    samplesForOverlay,
-    overlaySampleDigest,
     propagationEnvironment,
     propagationEnvironmentDigest,
     rxSensitivityTargetDbm,
@@ -2297,6 +2297,9 @@ export function MapView({
     meshExtensionFrequencyMHz,
     meshExtensionSites,
     selectedNetwork,
+    sites,
+    systems,
+    coverageAnalysisInputDigest,
     showOverlayDiagnostics,
     beginOverlayJob,
     beginCoverageHandoff,
@@ -2334,48 +2337,6 @@ export function MapView({
     return { min, max };
   }, [samplesForOverlay]);
 
-  const targetContourFeatures = useMemo(
-    () =>
-      coverageVizMode === "contours"
-        ? buildCoverageTargetContourFeatures(samplesForOverlay, rxSensitivityTargetDbm, overlayBounds, overlayPointMask)
-        : { type: "FeatureCollection" as const, features: [] },
-    [coverageVizMode, overlayBounds, overlayPointMask, rxSensitivityTargetDbm, samplesForOverlay],
-  );
-  const [displayedTargetContourFeatures, setDisplayedTargetContourFeatures] =
-    useState(targetContourFeatures);
-  const pendingTargetContourFeaturesRef = useRef(targetContourFeatures);
-  useEffect(() => {
-    if (
-      coverageVizMode === "contours" &&
-      targetContourFeatures.features.length > 0
-    ) {
-      if (
-        overlayHandoff.phase === "entering" ||
-        overlayHandoff.phase === "entered"
-      ) {
-        pendingTargetContourFeaturesRef.current = targetContourFeatures;
-      } else {
-        setDisplayedTargetContourFeatures(targetContourFeatures);
-      }
-    }
-    if (overlayHandoff.phase === "exiting") {
-      setDisplayedTargetContourFeatures(
-        coverageVizMode === "contours"
-          ? pendingTargetContourFeaturesRef.current
-          : { type: "FeatureCollection", features: [] },
-      );
-    }
-    if (overlayHandoff.phase !== "hiding") return;
-    const timeoutId = window.setTimeout(() => {
-      setDisplayedTargetContourFeatures({
-        type: "FeatureCollection",
-        features: [],
-      });
-    }, resolveSimulationOverlayTransition(false).durationMs);
-    return () => window.clearTimeout(timeoutId);
-  }, [coverageVizMode, overlayHandoff.phase, targetContourFeatures]);
-  const showTargetContourLine =
-    displayedTargetContourFeatures.features.length > 0;
   const coverageScaleRange = useMemo(() => {
     if (!coverageOverlay || (coverageVizMode !== "heatmap" && coverageVizMode !== "contours" && coverageVizMode !== "weakest")) {
       return null;
@@ -4259,25 +4220,6 @@ export function MapView({
           onCloudReady={handleLoadingCloudReady}
           pointMask={overlayPointMask}
         />
-
-        {showTargetContourLine ? (
-          <Source data={displayedTargetContourFeatures} id="coverage-target-contour-source" type="geojson">
-            <Layer
-              {...targetContourHaloLayer(
-                variant.cssVars["--bg"] ?? linkColor,
-                simulationOverlayFadedForCloud,
-                simulationOverlayHidden,
-              )}
-            />
-            <Layer
-              {...targetContourLineLayer(
-                variant.cssVars["--muted"] ?? selectedLinkColor,
-                simulationOverlayFadedForCloud,
-                simulationOverlayHidden,
-              )}
-            />
-          </Source>
-        ) : null}
 
         {userLocationFix ? (
           <Source data={userLocationAccuracyGeoJson} id="user-location-accuracy" type="geojson">

--- a/src/lib/coverage.test.ts
+++ b/src/lib/coverage.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildCoverage,
   buildCoverageAsync,
+  computeCanonicalOverlayGridDimensions,
   computeCoverageGridDimensions,
   CoverageBuildCancelledError,
 } from "./coverage";
@@ -161,5 +162,20 @@ describe("buildCoverage", () => {
     expect(dims.targetSamples).toBe(576);
     expect(dims.rows).toBeGreaterThan(0);
     expect(dims.cols).toBeGreaterThan(0);
+  });
+
+  it("uses the Pass/Fail raster as the canonical area-overlay grid", () => {
+    const bounds = {
+      minLat: 59.8,
+      maxLat: 60.1,
+      minLon: 10.7,
+      maxLon: 10.8,
+    };
+    const base = computeCoverageGridDimensions(24, bounds);
+    const canonical = computeCanonicalOverlayGridDimensions(24, bounds);
+
+    expect(canonical.width).toBe(Math.round(base.cols * Math.sqrt(174)));
+    expect(canonical.height).toBe(Math.round(base.rows * Math.sqrt(174)));
+    expect(canonical.totalSamples).toBe(canonical.width * canonical.height);
   });
 });

--- a/src/lib/coverage.ts
+++ b/src/lib/coverage.ts
@@ -68,6 +68,7 @@ export type CoverageGridPoint = {
 
 const COVERAGE_COMPUTE_CHUNK_SIZE = 48;
 const COVERAGE_COMPUTE_FRAME_BUDGET_MS = 12;
+export const CANONICAL_OVERLAY_PIXELS_PER_BASE_SAMPLE = 174;
 
 export const computeCoverageGridDimensions = (
   gridSize: number,
@@ -88,6 +89,32 @@ export const computeCoverageGridDimensions = (
     totalSamples: rows * cols,
     targetSamples,
   };
+};
+
+export const computeCanonicalOverlayGridDimensions = (
+  gridSize: number,
+  bounds: CoverageGridBounds,
+  resolutionScale = 1,
+): { width: number; height: number; totalSamples: number } => {
+  const { rows, cols } = computeCoverageGridDimensions(gridSize, bounds, 1);
+  const displaySupersample = Math.sqrt(CANONICAL_OVERLAY_PIXELS_PER_BASE_SAMPLE);
+  const width = Math.max(8, Math.min(1400, Math.round(cols * resolutionScale * displaySupersample)));
+  const height = Math.max(8, Math.min(1400, Math.round(rows * resolutionScale * displaySupersample)));
+  return { width, height, totalSamples: width * height };
+};
+
+export const resolveCanonicalOverlayResolutionScale = (bounds: CoverageGridBounds): number => {
+  const centerLat = (bounds.minLat + bounds.maxLat) / 2;
+  const latSpanKm = Math.abs(bounds.maxLat - bounds.minLat) * 111.32;
+  const lonSpanKm =
+    Math.abs(bounds.maxLon - bounds.minLon) *
+    111.32 *
+    Math.max(0.1, Math.cos((centerLat * Math.PI) / 180));
+  const diagonalKm = Math.hypot(latSpanKm, lonSpanKm);
+  if (diagonalKm > 600) return 0.52;
+  if (diagonalKm > 400) return 0.64;
+  if (diagonalKm > 250) return 0.76;
+  return 1;
 };
 
 export const buildCoverageGridPoints = (
@@ -268,6 +295,35 @@ const evaluateCoveragePoint = (
   return {
     valueDbm: Number.isFinite(strongestDbm) ? strongestDbm : -140,
     weakestDbm: Number.isFinite(weakestDbm) ? weakestDbm : -140,
+  };
+};
+
+export const createCoveragePointEvaluator = (
+  network: Network,
+  sites: Site[],
+  systems: RadioSystem[],
+  environment: PropagationEnvironment,
+  terrainSampler?: (coordinates: Coordinates) => number | null,
+  options?: Pick<BuildCoverageOptions, "terrainSamples" | "terrainCacheKey" | "requireCompleteTerrain">,
+): ((lat: number, lon: number) => { strongestDbm: number; weakestDbm: number }) => {
+  const memberships = resolveCoverageMemberships(network, sites, systems);
+  const frequencyMHz = network.frequencyOverrideMHz ?? network.frequencyMHz;
+  const terrainSamples = Math.max(16, Math.round(options?.terrainSamples ?? 20));
+  const effectiveTerrainSampler =
+    terrainSampler && options?.requireCompleteTerrain
+      ? requireTerrainSample(terrainSampler)
+      : terrainSampler;
+  return (lat, lon) => {
+    const levels = evaluateCoveragePoint(
+      { lat, lon },
+      memberships,
+      frequencyMHz,
+      terrainSamples,
+      environment,
+      effectiveTerrainSampler,
+      options?.terrainCacheKey,
+    );
+    return { strongestDbm: levels.valueDbm, weakestDbm: levels.weakestDbm ?? levels.valueDbm };
   };
 };
 

--- a/src/lib/overlayRaster.test.ts
+++ b/src/lib/overlayRaster.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildAdaptiveCoverageOverlayPixelsAsync,
   buildCoverageOverlayPixelsAsync,
   buildMeshExtensionOverlayPixelsAsync,
   computeCoverageRxTargetScale,
@@ -77,6 +78,79 @@ const environment: PropagationEnvironment = {
 const terrainSampler = () => 135;
 
 describe("overlayRaster async builders", () => {
+  it("builds Heatmap on the Pass/Fail logical grid with bounded adaptive error", async () => {
+    const dimensions = { width: 312, height: 312 };
+    let exactEvaluations = 0;
+    let adaptiveEvaluations = 0;
+    const evaluateSignal = (lat: number, lon: number) => {
+      const latOffset = (lat - 59.9) / 0.1;
+      const lonOffset = (lon - 10.7) / 0.1;
+      const ridgeOffset = latOffset - lonOffset * 0.4 - 0.42;
+      const strongestDbm = -116 + lonOffset * 16 + Math.exp(-(ridgeOffset ** 2) / 0.006) * 11;
+      return { strongestDbm, weakestDbm: strongestDbm - 7 };
+    };
+    const exact = await buildAdaptiveCoverageOverlayPixelsAsync({
+      bounds,
+      dimensions,
+      initialGridSize: 24,
+      mode: "heatmap",
+      rxTargetDbm: -118,
+      evaluatePoint: (lat, lon) => {
+        exactEvaluations += 1;
+        return evaluateSignal(lat, lon);
+      },
+      adaptive: false,
+    });
+    const adaptive = await buildAdaptiveCoverageOverlayPixelsAsync({
+      bounds,
+      dimensions,
+      initialGridSize: 24,
+      mode: "heatmap",
+      rxTargetDbm: -118,
+      evaluatePoint: (lat, lon) => {
+        adaptiveEvaluations += 1;
+        return evaluateSignal(lat, lon);
+      },
+      adaptive: true,
+    });
+
+    expect(exact?.signalValuesDbm).toHaveLength(dimensions.width * dimensions.height);
+    expect(adaptive?.signalValuesDbm).toHaveLength(dimensions.width * dimensions.height);
+    const errors = Array.from(exact!.signalValuesDbm!, (value, index) =>
+      Math.abs(value - adaptive!.signalValuesDbm![index]));
+    errors.sort((left, right) => left - right);
+    expect(errors[Math.floor(errors.length * 0.5)]).toBeLessThanOrEqual(0.25);
+    expect(errors[Math.floor(errors.length * 0.99)]).toBeLessThanOrEqual(1);
+    expect(adaptiveEvaluations).toBeLessThan(exactEvaluations * 0.45);
+    expect(adaptive?.analysisStats?.totalPixels).toBe(dimensions.width * dimensions.height);
+  });
+
+  it("reuses the same canonical signal samples when switching coverage overlay", async () => {
+    const dimensions = { width: 96, height: 96 };
+    let evaluations = 0;
+    const common = {
+      bounds,
+      dimensions,
+      initialGridSize: 24,
+      rxTargetDbm: -118,
+      evaluatePoint: (lat: number, lon: number) => {
+        evaluations += 1;
+        const strongestDbm = -104 + (lat - bounds.minLat) * 20 + (lon - bounds.minLon) * 10;
+        return { strongestDbm, weakestDbm: strongestDbm - 8 };
+      },
+      adaptive: true,
+      analysisCacheKey: "coverage-mode-switch-cache",
+    } as const;
+    const heatmap = await buildAdaptiveCoverageOverlayPixelsAsync({ ...common, mode: "heatmap" });
+    const firstEvaluations = evaluations;
+    const weakest = await buildAdaptiveCoverageOverlayPixelsAsync({ ...common, mode: "weakest" });
+
+    expect(heatmap?.signalValuesDbm).toHaveLength(dimensions.width * dimensions.height);
+    expect(weakest?.signalValuesDbm).toHaveLength(dimensions.width * dimensions.height);
+    expect(evaluations).toBe(firstEvaluations);
+    expect(weakest?.analysisStats?.evaluatedPaths).toBe(0);
+  });
+
   it("keeps adaptive Pass/Fail within the accuracy gate while reducing terrain work", async () => {
     const dimensions = { width: 120, height: 120 };
     let exactTerrainReads = 0;
@@ -579,6 +653,28 @@ describe("overlayRaster async builders", () => {
 
     expect(raster).not.toBeNull();
     expect(terrainReads).toBeLessThan(70_000);
+    expect(Array.from(raster!.pixels).filter((_, index) => index % 4 === 3).every((alpha) => alpha === 0)).toBe(true);
+  });
+
+  it("uses the canonical Mesh Extension candidate grid while merging safely failing regions", async () => {
+    const dimensions = { width: 48, height: 48 };
+    const raster = await buildMeshExtensionOverlayPixelsAsync({
+      bounds,
+      selectedSites: [fromSite],
+      frequencyMHz: 868,
+      propagationEnvironment: environment,
+      rxTargetDbm: -20,
+      environmentLossDb: 0,
+      terrainSampler,
+      dimensions,
+      candidateGridSize: 6,
+      coverageGridSize: 6,
+      terrainSamples: 16,
+      context: { phase: "mesh-extension", signature: "mesh-extension-canonical-grid" },
+    });
+
+    expect(raster?.analysisStats?.totalPixels).toBe(dimensions.width * dimensions.height);
+    expect(raster?.analysisStats?.evaluatedPaths).toBeLessThan(dimensions.width * dimensions.height * 0.25);
     expect(Array.from(raster!.pixels).filter((_, index) => index % 4 === 3).every((alpha) => alpha === 0)).toBe(true);
   });
 

--- a/src/lib/overlayRaster.ts
+++ b/src/lib/overlayRaster.ts
@@ -20,6 +20,19 @@ export type CoverageOverlayOptions = {
   rxTargetDbm?: number;
 };
 
+export type AdaptiveCoverageOverlayInput = {
+  bounds: TerrainBounds;
+  dimensions: { width: number; height: number };
+  initialGridSize: number;
+  mode: "heatmap" | "weakest" | "contours";
+  rxTargetDbm: number;
+  evaluatePoint: (lat: number, lon: number) => { strongestDbm: number; weakestDbm: number };
+  pointMask?: (lat: number, lon: number) => boolean;
+  context?: OverlayTaskContext;
+  adaptive?: boolean;
+  analysisCacheKey?: string;
+};
+
 export type OverlayRasterPixels = {
   width: number;
   height: number;
@@ -118,6 +131,14 @@ type PassFailMetricCache = {
   evaluated: Uint8Array;
 };
 
+type CoverageMetricCache = {
+  width: number;
+  height: number;
+  strongestDbm: Float32Array;
+  weakestDbm: Float32Array;
+  evaluated: Uint8Array;
+};
+
 type RelayMetricCache = {
   width: number;
   height: number;
@@ -127,6 +148,7 @@ type RelayMetricCache = {
 
 const passFailMetricCache = createLruCache<PassFailMetricCache>(2);
 const relayMetricCache = createLruCache<RelayMetricCache>(2);
+const coverageMetricCache = createLruCache<CoverageMetricCache>(2);
 
 const nowMs = (): number =>
   typeof performance !== "undefined" && typeof performance.now === "function"
@@ -241,6 +263,24 @@ const runCooperativeLoop = async (
   }
 };
 
+const contextForProgressRange = (
+  context: OverlayTaskContext | undefined,
+  startPercent: number,
+  endPercent: number,
+): OverlayTaskContext | undefined => {
+  if (!context) return undefined;
+  return {
+    ...context,
+    onProgress: context.onProgress
+      ? (payload) =>
+          context.onProgress?.({
+            ...payload,
+            percent: Math.round(lerp(startPercent, endPercent, payload.percent / 100)),
+          })
+      : undefined,
+  };
+};
+
 type RasterBlock = { x0: number; x1: number; y0: number; y1: number };
 
 const rasterBlockArea = (block: RasterBlock): number =>
@@ -316,7 +356,7 @@ const passFailSampleIndicesForRasterBlock = (block: RasterBlock, width: number):
 const runAdaptiveBlockQueue = async (
   blocks: RasterBlock[],
   totalPixels: number,
-  process: (block: RasterBlock) => RasterBlock[] | null,
+  process: (block: RasterBlock) => RasterBlock[] | null | Promise<RasterBlock[] | null>,
   context?: OverlayTaskContext,
 ): Promise<{ refinedBlocks: number; filledPixels: number }> => {
   const queue = blocks.slice().reverse();
@@ -329,7 +369,7 @@ const runAdaptiveBlockQueue = async (
   while (queue.length) {
     throwIfCancelled(context);
     const block = queue.pop()!;
-    const children = process(block);
+    const children = await process(block);
     if (children?.length) {
       refinedBlocks += 1;
       for (let index = children.length - 1; index >= 0; index -= 1) queue.push(children[index]);
@@ -599,6 +639,185 @@ const makeGridInterpolator = (
     const a = q00 + (q10 - q00) * tx;
     const b = q01 + (q11 - q01) * tx;
     return a + (b - a) * ty;
+  };
+};
+
+const computeDenseCoverageRxTargetScale = (
+  values: Float32Array,
+  rxTargetDbm: number,
+): CoverageRxTargetScale => {
+  const stride = Math.max(1, Math.floor(values.length / 20_000));
+  const finiteValues: number[] = [];
+  for (let index = 0; index < values.length; index += stride) {
+    const value = values[index];
+    if (Number.isFinite(value)) finiteValues.push(value);
+  }
+  if (!finiteValues.length || !Number.isFinite(rxTargetDbm)) {
+    const target = Number.isFinite(rxTargetDbm) ? rxTargetDbm : -120;
+    return { min: target - 30, max: target + 30 };
+  }
+  finiteValues.sort((left, right) => left - right);
+  const low = percentile(finiteValues, 0.05);
+  const high = percentile(finiteValues, 0.95);
+  const span = clamp(Math.max(rxTargetDbm - low, high - rxTargetDbm, 20), 20, 55);
+  return { min: rxTargetDbm - span, max: rxTargetDbm + span };
+};
+
+const computeDensePositivePercentile = (values: Float32Array, ratio: number): number => {
+  const stride = Math.max(1, Math.floor(values.length / 20_000));
+  const positiveValues: number[] = [];
+  for (let index = 0; index < values.length; index += stride) {
+    const value = values[index];
+    if (Number.isFinite(value) && value > 0) positiveValues.push(value);
+  }
+  positiveValues.sort((left, right) => left - right);
+  return positiveValues.length ? percentile(positiveValues, ratio) : 0;
+};
+
+export const buildAdaptiveCoverageOverlayPixelsAsync = async (
+  input: AdaptiveCoverageOverlayInput,
+): Promise<OverlayRasterPixels | null> => {
+  const { bounds, dimensions, initialGridSize, mode, rxTargetDbm, evaluatePoint, pointMask, context } = input;
+  const width = dimensions.width;
+  const height = dimensions.height;
+  const totalPixels = width * height;
+  if (totalPixels <= 0) return null;
+  const { latByRow, lonByCol } = precomputeGridAxes(bounds, dimensions);
+  const metricCacheKey = input.analysisCacheKey ? `${input.analysisCacheKey}|${width}x${height}` : "";
+  const cachedMetrics = metricCacheKey ? coverageMetricCache.get(metricCacheKey) : undefined;
+  const metricCache =
+    cachedMetrics?.width === width && cachedMetrics.height === height
+      ? cachedMetrics
+      : {
+          width,
+          height,
+          strongestDbm: new Float32Array(totalPixels).fill(Number.NaN),
+          weakestDbm: new Float32Array(totalPixels).fill(Number.NaN),
+          evaluated: new Uint8Array(totalPixels),
+        };
+  let evaluatedPaths = 0;
+  const analysisContext = contextForProgressRange(context, 0, 90);
+  const colorContext = contextForProgressRange(context, 90, 100);
+
+  const evaluate = (index: number): { strongestDbm: number; weakestDbm: number } => {
+    if (!metricCache.evaluated[index]) {
+      metricCache.evaluated[index] = 1;
+      const y = Math.floor(index / width);
+      const x = index - y * width;
+      const lat = latByRow[y];
+      const lon = lonByCol[x];
+      if (!pointMask || pointMask(lat, lon)) {
+        const value = evaluatePoint(lat, lon);
+        metricCache.strongestDbm[index] = value.strongestDbm;
+        metricCache.weakestDbm[index] = value.weakestDbm;
+        evaluatedPaths += 1;
+      }
+    }
+    return {
+      strongestDbm: metricCache.strongestDbm[index],
+      weakestDbm: metricCache.weakestDbm[index],
+    };
+  };
+
+  let refinedBlocks = 0;
+  let filledPixels = totalPixels;
+  if (input.adaptive === false) {
+    await runCooperativeLoop(totalPixels, evaluate, analysisContext);
+  } else {
+    const result = await runAdaptiveBlockQueue(
+      partitionRasterBlocks(width, height, initialGridSize, bounds),
+      totalPixels,
+      (block) => {
+        const area = rasterBlockArea(block);
+        const sampleIndices = passFailSampleIndicesForRasterBlock(block, width);
+        const samples = sampleIndices.map((index) => ({ index, ...evaluate(index) }));
+        const finiteSamples = samples.filter(
+          (sample) => Number.isFinite(sample.strongestDbm) && Number.isFinite(sample.weakestDbm),
+        );
+        if (area === 1 || finiteSamples.length === 0) return null;
+        if (finiteSamples.length !== samples.length) return splitRasterBlock(block);
+
+        const xLast = block.x1 - 1;
+        const yLast = block.y1 - 1;
+        const cornerIndices = [
+          block.y0 * width + block.x0,
+          block.y0 * width + xLast,
+          yLast * width + block.x0,
+          yLast * width + xLast,
+        ];
+        const corners = cornerIndices.map(evaluate);
+        const predict = (index: number, field: "strongestDbm" | "weakestDbm"): number => {
+          const y = Math.floor(index / width);
+          const x = index - y * width;
+          const tx = xLast === block.x0 ? 0 : (x - block.x0) / (xLast - block.x0);
+          const ty = yLast === block.y0 ? 0 : (y - block.y0) / (yLast - block.y0);
+          const top = corners[0][field] + (corners[1][field] - corners[0][field]) * tx;
+          const bottom = corners[2][field] + (corners[3][field] - corners[2][field]) * tx;
+          return top + (bottom - top) * ty;
+        };
+        const stable = finiteSamples.every(
+          (sample) =>
+            Math.abs(sample.strongestDbm - predict(sample.index, "strongestDbm")) <= 0.75 &&
+            Math.abs(sample.weakestDbm - predict(sample.index, "weakestDbm")) <= 0.75,
+        );
+        if (!stable) return splitRasterBlock(block);
+
+        for (let y = block.y0; y < block.y1; y += 1) {
+          for (let x = block.x0; x < block.x1; x += 1) {
+            const index = y * width + x;
+            metricCache.strongestDbm[index] = predict(index, "strongestDbm");
+            metricCache.weakestDbm[index] = predict(index, "weakestDbm");
+          }
+        }
+        return null;
+      },
+      analysisContext,
+    );
+    refinedBlocks = result.refinedBlocks;
+    filledPixels = result.filledPixels;
+  }
+  if (metricCacheKey) coverageMetricCache.set(metricCacheKey, metricCache);
+
+  const signalValuesDbm = mode === "weakest" ? metricCache.weakestDbm : metricCache.strongestDbm;
+  const scale = computeDenseCoverageRxTargetScale(signalValuesDbm, rxTargetDbm);
+  const pixels = new Uint8ClampedArray(totalPixels * 4);
+  await runCooperativeLoop(totalPixels, (index) => {
+    const valueDbm = signalValuesDbm[index];
+    if (!Number.isFinite(valueDbm)) return;
+    const y = Math.floor(index / width);
+    const x = index - y * width;
+    const lat = latByRow[y];
+    const lon = lonByCol[x];
+    if (pointMask && !pointMask(lat, lon)) return;
+    let isTargetContour = false;
+    if (mode === "contours") {
+      const rightValue = x < width - 1 ? signalValuesDbm[index + 1] : Number.NaN;
+      const downValue = y < height - 1 ? signalValuesDbm[index + width] : Number.NaN;
+      const crossesRight = Number.isFinite(rightValue) && (valueDbm - rxTargetDbm) * (rightValue - rxTargetDbm) <= 0;
+      const crossesDown = Number.isFinite(downValue) && (valueDbm - rxTargetDbm) * (downValue - rxTargetDbm) <= 0;
+      isTargetContour = Math.abs(valueDbm - rxTargetDbm) <= 1.25 || crossesRight || crossesDown;
+    }
+    const [r, g, b] = coverageColorFixed(
+      isTargetContour ? rxTargetDbm : valueDbm,
+      rxTargetDbm,
+      scale,
+    );
+    const px = index * 4;
+    pixels[px] = r;
+    pixels[px + 1] = g;
+    pixels[px + 2] = b;
+    pixels[px + 3] = isTargetContour ? 230 : 180;
+  }, colorContext);
+
+  return {
+    width,
+    height,
+    pixels,
+    coordinates: overlayCoordinates(bounds),
+    minDbm: scale.min,
+    maxDbm: scale.max,
+    signalValuesDbm,
+    analysisStats: { evaluatedPaths, refinedBlocks, filledPixels, totalPixels },
   };
 };
 
@@ -1245,25 +1464,13 @@ export const buildMeshExtensionOverlayPixelsAsync = async (
   if (!input.selectedSites.length) return null;
   const candidateGridSize = resolveMeshExtensionCandidateGridSize(input.candidateGridSize);
   const coverageGridSize = resolveMeshExtensionCoverageGridSize(input.coverageGridSize ?? candidateGridSize);
-  const candidatePoints = buildCoverageGridPoints(candidateGridSize, input.bounds);
   const coveragePoints = buildCoverageGridPoints(coverageGridSize, input.bounds);
   const coverageDimensions = computeCoverageGridDimensions(coverageGridSize, input.bounds);
   const profile = deriveMeshExtensionCandidateProfile(input.selectedSites);
   const terrainSamples = Math.max(16, Math.round(input.terrainSamples));
   const thresholdBeforeEnvironmentDbm = input.rxTargetDbm + input.environmentLossDb;
-  const contextForProgressRange = (startPercent: number, endPercent: number): OverlayTaskContext | undefined => {
-    if (!input.context) return undefined;
-    return {
-      ...input.context,
-      onProgress: input.context.onProgress
-        ? (payload) =>
-            input.context?.onProgress?.({
-              ...payload,
-              percent: Math.round(lerp(startPercent, endPercent, payload.percent / 100)),
-            })
-        : undefined,
-    };
-  };
+  const progressContext = (startPercent: number, endPercent: number): OverlayTaskContext | undefined =>
+    contextForProgressRange(input.context, startPercent, endPercent);
 
   const targetSites: Array<Site | null> = coveragePoints.map((point, index) => {
     if (input.pointMask && !input.pointMask(point.lat, point.lon)) return null;
@@ -1302,7 +1509,7 @@ export const buildMeshExtensionOverlayPixelsAsync = async (
         }
       }
     },
-    contextForProgressRange(0, 15),
+    progressContext(0, 15),
   );
 
   const uncoveredAreaByTarget = new Float64Array(coveragePoints.length);
@@ -1312,177 +1519,202 @@ export const buildMeshExtensionOverlayPixelsAsync = async (
   const uncoveredAreaPrefix = buildAreaPrefixSum(uncoveredAreaByTarget, coverageDimensions);
   const adaptiveBlocks = buildAdaptiveGridBlocks(coverageDimensions);
 
-  const candidateSites: Array<Site | null> = candidatePoints.map((point, index) => {
-    const ground = input.terrainSampler(point.lat, point.lon);
-    return ground === null ? null : siteFromProfile(`__mesh_extension_candidate_${index}__`, point.lat, point.lon, ground, profile);
-  });
-  const connectivityDbm = new Float64Array(candidatePoints.length).fill(Number.NEGATIVE_INFINITY);
-  const newlyCoveredAreaKm2 = new Float64Array(candidatePoints.length);
-
-  await runCooperativeLoop(
-    candidatePoints.length,
-    (candidateIndex) => {
-      const candidate = candidateSites[candidateIndex];
-      if (!candidate) return;
-      const peers = input.selectedSites.map((selectedSite) => {
-        const selectedToCandidateBase =
-          directionalBaseRxDbm(selectedSite, candidate, input.frequencyMHz, input.propagationEnvironment) -
-          input.environmentLossDb;
-        const candidateToSelectedBase =
-          directionalBaseRxDbm(candidate, selectedSite, input.frequencyMHz, input.propagationEnvironment) -
-          input.environmentLossDb;
-        if (Math.min(selectedToCandidateBase, candidateToSelectedBase) < input.rxTargetDbm) {
-          return {
-            selectedToCandidateDbm: selectedToCandidateBase,
-            candidateToSelectedDbm: candidateToSelectedBase,
-          };
-        }
-        return {
-          selectedToCandidateDbm:
-            directionalTerrainRxDbm(
-              selectedSite,
-              candidate,
-              input.frequencyMHz,
-              input.propagationEnvironment,
-              input.terrainSampler,
-              terrainSamples,
-            ) - input.environmentLossDb,
-          candidateToSelectedDbm:
-            directionalTerrainRxDbm(
-              candidate,
-              selectedSite,
-              input.frequencyMHz,
-              input.propagationEnvironment,
-              input.terrainSampler,
-              terrainSamples,
-            ) - input.environmentLossDb,
-        };
-      });
-      connectivityDbm[candidateIndex] = strongestBidirectionalPeerDbm(peers);
-    },
-    contextForProgressRange(15, 30),
-  );
-
+  const width = input.dimensions.width;
+  const height = input.dimensions.height;
+  const totalCandidates = width * height;
+  const { latByRow, lonByCol } = precomputeGridAxes(input.bounds, input.dimensions);
+  const connectivityDbm = new Float32Array(totalCandidates).fill(Number.NaN);
+  const newlyCoveredAreaKm2 = new Float32Array(totalCandidates).fill(Number.NaN);
+  const candidateEvaluated = new Uint8Array(totalCandidates);
   const evaluationStamp = new Uint32Array(coveragePoints.length);
   const evaluationPass = new Uint8Array(coveragePoints.length);
-  const areaContext = contextForProgressRange(30, 85);
+  const candidateContext = progressContext(15, 90);
   const areaFrameBudgetMs = Math.max(1, input.context?.frameBudgetMs ?? DEFAULT_FRAME_BUDGET_MS);
   const areaLongTaskMs = Math.max(areaFrameBudgetMs, input.context?.longTaskMs ?? DEFAULT_LONG_TASK_MS);
-  let areaLoopChunkStartedAt = nowMs();
+  let evaluatedCandidates = 0;
 
-  for (let candidateIndex = 0; candidateIndex < candidatePoints.length; candidateIndex += 1) {
-    throwIfCancelled(input.context);
-    const candidate = candidateSites[candidateIndex];
-    if (candidate && connectivityDbm[candidateIndex] >= input.rxTargetDbm) {
-      const stamp = candidateIndex + 1;
-      const stack = adaptiveBlocks.slice();
-      let chunkStartedAt = nowMs();
-      const evaluateTarget = (targetIndex: number): number => {
-        if (existingCovered[targetIndex] || !targetSites[targetIndex]) return -1;
-        if (evaluationStamp[targetIndex] === stamp) return evaluationPass[targetIndex];
-        const target = targetSites[targetIndex]!;
-        const optimistic = directionalBaseRxDbm(
-          candidate,
-          target,
-          input.frequencyMHz,
-          input.propagationEnvironment,
-        );
-        let pass = false;
-        if (optimistic >= thresholdBeforeEnvironmentDbm) {
-          const actual = directionalTerrainRxDbm(
+  const evaluateCandidate = async (candidateIndex: number): Promise<void> => {
+    if (candidateEvaluated[candidateIndex]) return;
+    candidateEvaluated[candidateIndex] = 1;
+    evaluatedCandidates += 1;
+    const y = Math.floor(candidateIndex / width);
+    const x = candidateIndex - y * width;
+    const lat = latByRow[y];
+    const lon = lonByCol[x];
+    if (input.pointMask && !input.pointMask(lat, lon)) return;
+    const ground = input.terrainSampler(lat, lon);
+    if (ground === null) return;
+    const candidate = siteFromProfile(`__mesh_extension_candidate_${candidateIndex}__`, lat, lon, ground, profile);
+    const peers = input.selectedSites.map((selectedSite) => {
+      const selectedToCandidateBase =
+        directionalBaseRxDbm(selectedSite, candidate, input.frequencyMHz, input.propagationEnvironment) -
+        input.environmentLossDb;
+      const candidateToSelectedBase =
+        directionalBaseRxDbm(candidate, selectedSite, input.frequencyMHz, input.propagationEnvironment) -
+        input.environmentLossDb;
+      if (Math.min(selectedToCandidateBase, candidateToSelectedBase) < input.rxTargetDbm) {
+        return {
+          selectedToCandidateDbm: selectedToCandidateBase,
+          candidateToSelectedDbm: candidateToSelectedBase,
+        };
+      }
+      return {
+        selectedToCandidateDbm:
+          directionalTerrainRxDbm(
+            selectedSite,
             candidate,
-            target,
             input.frequencyMHz,
             input.propagationEnvironment,
             input.terrainSampler,
             terrainSamples,
-          );
-          pass = actual - input.environmentLossDb >= input.rxTargetDbm;
-        }
-        evaluationStamp[targetIndex] = stamp;
-        evaluationPass[targetIndex] = pass ? 1 : 0;
-        return evaluationPass[targetIndex];
+          ) - input.environmentLossDb,
+        candidateToSelectedDbm:
+          directionalTerrainRxDbm(
+            candidate,
+            selectedSite,
+            input.frequencyMHz,
+            input.propagationEnvironment,
+            input.terrainSampler,
+            terrainSamples,
+          ) - input.environmentLossDb,
       };
+    });
+    const connectivity = strongestBidirectionalPeerDbm(peers);
+    connectivityDbm[candidateIndex] = connectivity;
+    newlyCoveredAreaKm2[candidateIndex] = 0;
+    if (connectivity < input.rxTargetDbm) return;
 
-      while (stack.length) {
-        throwIfCancelled(input.context);
-        const block = stack.pop()!;
-        const blockArea = areaForGridBlock(uncoveredAreaPrefix, coverageDimensions, block);
-        if (blockArea <= 0) continue;
-        const states = uniqueBlockSampleIndices(block, coverageDimensions.cols)
-          .map(evaluateTarget)
-          .filter((state) => state >= 0);
-        const isLeaf = block.rowEnd - block.rowStart === 1 && block.colEnd - block.colStart === 1;
-        if (states.length && states.every((state) => state === states[0])) {
-          if (states[0] === 1) newlyCoveredAreaKm2[candidateIndex] += blockArea;
-        } else if (!isLeaf) {
-          stack.push(...splitAdaptiveGridBlock(block));
-        }
+    const stamp = candidateIndex + 1;
+    const stack = adaptiveBlocks.slice();
+    let chunkStartedAt = nowMs();
+    const evaluateTarget = (targetIndex: number): number => {
+      if (existingCovered[targetIndex] || !targetSites[targetIndex]) return -1;
+      if (evaluationStamp[targetIndex] === stamp) return evaluationPass[targetIndex];
+      const target = targetSites[targetIndex]!;
+      const optimistic = directionalBaseRxDbm(candidate, target, input.frequencyMHz, input.propagationEnvironment);
+      let pass = false;
+      if (optimistic >= thresholdBeforeEnvironmentDbm) {
+        const actual = directionalTerrainRxDbm(
+          candidate,
+          target,
+          input.frequencyMHz,
+          input.propagationEnvironment,
+          input.terrainSampler,
+          terrainSamples,
+        );
+        pass = actual - input.environmentLossDb >= input.rxTargetDbm;
+      }
+      evaluationStamp[targetIndex] = stamp;
+      evaluationPass[targetIndex] = pass ? 1 : 0;
+      return evaluationPass[targetIndex];
+    };
 
-        const chunkDuration = nowMs() - chunkStartedAt;
-        if (chunkDuration >= areaFrameBudgetMs && stack.length) {
-          if (chunkDuration >= areaLongTaskMs) {
-            input.context?.onLongTask?.({
-              phase: input.context.phase,
-              signature: input.context.signature,
-              durationMs: chunkDuration,
-              processed: candidateIndex,
-              total: candidatePoints.length,
-            });
-          }
-          await nextFrame();
-          chunkStartedAt = nowMs();
+    while (stack.length) {
+      throwIfCancelled(input.context);
+      const block = stack.pop()!;
+      const blockArea = areaForGridBlock(uncoveredAreaPrefix, coverageDimensions, block);
+      if (blockArea <= 0) continue;
+      const states = uniqueBlockSampleIndices(block, coverageDimensions.cols)
+        .map(evaluateTarget)
+        .filter((state) => state >= 0);
+      const isLeaf = block.rowEnd - block.rowStart === 1 && block.colEnd - block.colStart === 1;
+      if (states.length && states.every((state) => state === states[0])) {
+        if (states[0] === 1) newlyCoveredAreaKm2[candidateIndex] += blockArea;
+      } else if (!isLeaf) {
+        stack.push(...splitAdaptiveGridBlock(block));
+      }
+
+      const chunkDuration = nowMs() - chunkStartedAt;
+      if (chunkDuration >= areaFrameBudgetMs && stack.length) {
+        if (chunkDuration >= areaLongTaskMs) {
+          input.context?.onLongTask?.({
+            phase: input.context.phase,
+            signature: input.context.signature,
+            durationMs: chunkDuration,
+            processed: evaluatedCandidates,
+            total: totalCandidates,
+          });
         }
+        await nextFrame();
+        chunkStartedAt = nowMs();
       }
     }
+  };
 
-    areaContext?.onProgress?.({
-      phase: areaContext.phase,
-      signature: areaContext.signature,
-      processed: candidateIndex + 1,
-      total: candidatePoints.length,
-      percent: Math.round(((candidateIndex + 1) / candidatePoints.length) * 100),
-    });
-    if (candidateIndex + 1 < candidatePoints.length && nowMs() - areaLoopChunkStartedAt >= areaFrameBudgetMs) {
-      await nextFrame();
-      areaLoopChunkStartedAt = nowMs();
-    }
-  }
+  const candidateResult = await runAdaptiveBlockQueue(
+    partitionRasterBlocks(width, height, candidateGridSize, input.bounds),
+    totalCandidates,
+    async (block) => {
+      const area = rasterBlockArea(block);
+      const sampleIndices = passFailSampleIndicesForRasterBlock(block, width);
+      for (const index of sampleIndices) await evaluateCandidate(index);
+      const finiteIndices = sampleIndices.filter(
+        (index) => Number.isFinite(connectivityDbm[index]) && Number.isFinite(newlyCoveredAreaKm2[index]),
+      );
+      if (area === 1 || finiteIndices.length === 0) return null;
+      if (finiteIndices.length !== sampleIndices.length) return splitRasterBlock(block);
 
-  const areaSamples: CoverageSampleLite[] = [];
-  const connectivitySamples: CoverageSampleLite[] = [];
-  for (let index = 0; index < candidatePoints.length; index += 1) {
-    if (!candidateSites[index] || !Number.isFinite(connectivityDbm[index])) continue;
-    const point = candidatePoints[index];
-    areaSamples.push({ ...point, valueDbm: newlyCoveredAreaKm2[index] });
-    connectivitySamples.push({ ...point, valueDbm: connectivityDbm[index] });
-  }
-  if (!areaSamples.length) return null;
+      const xLast = block.x1 - 1;
+      const yLast = block.y1 - 1;
+      const cornerIndices = [
+        block.y0 * width + block.x0,
+        block.y0 * width + xLast,
+        yLast * width + block.x0,
+        yLast * width + xLast,
+      ];
+      const predict = (index: number, values: Float32Array): number => {
+        const y = Math.floor(index / width);
+        const x = index - y * width;
+        const tx = xLast === block.x0 ? 0 : (x - block.x0) / (xLast - block.x0);
+        const ty = yLast === block.y0 ? 0 : (y - block.y0) / (yLast - block.y0);
+        const top = values[cornerIndices[0]] + (values[cornerIndices[1]] - values[cornerIndices[0]]) * tx;
+        const bottom = values[cornerIndices[2]] + (values[cornerIndices[3]] - values[cornerIndices[2]]) * tx;
+        return top + (bottom - top) * ty;
+      };
+      const allSafelyFail = finiteIndices.every((index) => connectivityDbm[index] <= input.rxTargetDbm - 5);
+      const areaScale = Math.max(0.01, ...finiteIndices.map((index) => newlyCoveredAreaKm2[index])) * 0.02;
+      const stable = allSafelyFail || finiteIndices.every(
+        (index) =>
+          Math.abs(connectivityDbm[index] - predict(index, connectivityDbm)) <= 0.75 &&
+          Math.abs(newlyCoveredAreaKm2[index] - predict(index, newlyCoveredAreaKm2)) <= Math.max(0.01, areaScale),
+      );
+      if (!stable) return splitRasterBlock(block);
 
-  const positiveAreas = areaSamples
-    .map((sample) => sample.valueDbm)
-    .filter((value) => value > 0)
-    .sort((a, b) => a - b);
-  const maxAreaKm2 = positiveAreas.length ? percentile(positiveAreas, 0.95) : 0;
-  const connectivityScale = computeCoverageRxTargetScale(connectivitySamples, input.rxTargetDbm);
-  const areaAt = makeGridInterpolator(areaSamples) ?? ((lat: number, lon: number) => interpolateCoverageDbm(areaSamples, lat, lon));
-  const connectivityAt = makeGridInterpolator(connectivitySamples) ??
-    ((lat: number, lon: number) => interpolateCoverageDbm(connectivitySamples, lat, lon));
-  const pixels = new Uint8ClampedArray(input.dimensions.width * input.dimensions.height * 4);
-  const { latByRow, lonByCol } = precomputeGridAxes(input.bounds, input.dimensions);
+      for (let y = block.y0; y < block.y1; y += 1) {
+        for (let x = block.x0; x < block.x1; x += 1) {
+          const index = y * width + x;
+          if (allSafelyFail) {
+            connectivityDbm[index] = input.rxTargetDbm - 5;
+            newlyCoveredAreaKm2[index] = 0;
+          } else {
+            connectivityDbm[index] = predict(index, connectivityDbm);
+            newlyCoveredAreaKm2[index] = Math.max(0, predict(index, newlyCoveredAreaKm2));
+          }
+        }
+      }
+      return null;
+    },
+    candidateContext,
+  );
+
+  const hasFiniteCandidate = connectivityDbm.some(Number.isFinite);
+  if (!hasFiniteCandidate) return null;
+  const maxAreaKm2 = computeDensePositivePercentile(newlyCoveredAreaKm2, 0.95);
+  const connectivityScale = computeDenseCoverageRxTargetScale(connectivityDbm, input.rxTargetDbm);
+  const pixels = new Uint8ClampedArray(totalCandidates * 4);
 
   await runCooperativeLoop(
-    input.dimensions.width * input.dimensions.height,
+    totalCandidates,
     (index) => {
-      const y = Math.floor(index / input.dimensions.width);
-      const x = index - y * input.dimensions.width;
+      const y = Math.floor(index / width);
+      const x = index - y * width;
       const lat = latByRow[y];
       const lon = lonByCol[x];
       if (input.pointMask && !input.pointMask(lat, lon)) return;
       if (input.terrainSampler(lat, lon) === null) return;
-      const area = areaAt(lat, lon);
-      const connectivity = connectivityAt(lat, lon);
-      if (area === null || connectivity === null) return;
+      const area = newlyCoveredAreaKm2[index];
+      const connectivity = connectivityDbm[index];
+      if (!Number.isFinite(area) || !Number.isFinite(connectivity)) return;
       const [r, g, b] = meshExtensionColorForArea(area, maxAreaKm2);
       const px = index * 4;
       pixels[px] = r;
@@ -1490,7 +1722,7 @@ export const buildMeshExtensionOverlayPixelsAsync = async (
       pixels[px + 2] = b;
       pixels[px + 3] = meshExtensionAlphaForDbm(connectivity, input.rxTargetDbm, connectivityScale);
     },
-    contextForProgressRange(85, 100),
+    progressContext(85, 100),
   );
 
   return {
@@ -1502,6 +1734,12 @@ export const buildMeshExtensionOverlayPixelsAsync = async (
     maxDbm: connectivityScale.max,
     minAreaKm2: 0,
     maxAreaKm2,
+    analysisStats: {
+      evaluatedPaths: evaluatedCandidates,
+      refinedBlocks: candidateResult.refinedBlocks,
+      filledPixels: candidateResult.filledPixels,
+      totalPixels: totalCandidates,
+    },
   };
 };
 

--- a/src/lib/simulationPerf.ts
+++ b/src/lib/simulationPerf.ts
@@ -1,12 +1,3 @@
-type CoveragePerfRecord = {
-  runId: string;
-  signature: string;
-  durationMs: number;
-  sampleCount: number;
-  gridSize: number;
-  effectiveRadiusKm: number;
-};
-
 type OverlayPerfRecord = {
   runId: string;
   mode: "heatmap" | "contours" | "weakest" | "passfail" | "relay" | "mesh-extension" | "terrain";
@@ -19,12 +10,6 @@ type OverlayPerfRecord = {
   effectiveRadiusKm: number;
   evaluatedPaths?: number;
   refinedBlocks?: number;
-};
-
-type PendingRunPerf = {
-  coverage?: CoveragePerfRecord;
-  overlay?: OverlayPerfRecord;
-  logged: boolean;
 };
 
 const isPrivateIpv4Host = (host: string): boolean =>
@@ -57,62 +42,24 @@ const inDevDiagnostics =
   ) &&
   (import.meta as { env?: { MODE?: string } }).env?.MODE !== "test";
 
-const pendingByRun = new Map<string, PendingRunPerf>();
-
 const round2 = (value: number): number => Math.round(value * 100) / 100;
-
-const ensurePending = (runId: string): PendingRunPerf => {
-  const existing = pendingByRun.get(runId);
-  if (existing) return existing;
-  const created: PendingRunPerf = { logged: false };
-  pendingByRun.set(runId, created);
-  if (pendingByRun.size > 100) {
-    const oldest = pendingByRun.keys().next().value;
-    if (typeof oldest === "string") pendingByRun.delete(oldest);
-  }
-  return created;
-};
-
-const maybeLogRun = (runId: string): void => {
-  if (!inDevDiagnostics) return;
-  const pending = pendingByRun.get(runId);
-  if (!pending || pending.logged || !pending.coverage || !pending.overlay) return;
-
-  pending.logged = true;
-  console.info("[simulation-perf-run]", {
-    runId,
-    signature: pending.coverage.signature,
-    coverageComputeMs: round2(pending.coverage.durationMs),
-    overlayMode: pending.overlay.mode,
-    overlayBuildMs: round2(pending.overlay.buildDurationMs),
-    overlayEncodeMs: round2(pending.overlay.encodeDurationMs),
-    sampleCount: pending.coverage.sampleCount,
-    overlayPixelCount: pending.overlay.pixelCount,
-    overlayWidth: pending.overlay.width,
-    overlayHeight: pending.overlay.height,
-    gridSize: pending.coverage.gridSize,
-    overlayGridSize: pending.overlay.gridSize,
-    effectiveRadiusKm: pending.coverage.effectiveRadiusKm,
-    overlayRadiusKm: pending.overlay.effectiveRadiusKm,
-    evaluatedPaths: pending.overlay.evaluatedPaths,
-    refinedBlocks: pending.overlay.refinedBlocks,
-  });
-
-  pendingByRun.delete(runId);
-};
-
-export const recordSimulationCoveragePerf = (record: CoveragePerfRecord): void => {
-  if (!inDevDiagnostics) return;
-  const pending = ensurePending(record.runId);
-  pending.coverage = record;
-  maybeLogRun(record.runId);
-};
 
 export const recordSimulationOverlayPerf = (record: OverlayPerfRecord): void => {
   if (!inDevDiagnostics) return;
-  const pending = ensurePending(record.runId);
-  pending.overlay = record;
-  maybeLogRun(record.runId);
+  console.info("[simulation-perf-run]", {
+    runId: record.runId,
+    overlayMode: record.mode,
+    overlayBuildMs: round2(record.buildDurationMs),
+    overlayEncodeMs: round2(record.encodeDurationMs),
+    logicalSampleCount: record.pixelCount,
+    overlayPixelCount: record.pixelCount,
+    overlayWidth: record.width,
+    overlayHeight: record.height,
+    gridSize: record.gridSize,
+    effectiveRadiusKm: record.effectiveRadiusKm,
+    evaluatedPaths: record.evaluatedPaths,
+    refinedBlocks: record.refinedBlocks,
+  });
 };
 
 export const recordSimulationRunCancelled = (payload: {
@@ -124,17 +71,4 @@ export const recordSimulationRunCancelled = (payload: {
 }): void => {
   if (!inDevDiagnostics) return;
   console.info("[simulation-perf-cancelled]", payload);
-  if (payload.phase === "coverage") {
-    pendingByRun.delete(payload.runId);
-    return;
-  }
-
-  const pending = pendingByRun.get(payload.runId);
-  if (!pending) return;
-
-  // Overlay tasks can cancel and restart while the same coverage run is still active.
-  // Keep pending coverage timing so a later successful overlay can still emit a full run log.
-  if (!pending.coverage) {
-    pendingByRun.delete(payload.runId);
-  }
 };

--- a/src/store/coverageStore.test.ts
+++ b/src/store/coverageStore.test.ts
@@ -8,7 +8,7 @@ import {
 import * as coverageLib from "../lib/coverage";
 import { simulationAreaBoundsForSites } from "../lib/simulationArea";
 import { tilesForBounds } from "../lib/terrainTiles";
-import type { CoverageSample, Site, SrtmTile } from "../types/radio";
+import type { Site, SrtmTile } from "../types/radio";
 
 const site: Site = {
   id: "site-1",
@@ -118,15 +118,8 @@ describe("coverageStore simulation progress phases", () => {
     vi.restoreAllMocks();
   });
 
-  it("uses indeterminate prep/finalizing phases and determinate sampling percent", async () => {
-    let resolveBuild!: (value: CoverageSample[]) => void;
-    vi.spyOn(coverageLib, "buildCoverageAsync").mockImplementation((...args) => {
-      const options = args[6];
-      options?.onProgress?.(0.5);
-      return new Promise<CoverageSample[]>((resolve) => {
-        resolveBuild = resolve;
-      });
-    });
+  it("hands every area overlay to the canonical raster pipeline", async () => {
+    const buildSpy = vi.spyOn(coverageLib, "buildCoverageAsync").mockResolvedValue([]);
 
     useCoverageStore.getState().recomputeCoverage();
     expect(useCoverageStore.getState().simulationProgressMode).toBe("indeterminate");
@@ -135,20 +128,9 @@ describe("coverageStore simulation progress phases", () => {
     vi.advanceTimersByTime(180);
     await flushAsyncTicks();
 
-    expect(useCoverageStore.getState().simulationProgressMode).toBe("determinate");
-    expect(useCoverageStore.getState().simulationProgress).toBe(50);
-    expect(useCoverageStore.getState().simulationStepLabel).toBe("Sampling simulation grid...");
-
-    resolveBuild([{ lat: site.position.lat, lon: site.position.lon, valueDbm: -90 }]);
-    await flushAsyncTicks();
-    expect(useCoverageStore.getState().simulationProgressMode).toBe("indeterminate");
-    expect(useCoverageStore.getState().simulationStepLabel).toBe("Finalizing simulation overlay...");
-
-    vi.advanceTimersByTime(700);
-    await flushAsyncTicks();
-
+    expect(buildSpy).not.toHaveBeenCalled();
     expect(useCoverageStore.getState().isSimulationRecomputing).toBe(false);
-    expect(useCoverageStore.getState().coverageSamples).toHaveLength(1);
+    expect(useCoverageStore.getState().completedCoverageRunToken).not.toBe("");
   });
 
   it("suppresses automatic recomputes while Auto calculate is off", () => {
@@ -170,13 +152,12 @@ describe("coverageStore simulation progress phases", () => {
     vi.advanceTimersByTime(700);
     await flushAsyncTicks();
 
-    expect(buildSpy).toHaveBeenCalledTimes(1);
+    expect(buildSpy).not.toHaveBeenCalled();
     expect(useCoverageStore.getState().autoCalculateEnabled).toBe(false);
     expect(useCoverageStore.getState().calculationCycleSource).toBe("manual");
-    expect(buildSpy.mock.calls[0]?.[6]).toEqual(expect.objectContaining({ overlayRadiusKm: 50 }));
   });
 
-  it("skips the generic coverage grid for direct-analysis overlay modes", async () => {
+  it("clears legacy coverage samples when handing off to the canonical raster", async () => {
     const buildSpy = vi.spyOn(coverageLib, "buildCoverageAsync").mockResolvedValue([]);
     bridgeState.mapOverlayMode = "passfail";
     useCoverageStore.setState({
@@ -190,7 +171,7 @@ describe("coverageStore simulation progress phases", () => {
     expect(buildSpy).not.toHaveBeenCalled();
     expect(useCoverageStore.getState().isSimulationRecomputing).toBe(false);
     expect(useCoverageStore.getState().completedCoverageRunToken).not.toBe("");
-    expect(useCoverageStore.getState().coverageSamples[0]?.valueDbm).toBe(-88);
+    expect(useCoverageStore.getState().coverageSamples).toEqual([]);
   });
 
   it("does not calculate or retain results when required terrain tiles remain unavailable", async () => {
@@ -226,7 +207,7 @@ describe("coverageStore simulation progress phases", () => {
     vi.advanceTimersByTime(220);
     await flushAsyncTicks();
 
-    expect(buildSpy).toHaveBeenCalledTimes(1);
+    expect(buildSpy).not.toHaveBeenCalled();
     expect(useCoverageStore.getState().simulationErrorMessage).toBe("");
   });
 
@@ -255,27 +236,14 @@ describe("coverageStore simulation progress phases", () => {
     expect(useCoverageStore.getState().calculationCycleSource).toBe("auto");
   });
 
-  it("stops active coverage work and clears queued reruns", async () => {
-    let observedCancellation = false;
-    vi.spyOn(coverageLib, "buildCoverageAsync").mockImplementation((...args) => {
-      const options = args[6];
-      return new Promise<CoverageSample[]>((resolve) => {
-        window.setTimeout(() => {
-          observedCancellation = options?.shouldCancel?.() ?? false;
-          resolve([]);
-        }, 20);
-      });
-    });
-
+  it("stops a queued canonical-overlay run", async () => {
     useCoverageStore.getState().recomputeCoverage();
+    useCoverageStore.getState().stopCalculation();
     vi.advanceTimersByTime(220);
     await flushAsyncTicks();
-    useCoverageStore.getState().stopCalculation();
-    vi.advanceTimersByTime(30);
-    await flushAsyncTicks();
 
-    expect(observedCancellation).toBe(true);
     expect(useCoverageStore.getState().isSimulationRecomputing).toBe(false);
+    expect(useCoverageStore.getState().simulationRunToken).toBe("");
     expect(useCoverageStore.getState().calculationCycleSource).toBe(null);
   });
 
@@ -298,7 +266,8 @@ describe("coverageStore simulation progress phases", () => {
     vi.advanceTimersByTime(700);
     await flushAsyncTicks();
 
-    expect(buildSpy).toHaveBeenCalledTimes(1);
+    expect(buildSpy).not.toHaveBeenCalled();
+    expect(useCoverageStore.getState().completedCoverageRunToken).not.toBe("");
   });
 
   it("keeps a manual Start waiting without committing coverage while terrain loads", async () => {
@@ -322,117 +291,31 @@ describe("coverageStore simulation progress phases", () => {
     vi.advanceTimersByTime(700);
     await flushAsyncTicks();
 
-    expect(buildSpy).toHaveBeenCalledTimes(1);
+    expect(buildSpy).not.toHaveBeenCalled();
+    expect(useCoverageStore.getState().completedCoverageRunToken).not.toBe("");
   });
 
-  it("runs as single-flight with one queued rerun under rapid triggers", async () => {
-    let resolveFirst!: (value: CoverageSample[]) => void;
-    let resolveSecond!: (value: CoverageSample[]) => void;
-    const runResolvers: Array<(value: CoverageSample[]) => void> = [];
-    vi.spyOn(coverageLib, "buildCoverageAsync").mockImplementation(() => {
-      return new Promise<CoverageSample[]>((resolve) => {
-        runResolvers.push(resolve);
-        if (runResolvers.length === 1) resolveFirst = resolve;
-        if (runResolvers.length === 2) resolveSecond = resolve;
-      });
-    });
-
+  it("coalesces rapid triggers into one canonical-overlay handoff", async () => {
     useCoverageStore.getState().recomputeCoverage();
-    vi.advanceTimersByTime(220);
-    await flushAsyncTicks();
-    expect(runResolvers).toHaveLength(1);
-
-    bridgeState.selectedCoverageResolution = "42";
     useCoverageStore.getState().recomputeCoverage();
     useCoverageStore.getState().recomputeCoverage();
     useCoverageStore.getState().recomputeCoverage();
     vi.advanceTimersByTime(220);
     await flushAsyncTicks();
 
-    expect(runResolvers).toHaveLength(1);
-
-    resolveFirst([{ lat: site.position.lat, lon: site.position.lon, valueDbm: -95 }]);
-    await flushAsyncTicks();
-    vi.advanceTimersByTime(40);
-    await flushAsyncTicks();
-    expect(runResolvers).toHaveLength(2);
-
-    resolveSecond([{ lat: site.position.lat, lon: site.position.lon, valueDbm: -82 }]);
-    await flushAsyncTicks();
-    vi.advanceTimersByTime(760);
-    await flushAsyncTicks();
-    expect(useCoverageStore.getState().coverageSamples[0]?.valueDbm).toBe(-82);
+    expect(useCoverageStore.getState().completedCoverageRunToken).not.toBe("");
+    expect(useCoverageStore.getState().isSimulationRecomputing).toBe(false);
   });
 
   it("skips recompute when effective simulation inputs are unchanged", async () => {
-    const buildSpy = vi.spyOn(coverageLib, "buildCoverageAsync").mockResolvedValue([]);
+    useCoverageStore.getState().recomputeCoverage();
+    vi.advanceTimersByTime(220);
+    await flushAsyncTicks();
+    const completedToken = useCoverageStore.getState().completedCoverageRunToken;
 
     useCoverageStore.getState().recomputeCoverage();
     vi.advanceTimersByTime(220);
     await flushAsyncTicks();
-    vi.advanceTimersByTime(760);
-    await flushAsyncTicks();
-    expect(buildSpy).toHaveBeenCalledTimes(1);
-
-    useCoverageStore.getState().recomputeCoverage();
-    vi.advanceTimersByTime(220);
-    await flushAsyncTicks();
-    vi.advanceTimersByTime(760);
-    await flushAsyncTicks();
-    expect(buildSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not commit stale run results when a rerun is queued", async () => {
-    const runResolvers: Array<(value: CoverageSample[]) => void> = [];
-    vi.spyOn(coverageLib, "buildCoverageAsync").mockImplementation(() => {
-      return new Promise<CoverageSample[]>((resolve) => {
-        runResolvers.push(resolve);
-      });
-    });
-
-    useCoverageStore.getState().recomputeCoverage();
-    vi.advanceTimersByTime(220);
-    await flushAsyncTicks();
-    expect(runResolvers).toHaveLength(1);
-
-    bridgeState.selectedCoverageResolution = "42";
-    useCoverageStore.getState().recomputeCoverage();
-    vi.advanceTimersByTime(220);
-    await flushAsyncTicks();
-
-    runResolvers[0]([{ lat: site.position.lat, lon: site.position.lon, valueDbm: -110 }]);
-    await flushAsyncTicks();
-    vi.advanceTimersByTime(60);
-    await flushAsyncTicks();
-    expect(useCoverageStore.getState().coverageSamples).toEqual([]);
-
-    vi.advanceTimersByTime(80);
-    await flushAsyncTicks();
-    expect(runResolvers).toHaveLength(2);
-
-    runResolvers[1]([{ lat: site.position.lat, lon: site.position.lon, valueDbm: -70 }]);
-    await flushAsyncTicks();
-    vi.advanceTimersByTime(760);
-    await flushAsyncTicks();
-    expect(useCoverageStore.getState().coverageSamples[0]?.valueDbm).toBe(-70);
-  });
-
-  it("discards a stale result without scheduling a rerun while automatic calculation is off", async () => {
-    let resolveBuild!: (value: CoverageSample[]) => void;
-    vi.spyOn(coverageLib, "buildCoverageAsync").mockImplementation(
-      () => new Promise<CoverageSample[]>((resolve) => { resolveBuild = resolve; }),
-    );
-
-    useCoverageStore.getState().recomputeCoverage();
-    vi.advanceTimersByTime(220);
-    await flushAsyncTicks();
-    useCoverageStore.getState().setAutoCalculateEnabled(false);
-    bridgeState.selectedCoverageResolution = "42";
-    useCoverageStore.getState().recomputeCoverage();
-    resolveBuild([{ lat: site.position.lat, lon: site.position.lon, valueDbm: -60 }]);
-    await flushAsyncTicks();
-
-    expect(useCoverageStore.getState().coverageSamples).toEqual([]);
-    expect(useCoverageStore.getState().isSimulationRecomputing).toBe(false);
+    expect(useCoverageStore.getState().completedCoverageRunToken).toBe(completedToken);
   });
 });

--- a/src/store/coverageStore.ts
+++ b/src/store/coverageStore.ts
@@ -1,9 +1,7 @@
 import { create } from "zustand";
 import {
-  buildCoverageAsync,
-  computeCoverageGridDimensions,
-  CoverageBuildCancelledError,
-  CoverageTerrainUnavailableError,
+  computeCanonicalOverlayGridDimensions,
+  resolveCanonicalOverlayResolutionScale,
 } from "../lib/coverage";
 import { simulationAreaBoundsForSites } from "../lib/simulationArea";
 import {
@@ -15,7 +13,6 @@ import {
   resolveTargetOverlayRadiusKm,
 } from "../lib/simulationOverlayRadius";
 import {
-  recordSimulationCoveragePerf,
   recordSimulationRunCancelled,
 } from "../lib/simulationPerf";
 import { sampleSrtmElevation } from "../lib/srtm";
@@ -277,18 +274,6 @@ const queueCoverageRunFlush = (delay = COVERAGE_RECOMPUTE_DEBOUNCE_MS): void => 
   }, Math.max(0, delay));
 };
 
-const shouldSkipStaleCommit = (runSignature: string): boolean => {
-  if (!appStoreBridge) return false;
-  const latestState = appStoreBridge.getState();
-  const latestInputs = readCoverageInputs(latestState);
-  const latestSignature = coverageInputSignature(latestInputs);
-  if (latestSignature === runSignature) {
-    coverageRerunQueued = false;
-    return false;
-  }
-  return true;
-};
-
 const finalizeRunComplete = (
   set: (patch: Partial<CoverageState>) => void,
   get: () => CoverageState,
@@ -321,7 +306,6 @@ const runCoverageComputation = async (
   inputs: CoverageInputs,
 ): Promise<void> => {
   const startedAt = nowMs();
-  let coverageSamples: CoverageSample[] = [];
   let loggedCancellation = false;
 
   const markCancelled = (reason: string): void => {
@@ -373,7 +357,6 @@ const runCoverageComputation = async (
         : null;
     warnLongTask("auto-propagation-environment", runSignature, nowMs() - autoEnvironmentStartedAt);
 
-    const effectiveEnvironment = autoDerived?.environment ?? inputs.propagationEnvironment;
     if (autoDerived) {
       if (
         inputs.propagationEnvironmentReason !== autoDerived.reason ||
@@ -399,135 +382,28 @@ const runCoverageComputation = async (
     const targetRadiusKm = resolveTargetOverlayRadiusKm(selectionCount, selectedOverlayRadiusOption);
     const effectiveOverlayRadiusKm = targetRadiusKm;
 
-    const requiresCoverageSamples =
-      inputs.mapOverlayMode === "heatmap" ||
-      inputs.mapOverlayMode === "weakest" ||
-      inputs.mapOverlayMode === "contours";
-    if (!requiresCoverageSamples) {
-      set({
-        simulationProgressMode: "indeterminate",
-        simulationStepLabel: "Preparing Simulation overlay...",
-      });
-      if (get().simulationRunToken !== runId) {
-        markCancelled("token-mismatch-before-mode-finalize");
-        return;
-      }
-      finalizeRunComplete(set, get, runId, get().coverageSamples);
-      lastAppliedCoverageSignature = runSignature;
-      return;
-    }
-
     const boundsForCount = simulationAreaBoundsForSites(inputs.sites, { overlayRadiusKm: effectiveOverlayRadiusKm });
     const sampleCount = boundsForCount
-      ? computeCoverageGridDimensions(gridSize, boundsForCount, 1).totalSamples
+      ? computeCanonicalOverlayGridDimensions(
+          gridSize,
+          boundsForCount,
+          resolveCanonicalOverlayResolutionScale(boundsForCount),
+        ).totalSamples
       : 0;
     set({
       simulationProgress: 0,
-      simulationProgressMode: "determinate",
-      simulationStepLabel: "Sampling simulation grid...",
+      simulationProgressMode: "indeterminate",
+      simulationStepLabel: "Preparing Simulation overlay...",
       simulationSamplesDone: 0,
       simulationSamplesTotal: sampleCount,
     });
-
-    let lastProgress = 0;
-    const buildCoverageStartedAt = nowMs();
-    coverageSamples = await buildCoverageAsync(
-      gridSize,
-      network as Parameters<typeof buildCoverageAsync>[1],
-      inputs.sites as Parameters<typeof buildCoverageAsync>[2],
-      inputs.systems as Parameters<typeof buildCoverageAsync>[3],
-      effectiveEnvironment as Parameters<typeof buildCoverageAsync>[4],
-      ({ lat, lon }: { lat: number; lon: number }) => sampleSrtmElevation(inputs.srtmTiles, lat, lon),
-      {
-        sampleMultiplier: 1,
-        terrainSamples: 20,
-        overlayRadiusKm: effectiveOverlayRadiusKm,
-        onProgress: (progress: number) => {
-          if (get().simulationRunToken !== runId) return;
-          const next = Math.round(progress * 100);
-          if (next - lastProgress >= 2 || next >= 99) {
-            lastProgress = next;
-            set({ simulationProgress: next });
-          }
-        },
-        shouldCancel: () => get().simulationRunToken !== runId,
-        requireCompleteTerrain: true,
-        terrainCacheKey: `${inputs.effectiveCoverageResolution}|${inputs.selectedNetworkId}|${inputs.propagationModel}|${inputs.terrainLoadEpoch}`,
-      },
-    );
-    const coverageComputeMs = nowMs() - buildCoverageStartedAt;
-    warnLongTask("coverage-build", runSignature, coverageComputeMs);
-
     if (get().simulationRunToken !== runId) {
-      markCancelled("token-mismatch-after-coverage-build");
+      markCancelled("token-mismatch-before-mode-finalize");
       return;
     }
-
-    if (shouldSkipStaleCommit(runSignature)) {
-      const hasQueuedRerun = coverageRerunQueued;
-      set({
-        isSimulationRecomputing: hasQueuedRerun,
-        simulationProgress: 0,
-        simulationProgressMode: "indeterminate",
-        simulationStepLabel: hasQueuedRerun ? "Preparing simulation bounds..." : "",
-        simulationSamplesDone: 0,
-        simulationSamplesTotal: 0,
-        simulationRunToken: hasQueuedRerun ? runId : "",
-      });
-      markCancelled("stale-signature-superseded");
-      return;
-    }
-
-    recordSimulationCoveragePerf({
-      runId,
-      signature: runSignature,
-      durationMs: coverageComputeMs,
-      sampleCount,
-      gridSize,
-      effectiveRadiusKm: effectiveOverlayRadiusKm,
-    });
-
-    set({
-      simulationProgressMode: "indeterminate",
-      simulationStepLabel: "Finalizing simulation overlay...",
-    });
-
-    const waitMs = Math.max(0, COVERAGE_MIN_VISIBLE_MS - (nowMs() - startedAt));
-    if (waitMs > 0) await delayMs(waitMs);
-    if (get().simulationRunToken !== runId) {
-      markCancelled("token-mismatch-before-finalize");
-      return;
-    }
-
-    finalizeRunComplete(set, get, runId, coverageSamples);
+    finalizeRunComplete(set, get, runId, []);
     lastAppliedCoverageSignature = runSignature;
-    warnLongTask("coverage-total-run", runSignature, nowMs() - startedAt);
   } catch (error) {
-    if (error instanceof CoverageBuildCancelledError) {
-      markCancelled("coverage-build-cancelled");
-      return;
-    }
-    if (error instanceof CoverageTerrainUnavailableError) {
-      const message =
-        "Simulation could not be completed because required terrain samples are unavailable.";
-      if (get().simulationRunToken === runId) {
-        set({
-          coverageSamples: [],
-          isSimulationRecomputing: false,
-          simulationProgress: 0,
-          simulationProgressMode: "indeterminate",
-          simulationStepLabel: "",
-          simulationSamplesDone: 0,
-          simulationSamplesTotal: 0,
-          simulationRunToken: "",
-          completedCoverageRunToken: "",
-          calculationCycleSource: null,
-          simulationErrorMessage: message,
-        });
-        appStoreBridge?.setState({ terrainFetchStatus: message });
-      }
-      return;
-    }
     console.error("Coverage recompute failed", error);
     if (get().simulationRunToken === runId) {
       set({


### PR DESCRIPTION
## What changed

- makes Pass/Fail's logical raster the canonical sampling grid for area overlays
- evaluates Heatmap, Weakest Signal, and Contours directly on that grid instead of stretching a smaller coverage grid
- shares cached RF samples across those display modes
- retains adaptive performance only after bounded interpolation checks
- uses the canonical grid for Mesh Extension candidate placement, merging only checked smooth regions or candidates safely below threshold
- reports the actual canonical logical point count in the existing resolution selector
- preserves the Heatmap background in Contours while emphasizing the target threshold
- consolidates area-overlay orchestration in MapView and removes the duplicate coarse coverage pass

## Why

Different display modes previously used different underlying sampling densities even when the UI showed the same resolution. Heatmap was calculated on a much smaller grid and enlarged for display, while Pass/Fail used the full logical raster. This made performance and apparent resolution vary for reasons the user could not see.

## Validation

- `npm test` — 133 files, 782 tests passed
- `npm run lint`
- `npm run build`
- exact-vs-adaptive Heatmap, Pass/Fail, and Relay accuracy gates
- cross-mode signal-cache reuse test
- canonical Mesh Extension candidate-grid test

Closes #998
