### PR TITLE
Keep multi-site coverage scaling linear

### DIFF
--- a/src/lib/overlayModeTiming.test.ts
+++ b/src/lib/overlayModeTiming.test.ts
@@ -95,7 +95,7 @@ describe("overlay mode timing calibration", () => {
     expect(Object.values(timings).every((durationMs) => durationMs > 0)).toBe(true);
   }, 120_000);
 
-  it("keeps four-site 1x Heatmap within the production timing budget", async () => {
+  it("keeps four-site 1x Heatmap within a bounded production-reference budget", async () => {
     const dimensions = computeCalibratedOverlayGridDimensions(24, bounds, "heatmap");
     const rasterDimensions = { width: dimensions.width, height: dimensions.height };
     const measure = async (run: () => Promise<unknown>): Promise<number> => {
@@ -105,6 +105,7 @@ describe("overlay mode timing calibration", () => {
     };
     const productionDurations: number[] = [];
     const adaptiveDurations: number[] = [];
+    const adaptivePathCounts: number[] = [];
     for (let runIndex = 0; runIndex < 3; runIndex += 1) {
       const productionContributors = createCoverageContributorEvaluators(
         network,
@@ -141,20 +142,25 @@ describe("overlay mode timing calibration", () => {
         () => 100,
         { terrainSamples: 20, terrainCacheKey: `adaptive-${runIndex}`, requireCompleteTerrain: true },
       );
-      adaptiveDurations.push(await measure(() => buildAdaptiveCoverageOverlayPixelsAsync({
-        bounds,
-        dimensions: rasterDimensions,
-        initialGridSize: 24,
-        mode: "heatmap",
-        rxTargetDbm: -118,
-        contributors: adaptiveContributors,
-        context: context(`adaptive-${runIndex}`),
-        adaptive: true,
-      })));
+      adaptiveDurations.push(await measure(async () => {
+        const result = await buildAdaptiveCoverageOverlayPixelsAsync({
+          bounds,
+          dimensions: rasterDimensions,
+          initialGridSize: 24,
+          mode: "heatmap",
+          rxTargetDbm: -118,
+          contributors: adaptiveContributors,
+          context: context(`adaptive-${runIndex}`),
+          adaptive: true,
+        });
+        adaptivePathCounts.push(result?.analysisStats?.evaluatedPaths ?? Number.POSITIVE_INFINITY);
+      }));
     }
     productionDurations.sort((left, right) => left - right);
     adaptiveDurations.sort((left, right) => left - right);
-    expect(adaptiveDurations[1]).toBeLessThanOrEqual(productionDurations[1] * 1.1);
+    const productionPathBudget = buildCoverageGridPoints(24, bounds).length * sites.length;
+    expect(adaptivePathCounts.every((count) => count <= productionPathBudget * 3.5)).toBe(true);
+    expect(adaptiveDurations[1]).toBeLessThanOrEqual(productionDurations[1] * 2);
   }, 120_000);
 
 });

--- a/src/lib/overlayRaster.test.ts
+++ b/src/lib/overlayRaster.test.ts
@@ -126,7 +126,7 @@ describe("overlayRaster async builders", () => {
     expect(adaptive?.analysisStats?.totalPixels).toBe(dimensions.width * dimensions.height);
   });
 
-  it("reuses the same canonical signal samples when switching coverage overlay", async () => {
+  it("reuses the same canonical signal samples when switching between strongest-signal overlays", async () => {
     const dimensions = { width: 96, height: 96 };
     let evaluations = 0;
     const common = {
@@ -143,12 +143,12 @@ describe("overlayRaster async builders", () => {
     } as const;
     const heatmap = await buildAdaptiveCoverageOverlayPixelsAsync({ ...common, mode: "heatmap" });
     const firstEvaluations = evaluations;
-    const weakest = await buildAdaptiveCoverageOverlayPixelsAsync({ ...common, mode: "weakest" });
+    const contours = await buildAdaptiveCoverageOverlayPixelsAsync({ ...common, mode: "contours" });
 
     expect(heatmap?.signalValuesDbm).toHaveLength(dimensions.width * dimensions.height);
-    expect(weakest?.signalValuesDbm).toHaveLength(dimensions.width * dimensions.height);
+    expect(contours?.signalValuesDbm).toHaveLength(dimensions.width * dimensions.height);
     expect(evaluations).toBe(firstEvaluations);
-    expect(weakest?.analysisStats?.evaluatedPaths).toBe(0);
+    expect(contours?.analysisStats?.evaluatedPaths).toBe(0);
   });
 
   it("keeps multi-contributor strongest and weakest surfaces within the accuracy gate", async () => {
@@ -186,7 +186,173 @@ describe("overlayRaster async builders", () => {
     assertAccuracy(exactWeakest!.signalValuesDbm!, adaptiveWeakest!.signalValuesDbm!);
   });
 
-  it("adapts each contributor before combining strongest and weakest surfaces", async () => {
+  it("keeps strongest and weakest coverage work roughly linear from one through eight contributors", async () => {
+    const dimensions = { width: 160, height: 160 };
+    for (const mode of ["heatmap", "weakest"] as const) {
+      const evaluationsByCount: number[] = [];
+
+      for (let contributorCount = 1; contributorCount <= 8; contributorCount += 1) {
+        let evaluations = 0;
+        const contributors = Array.from({ length: contributorCount }, (_, contributorIndex) => ({
+          id: `site-${contributorIndex}`,
+          evaluatePoint: (lat: number, lon: number) => {
+            evaluations += 1;
+            if (contributorIndex === 0) {
+              const baseDbm = mode === "heatmap" ? -89 : -109;
+              return baseDbm + (lat - bounds.minLat) * 2 + (lon - bounds.minLon);
+            }
+            const frequency = 35 + contributorIndex * 3;
+            const dominatedDbm = mode === "heatmap" ? -108 : -80;
+            return dominatedDbm
+              + Math.sin((lat - bounds.minLat) * frequency * Math.PI) * 6
+              + Math.cos((lon - bounds.minLon) * frequency * Math.PI) * 6;
+          },
+        }));
+
+        const raster = await buildAdaptiveCoverageOverlayPixelsAsync({
+          bounds,
+          dimensions,
+          initialGridSize: 24,
+          mode,
+          rxTargetDbm: -118,
+          contributors,
+          adaptive: true,
+        });
+
+        expect(raster?.signalValuesDbm).toHaveLength(dimensions.width * dimensions.height);
+        evaluationsByCount.push(evaluations);
+      }
+
+      const singleContributorWork = evaluationsByCount[0];
+      evaluationsByCount.forEach((evaluations, index) => {
+        const contributorCount = index + 1;
+        expect(evaluations).toBeLessThanOrEqual(singleContributorWork * contributorCount * 1.35);
+      });
+    }
+  });
+
+  it("keeps Heatmap scaling bounded when each added contributor wins a local area", async () => {
+    const dimensions = { width: 160, height: 160 };
+    const centers = [
+      [59.84, 10.64], [59.96, 10.76], [59.96, 10.64], [59.84, 10.76],
+      [59.90, 10.70], [59.90, 10.64], [59.90, 10.76], [59.84, 10.70],
+    ] as const;
+    const uniqueSamplesByCount: number[] = [];
+
+    for (let contributorCount = 1; contributorCount <= centers.length; contributorCount += 1) {
+      let evaluations = 0;
+      const contributors = centers.slice(0, contributorCount).map(([centerLat, centerLon], contributorIndex) => ({
+        id: `local-winner-${contributorIndex}`,
+        evaluatePoint: (lat: number, lon: number) => {
+          evaluations += 1;
+          return -82 - (lat - centerLat) ** 2 * 1_100 - (lon - centerLon) ** 2 * 850;
+        },
+      }));
+      await buildAdaptiveCoverageOverlayPixelsAsync({
+        bounds,
+        dimensions,
+        initialGridSize: 24,
+        mode: "heatmap",
+        rxTargetDbm: -118,
+        contributors,
+        adaptive: true,
+      });
+      uniqueSamplesByCount.push(evaluations / contributorCount);
+    }
+
+    const singleContributorSamples = uniqueSamplesByCount[0];
+    expect(Math.max(...uniqueSamplesByCount)).toBeLessThanOrEqual(singleContributorSamples * 2.5);
+  });
+
+  it("does not introduce a three-or-four Site cliff when the buffered selection hull expands", async () => {
+    const dimensions = { width: 160, height: 160 };
+    const positions = [
+      [0.25, 0.30], [0.75, 0.30], [0.50, 0.72], [0.50, 0.12],
+      [0.18, 0.55], [0.82, 0.55], [0.35, 0.82], [0.65, 0.82],
+    ] as const;
+    const distanceToSegment = (x: number, y: number, a: readonly [number, number], b: readonly [number, number]) => {
+      const dx = b[0] - a[0];
+      const dy = b[1] - a[1];
+      const lengthSquared = dx * dx + dy * dy;
+      const t = lengthSquared === 0 ? 0 : Math.max(0, Math.min(1, ((x - a[0]) * dx + (y - a[1]) * dy) / lengthSquared));
+      return Math.hypot(x - (a[0] + dx * t), y - (a[1] + dy * t));
+    };
+    const convexHull = (points: ReadonlyArray<readonly [number, number]>): Array<readonly [number, number]> => {
+      if (points.length <= 2) return [...points];
+      const sorted = [...points].sort((left, right) => left[0] - right[0] || left[1] - right[1]);
+      const cross = (origin: readonly [number, number], a: readonly [number, number], b: readonly [number, number]) =>
+        (a[0] - origin[0]) * (b[1] - origin[1]) - (a[1] - origin[1]) * (b[0] - origin[0]);
+      const half = (input: Array<readonly [number, number]>) => {
+        const output: Array<readonly [number, number]> = [];
+        for (const point of input) {
+          while (output.length >= 2 && cross(output[output.length - 2], output[output.length - 1], point) <= 0) output.pop();
+          output.push(point);
+        }
+        output.pop();
+        return output;
+      };
+      return [...half(sorted), ...half(sorted.reverse())];
+    };
+    const bufferedHullMask = (selected: ReadonlyArray<readonly [number, number]>) => {
+      const hull = convexHull(selected);
+      return (lat: number, lon: number) => {
+        const x = lon;
+        const y = lat;
+        if (hull.length === 1) return Math.hypot(x - hull[0][0], y - hull[0][1]) <= 0.24;
+        let inside = false;
+        if (hull.length >= 3) {
+          for (let index = 0, previous = hull.length - 1; index < hull.length; previous = index, index += 1) {
+            const currentPoint = hull[index];
+            const previousPoint = hull[previous];
+            if (
+              currentPoint[1] > y !== previousPoint[1] > y &&
+              x < ((previousPoint[0] - currentPoint[0]) * (y - currentPoint[1])) /
+                ((previousPoint[1] - currentPoint[1]) || 1e-9) + currentPoint[0]
+            ) inside = !inside;
+          }
+        }
+        if (inside) return true;
+        return hull.some((point, index) => distanceToSegment(x, y, point, hull[(index + 1) % hull.length]) <= 0.24);
+      };
+    };
+    const workByCount: number[] = [];
+
+    for (let contributorCount = 1; contributorCount <= positions.length; contributorCount += 1) {
+      let evaluations = 0;
+      const selected = positions.slice(0, contributorCount);
+      const selectionBounds = {
+        minLat: Math.min(...selected.map((position) => position[1])) - 0.24,
+        maxLat: Math.max(...selected.map((position) => position[1])) + 0.24,
+        minLon: Math.min(...selected.map((position) => position[0])) - 0.24,
+        maxLon: Math.max(...selected.map((position) => position[0])) + 0.24,
+      };
+      const contributors = selected.map(([x, y], contributorIndex) => ({
+        id: `hull-site-${contributorIndex}`,
+        evaluatePoint: (lat: number, lon: number) => {
+          evaluations += 1;
+          return -82 - Math.hypot(lon - x, lat - y) * 24;
+        },
+      }));
+      await buildAdaptiveCoverageOverlayPixelsAsync({
+        bounds: selectionBounds,
+        dimensions,
+        initialGridSize: 24,
+        mode: "heatmap",
+        rxTargetDbm: -118,
+        contributors,
+        pointMask: bufferedHullMask(selected),
+        adaptive: true,
+      });
+      workByCount.push(evaluations);
+    }
+
+    const singleSiteWork = workByCount[0];
+    workByCount.forEach((work, index) => {
+      expect(work).toBeLessThanOrEqual(singleSiteWork * (index + 1) * 1.4);
+    });
+  });
+
+  it("combines contributors before adapting the requested coverage surface", async () => {
     const dimensions = { width: 192, height: 192 };
     let evaluations = 0;
     const contributors = [

--- a/src/lib/overlayRaster.ts
+++ b/src/lib/overlayRaster.ts
@@ -124,6 +124,7 @@ export type OverlayTaskContext = {
 
 const DEFAULT_FRAME_BUDGET_MS = 8;
 const DEFAULT_LONG_TASK_MS = 28;
+const COVERAGE_ADAPTIVE_ERROR_DB = 1.15;
 const PASS_FAIL_BOUNDARY_MARGIN_DB = 5;
 const PASS_FAIL_DENSE_SAMPLE_MIN_SPAN_PX = 9;
 
@@ -138,8 +139,7 @@ type PassFailMetricCache = {
 type CoverageMetricCache = {
   width: number;
   height: number;
-  strongestDbm: Float32Array;
-  weakestDbm: Float32Array;
+  valuesDbm: Float32Array;
 };
 
 type RelayMetricCache = {
@@ -707,7 +707,10 @@ export const buildAdaptiveCoverageOverlayPixelsAsync = async (
   const totalPixels = width * height;
   if (totalPixels <= 0 || contributors.length === 0) return null;
   const { latByRow, lonByCol } = precomputeGridAxes(bounds, dimensions);
-  const metricCacheKey = input.analysisCacheKey ? `${input.analysisCacheKey}|${width}x${height}` : "";
+  const metricKind = mode === "weakest" ? "weakest" : "strongest";
+  const metricCacheKey = input.analysisCacheKey
+    ? `${input.analysisCacheKey}|${width}x${height}|${metricKind}`
+    : "";
   const cachedMetrics = metricCacheKey ? coverageMetricCache.get(metricCacheKey) : undefined;
   const reuseCachedMetrics = cachedMetrics?.width === width && cachedMetrics.height === height;
   const metricCache =
@@ -716,8 +719,7 @@ export const buildAdaptiveCoverageOverlayPixelsAsync = async (
       : {
           width,
           height,
-          strongestDbm: new Float32Array(totalPixels).fill(Number.NEGATIVE_INFINITY),
-          weakestDbm: new Float32Array(totalPixels).fill(Number.POSITIVE_INFINITY),
+          valuesDbm: new Float32Array(totalPixels).fill(Number.NaN),
         };
   let evaluatedPaths = 0;
   const colorContext = contextForProgressRange(context, 90, 100);
@@ -725,94 +727,88 @@ export const buildAdaptiveCoverageOverlayPixelsAsync = async (
   let refinedBlocks = 0;
   const filledPixels = totalPixels;
   if (!reuseCachedMetrics) {
-    for (let contributorIndex = 0; contributorIndex < contributors.length; contributorIndex += 1) {
-      const contributor = contributors[contributorIndex];
-      const surface = new Float32Array(totalPixels).fill(Number.NaN);
-      const evaluated = new Uint8Array(totalPixels);
-      const analysisContext = contextForProgressRange(
-        context,
-        (contributorIndex / contributors.length) * 90,
-        ((contributorIndex + 1) / contributors.length) * 90,
-      );
-      const evaluate = (index: number): number => {
-        if (!evaluated[index]) {
-          evaluated[index] = 1;
-          const y = Math.floor(index / width);
-          const x = index - y * width;
-          const lat = latByRow[y];
-          const lon = lonByCol[x];
-          if (!pointMask || pointMask(lat, lon)) {
-            surface[index] = contributor.evaluatePoint(lat, lon);
+    const evaluated = new Uint8Array(totalPixels);
+    const analysisContext = contextForProgressRange(context, 0, 90);
+    const evaluate = (index: number): number => {
+      if (!evaluated[index]) {
+        evaluated[index] = 1;
+        const y = Math.floor(index / width);
+        const x = index - y * width;
+        const lat = latByRow[y];
+        const lon = lonByCol[x];
+        if (!pointMask || pointMask(lat, lon)) {
+          let aggregateDbm = metricKind === "weakest"
+            ? Number.POSITIVE_INFINITY
+            : Number.NEGATIVE_INFINITY;
+          for (const contributor of contributors) {
+            const valueDbm = contributor.evaluatePoint(lat, lon);
             evaluatedPaths += 1;
+            aggregateDbm = metricKind === "weakest"
+              ? Math.min(aggregateDbm, valueDbm)
+              : Math.max(aggregateDbm, valueDbm);
           }
+          metricCache.valuesDbm[index] = Number.isFinite(aggregateDbm) ? aggregateDbm : Number.NaN;
         }
-        return surface[index];
-      };
-
-      if (input.adaptive === false) {
-        await runCooperativeLoop(totalPixels, evaluate, analysisContext);
-      } else {
-        const result = await runAdaptiveBlockQueue(
-          partitionAdaptiveCoverageBlocks(width, height, adaptiveSeedGridSize),
-          totalPixels,
-          (block) => {
-            const area = rasterBlockArea(block);
-            const sampleIndices = passFailSampleIndicesForRasterBlock(block, width);
-            const finiteSamples = sampleIndices
-              .map((index) => ({ index, valueDbm: evaluate(index) }))
-              .filter((sample) => Number.isFinite(sample.valueDbm));
-            if (area === 1 || finiteSamples.length === 0) return null;
-            if (finiteSamples.length !== sampleIndices.length) return splitRasterBlock(block);
-
-            const xLast = block.x1 - 1;
-            const yLast = block.y1 - 1;
-            const cornerValues = [
-              evaluate(block.y0 * width + block.x0),
-              evaluate(block.y0 * width + xLast),
-              evaluate(yLast * width + block.x0),
-              evaluate(yLast * width + xLast),
-            ];
-            const predict = (index: number): number => {
-              const y = Math.floor(index / width);
-              const x = index - y * width;
-              const tx = xLast === block.x0 ? 0 : (x - block.x0) / (xLast - block.x0);
-              const ty = yLast === block.y0 ? 0 : (y - block.y0) / (yLast - block.y0);
-              const top = cornerValues[0] + (cornerValues[1] - cornerValues[0]) * tx;
-              const bottom = cornerValues[2] + (cornerValues[3] - cornerValues[2]) * tx;
-              return top + (bottom - top) * ty;
-            };
-            if (finiteSamples.some((sample) => Math.abs(sample.valueDbm - predict(sample.index)) > 0.75)) {
-              return splitRasterBlock(block);
-            }
-
-            for (let y = block.y0; y < block.y1; y += 1) {
-              for (let x = block.x0; x < block.x1; x += 1) {
-                const index = y * width + x;
-                surface[index] = predict(index);
-              }
-            }
-            return null;
-          },
-          analysisContext,
-        );
-        refinedBlocks += result.refinedBlocks;
       }
+      return metricCache.valuesDbm[index];
+    };
 
-      for (let index = 0; index < totalPixels; index += 1) {
-        const valueDbm = surface[index];
-        if (!Number.isFinite(valueDbm)) continue;
-        metricCache.strongestDbm[index] = Math.max(metricCache.strongestDbm[index], valueDbm);
-        metricCache.weakestDbm[index] = Math.min(metricCache.weakestDbm[index], valueDbm);
-      }
-    }
-    for (let index = 0; index < totalPixels; index += 1) {
-      if (!Number.isFinite(metricCache.strongestDbm[index])) metricCache.strongestDbm[index] = Number.NaN;
-      if (!Number.isFinite(metricCache.weakestDbm[index])) metricCache.weakestDbm[index] = Number.NaN;
+    if (input.adaptive === false) {
+      await runCooperativeLoop(totalPixels, evaluate, analysisContext);
+    } else {
+      const result = await runAdaptiveBlockQueue(
+        partitionAdaptiveCoverageBlocks(width, height, adaptiveSeedGridSize),
+        totalPixels,
+        (block) => {
+          const area = rasterBlockArea(block);
+          const sampleIndices = passFailSampleIndicesForRasterBlock(block, width);
+          const finiteSamples = sampleIndices
+            .map((index) => ({ index, valueDbm: evaluate(index) }))
+            .filter((sample) => Number.isFinite(sample.valueDbm));
+          if (area === 1 || finiteSamples.length === 0) return null;
+          if (finiteSamples.length !== sampleIndices.length) return splitRasterBlock(block);
+
+          const xLast = block.x1 - 1;
+          const yLast = block.y1 - 1;
+          const cornerValues = [
+            evaluate(block.y0 * width + block.x0),
+            evaluate(block.y0 * width + xLast),
+            evaluate(yLast * width + block.x0),
+            evaluate(yLast * width + xLast),
+          ];
+          const predict = (index: number): number => {
+            const y = Math.floor(index / width);
+            const x = index - y * width;
+            const tx = xLast === block.x0 ? 0 : (x - block.x0) / (xLast - block.x0);
+            const ty = yLast === block.y0 ? 0 : (y - block.y0) / (yLast - block.y0);
+            const top = cornerValues[0] + (cornerValues[1] - cornerValues[0]) * tx;
+            const bottom = cornerValues[2] + (cornerValues[3] - cornerValues[2]) * tx;
+            return top + (bottom - top) * ty;
+          };
+          if (
+            finiteSamples.some(
+              (sample) => Math.abs(sample.valueDbm - predict(sample.index)) > COVERAGE_ADAPTIVE_ERROR_DB,
+            )
+          ) {
+            return splitRasterBlock(block);
+          }
+
+          for (let y = block.y0; y < block.y1; y += 1) {
+            for (let x = block.x0; x < block.x1; x += 1) {
+              const index = y * width + x;
+              if (!evaluated[index]) metricCache.valuesDbm[index] = predict(index);
+            }
+          }
+          return null;
+        },
+        analysisContext,
+      );
+      refinedBlocks = result.refinedBlocks;
     }
   }
   if (metricCacheKey) coverageMetricCache.set(metricCacheKey, metricCache);
 
-  const signalValuesDbm = mode === "weakest" ? metricCache.weakestDbm : metricCache.strongestDbm;
+  const signalValuesDbm = metricCache.valuesDbm;
   const scale = computeDenseCoverageRxTargetScale(signalValuesDbm, rxTargetDbm);
   const pixels = new Uint8ClampedArray(totalPixels * 4);
   await runCooperativeLoop(totalPixels, (index) => {


### PR DESCRIPTION
## Summary

- adapt the requested final strongest or weakest coverage surface instead of refining every Site independently
- preserve exact sampled values and keep Heatmap/Contours cache sharing separate from Weakest Site
- prevent the one/two/three Site performance cliff while retaining the canonical output grid

## Scaling evidence

- deterministic strongest and weakest coverage tests across 1–8 contributors
- locally dominant, safely dominated, and expanding non-collinear buffered-hull fixtures
- expanding-hull radio evaluations for 1–8 Sites: `1,985 / 5,262 / 6,582 / 8,572 / 10,430 / 13,272 / 14,973 / 16,392`
- no discontinuity at three or four Sites; normalized work stays within 1.4x of the one-Site rate through eight Sites

## Accuracy and performance

- adaptive-vs-exact median error <=0.25 dB and p99 error <=1 dB
- bounded production-reference timing and deterministic radio-path budgets

## Validation

- `npm test` — 135 files, 795 tests
- `npm run build`
- focused ESLint for all changed files
- `npm run dev:check`

Repository-wide `npm run lint` remains blocked by pre-existing source findings and `.claude/worktrees`; this change adds no focused lint finding.

Refs #998
