### PR TITLE
Balance multi-site overlay performance and resolution

### DIFF
--- a/src/components/MapView.overlayHandoff.test.tsx
+++ b/src/components/MapView.overlayHandoff.test.tsx
@@ -296,7 +296,7 @@ describe("MapView overlay handoff", () => {
     await waitFor(() => expect(recomputeCoverage).toHaveBeenCalledTimes(1));
   });
 
-  it("shows the same compact logical grid-point count for every area overlay", async () => {
+  it("shows the actual Mesh Extension analysis grid in the existing resolution selector", async () => {
     render(
       <MapView
         canPersist
@@ -313,8 +313,9 @@ describe("MapView overlay handoff", () => {
 
     act(() => useAppStore.getState().setMapOverlayMode("mesh-extension"));
     await waitFor(() => {
-      expect((screen.getByLabelText("Simulation Resolution") as HTMLSelectElement).options[0].textContent)
-        .toBe(heatmapLabel);
+      const meshLabel = (screen.getByLabelText("Simulation Resolution") as HTMLSelectElement).options[0].textContent ?? "";
+      expect(meshLabel).not.toBe(heatmapLabel);
+      expect(meshLabel).toContain("~576 grid points");
     });
   });
 

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -16,7 +16,8 @@ import Map, {
 import type { LayerProps } from "react-map-gl/maplibre";
 import {
   computeCalibratedOverlayGridDimensions,
-  createCoveragePointEvaluator,
+  computeCoverageGridDimensions,
+  createCoverageContributorEvaluators,
   resolveCanonicalOverlayResolutionScale,
   resolveMeshExtensionCoverageBudgetGridSize,
   type CalibratedOverlayGridMode,
@@ -1688,12 +1689,17 @@ export function MapView({
     return options.map(({ gridSize, name }) => {
       const fallback = { width: gridSize, height: gridSize, totalSamples: gridSize * gridSize };
       const dims = overlayBounds
-        ? computeCalibratedOverlayGridDimensions(
-            gridSize,
-            overlayBounds,
-            calibratedOverlayMode,
-            overlayResolutionScale,
-          )
+        ? calibratedOverlayMode === "mesh-extension"
+          ? (() => {
+              const analysis = computeCoverageGridDimensions(gridSize, overlayBounds);
+              return { width: analysis.cols, height: analysis.rows, totalSamples: analysis.totalSamples };
+            })()
+          : computeCalibratedOverlayGridDimensions(
+              gridSize,
+              overlayBounds,
+              calibratedOverlayMode,
+              overlayResolutionScale,
+            )
         : fallback;
       const isDefault = gridSize === 24;
       return {
@@ -2161,7 +2167,7 @@ export function MapView({
           } as const;
           let rasterPixels: OverlayRasterPixels | null = null;
           if (mode === "heatmap" || mode === "contours" || mode === "weakest") {
-            const evaluateCoveragePoint = createCoveragePointEvaluator(
+            const contributors = createCoverageContributorEvaluators(
               selectedNetwork!,
               coverageSites,
               systems,
@@ -2179,7 +2185,7 @@ export function MapView({
               initialGridSize: effectiveGridSize,
               mode,
               rxTargetDbm: rxSensitivityTargetDbm,
-              evaluatePoint: evaluateCoveragePoint,
+              contributors,
               pointMask: overlayPointMask,
               context,
               adaptive: true,

--- a/src/lib/coverage.test.ts
+++ b/src/lib/coverage.test.ts
@@ -6,7 +6,7 @@ import {
   computeCanonicalOverlayGridDimensions,
   computeCoverageGridDimensions,
   CoverageBuildCancelledError,
-  createCoveragePointEvaluator,
+  createCoverageContributorEvaluators,
   resolveMeshExtensionCoverageBudgetGridSize,
   resolveOverlayGridWorkloadScale,
 } from "./coverage";
@@ -98,20 +98,24 @@ describe("buildCoverage", () => {
 
   it("evaluates only the selected coverage contributors", () => {
     const selectedSites = resolveSimulationSitesForSelection(sites, ["s1"]);
-    const selectedEvaluator = createCoveragePointEvaluator(
+    const selectedEvaluators = createCoverageContributorEvaluators(
       network,
       selectedSites,
       systems,
       defaultPropagationEnvironment(),
     );
-    const singleMembershipEvaluator = createCoveragePointEvaluator(
+    const singleMembershipEvaluators = createCoverageContributorEvaluators(
       { ...network, memberships: [network.memberships[0]] },
       sites,
       systems,
       defaultPropagationEnvironment(),
     );
 
-    expect(selectedEvaluator(59.95, 10.85)).toEqual(singleMembershipEvaluator(59.95, 10.85));
+    expect(selectedEvaluators).toHaveLength(1);
+    expect(singleMembershipEvaluators).toHaveLength(1);
+    expect(selectedEvaluators[0].evaluatePoint(59.95, 10.85)).toBe(
+      singleMembershipEvaluators[0].evaluatePoint(59.95, 10.85),
+    );
   });
 
   it("keeps Mesh Extension's nested comparison grid at the selected resolution", () => {

--- a/src/lib/coverage.ts
+++ b/src/lib/coverage.ts
@@ -84,9 +84,13 @@ export type CalibratedOverlayGridMode =
  * reduce the number of expensive RF calculations underneath that grid.
  */
 export const resolveOverlayGridWorkloadScale = (
-  _mode: CalibratedOverlayGridMode,
-  _participantCount = 1,
-): number => 1;
+  mode: CalibratedOverlayGridMode,
+  participantCount = 1,
+): number => {
+  void mode;
+  void participantCount;
+  return 1;
+};
 
 export const resolveMeshExtensionCoverageBudgetGridSize = (gridSize: number): number =>
   Math.max(6, Math.round(gridSize));
@@ -332,14 +336,19 @@ const evaluateCoveragePoint = (
   };
 };
 
-export const createCoveragePointEvaluator = (
+export type CoverageContributorEvaluator = {
+  id: string;
+  evaluatePoint: (lat: number, lon: number) => number;
+};
+
+export const createCoverageContributorEvaluators = (
   network: Network,
   sites: Site[],
   systems: RadioSystem[],
   environment: PropagationEnvironment,
   terrainSampler?: (coordinates: Coordinates) => number | null,
   options?: Pick<BuildCoverageOptions, "terrainSamples" | "terrainCacheKey" | "requireCompleteTerrain">,
-): ((lat: number, lon: number) => { strongestDbm: number; weakestDbm: number }) => {
+): CoverageContributorEvaluator[] => {
   const memberships = resolveCoverageMemberships(network, sites, systems);
   const frequencyMHz = network.frequencyOverrideMHz ?? network.frequencyMHz;
   const terrainSamples = Math.max(16, Math.round(options?.terrainSamples ?? 20));
@@ -347,18 +356,21 @@ export const createCoveragePointEvaluator = (
     terrainSampler && options?.requireCompleteTerrain
       ? requireTerrainSample(terrainSampler)
       : terrainSampler;
-  return (lat, lon) => {
-    const levels = evaluateCoveragePoint(
-      { lat, lon },
-      memberships,
-      frequencyMHz,
-      terrainSamples,
-      environment,
-      effectiveTerrainSampler,
-      options?.terrainCacheKey,
-    );
-    return { strongestDbm: levels.valueDbm, weakestDbm: levels.weakestDbm ?? levels.valueDbm };
-  };
+  return memberships.map(({ site, system }) => ({
+    id: `${site.id}:${system.id}`,
+    evaluatePoint: (lat, lon) =>
+      evalRx(
+        lat,
+        lon,
+        site,
+        system,
+        frequencyMHz,
+        terrainSamples,
+        environment,
+        effectiveTerrainSampler,
+        options?.terrainCacheKey,
+      ),
+  }));
 };
 
 

--- a/src/lib/overlayModeTiming.test.ts
+++ b/src/lib/overlayModeTiming.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildCoverageGridPoints,
   computeCalibratedOverlayGridDimensions,
-  createCoveragePointEvaluator,
+  createCoverageContributorEvaluators,
   resolveMeshExtensionCoverageBudgetGridSize,
 } from "./coverage";
 import {
   buildAdaptiveCoverageOverlayPixelsAsync,
+  buildCoverageOverlayPixelsAsync,
   buildMeshExtensionOverlayPixelsAsync,
   buildRelayCandidateOverlayPixelsAsync,
   buildSourcePassFailOverlayPixelsAsync,
@@ -29,6 +31,14 @@ const sites: Site[] = [
   {
     id: "b", name: "B", position: { lat: 59.93, lon: 10.74 }, groundElevationM: 140,
     antennaHeightM: 12, txPowerDbm: 20, txGainDbi: 2, rxGainDbi: 2, cableLossDb: 1,
+  },
+  {
+    id: "c", name: "C", position: { lat: 59.84, lon: 10.72 }, groundElevationM: 110,
+    antennaHeightM: 14, txPowerDbm: 20, txGainDbi: 2, rxGainDbi: 2, cableLossDb: 1,
+  },
+  {
+    id: "d", name: "D", position: { lat: 59.97, lon: 10.66 }, groundElevationM: 150,
+    antennaHeightM: 10, txPowerDbm: 20, txGainDbi: 2, rxGainDbi: 2, cableLossDb: 1,
   },
 ];
 const system: RadioSystem = {
@@ -66,7 +76,7 @@ describe("overlay mode timing calibration", () => {
     ));
     await measure("heatmap", () => buildAdaptiveCoverageOverlayPixelsAsync({
       bounds, dimensions: heatmapDimensions, initialGridSize: 24, mode: "heatmap", rxTargetDbm: -118,
-      evaluatePoint: createCoveragePointEvaluator(network, sites, [system], environment, () => 100, {
+      contributors: createCoverageContributorEvaluators(network, sites, [system], environment, () => 100, {
         terrainSamples: 20, terrainCacheKey: "bench-heatmap", requireCompleteTerrain: true,
       }),
       context: context("heatmap"), adaptive: true, analysisCacheKey: "bench-heatmap",
@@ -83,6 +93,68 @@ describe("overlay mode timing calibration", () => {
     }));
     expect(Object.values(timings)).toHaveLength(4);
     expect(Object.values(timings).every((durationMs) => durationMs > 0)).toBe(true);
+  }, 120_000);
+
+  it("keeps four-site 1x Heatmap within the production timing budget", async () => {
+    const dimensions = computeCalibratedOverlayGridDimensions(24, bounds, "heatmap");
+    const rasterDimensions = { width: dimensions.width, height: dimensions.height };
+    const measure = async (run: () => Promise<unknown>): Promise<number> => {
+      const startedAt = performance.now();
+      await run();
+      return performance.now() - startedAt;
+    };
+    const productionDurations: number[] = [];
+    const adaptiveDurations: number[] = [];
+    for (let runIndex = 0; runIndex < 3; runIndex += 1) {
+      const productionContributors = createCoverageContributorEvaluators(
+        network,
+        sites,
+        [system],
+        environment,
+        () => 100,
+        { terrainSamples: 20, terrainCacheKey: `production-${runIndex}`, requireCompleteTerrain: true },
+      );
+      productionDurations.push(await measure(async () => {
+        const samples = buildCoverageGridPoints(24, bounds).map((point) => ({
+          ...point,
+          valueDbm: Math.max(...productionContributors.map((contributor) =>
+            contributor.evaluatePoint(point.lat, point.lon))),
+        }));
+        await buildCoverageOverlayPixelsAsync(
+          bounds,
+          samples,
+          "heatmap",
+          5,
+          rasterDimensions,
+          undefined,
+          () => 100,
+          context(`production-${runIndex}`),
+          { rxTargetDbm: -118 },
+        );
+      }));
+
+      const adaptiveContributors = createCoverageContributorEvaluators(
+        network,
+        sites,
+        [system],
+        environment,
+        () => 100,
+        { terrainSamples: 20, terrainCacheKey: `adaptive-${runIndex}`, requireCompleteTerrain: true },
+      );
+      adaptiveDurations.push(await measure(() => buildAdaptiveCoverageOverlayPixelsAsync({
+        bounds,
+        dimensions: rasterDimensions,
+        initialGridSize: 24,
+        mode: "heatmap",
+        rxTargetDbm: -118,
+        contributors: adaptiveContributors,
+        context: context(`adaptive-${runIndex}`),
+        adaptive: true,
+      })));
+    }
+    productionDurations.sort((left, right) => left - right);
+    adaptiveDurations.sort((left, right) => left - right);
+    expect(adaptiveDurations[1]).toBeLessThanOrEqual(productionDurations[1] * 1.1);
   }, 120_000);
 
 });

--- a/src/lib/overlayRaster.test.ts
+++ b/src/lib/overlayRaster.test.ts
@@ -19,6 +19,7 @@ import {
   type CoverageSampleLite,
   type TerrainBounds,
 } from "./overlayRaster";
+import { computeCoverageGridDimensions } from "./coverage";
 import type { Link, PropagationEnvironment, Site } from "../types/radio";
 
 const bounds: TerrainBounds = {
@@ -87,7 +88,7 @@ describe("overlayRaster async builders", () => {
       const lonOffset = (lon - 10.7) / 0.1;
       const ridgeOffset = latOffset - lonOffset * 0.4 - 0.42;
       const strongestDbm = -116 + lonOffset * 16 + Math.exp(-(ridgeOffset ** 2) / 0.006) * 11;
-      return { strongestDbm, weakestDbm: strongestDbm - 7 };
+      return strongestDbm;
     };
     const exact = await buildAdaptiveCoverageOverlayPixelsAsync({
       bounds,
@@ -95,10 +96,10 @@ describe("overlayRaster async builders", () => {
       initialGridSize: 24,
       mode: "heatmap",
       rxTargetDbm: -118,
-      evaluatePoint: (lat, lon) => {
-        exactEvaluations += 1;
-        return evaluateSignal(lat, lon);
-      },
+      contributors: [{ id: "site-a", evaluatePoint: (lat, lon) => {
+          exactEvaluations += 1;
+          return evaluateSignal(lat, lon);
+        } }],
       adaptive: false,
     });
     const adaptive = await buildAdaptiveCoverageOverlayPixelsAsync({
@@ -107,10 +108,10 @@ describe("overlayRaster async builders", () => {
       initialGridSize: 24,
       mode: "heatmap",
       rxTargetDbm: -118,
-      evaluatePoint: (lat, lon) => {
-        adaptiveEvaluations += 1;
-        return evaluateSignal(lat, lon);
-      },
+      contributors: [{ id: "site-a", evaluatePoint: (lat, lon) => {
+          adaptiveEvaluations += 1;
+          return evaluateSignal(lat, lon);
+        } }],
       adaptive: true,
     });
 
@@ -133,11 +134,10 @@ describe("overlayRaster async builders", () => {
       dimensions,
       initialGridSize: 24,
       rxTargetDbm: -118,
-      evaluatePoint: (lat: number, lon: number) => {
+      contributors: [{ id: "site-a", evaluatePoint: (lat: number, lon: number) => {
         evaluations += 1;
-        const strongestDbm = -104 + (lat - bounds.minLat) * 20 + (lon - bounds.minLon) * 10;
-        return { strongestDbm, weakestDbm: strongestDbm - 8 };
-      },
+        return -104 + (lat - bounds.minLat) * 20 + (lon - bounds.minLon) * 10;
+      } }],
       adaptive: true,
       analysisCacheKey: "coverage-mode-switch-cache",
     } as const;
@@ -149,6 +149,92 @@ describe("overlayRaster async builders", () => {
     expect(weakest?.signalValuesDbm).toHaveLength(dimensions.width * dimensions.height);
     expect(evaluations).toBe(firstEvaluations);
     expect(weakest?.analysisStats?.evaluatedPaths).toBe(0);
+  });
+
+  it("keeps multi-contributor strongest and weakest surfaces within the accuracy gate", async () => {
+    const dimensions = { width: 96, height: 96 };
+    const contributors = [
+      { id: "a", evaluatePoint: (lat: number, lon: number) => -86 - (lat - 59.84) ** 2 * 900 - (lon - 10.64) ** 2 * 700 },
+      { id: "b", evaluatePoint: (lat: number, lon: number) => -90 - (lat - 59.96) ** 2 * 650 - (lon - 10.76) ** 2 * 850 },
+      { id: "c", evaluatePoint: (lat: number, lon: number) => -94 + (lat - bounds.minLat) * 22 - (lon - bounds.minLon) * 15 },
+      { id: "d", evaluatePoint: (lat: number, lon: number) => -82 - (lat - bounds.minLat) * 28 + (lon - bounds.minLon) * 10 },
+    ];
+    const build = (mode: "heatmap" | "weakest", adaptive: boolean) =>
+      buildAdaptiveCoverageOverlayPixelsAsync({
+        bounds,
+        dimensions,
+        initialGridSize: 24,
+        mode,
+        rxTargetDbm: -118,
+        contributors,
+        adaptive,
+      });
+    const [exactStrongest, adaptiveStrongest, exactWeakest, adaptiveWeakest] = await Promise.all([
+      build("heatmap", false),
+      build("heatmap", true),
+      build("weakest", false),
+      build("weakest", true),
+    ]);
+    const assertAccuracy = (exact: Float32Array, adaptive: Float32Array) => {
+      const errors = Array.from(exact, (value, index) => Math.abs(value - adaptive[index]))
+        .sort((left, right) => left - right);
+      expect(errors[Math.floor(errors.length * 0.5)]).toBeLessThanOrEqual(0.25);
+      expect(errors[Math.floor(errors.length * 0.99)]).toBeLessThanOrEqual(1);
+    };
+
+    assertAccuracy(exactStrongest!.signalValuesDbm!, adaptiveStrongest!.signalValuesDbm!);
+    assertAccuracy(exactWeakest!.signalValuesDbm!, adaptiveWeakest!.signalValuesDbm!);
+  });
+
+  it("adapts each contributor before combining strongest and weakest surfaces", async () => {
+    const dimensions = { width: 192, height: 192 };
+    let evaluations = 0;
+    const contributors = [
+      {
+        id: "west",
+        evaluatePoint: (_lat: number, lon: number) => {
+          evaluations += 1;
+          return -80 - (lon - bounds.minLon) * 120;
+        },
+      },
+      {
+        id: "east",
+        evaluatePoint: (_lat: number, lon: number) => {
+          evaluations += 1;
+          return -104 + (lon - bounds.minLon) * 120;
+        },
+      },
+      {
+        id: "north",
+        evaluatePoint: (lat: number) => {
+          evaluations += 1;
+          return -92 + (lat - bounds.minLat) * 50;
+        },
+      },
+      {
+        id: "south",
+        evaluatePoint: (lat: number) => {
+          evaluations += 1;
+          return -82 - (lat - bounds.minLat) * 50;
+        },
+      },
+    ];
+
+    const raster = await buildAdaptiveCoverageOverlayPixelsAsync({
+      bounds,
+      dimensions,
+      initialGridSize: 24,
+      mode: "heatmap",
+      rxTargetDbm: -118,
+      contributors,
+      adaptive: true,
+    });
+
+    expect(raster?.signalValuesDbm).toHaveLength(dimensions.width * dimensions.height);
+    const productionPathBudget = computeCoverageGridDimensions(24, bounds).totalSamples * contributors.length;
+    expect(evaluations).toBeLessThanOrEqual(productionPathBudget * 1.1);
+    const center = Math.floor(dimensions.height / 2) * dimensions.width + Math.floor(dimensions.width / 2);
+    expect(raster!.signalValuesDbm![center]).toBeGreaterThan(-93);
   });
 
   it("keeps adaptive Pass/Fail within the accuracy gate while reducing terrain work", async () => {
@@ -344,32 +430,6 @@ describe("overlayRaster async builders", () => {
 
     expect(firstReads).toBeGreaterThan(0);
     expect(secondReads).toBeLessThan(firstReads * 0.2);
-  });
-
-  it("builds adaptive Pass/Fail at least three times faster than the exact reference fixture", async () => {
-    const dimensions = { width: 120, height: 120 };
-    const measure = async (adaptive: boolean): Promise<number> => {
-      const startedAt = performance.now();
-      await buildSourcePassFailOverlayPixelsAsync(
-        bounds, fromSite, link, toSite.antennaHeightM, toSite.rxGainDbi, environment,
-        -118, 0, terrainSampler, dimensions, 24, undefined,
-        { phase: "passfail", signature: adaptive ? "timing-adaptive" : "timing-reference" },
-        { adaptive },
-      );
-      return performance.now() - startedAt;
-    };
-
-    await measure(true);
-    await measure(false);
-    const exactDurations: number[] = [];
-    const adaptiveDurations: number[] = [];
-    for (let run = 0; run < 3; run += 1) {
-      exactDurations.push(await measure(false));
-      adaptiveDurations.push(await measure(true));
-    }
-    exactDurations.sort((left, right) => left - right);
-    adaptiveDurations.sort((left, right) => left - right);
-    expect(adaptiveDurations[1] * 3).toBeLessThan(exactDurations[1]);
   });
 
   it("derives a representative mesh-extension profile from selected-site medians", () => {
@@ -656,7 +716,7 @@ describe("overlayRaster async builders", () => {
     expect(Array.from(raster!.pixels).filter((_, index) => index % 4 === 3).every((alpha) => alpha === 0)).toBe(true);
   });
 
-  it("uses the canonical Mesh Extension candidate grid while merging safely failing regions", async () => {
+  it("uses the production-style Mesh Extension analysis grid and interpolates the display raster", async () => {
     const dimensions = { width: 48, height: 48 };
     const raster = await buildMeshExtensionOverlayPixelsAsync({
       bounds,
@@ -673,8 +733,11 @@ describe("overlayRaster async builders", () => {
       context: { phase: "mesh-extension", signature: "mesh-extension-canonical-grid" },
     });
 
-    expect(raster?.analysisStats?.totalPixels).toBe(dimensions.width * dimensions.height);
-    expect(raster?.analysisStats?.evaluatedPaths).toBeLessThan(dimensions.width * dimensions.height * 0.25);
+    expect(raster?.width).toBe(dimensions.width);
+    expect(raster?.height).toBe(dimensions.height);
+    const analysisPoints = computeCoverageGridDimensions(6, bounds).totalSamples;
+    expect(raster?.analysisStats?.totalPixels).toBe(analysisPoints);
+    expect(raster?.analysisStats?.evaluatedPaths).toBeLessThanOrEqual(analysisPoints);
     expect(Array.from(raster!.pixels).filter((_, index) => index % 4 === 3).every((alpha) => alpha === 0)).toBe(true);
   });
 

--- a/src/lib/overlayRaster.ts
+++ b/src/lib/overlayRaster.ts
@@ -1,6 +1,10 @@
 import { classifyPassFailState, computeSourceCentricRxMetrics } from "./passFailState";
 import { STANDARD_SITE_RADIO } from "./linkRadio";
-import { buildCoverageGridPoints, computeCoverageGridDimensions } from "./coverage";
+import {
+  buildCoverageGridPoints,
+  computeCoverageGridDimensions,
+  type CoverageContributorEvaluator,
+} from "./coverage";
 import { haversineDistanceKm } from "./geo";
 import { getPathLossDb } from "./rfModels";
 import type { Link, PropagationEnvironment, Site } from "../types/radio";
@@ -26,7 +30,7 @@ export type AdaptiveCoverageOverlayInput = {
   initialGridSize: number;
   mode: "heatmap" | "weakest" | "contours";
   rxTargetDbm: number;
-  evaluatePoint: (lat: number, lon: number) => { strongestDbm: number; weakestDbm: number };
+  contributors: readonly CoverageContributorEvaluator[];
   pointMask?: (lat: number, lon: number) => boolean;
   context?: OverlayTaskContext;
   adaptive?: boolean;
@@ -136,7 +140,6 @@ type CoverageMetricCache = {
   height: number;
   strongestDbm: Float32Array;
   weakestDbm: Float32Array;
-  evaluated: Uint8Array;
 };
 
 type RelayMetricCache = {
@@ -293,8 +296,17 @@ const partitionRasterBlocks = (
   bounds: TerrainBounds,
 ): RasterBlock[] => {
   const dimensions = computeCoverageGridDimensions(gridSize, bounds);
-  const rowPartitions = Math.max(1, Math.min(height, dimensions.rows));
-  const colPartitions = Math.max(1, Math.min(width, dimensions.cols));
+  return partitionRasterBlocksByCount(width, height, dimensions.rows, dimensions.cols);
+};
+
+const partitionRasterBlocksByCount = (
+  width: number,
+  height: number,
+  requestedRows: number,
+  requestedCols: number,
+): RasterBlock[] => {
+  const rowPartitions = Math.max(1, Math.min(height, requestedRows));
+  const colPartitions = Math.max(1, Math.min(width, requestedCols));
   const blocks: RasterBlock[] = [];
   for (let row = 0; row < rowPartitions; row += 1) {
     const y0 = Math.floor((row * height) / rowPartitions);
@@ -306,6 +318,18 @@ const partitionRasterBlocks = (
     }
   }
   return blocks;
+};
+
+const partitionAdaptiveCoverageBlocks = (
+  width: number,
+  height: number,
+  seedGridSize: number,
+): RasterBlock[] => {
+  const targetBlocks = Math.max(16, Math.round(seedGridSize * seedGridSize));
+  const aspect = Math.max(0.2, Math.min(5, width / Math.max(1, height)));
+  const cols = Math.max(2, Math.round(Math.sqrt(targetBlocks * aspect)));
+  const rows = Math.max(2, Math.round(targetBlocks / cols));
+  return partitionRasterBlocksByCount(width, height, rows, cols);
 };
 
 const splitRasterBlock = (block: RasterBlock): RasterBlock[] => {
@@ -646,7 +670,7 @@ const computeDenseCoverageRxTargetScale = (
   values: Float32Array,
   rxTargetDbm: number,
 ): CoverageRxTargetScale => {
-  const stride = Math.max(1, Math.floor(values.length / 20_000));
+  const stride = Math.max(1, Math.floor(values.length / 1_024));
   const finiteValues: number[] = [];
   for (let index = 0; index < values.length; index += stride) {
     const value = values[index];
@@ -677,104 +701,114 @@ const computeDensePositivePercentile = (values: Float32Array, ratio: number): nu
 export const buildAdaptiveCoverageOverlayPixelsAsync = async (
   input: AdaptiveCoverageOverlayInput,
 ): Promise<OverlayRasterPixels | null> => {
-  const { bounds, dimensions, initialGridSize, mode, rxTargetDbm, evaluatePoint, pointMask, context } = input;
+  const { bounds, dimensions, initialGridSize, mode, rxTargetDbm, contributors, pointMask, context } = input;
   const width = dimensions.width;
   const height = dimensions.height;
   const totalPixels = width * height;
-  if (totalPixels <= 0) return null;
+  if (totalPixels <= 0 || contributors.length === 0) return null;
   const { latByRow, lonByCol } = precomputeGridAxes(bounds, dimensions);
   const metricCacheKey = input.analysisCacheKey ? `${input.analysisCacheKey}|${width}x${height}` : "";
   const cachedMetrics = metricCacheKey ? coverageMetricCache.get(metricCacheKey) : undefined;
+  const reuseCachedMetrics = cachedMetrics?.width === width && cachedMetrics.height === height;
   const metricCache =
-    cachedMetrics?.width === width && cachedMetrics.height === height
+    reuseCachedMetrics
       ? cachedMetrics
       : {
           width,
           height,
-          strongestDbm: new Float32Array(totalPixels).fill(Number.NaN),
-          weakestDbm: new Float32Array(totalPixels).fill(Number.NaN),
-          evaluated: new Uint8Array(totalPixels),
+          strongestDbm: new Float32Array(totalPixels).fill(Number.NEGATIVE_INFINITY),
+          weakestDbm: new Float32Array(totalPixels).fill(Number.POSITIVE_INFINITY),
         };
   let evaluatedPaths = 0;
-  const analysisContext = contextForProgressRange(context, 0, 90);
   const colorContext = contextForProgressRange(context, 90, 100);
-
-  const evaluate = (index: number): { strongestDbm: number; weakestDbm: number } => {
-    if (!metricCache.evaluated[index]) {
-      metricCache.evaluated[index] = 1;
-      const y = Math.floor(index / width);
-      const x = index - y * width;
-      const lat = latByRow[y];
-      const lon = lonByCol[x];
-      if (!pointMask || pointMask(lat, lon)) {
-        const value = evaluatePoint(lat, lon);
-        metricCache.strongestDbm[index] = value.strongestDbm;
-        metricCache.weakestDbm[index] = value.weakestDbm;
-        evaluatedPaths += 1;
-      }
-    }
-    return {
-      strongestDbm: metricCache.strongestDbm[index],
-      weakestDbm: metricCache.weakestDbm[index],
-    };
-  };
-
+  const adaptiveSeedGridSize = Math.max(4, Math.round(initialGridSize / 4));
   let refinedBlocks = 0;
-  let filledPixels = totalPixels;
-  if (input.adaptive === false) {
-    await runCooperativeLoop(totalPixels, evaluate, analysisContext);
-  } else {
-    const result = await runAdaptiveBlockQueue(
-      partitionRasterBlocks(width, height, initialGridSize, bounds),
-      totalPixels,
-      (block) => {
-        const area = rasterBlockArea(block);
-        const sampleIndices = passFailSampleIndicesForRasterBlock(block, width);
-        const samples = sampleIndices.map((index) => ({ index, ...evaluate(index) }));
-        const finiteSamples = samples.filter(
-          (sample) => Number.isFinite(sample.strongestDbm) && Number.isFinite(sample.weakestDbm),
-        );
-        if (area === 1 || finiteSamples.length === 0) return null;
-        if (finiteSamples.length !== samples.length) return splitRasterBlock(block);
-
-        const xLast = block.x1 - 1;
-        const yLast = block.y1 - 1;
-        const cornerIndices = [
-          block.y0 * width + block.x0,
-          block.y0 * width + xLast,
-          yLast * width + block.x0,
-          yLast * width + xLast,
-        ];
-        const corners = cornerIndices.map(evaluate);
-        const predict = (index: number, field: "strongestDbm" | "weakestDbm"): number => {
+  const filledPixels = totalPixels;
+  if (!reuseCachedMetrics) {
+    for (let contributorIndex = 0; contributorIndex < contributors.length; contributorIndex += 1) {
+      const contributor = contributors[contributorIndex];
+      const surface = new Float32Array(totalPixels).fill(Number.NaN);
+      const evaluated = new Uint8Array(totalPixels);
+      const analysisContext = contextForProgressRange(
+        context,
+        (contributorIndex / contributors.length) * 90,
+        ((contributorIndex + 1) / contributors.length) * 90,
+      );
+      const evaluate = (index: number): number => {
+        if (!evaluated[index]) {
+          evaluated[index] = 1;
           const y = Math.floor(index / width);
           const x = index - y * width;
-          const tx = xLast === block.x0 ? 0 : (x - block.x0) / (xLast - block.x0);
-          const ty = yLast === block.y0 ? 0 : (y - block.y0) / (yLast - block.y0);
-          const top = corners[0][field] + (corners[1][field] - corners[0][field]) * tx;
-          const bottom = corners[2][field] + (corners[3][field] - corners[2][field]) * tx;
-          return top + (bottom - top) * ty;
-        };
-        const stable = finiteSamples.every(
-          (sample) =>
-            Math.abs(sample.strongestDbm - predict(sample.index, "strongestDbm")) <= 0.75 &&
-            Math.abs(sample.weakestDbm - predict(sample.index, "weakestDbm")) <= 0.75,
-        );
-        if (!stable) return splitRasterBlock(block);
-
-        for (let y = block.y0; y < block.y1; y += 1) {
-          for (let x = block.x0; x < block.x1; x += 1) {
-            const index = y * width + x;
-            metricCache.strongestDbm[index] = predict(index, "strongestDbm");
-            metricCache.weakestDbm[index] = predict(index, "weakestDbm");
+          const lat = latByRow[y];
+          const lon = lonByCol[x];
+          if (!pointMask || pointMask(lat, lon)) {
+            surface[index] = contributor.evaluatePoint(lat, lon);
+            evaluatedPaths += 1;
           }
         }
-        return null;
-      },
-      analysisContext,
-    );
-    refinedBlocks = result.refinedBlocks;
-    filledPixels = result.filledPixels;
+        return surface[index];
+      };
+
+      if (input.adaptive === false) {
+        await runCooperativeLoop(totalPixels, evaluate, analysisContext);
+      } else {
+        const result = await runAdaptiveBlockQueue(
+          partitionAdaptiveCoverageBlocks(width, height, adaptiveSeedGridSize),
+          totalPixels,
+          (block) => {
+            const area = rasterBlockArea(block);
+            const sampleIndices = passFailSampleIndicesForRasterBlock(block, width);
+            const finiteSamples = sampleIndices
+              .map((index) => ({ index, valueDbm: evaluate(index) }))
+              .filter((sample) => Number.isFinite(sample.valueDbm));
+            if (area === 1 || finiteSamples.length === 0) return null;
+            if (finiteSamples.length !== sampleIndices.length) return splitRasterBlock(block);
+
+            const xLast = block.x1 - 1;
+            const yLast = block.y1 - 1;
+            const cornerValues = [
+              evaluate(block.y0 * width + block.x0),
+              evaluate(block.y0 * width + xLast),
+              evaluate(yLast * width + block.x0),
+              evaluate(yLast * width + xLast),
+            ];
+            const predict = (index: number): number => {
+              const y = Math.floor(index / width);
+              const x = index - y * width;
+              const tx = xLast === block.x0 ? 0 : (x - block.x0) / (xLast - block.x0);
+              const ty = yLast === block.y0 ? 0 : (y - block.y0) / (yLast - block.y0);
+              const top = cornerValues[0] + (cornerValues[1] - cornerValues[0]) * tx;
+              const bottom = cornerValues[2] + (cornerValues[3] - cornerValues[2]) * tx;
+              return top + (bottom - top) * ty;
+            };
+            if (finiteSamples.some((sample) => Math.abs(sample.valueDbm - predict(sample.index)) > 0.75)) {
+              return splitRasterBlock(block);
+            }
+
+            for (let y = block.y0; y < block.y1; y += 1) {
+              for (let x = block.x0; x < block.x1; x += 1) {
+                const index = y * width + x;
+                surface[index] = predict(index);
+              }
+            }
+            return null;
+          },
+          analysisContext,
+        );
+        refinedBlocks += result.refinedBlocks;
+      }
+
+      for (let index = 0; index < totalPixels; index += 1) {
+        const valueDbm = surface[index];
+        if (!Number.isFinite(valueDbm)) continue;
+        metricCache.strongestDbm[index] = Math.max(metricCache.strongestDbm[index], valueDbm);
+        metricCache.weakestDbm[index] = Math.min(metricCache.weakestDbm[index], valueDbm);
+      }
+    }
+    for (let index = 0; index < totalPixels; index += 1) {
+      if (!Number.isFinite(metricCache.strongestDbm[index])) metricCache.strongestDbm[index] = Number.NaN;
+      if (!Number.isFinite(metricCache.weakestDbm[index])) metricCache.weakestDbm[index] = Number.NaN;
+    }
   }
   if (metricCacheKey) coverageMetricCache.set(metricCacheKey, metricCache);
 
@@ -1466,6 +1500,7 @@ export const buildMeshExtensionOverlayPixelsAsync = async (
   const coverageGridSize = resolveMeshExtensionCoverageGridSize(input.coverageGridSize ?? candidateGridSize);
   const coveragePoints = buildCoverageGridPoints(coverageGridSize, input.bounds);
   const coverageDimensions = computeCoverageGridDimensions(coverageGridSize, input.bounds);
+  const candidateDimensions = computeCoverageGridDimensions(candidateGridSize, input.bounds);
   const profile = deriveMeshExtensionCandidateProfile(input.selectedSites);
   const terrainSamples = Math.max(16, Math.round(input.terrainSamples));
   const thresholdBeforeEnvironmentDbm = input.rxTargetDbm + input.environmentLossDb;
@@ -1519,10 +1554,10 @@ export const buildMeshExtensionOverlayPixelsAsync = async (
   const uncoveredAreaPrefix = buildAreaPrefixSum(uncoveredAreaByTarget, coverageDimensions);
   const adaptiveBlocks = buildAdaptiveGridBlocks(coverageDimensions);
 
-  const width = input.dimensions.width;
-  const height = input.dimensions.height;
+  const width = candidateDimensions.cols;
+  const height = candidateDimensions.rows;
   const totalCandidates = width * height;
-  const { latByRow, lonByCol } = precomputeGridAxes(input.bounds, input.dimensions);
+  const { latByRow, lonByCol } = precomputeGridAxes(input.bounds, { width, height });
   const connectivityDbm = new Float32Array(totalCandidates).fill(Number.NaN);
   const newlyCoveredAreaKm2 = new Float32Array(totalCandidates).fill(Number.NaN);
   const candidateEvaluated = new Uint8Array(totalCandidates);
@@ -1541,7 +1576,6 @@ export const buildMeshExtensionOverlayPixelsAsync = async (
     const x = candidateIndex - y * width;
     const lat = latByRow[y];
     const lon = lonByCol[x];
-    if (input.pointMask && !input.pointMask(lat, lon)) return;
     const ground = input.terrainSampler(lat, lon);
     if (ground === null) return;
     const candidate = siteFromProfile(`__mesh_extension_candidate_${candidateIndex}__`, lat, lon, ground, profile);
@@ -1701,19 +1735,44 @@ export const buildMeshExtensionOverlayPixelsAsync = async (
   if (!hasFiniteCandidate) return null;
   const maxAreaKm2 = computeDensePositivePercentile(newlyCoveredAreaKm2, 0.95);
   const connectivityScale = computeDenseCoverageRxTargetScale(connectivityDbm, input.rxTargetDbm);
-  const pixels = new Uint8ClampedArray(totalCandidates * 4);
+  const outputWidth = input.dimensions.width;
+  const outputHeight = input.dimensions.height;
+  const outputPixels = outputWidth * outputHeight;
+  const pixels = new Uint8ClampedArray(outputPixels * 4);
+  const { latByRow: outputLatByRow, lonByCol: outputLonByCol } = precomputeGridAxes(
+    input.bounds,
+    input.dimensions,
+  );
+  const interpolateCandidateValue = (values: Float32Array, x: number, y: number): number => {
+    const sourceX = outputWidth <= 1 ? 0 : (x / (outputWidth - 1)) * (width - 1);
+    const sourceY = outputHeight <= 1 ? 0 : (y / (outputHeight - 1)) * (height - 1);
+    const x0 = Math.floor(sourceX);
+    const y0 = Math.floor(sourceY);
+    const x1 = Math.min(width - 1, x0 + 1);
+    const y1 = Math.min(height - 1, y0 + 1);
+    const tx = sourceX - x0;
+    const ty = sourceY - y0;
+    const q00 = values[y0 * width + x0];
+    const q10 = values[y0 * width + x1];
+    const q01 = values[y1 * width + x0];
+    const q11 = values[y1 * width + x1];
+    if (![q00, q10, q01, q11].every(Number.isFinite)) return Number.NaN;
+    const top = q00 + (q10 - q00) * tx;
+    const bottom = q01 + (q11 - q01) * tx;
+    return top + (bottom - top) * ty;
+  };
 
   await runCooperativeLoop(
-    totalCandidates,
+    outputPixels,
     (index) => {
-      const y = Math.floor(index / width);
-      const x = index - y * width;
-      const lat = latByRow[y];
-      const lon = lonByCol[x];
+      const y = Math.floor(index / outputWidth);
+      const x = index - y * outputWidth;
+      const lat = outputLatByRow[y];
+      const lon = outputLonByCol[x];
       if (input.pointMask && !input.pointMask(lat, lon)) return;
       if (input.terrainSampler(lat, lon) === null) return;
-      const area = newlyCoveredAreaKm2[index];
-      const connectivity = connectivityDbm[index];
+      const area = interpolateCandidateValue(newlyCoveredAreaKm2, x, y);
+      const connectivity = interpolateCandidateValue(connectivityDbm, x, y);
       if (!Number.isFinite(area) || !Number.isFinite(connectivity)) return;
       const [r, g, b] = meshExtensionColorForArea(area, maxAreaKm2);
       const px = index * 4;
@@ -1726,8 +1785,8 @@ export const buildMeshExtensionOverlayPixelsAsync = async (
   );
 
   return {
-    width: input.dimensions.width,
-    height: input.dimensions.height,
+    width: outputWidth,
+    height: outputHeight,
     pixels,
     coordinates: overlayCoordinates(input.bounds),
     minDbm: connectivityScale.min,

--- a/src/store/coverageStore.ts
+++ b/src/store/coverageStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import {
   computeCalibratedOverlayGridDimensions,
+  computeCoverageGridDimensions,
   resolveCanonicalOverlayResolutionScale,
   type CalibratedOverlayGridMode,
 } from "../lib/coverage";
@@ -388,12 +389,14 @@ const runCoverageComputation = async (
     const boundsForCount = simulationAreaBoundsForSites(countSites, { overlayRadiusKm: effectiveOverlayRadiusKm });
     const calibratedMode = normalizeCalibratedOverlayGridMode(inputs.mapOverlayMode);
     const sampleCount = boundsForCount
-      ? computeCalibratedOverlayGridDimensions(
-          gridSize,
-          boundsForCount,
-          calibratedMode,
-          resolveCanonicalOverlayResolutionScale(boundsForCount),
-        ).totalSamples
+      ? calibratedMode === "mesh-extension"
+        ? computeCoverageGridDimensions(gridSize, boundsForCount).totalSamples
+        : computeCalibratedOverlayGridDimensions(
+            gridSize,
+            boundsForCount,
+            calibratedMode,
+            resolveCanonicalOverlayResolutionScale(boundsForCount),
+          ).totalSamples
       : 0;
     set({
       simulationProgress: 0,


### PR DESCRIPTION
## Summary

- compute Heatmap, Weakest Site, and Contours from independent adaptive per-Site surfaces before combining them
- keep the shared logical display grid and honest sample labels while reducing redundant RF work
- restore Mesh Extension 1x RF analysis to the aspect-adjusted 24-grid budget and interpolate it onto the display raster
- cache combined coverage fields for fast switches between related overlay modes

## Accuracy and performance

- multi-Site adaptive-vs-exact median error <= 0.25 dB and p99 error <= 1 dB
- four-Site 1x Heatmap benchmark remains within 1.1x of the production-style reference median
- Mesh Extension returns the full display raster while performing RF candidate analysis only at its base grid budget

## Validation

- `npm test` (135 files, 792 tests)
- `npm run build`
- focused ESLint for changed algorithm, store, and test files
- `npm run dev:check`

Repository-wide `npm run lint` remains blocked by pre-existing source findings and files under `.claude/worktrees`; this change adds no focused lint finding.

Closes #998
