### PR TITLE
Calibrate simulation overlay workloads

### DIFF
--- a/src/components/MapView.overlayHandoff.test.tsx
+++ b/src/components/MapView.overlayHandoff.test.tsx
@@ -296,6 +296,28 @@ describe("MapView overlay handoff", () => {
     await waitFor(() => expect(recomputeCoverage).toHaveBeenCalledTimes(1));
   });
 
+  it("shows compact, mode-specific logical grid-point counts in the existing resolution selector", async () => {
+    render(
+      <MapView
+        canPersist
+        isMapExpanded={false}
+        onToggleMapExpanded={() => undefined}
+        showInspector
+      />,
+    );
+
+    const resolutionSelect = screen.getByLabelText("Simulation Resolution") as HTMLSelectElement;
+    const heatmapLabel = resolutionSelect.options[0].textContent ?? "";
+    expect(heatmapLabel).toMatch(/~\d+(?:\.\d+)?k grid points/u);
+    expect(heatmapLabel).not.toContain("samples");
+
+    act(() => useAppStore.getState().setMapOverlayMode("mesh-extension"));
+    await waitFor(() => {
+      expect((screen.getByLabelText("Simulation Resolution") as HTMLSelectElement).options[0].textContent)
+        .not.toBe(heatmapLabel);
+    });
+  });
+
   it("starts clouds while cold-start terrain loads before Pass/Fail is raster-ready", async () => {
     useAppStore.setState({
       mapOverlayMode: "passfail",

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -15,10 +15,14 @@ import Map, {
 } from "react-map-gl/maplibre";
 import type { LayerProps } from "react-map-gl/maplibre";
 import {
-  computeCanonicalOverlayGridDimensions,
+  computeCalibratedOverlayGridDimensions,
   createCoveragePointEvaluator,
   resolveCanonicalOverlayResolutionScale,
+  resolveCoverageParticipantCount,
+  resolveMeshExtensionCoverageBudgetGridSize,
+  type CalibratedOverlayGridMode,
 } from "../lib/coverage";
+import { formatCompactCount } from "../lib/locale";
 import { STANDARD_SITE_RADIO } from "../lib/linkRadio";
 import { sampleSrtmElevation } from "../lib/srtm";
 import { getUiErrorMessage } from "../lib/uiError";
@@ -485,9 +489,17 @@ const boundsDiagonalKm = (bounds: TerrainBounds): number => {
 const computeOverlayDimensions = (
   bounds: TerrainBounds,
   targetGridSize: number,
+  mode: CalibratedOverlayGridMode,
   resolutionScale = 1,
+  participantCount = 1,
 ): { width: number; height: number } => {
-  const dimensions = computeCanonicalOverlayGridDimensions(targetGridSize, bounds, resolutionScale);
+  const dimensions = computeCalibratedOverlayGridDimensions(
+    targetGridSize,
+    bounds,
+    mode,
+    resolutionScale,
+    participantCount,
+  );
   return { width: dimensions.width, height: dimensions.height };
 };
 
@@ -1099,6 +1111,10 @@ export function MapView({
     [selectedSiteIds, sites],
   );
   const meshExtensionSites = selectedSites.length > 0 ? selectedSites : sites;
+  const coverageParticipantCount = useMemo(
+    () => selectedNetwork ? resolveCoverageParticipantCount(selectedNetwork, sites, systems) : 1,
+    [selectedNetwork, sites, systems],
+  );
   const selectedSiteSet = useMemo(() => new Set(selectedSites.map((site) => site.id)), [selectedSites]);
   const selectionCount = selectedSites.length;
   const singleSelectedSite = selectionCount === 1 ? selectedSites[0] ?? null : null;
@@ -1637,11 +1653,42 @@ export function MapView({
         ? lastCompletedGridSize
         : selectedGridSize;
 
+  const calibratedOverlayMode: CalibratedOverlayGridMode =
+    coverageVizMode === "heatmap" ||
+    coverageVizMode === "weakest" ||
+    coverageVizMode === "contours" ||
+    coverageVizMode === "passfail" ||
+    coverageVizMode === "relay" ||
+    coverageVizMode === "mesh-extension"
+      ? coverageVizMode
+      : "passfail";
+  const overlayParticipantCount =
+    calibratedOverlayMode === "mesh-extension"
+      ? Math.max(1, meshExtensionSites.length)
+      : calibratedOverlayMode === "heatmap" ||
+          calibratedOverlayMode === "weakest" ||
+          calibratedOverlayMode === "contours"
+        ? coverageParticipantCount
+        : 1;
+
   const overlayDimensions = useMemo(() => {
     const bounds = analysisBounds ?? computeCoverageBounds(samplesForOverlay);
     if (!bounds) return { width: 24, height: 24 };
-    return computeOverlayDimensions(bounds, effectiveGridSize, overlayResolutionScale);
-  }, [analysisBounds, samplesForOverlay, effectiveGridSize, overlayResolutionScale]);
+    return computeOverlayDimensions(
+      bounds,
+      effectiveGridSize,
+      calibratedOverlayMode,
+      overlayResolutionScale,
+      overlayParticipantCount,
+    );
+  }, [
+    analysisBounds,
+    samplesForOverlay,
+    effectiveGridSize,
+    calibratedOverlayMode,
+    overlayResolutionScale,
+    overlayParticipantCount,
+  ]);
 
   const overlayBounds = useMemo(() => analysisBounds ?? computeCoverageBounds(samplesForOverlay), [analysisBounds, samplesForOverlay]);
   const resolutionOptionLabels = useMemo(() => {
@@ -1654,15 +1701,21 @@ export function MapView({
     return options.map(({ gridSize, name }) => {
       const fallback = { width: gridSize, height: gridSize, totalSamples: gridSize * gridSize };
       const dims = overlayBounds
-        ? computeCanonicalOverlayGridDimensions(gridSize, overlayBounds, overlayResolutionScale)
+        ? computeCalibratedOverlayGridDimensions(
+            gridSize,
+            overlayBounds,
+            calibratedOverlayMode,
+            overlayResolutionScale,
+            overlayParticipantCount,
+          )
         : fallback;
       const isDefault = gridSize === 24;
       return {
         value: String(gridSize) as "24" | "42" | "84" | "168",
-        label: `${name} (${dims.height}x${dims.width}, ${dims.totalSamples} samples)${isDefault ? " - Default" : ""}`,
+        label: `${name} (${dims.height}×${dims.width} · ~${formatCompactCount(dims.totalSamples)} grid points)${isDefault ? " - Default" : ""}`,
       };
     });
-  }, [overlayBounds, overlayResolutionScale]);
+  }, [calibratedOverlayMode, overlayBounds, overlayParticipantCount, overlayResolutionScale]);
   const overlayLongTaskWarnedRef = useRef<Set<string>>(new Set());
   const showOverlayDiagnostics =
     import.meta.env.DEV || (typeof window !== "undefined" && window.location.hostname === "localhost");
@@ -2191,7 +2244,7 @@ export function MapView({
               terrainSampler,
               dimensions: overlayDimensions,
               candidateGridSize: effectiveGridSize,
-              coverageGridSize: effectiveGridSize,
+              coverageGridSize: resolveMeshExtensionCoverageBudgetGridSize(effectiveGridSize),
               terrainSamples: 20,
               pointMask: overlayPointMask,
               context,

--- a/src/lib/coverage.test.ts
+++ b/src/lib/coverage.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, it } from "vitest";
 import {
   buildCoverage,
   buildCoverageAsync,
+  computeCalibratedOverlayGridDimensions,
   computeCanonicalOverlayGridDimensions,
   computeCoverageGridDimensions,
   CoverageBuildCancelledError,
+  resolveMeshExtensionCoverageBudgetGridSize,
+  resolveOverlayGridWorkloadScale,
 } from "./coverage";
 import { haversineDistanceKm } from "./geo";
 import { defaultPropagationEnvironment } from "./propagationEnvironment";
@@ -64,6 +67,32 @@ const NORMAL_GRID = 24;
 const HIGH_GRID = 42;
 
 describe("buildCoverage", () => {
+  it("keeps Pass/Fail as the 1x workload baseline and budgets costlier modes independently", () => {
+    expect(resolveOverlayGridWorkloadScale("passfail", 2)).toBe(1);
+    expect(resolveOverlayGridWorkloadScale("relay", 2)).toBeLessThan(1);
+    expect(resolveOverlayGridWorkloadScale("heatmap", 2)).toBeLessThan(
+      resolveOverlayGridWorkloadScale("heatmap", 1),
+    );
+    expect(resolveOverlayGridWorkloadScale("mesh-extension", 4)).toBeLessThan(
+      resolveOverlayGridWorkloadScale("mesh-extension", 2),
+    );
+  });
+
+  it("returns the honest logical grid size for the active overlay workload", () => {
+    const bounds = { minLat: 59.8, maxLat: 60, minLon: 10.6, maxLon: 10.8 };
+    const passFail = computeCalibratedOverlayGridDimensions(24, bounds, "passfail", 1, 2);
+    const heatmap = computeCalibratedOverlayGridDimensions(24, bounds, "heatmap", 1, 2);
+
+    expect(passFail).toEqual(computeCanonicalOverlayGridDimensions(24, bounds, 1));
+    expect(heatmap.totalSamples).toBeLessThan(passFail.totalSamples);
+    expect(heatmap.totalSamples).toBe(heatmap.width * heatmap.height);
+  });
+
+  it("budgets Mesh Extension's nested coverage comparison grid separately", () => {
+    expect(resolveMeshExtensionCoverageBudgetGridSize(24)).toBe(12);
+    expect(resolveMeshExtensionCoverageBudgetGridSize(42)).toBe(21);
+  });
+
   it("creates non-empty coverage at normal resolution", () => {
     const result = buildCoverage(NORMAL_GRID, network, sites, systems, defaultPropagationEnvironment());
     expect(result.length).toBeGreaterThan(100);

--- a/src/lib/coverage.ts
+++ b/src/lib/coverage.ts
@@ -70,6 +70,43 @@ const COVERAGE_COMPUTE_CHUNK_SIZE = 48;
 const COVERAGE_COMPUTE_FRAME_BUDGET_MS = 12;
 export const CANONICAL_OVERLAY_PIXELS_PER_BASE_SAMPLE = 174;
 
+export type CalibratedOverlayGridMode =
+  | "heatmap"
+  | "weakest"
+  | "contours"
+  | "passfail"
+  | "relay"
+  | "mesh-extension";
+
+const COVERAGE_OVERLAY_BASE_SCALE = 0.22;
+const RELAY_OVERLAY_SCALE = 0.52;
+const MESH_EXTENSION_BASE_SCALE = 0.12;
+const MESH_EXTENSION_COVERAGE_GRID_SCALE = 0.5;
+
+const participantAdjustedScale = (baseScale: number, participantCount: number): number => {
+  const count = Math.max(1, Math.round(participantCount));
+  return Math.max(0.1, Math.min(1, baseScale * Math.sqrt(2 / count)));
+};
+
+/**
+ * Workload calibration uses Pass/Fail 1x as the timing baseline. Coverage and
+ * Mesh Extension scale with the number of sites they evaluate at each point.
+ */
+export const resolveOverlayGridWorkloadScale = (
+  mode: CalibratedOverlayGridMode,
+  participantCount = 1,
+): number => {
+  if (mode === "passfail") return 1;
+  if (mode === "relay") return RELAY_OVERLAY_SCALE;
+  if (mode === "mesh-extension") {
+    return participantAdjustedScale(MESH_EXTENSION_BASE_SCALE, participantCount);
+  }
+  return participantAdjustedScale(COVERAGE_OVERLAY_BASE_SCALE, participantCount);
+};
+
+export const resolveMeshExtensionCoverageBudgetGridSize = (gridSize: number): number =>
+  Math.max(6, Math.round(gridSize * MESH_EXTENSION_COVERAGE_GRID_SCALE));
+
 export const computeCoverageGridDimensions = (
   gridSize: number,
   bounds: CoverageGridBounds,
@@ -102,6 +139,19 @@ export const computeCanonicalOverlayGridDimensions = (
   const height = Math.max(8, Math.min(1400, Math.round(rows * resolutionScale * displaySupersample)));
   return { width, height, totalSamples: width * height };
 };
+
+export const computeCalibratedOverlayGridDimensions = (
+  gridSize: number,
+  bounds: CoverageGridBounds,
+  mode: CalibratedOverlayGridMode,
+  resolutionScale = 1,
+  participantCount = 1,
+): { width: number; height: number; totalSamples: number } =>
+  computeCanonicalOverlayGridDimensions(
+    gridSize,
+    bounds,
+    resolutionScale * resolveOverlayGridWorkloadScale(mode, participantCount),
+  );
 
 export const resolveCanonicalOverlayResolutionScale = (bounds: CoverageGridBounds): number => {
   const centerLat = (bounds.minLat + bounds.maxLat) / 2;
@@ -265,6 +315,12 @@ const resolveCoverageMemberships = (
   const fallbackSystem = systems[0];
   return fallbackSystem ? sites.map((site) => ({ site, system: fallbackSystem })) : [];
 };
+
+export const resolveCoverageParticipantCount = (
+  network: Network,
+  sites: Site[],
+  systems: RadioSystem[],
+): number => Math.max(1, resolveCoverageMemberships(network, sites, systems).length);
 
 const evaluateCoveragePoint = (
   sample: CoverageGridPoint,

--- a/src/lib/locale.test.ts
+++ b/src/lib/locale.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { formatCompactCount } from "./locale";
+
+describe("formatCompactCount", () => {
+  it("keeps small counts exact and compacts large grid counts with k/M/G suffixes", () => {
+    expect(formatCompactCount(999)).toBe("999");
+    expect(formatCompactCount(100_489)).toBe("100.5k");
+    expect(formatCompactCount(1_960_000)).toBe("1.96M");
+    expect(formatCompactCount(1_250_000_000)).toBe("1.25G");
+  });
+});

--- a/src/lib/locale.ts
+++ b/src/lib/locale.ts
@@ -130,6 +130,25 @@ export function formatNumber(num: number): string {
   }
 }
 
+/** Compact, predictable notation for large logical grid-point counts. */
+export function formatCompactCount(value: number): string {
+  const count = Math.max(0, Math.round(value));
+  if (count < 1_000) return String(count);
+  const units = [
+    { divisor: 1_000_000_000, suffix: "G" },
+    { divisor: 1_000_000, suffix: "M" },
+    { divisor: 1_000, suffix: "k" },
+  ] as const;
+  const unit = units.find(({ divisor }) => count >= divisor)!;
+  const scaled = count / unit.divisor;
+  const maximumFractionDigits = scaled >= 10 ? 1 : 2;
+  return `${new Intl.NumberFormat("en-US", {
+    maximumFractionDigits,
+    minimumFractionDigits: 0,
+    useGrouping: false,
+  }).format(scaled)}${unit.suffix}`;
+}
+
 /**
  * Format a date for display in UI (shorter format)
  */

--- a/src/lib/overlayModeTiming.test.ts
+++ b/src/lib/overlayModeTiming.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeCalibratedOverlayGridDimensions,
+  createCoveragePointEvaluator,
+  resolveMeshExtensionCoverageBudgetGridSize,
+} from "./coverage";
+import {
+  buildAdaptiveCoverageOverlayPixelsAsync,
+  buildMeshExtensionOverlayPixelsAsync,
+  buildRelayCandidateOverlayPixelsAsync,
+  buildSourcePassFailOverlayPixelsAsync,
+} from "./overlayRaster";
+import type { Link, Network, PropagationEnvironment, RadioSystem, Site } from "../types/radio";
+
+const bounds = { minLat: 59.8, maxLat: 60, minLon: 10.6, maxLon: 10.8 };
+const environment: PropagationEnvironment = {
+  radioClimate: "Continental Temperate",
+  polarization: "Vertical",
+  clutterHeightM: 10,
+  groundDielectric: 15,
+  groundConductivity: 0.005,
+  atmosphericBendingNUnits: 301,
+};
+const sites: Site[] = [
+  {
+    id: "a", name: "A", position: { lat: 59.9, lon: 10.65 }, groundElevationM: 120,
+    antennaHeightM: 15, txPowerDbm: 20, txGainDbi: 2, rxGainDbi: 2, cableLossDb: 1,
+  },
+  {
+    id: "b", name: "B", position: { lat: 59.93, lon: 10.74 }, groundElevationM: 140,
+    antennaHeightM: 12, txPowerDbm: 20, txGainDbi: 2, rxGainDbi: 2, cableLossDb: 1,
+  },
+];
+const system: RadioSystem = {
+  id: "sys", name: "System", txPowerDbm: 20, txGainDbi: 2, rxGainDbi: 2, cableLossDb: 1,
+  antennaHeightM: 15,
+};
+const network: Network = {
+  id: "network", name: "Network", frequencyMHz: 868, bandwidthKhz: 250, spreadFactor: 11,
+  codingRate: 5, memberships: sites.map((site) => ({ siteId: site.id, systemId: system.id })),
+};
+const link: Link = { id: "link", fromSiteId: "a", toSiteId: "b", frequencyMHz: 868 };
+const terrain = () => 100;
+const context = (signature: string) => ({ phase: "benchmark", signature, frameBudgetMs: 1_000_000 });
+
+describe("overlay mode timing calibration", () => {
+  it("keeps representative cold 1x modes within the same broad performance budget", async () => {
+    const timings: Record<string, number> = {};
+    const measure = async (name: string, run: () => Promise<unknown>) => {
+      const startedAt = performance.now();
+      await run();
+      timings[name] = performance.now() - startedAt;
+    };
+    const dimensionsFor = (mode: "passfail" | "heatmap" | "relay" | "mesh-extension", participants: number) => {
+      const { width, height } = computeCalibratedOverlayGridDimensions(24, bounds, mode, 1, participants);
+      return { width, height };
+    };
+    const passFailDimensions = dimensionsFor("passfail", 1);
+    const heatmapDimensions = dimensionsFor("heatmap", sites.length);
+    const relayDimensions = dimensionsFor("relay", 2);
+    const meshDimensions = dimensionsFor("mesh-extension", sites.length);
+    await measure("passfail", () => buildSourcePassFailOverlayPixelsAsync(
+      bounds, sites[0], link, sites[1].antennaHeightM, sites[1].rxGainDbi, environment,
+      -118, 0, terrain, passFailDimensions, 24, undefined, context("passfail"),
+      { adaptive: true, analysisCacheKey: "bench-passfail" },
+    ));
+    await measure("heatmap", () => buildAdaptiveCoverageOverlayPixelsAsync({
+      bounds, dimensions: heatmapDimensions, initialGridSize: 24, mode: "heatmap", rxTargetDbm: -118,
+      evaluatePoint: createCoveragePointEvaluator(network, sites, [system], environment, () => 100, {
+        terrainSamples: 20, terrainCacheKey: "bench-heatmap", requireCompleteTerrain: true,
+      }),
+      context: context("heatmap"), adaptive: true, analysisCacheKey: "bench-heatmap",
+    }));
+    await measure("relay", () => buildRelayCandidateOverlayPixelsAsync(
+      bounds, sites[0], sites[1], link, environment, 0, terrain, relayDimensions, 24, undefined,
+      context("relay"), { adaptive: true, analysisCacheKey: "bench-relay" },
+    ));
+    await measure("mesh-extension", () => buildMeshExtensionOverlayPixelsAsync({
+      bounds, selectedSites: sites, frequencyMHz: 868, propagationEnvironment: environment,
+      rxTargetDbm: -118, environmentLossDb: 0, terrainSampler: terrain, dimensions: meshDimensions,
+      candidateGridSize: 24, coverageGridSize: resolveMeshExtensionCoverageBudgetGridSize(24), terrainSamples: 20,
+      context: context("mesh-extension"),
+    }));
+    expect(timings.passfail).toBeGreaterThan(0);
+    expect(timings.heatmap).toBeLessThan(timings.passfail * 1.75);
+    expect(timings.relay).toBeLessThan(timings.passfail * 1.75);
+    expect(timings["mesh-extension"]).toBeLessThan(timings.passfail * 1.75);
+  }, 120_000);
+
+  it("keeps the calibrated Mesh Extension area estimate close to the former 1x comparison grid", async () => {
+    const meshBounds = { minLat: 59.89, maxLat: 59.91, minLon: 10.64, maxLon: 10.68 };
+    const { width, height } = computeCalibratedOverlayGridDimensions(
+      24,
+      meshBounds,
+      "mesh-extension",
+      1,
+      1,
+    );
+    const common = {
+      bounds: meshBounds,
+      selectedSites: [sites[0]],
+      frequencyMHz: 868,
+      propagationEnvironment: environment,
+      rxTargetDbm: -70,
+      environmentLossDb: 0,
+      terrainSampler: terrain,
+      dimensions: { width, height },
+      candidateGridSize: 24,
+      terrainSamples: 20,
+    };
+    const reference = await buildMeshExtensionOverlayPixelsAsync({ ...common, coverageGridSize: 24 });
+    const calibrated = await buildMeshExtensionOverlayPixelsAsync({
+      ...common,
+      coverageGridSize: resolveMeshExtensionCoverageBudgetGridSize(24),
+    });
+
+    expect(reference?.maxAreaKm2).toBeGreaterThan(0);
+    expect(calibrated?.maxAreaKm2).toBeGreaterThan(0);
+    const relativeError = Math.abs(calibrated!.maxAreaKm2! - reference!.maxAreaKm2!) / reference!.maxAreaKm2!;
+    expect(relativeError).toBeLessThanOrEqual(0.15);
+  });
+});

--- a/src/store/coverageStore.ts
+++ b/src/store/coverageStore.ts
@@ -1,7 +1,9 @@
 import { create } from "zustand";
 import {
-  computeCanonicalOverlayGridDimensions,
+  computeCalibratedOverlayGridDimensions,
   resolveCanonicalOverlayResolutionScale,
+  resolveCoverageParticipantCount,
+  type CalibratedOverlayGridMode,
 } from "../lib/coverage";
 import { simulationAreaBoundsForSites } from "../lib/simulationArea";
 import {
@@ -16,8 +18,7 @@ import {
   recordSimulationRunCancelled,
 } from "../lib/simulationPerf";
 import { sampleSrtmElevation } from "../lib/srtm";
-import type { Site, SrtmTile } from "../types/radio";
-import type { CoverageSample } from "../types/radio";
+import type { CoverageSample, Network, RadioSystem, Site, SrtmTile } from "../types/radio";
 
 const COVERAGE_RECOMPUTE_DEBOUNCE_MS = 140;
 const COVERAGE_MIN_VISIBLE_MS = 600;
@@ -105,14 +106,6 @@ export const resolveAutomaticCalculationThresholds = (
   };
 };
 
-type NetworkLike = {
-  id: string;
-  frequencyMHz?: number;
-  frequencyOverrideMHz?: number;
-  memberships?: Array<{ siteId: string; systemId: string }>;
-  [key: string]: unknown;
-};
-
 type LinkLike = {
   id: string;
   fromSiteId: string;
@@ -123,10 +116,10 @@ type LinkLike = {
 type CoverageInputs = {
   selectedCoverageResolution: "24" | "42" | "84" | "168";
   effectiveCoverageResolution: "24" | "42" | "84" | "168";
-  networks: NetworkLike[];
+  networks: Network[];
   selectedNetworkId: string;
   sites: Site[];
-  systems: unknown[];
+  systems: RadioSystem[];
   propagationModel: string;
   srtmTiles: SrtmTile[];
   links: LinkLike[];
@@ -147,6 +140,28 @@ const normalizeCoverageResolution = (raw: unknown): "24" | "42" | "84" | "168" =
   return "24";
 };
 
+const normalizeCalibratedOverlayGridMode = (raw: string): CalibratedOverlayGridMode =>
+  raw === "heatmap" ||
+  raw === "weakest" ||
+  raw === "contours" ||
+  raw === "passfail" ||
+  raw === "relay" ||
+  raw === "mesh-extension"
+    ? raw
+    : "passfail";
+
+const overlayParticipantCount = (
+  mode: CalibratedOverlayGridMode,
+  inputs: CoverageInputs,
+  network: Network,
+): number => {
+  if (mode === "mesh-extension") {
+    return Math.max(1, inputs.selectedSiteIds.length || inputs.sites.length);
+  }
+  if (mode !== "heatmap" && mode !== "weakest" && mode !== "contours") return 1;
+  return resolveCoverageParticipantCount(network, inputs.sites, inputs.systems);
+};
+
 const readCoverageInputs = (appState: Record<string, unknown>): CoverageInputs => {
   const selectedCoverageResolution = normalizeCoverageResolution(appState.selectedCoverageResolution);
   const isTerrainFetching = Boolean(appState.isTerrainFetching);
@@ -154,10 +169,10 @@ const readCoverageInputs = (appState: Record<string, unknown>): CoverageInputs =
   return {
     selectedCoverageResolution,
     effectiveCoverageResolution,
-    networks: (appState.networks as NetworkLike[]) ?? [],
+    networks: (appState.networks as Network[]) ?? [],
     selectedNetworkId: (appState.selectedNetworkId as string) ?? "",
     sites: (appState.sites as Site[]) ?? [],
-    systems: (appState.systems as unknown[]) ?? [],
+    systems: (appState.systems as RadioSystem[]) ?? [],
     propagationModel: (appState.propagationModel as string) ?? "",
     srtmTiles: (appState.srtmTiles as SrtmTile[]) ?? [],
     links: (appState.links as LinkLike[]) ?? [],
@@ -188,7 +203,7 @@ const siteSignature = (site: Site): string =>
 
 const linkSignature = (link: LinkLike): string => [link.id, link.fromSiteId, link.toSiteId].join(":");
 
-const networkSignature = (network: NetworkLike): string => {
+const networkSignature = (network: Network): string => {
   const memberships = (network.memberships ?? [])
     .map((member) => `${member.siteId}>${member.systemId}`)
     .sort()
@@ -382,12 +397,19 @@ const runCoverageComputation = async (
     const targetRadiusKm = resolveTargetOverlayRadiusKm(selectionCount, selectedOverlayRadiusOption);
     const effectiveOverlayRadiusKm = targetRadiusKm;
 
-    const boundsForCount = simulationAreaBoundsForSites(inputs.sites, { overlayRadiusKm: effectiveOverlayRadiusKm });
+    const countSites =
+      selectionCount === 1
+        ? inputs.sites.filter((site) => site.id === inputs.selectedSiteIds[0])
+        : inputs.sites;
+    const boundsForCount = simulationAreaBoundsForSites(countSites, { overlayRadiusKm: effectiveOverlayRadiusKm });
+    const calibratedMode = normalizeCalibratedOverlayGridMode(inputs.mapOverlayMode);
     const sampleCount = boundsForCount
-      ? computeCanonicalOverlayGridDimensions(
+      ? computeCalibratedOverlayGridDimensions(
           gridSize,
           boundsForCount,
+          calibratedMode,
           resolveCanonicalOverlayResolutionScale(boundsForCount),
+          overlayParticipantCount(calibratedMode, inputs, network),
         ).totalSamples
       : 0;
     set({


### PR DESCRIPTION
## What changed

- keeps Pass/Fail's current 1x workload unchanged as the timing reference
- gives Heatmap, Weakest Site, and Heatmap + Target Line a shared participant-aware logical-grid budget
- gives Relay an independently measured grid budget
- separately calibrates Mesh Extension candidate placement and its nested coverage-comparison grid
- derives displayed and calculated point counts from the same shared membership resolver
- changes the existing resolution labels to compact mode-specific notation such as `98×98 · ~9.6k grid points`
- adds representative cold 1x timing coverage and compact-count tests

## Why

Equal logical point counts do not mean equal work. Coverage modes evaluate every resolved network member per point, Relay evaluates both path directions, and Mesh Extension performs nested coverage scoring. Treating 1x as a common workload budget makes the modes feel more consistent while still reporting each mode's real logical grid size.

## Accuracy and performance

- Pass/Fail behavior and point count are unchanged
- existing exact-vs-adaptive accuracy gates remain green
- representative cold 1x modes stay within the same broad timing budget
- calibrated Mesh Extension remains within 15% of the former 1x area estimate on the comparison fixture

## Validation

- `npx tsc -b config/tsconfig.json --pretty false`
- `npm run lint`
- `npm test` — 135 files, 789 tests passed
- `npm run build`
- `npm run dev:check`

Follow-up for #998
