### PR TITLE
Restore full overlay sampling resolution

### DIFF
--- a/src/components/MapView.overlayHandoff.test.tsx
+++ b/src/components/MapView.overlayHandoff.test.tsx
@@ -296,7 +296,7 @@ describe("MapView overlay handoff", () => {
     await waitFor(() => expect(recomputeCoverage).toHaveBeenCalledTimes(1));
   });
 
-  it("shows compact, mode-specific logical grid-point counts in the existing resolution selector", async () => {
+  it("shows the same compact logical grid-point count for every area overlay", async () => {
     render(
       <MapView
         canPersist
@@ -314,7 +314,7 @@ describe("MapView overlay handoff", () => {
     act(() => useAppStore.getState().setMapOverlayMode("mesh-extension"));
     await waitFor(() => {
       expect((screen.getByLabelText("Simulation Resolution") as HTMLSelectElement).options[0].textContent)
-        .not.toBe(heatmapLabel);
+        .toBe(heatmapLabel);
     });
   });
 

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -18,10 +18,10 @@ import {
   computeCalibratedOverlayGridDimensions,
   createCoveragePointEvaluator,
   resolveCanonicalOverlayResolutionScale,
-  resolveCoverageParticipantCount,
   resolveMeshExtensionCoverageBudgetGridSize,
   type CalibratedOverlayGridMode,
 } from "../lib/coverage";
+import { resolveSimulationSitesForSelection } from "../lib/simulationArea";
 import { formatCompactCount } from "../lib/locale";
 import { STANDARD_SITE_RADIO } from "../lib/linkRadio";
 import { sampleSrtmElevation } from "../lib/srtm";
@@ -491,14 +491,12 @@ const computeOverlayDimensions = (
   targetGridSize: number,
   mode: CalibratedOverlayGridMode,
   resolutionScale = 1,
-  participantCount = 1,
 ): { width: number; height: number } => {
   const dimensions = computeCalibratedOverlayGridDimensions(
     targetGridSize,
     bounds,
     mode,
     resolutionScale,
-    participantCount,
   );
   return { width: dimensions.width, height: dimensions.height };
 };
@@ -1110,11 +1108,11 @@ export function MapView({
     () => selectedSiteIds.map((id) => sites.find((site) => site.id === id)).filter((site): site is Site => Boolean(site)),
     [selectedSiteIds, sites],
   );
-  const meshExtensionSites = selectedSites.length > 0 ? selectedSites : sites;
-  const coverageParticipantCount = useMemo(
-    () => selectedNetwork ? resolveCoverageParticipantCount(selectedNetwork, sites, systems) : 1,
-    [selectedNetwork, sites, systems],
+  const coverageSites = useMemo(
+    () => resolveSimulationSitesForSelection(sites, selectedSiteIds),
+    [selectedSiteIds, sites],
   );
+  const meshExtensionSites = selectedSites.length > 0 ? selectedSites : sites;
   const selectedSiteSet = useMemo(() => new Set(selectedSites.map((site) => site.id)), [selectedSites]);
   const selectionCount = selectedSites.length;
   const singleSelectedSite = selectionCount === 1 ? selectedSites[0] ?? null : null;
@@ -1273,7 +1271,7 @@ export function MapView({
   const hasPassFailTopology = selectionCount >= 1;
   const hasRelayTopology = selectionCount >= 2;
   const hasMinimumTopology = sites.length >= 1;
-  const analysisTargetSites = selectionCount === 1 ? selectedSites : sites;
+  const analysisTargetSites = coverageSites;
   const normalizedOverlayRadiusOption = resolveOverlayRadiusOptionForSelectionTransition({
     previousSelectionCount: selectionCount,
     selectionCount,
@@ -1662,15 +1660,6 @@ export function MapView({
     coverageVizMode === "mesh-extension"
       ? coverageVizMode
       : "passfail";
-  const overlayParticipantCount =
-    calibratedOverlayMode === "mesh-extension"
-      ? Math.max(1, meshExtensionSites.length)
-      : calibratedOverlayMode === "heatmap" ||
-          calibratedOverlayMode === "weakest" ||
-          calibratedOverlayMode === "contours"
-        ? coverageParticipantCount
-        : 1;
-
   const overlayDimensions = useMemo(() => {
     const bounds = analysisBounds ?? computeCoverageBounds(samplesForOverlay);
     if (!bounds) return { width: 24, height: 24 };
@@ -1679,7 +1668,6 @@ export function MapView({
       effectiveGridSize,
       calibratedOverlayMode,
       overlayResolutionScale,
-      overlayParticipantCount,
     );
   }, [
     analysisBounds,
@@ -1687,7 +1675,6 @@ export function MapView({
     effectiveGridSize,
     calibratedOverlayMode,
     overlayResolutionScale,
-    overlayParticipantCount,
   ]);
 
   const overlayBounds = useMemo(() => analysisBounds ?? computeCoverageBounds(samplesForOverlay), [analysisBounds, samplesForOverlay]);
@@ -1706,7 +1693,6 @@ export function MapView({
             overlayBounds,
             calibratedOverlayMode,
             overlayResolutionScale,
-            overlayParticipantCount,
           )
         : fallback;
       const isDefault = gridSize === 24;
@@ -1715,7 +1701,7 @@ export function MapView({
         label: `${name} (${dims.height}×${dims.width} · ~${formatCompactCount(dims.totalSamples)} grid points)${isDefault ? " - Default" : ""}`,
       };
     });
-  }, [calibratedOverlayMode, overlayBounds, overlayParticipantCount, overlayResolutionScale]);
+  }, [calibratedOverlayMode, overlayBounds, overlayResolutionScale]);
   const overlayLongTaskWarnedRef = useRef<Set<string>>(new Set());
   const showOverlayDiagnostics =
     import.meta.env.DEV || (typeof window !== "undefined" && window.location.hostname === "localhost");
@@ -2067,6 +2053,7 @@ export function MapView({
       terrainLoadEpoch,
       effectiveGridSize,
       coverageAnalysisInputDigest,
+      selectedSiteDigest,
       propagationEnvironmentDigest,
     ].join("|");
     if (
@@ -2176,7 +2163,7 @@ export function MapView({
           if (mode === "heatmap" || mode === "contours" || mode === "weakest") {
             const evaluateCoveragePoint = createCoveragePointEvaluator(
               selectedNetwork!,
-              sites,
+              coverageSites,
               systems,
               propagationEnvironment,
               ({ lat, lon }) => terrainSampler(lat, lon),
@@ -2350,6 +2337,7 @@ export function MapView({
     meshExtensionFrequencyMHz,
     meshExtensionSites,
     selectedNetwork,
+    coverageSites,
     sites,
     systems,
     coverageAnalysisInputDigest,

--- a/src/lib/coverage.test.ts
+++ b/src/lib/coverage.test.ts
@@ -6,11 +6,13 @@ import {
   computeCanonicalOverlayGridDimensions,
   computeCoverageGridDimensions,
   CoverageBuildCancelledError,
+  createCoveragePointEvaluator,
   resolveMeshExtensionCoverageBudgetGridSize,
   resolveOverlayGridWorkloadScale,
 } from "./coverage";
 import { haversineDistanceKm } from "./geo";
 import { defaultPropagationEnvironment } from "./propagationEnvironment";
+import { resolveSimulationSitesForSelection } from "./simulationArea";
 import type { Network, RadioSystem, Site } from "../types/radio";
 
 const sites: Site[] = [
@@ -67,30 +69,54 @@ const NORMAL_GRID = 24;
 const HIGH_GRID = 42;
 
 describe("buildCoverage", () => {
-  it("keeps Pass/Fail as the 1x workload baseline and budgets costlier modes independently", () => {
+  it("keeps every area overlay on the full Pass/Fail logical grid", () => {
     expect(resolveOverlayGridWorkloadScale("passfail", 2)).toBe(1);
-    expect(resolveOverlayGridWorkloadScale("relay", 2)).toBeLessThan(1);
-    expect(resolveOverlayGridWorkloadScale("heatmap", 2)).toBeLessThan(
-      resolveOverlayGridWorkloadScale("heatmap", 1),
-    );
-    expect(resolveOverlayGridWorkloadScale("mesh-extension", 4)).toBeLessThan(
-      resolveOverlayGridWorkloadScale("mesh-extension", 2),
-    );
+    expect(resolveOverlayGridWorkloadScale("relay", 2)).toBe(1);
+    expect(resolveOverlayGridWorkloadScale("heatmap", 1)).toBe(1);
+    expect(resolveOverlayGridWorkloadScale("heatmap", 4)).toBe(1);
+    expect(resolveOverlayGridWorkloadScale("weakest", 4)).toBe(1);
+    expect(resolveOverlayGridWorkloadScale("contours", 4)).toBe(1);
+    expect(resolveOverlayGridWorkloadScale("mesh-extension", 2)).toBe(1);
+    expect(resolveOverlayGridWorkloadScale("mesh-extension", 4)).toBe(1);
   });
 
-  it("returns the honest logical grid size for the active overlay workload", () => {
+  it("returns the same honest logical grid size for Pass/Fail and coverage modes", () => {
     const bounds = { minLat: 59.8, maxLat: 60, minLon: 10.6, maxLon: 10.8 };
     const passFail = computeCalibratedOverlayGridDimensions(24, bounds, "passfail", 1, 2);
-    const heatmap = computeCalibratedOverlayGridDimensions(24, bounds, "heatmap", 1, 2);
+    const heatmap = computeCalibratedOverlayGridDimensions(24, bounds, "heatmap", 1, 4);
 
     expect(passFail).toEqual(computeCanonicalOverlayGridDimensions(24, bounds, 1));
-    expect(heatmap.totalSamples).toBeLessThan(passFail.totalSamples);
-    expect(heatmap.totalSamples).toBe(heatmap.width * heatmap.height);
+    expect(heatmap).toEqual(passFail);
   });
 
-  it("budgets Mesh Extension's nested coverage comparison grid separately", () => {
-    expect(resolveMeshExtensionCoverageBudgetGridSize(24)).toBe(12);
-    expect(resolveMeshExtensionCoverageBudgetGridSize(42)).toBe(21);
+  it("uses selected sites as coverage contributors and all sites for an empty selection", () => {
+    expect(resolveSimulationSitesForSelection(sites, ["s2"])).toEqual([sites[1]]);
+    expect(resolveSimulationSitesForSelection(sites, ["missing", "s1"])).toEqual([sites[0]]);
+    expect(resolveSimulationSitesForSelection(sites, [])).toEqual(sites);
+    expect(resolveSimulationSitesForSelection(sites, ["missing"])).toEqual(sites);
+  });
+
+  it("evaluates only the selected coverage contributors", () => {
+    const selectedSites = resolveSimulationSitesForSelection(sites, ["s1"]);
+    const selectedEvaluator = createCoveragePointEvaluator(
+      network,
+      selectedSites,
+      systems,
+      defaultPropagationEnvironment(),
+    );
+    const singleMembershipEvaluator = createCoveragePointEvaluator(
+      { ...network, memberships: [network.memberships[0]] },
+      sites,
+      systems,
+      defaultPropagationEnvironment(),
+    );
+
+    expect(selectedEvaluator(59.95, 10.85)).toEqual(singleMembershipEvaluator(59.95, 10.85));
+  });
+
+  it("keeps Mesh Extension's nested comparison grid at the selected resolution", () => {
+    expect(resolveMeshExtensionCoverageBudgetGridSize(24)).toBe(24);
+    expect(resolveMeshExtensionCoverageBudgetGridSize(42)).toBe(42);
   });
 
   it("creates non-empty coverage at normal resolution", () => {

--- a/src/lib/coverage.ts
+++ b/src/lib/coverage.ts
@@ -78,34 +78,18 @@ export type CalibratedOverlayGridMode =
   | "relay"
   | "mesh-extension";
 
-const COVERAGE_OVERLAY_BASE_SCALE = 0.22;
-const RELAY_OVERLAY_SCALE = 0.52;
-const MESH_EXTENSION_BASE_SCALE = 0.12;
-const MESH_EXTENSION_COVERAGE_GRID_SCALE = 0.5;
-
-const participantAdjustedScale = (baseScale: number, participantCount: number): number => {
-  const count = Math.max(1, Math.round(participantCount));
-  return Math.max(0.1, Math.min(1, baseScale * Math.sqrt(2 / count)));
-};
-
 /**
- * Workload calibration uses Pass/Fail 1x as the timing baseline. Coverage and
- * Mesh Extension scale with the number of sites they evaluate at each point.
+ * Every area overlay shares Pass/Fail's logical grid so the selected
+ * resolution always means the same thing. Adaptive evaluation can still
+ * reduce the number of expensive RF calculations underneath that grid.
  */
 export const resolveOverlayGridWorkloadScale = (
-  mode: CalibratedOverlayGridMode,
-  participantCount = 1,
-): number => {
-  if (mode === "passfail") return 1;
-  if (mode === "relay") return RELAY_OVERLAY_SCALE;
-  if (mode === "mesh-extension") {
-    return participantAdjustedScale(MESH_EXTENSION_BASE_SCALE, participantCount);
-  }
-  return participantAdjustedScale(COVERAGE_OVERLAY_BASE_SCALE, participantCount);
-};
+  _mode: CalibratedOverlayGridMode,
+  _participantCount = 1,
+): number => 1;
 
 export const resolveMeshExtensionCoverageBudgetGridSize = (gridSize: number): number =>
-  Math.max(6, Math.round(gridSize * MESH_EXTENSION_COVERAGE_GRID_SCALE));
+  Math.max(6, Math.round(gridSize));
 
 export const computeCoverageGridDimensions = (
   gridSize: number,
@@ -315,12 +299,6 @@ const resolveCoverageMemberships = (
   const fallbackSystem = systems[0];
   return fallbackSystem ? sites.map((site) => ({ site, system: fallbackSystem })) : [];
 };
-
-export const resolveCoverageParticipantCount = (
-  network: Network,
-  sites: Site[],
-  systems: RadioSystem[],
-): number => Math.max(1, resolveCoverageMemberships(network, sites, systems).length);
 
 const evaluateCoveragePoint = (
   sample: CoverageGridPoint,

--- a/src/lib/overlayModeTiming.test.ts
+++ b/src/lib/overlayModeTiming.test.ts
@@ -44,7 +44,7 @@ const terrain = () => 100;
 const context = (signature: string) => ({ phase: "benchmark", signature, frameBudgetMs: 1_000_000 });
 
 describe("overlay mode timing calibration", () => {
-  it("keeps representative cold 1x modes within the same broad performance budget", async () => {
+  it("executes representative cold 1x modes on their resolved grids", async () => {
     const timings: Record<string, number> = {};
     const measure = async (name: string, run: () => Promise<unknown>) => {
       const startedAt = performance.now();
@@ -81,42 +81,8 @@ describe("overlay mode timing calibration", () => {
       candidateGridSize: 24, coverageGridSize: resolveMeshExtensionCoverageBudgetGridSize(24), terrainSamples: 20,
       context: context("mesh-extension"),
     }));
-    expect(timings.passfail).toBeGreaterThan(0);
-    expect(timings.heatmap).toBeLessThan(timings.passfail * 1.75);
-    expect(timings.relay).toBeLessThan(timings.passfail * 1.75);
-    expect(timings["mesh-extension"]).toBeLessThan(timings.passfail * 1.75);
+    expect(Object.values(timings)).toHaveLength(4);
+    expect(Object.values(timings).every((durationMs) => durationMs > 0)).toBe(true);
   }, 120_000);
 
-  it("keeps the calibrated Mesh Extension area estimate close to the former 1x comparison grid", async () => {
-    const meshBounds = { minLat: 59.89, maxLat: 59.91, minLon: 10.64, maxLon: 10.68 };
-    const { width, height } = computeCalibratedOverlayGridDimensions(
-      24,
-      meshBounds,
-      "mesh-extension",
-      1,
-      1,
-    );
-    const common = {
-      bounds: meshBounds,
-      selectedSites: [sites[0]],
-      frequencyMHz: 868,
-      propagationEnvironment: environment,
-      rxTargetDbm: -70,
-      environmentLossDb: 0,
-      terrainSampler: terrain,
-      dimensions: { width, height },
-      candidateGridSize: 24,
-      terrainSamples: 20,
-    };
-    const reference = await buildMeshExtensionOverlayPixelsAsync({ ...common, coverageGridSize: 24 });
-    const calibrated = await buildMeshExtensionOverlayPixelsAsync({
-      ...common,
-      coverageGridSize: resolveMeshExtensionCoverageBudgetGridSize(24),
-    });
-
-    expect(reference?.maxAreaKm2).toBeGreaterThan(0);
-    expect(calibrated?.maxAreaKm2).toBeGreaterThan(0);
-    const relativeError = Math.abs(calibrated!.maxAreaKm2! - reference!.maxAreaKm2!) / reference!.maxAreaKm2!;
-    expect(relativeError).toBeLessThanOrEqual(0.15);
-  });
 });

--- a/src/lib/simulationArea.ts
+++ b/src/lib/simulationArea.ts
@@ -19,6 +19,13 @@ export type SimulationAreaOptions = {
   singleSiteRadiusKm?: number;
 };
 
+export const resolveSimulationSitesForSelection = (sites: Site[], selectedSiteIds: string[]): Site[] => {
+  if (selectedSiteIds.length === 0) return sites;
+  const selectedIds = new Set(selectedSiteIds);
+  const selectedSites = sites.filter((site) => selectedIds.has(site.id));
+  return selectedSites.length > 0 ? selectedSites : sites;
+};
+
 export const simulationAreaBoundsForSites = (
   sites: Pick<Site, "position">[],
   options?: SimulationAreaOptions,

--- a/src/store/coverageStore.ts
+++ b/src/store/coverageStore.ts
@@ -2,10 +2,9 @@ import { create } from "zustand";
 import {
   computeCalibratedOverlayGridDimensions,
   resolveCanonicalOverlayResolutionScale,
-  resolveCoverageParticipantCount,
   type CalibratedOverlayGridMode,
 } from "../lib/coverage";
-import { simulationAreaBoundsForSites } from "../lib/simulationArea";
+import { resolveSimulationSitesForSelection, simulationAreaBoundsForSites } from "../lib/simulationArea";
 import {
   deriveDynamicPropagationEnvironment,
 } from "../lib/propagationEnvironment";
@@ -149,18 +148,6 @@ const normalizeCalibratedOverlayGridMode = (raw: string): CalibratedOverlayGridM
   raw === "mesh-extension"
     ? raw
     : "passfail";
-
-const overlayParticipantCount = (
-  mode: CalibratedOverlayGridMode,
-  inputs: CoverageInputs,
-  network: Network,
-): number => {
-  if (mode === "mesh-extension") {
-    return Math.max(1, inputs.selectedSiteIds.length || inputs.sites.length);
-  }
-  if (mode !== "heatmap" && mode !== "weakest" && mode !== "contours") return 1;
-  return resolveCoverageParticipantCount(network, inputs.sites, inputs.systems);
-};
 
 const readCoverageInputs = (appState: Record<string, unknown>): CoverageInputs => {
   const selectedCoverageResolution = normalizeCoverageResolution(appState.selectedCoverageResolution);
@@ -397,10 +384,7 @@ const runCoverageComputation = async (
     const targetRadiusKm = resolveTargetOverlayRadiusKm(selectionCount, selectedOverlayRadiusOption);
     const effectiveOverlayRadiusKm = targetRadiusKm;
 
-    const countSites =
-      selectionCount === 1
-        ? inputs.sites.filter((site) => site.id === inputs.selectedSiteIds[0])
-        : inputs.sites;
+    const countSites = resolveSimulationSitesForSelection(inputs.sites, inputs.selectedSiteIds);
     const boundsForCount = simulationAreaBoundsForSites(countSites, { overlayRadiusKm: effectiveOverlayRadiusKm });
     const calibratedMode = normalizeCalibratedOverlayGridMode(inputs.mapOverlayMode);
     const sampleCount = boundsForCount
@@ -409,7 +393,6 @@ const runCoverageComputation = async (
           boundsForCount,
           calibratedMode,
           resolveCanonicalOverlayResolutionScale(boundsForCount),
-          overlayParticipantCount(calibratedMode, inputs, network),
         ).totalSamples
       : 0;
     set({
@@ -466,10 +449,7 @@ const flushCoverageRunQueue = async (): Promise<void> => {
     return;
   }
   const selectionCount = inputs.selectedSiteIds.length;
-  const selectedTerrainSites =
-    selectionCount === 1
-      ? inputs.sites.filter((site) => site.id === inputs.selectedSiteIds[0])
-      : inputs.sites;
+  const selectedTerrainSites = resolveSimulationSitesForSelection(inputs.sites, inputs.selectedSiteIds);
   const selectedOverlayRadiusOption = normalizeOverlayRadiusOptionForSelectionCount(
     selectionCount,
     inputs.selectedOverlayRadiusOptionRaw,


### PR DESCRIPTION
## What changed

- restores the full Pass/Fail logical grid for every area overlay at the same resolution setting
- restores Mesh Extension's nested comparison grid to the selected resolution
- scopes Heatmap, Weakest Signal, and Contours to the selected sites
- treats an empty site selection as all sites
- uses the same selected-site scope for calculation bounds and terrain requirements
- retains adaptive evaluation and compact honest grid-point labels

## Validation

- npx tsc -b config/tsconfig.json --pretty false
- npm run lint
- npm test: 135 files, 790 tests passed
- npm run build
- npm run dev:check

Follow-up for #998. Production is unchanged.