### PR TITLE
Halve smooth coverage resolution and fix terrain cache churn

### DIFF
--- a/src/components/MapView.overlayHandoff.test.tsx
+++ b/src/components/MapView.overlayHandoff.test.tsx
@@ -308,7 +308,8 @@ describe("MapView overlay handoff", () => {
 
     const resolutionSelect = screen.getByLabelText("Simulation Resolution") as HTMLSelectElement;
     const heatmapLabel = resolutionSelect.options[0].textContent ?? "";
-    expect(heatmapLabel).toMatch(/~\d+(?:\.\d+)?k grid points/u);
+    expect(heatmapLabel).toContain("158×158");
+    expect(heatmapLabel).toContain("~25k grid points");
     expect(heatmapLabel).not.toContain("samples");
 
     act(() => useAppStore.getState().setMapOverlayMode("mesh-extension"));

--- a/src/lib/coverage.test.ts
+++ b/src/lib/coverage.test.ts
@@ -6,6 +6,7 @@ import {
   computeCanonicalOverlayGridDimensions,
   computeCoverageGridDimensions,
   CoverageBuildCancelledError,
+  clearTerrainLossCache,
   createCoverageContributorEvaluators,
   resolveMeshExtensionCoverageBudgetGridSize,
   resolveOverlayGridWorkloadScale,
@@ -69,24 +70,29 @@ const NORMAL_GRID = 24;
 const HIGH_GRID = 42;
 
 describe("buildCoverage", () => {
-  it("keeps every area overlay on the full Pass/Fail logical grid", () => {
+  it("renders smooth coverage modes at half the Pass/Fail resolution per axis", () => {
     expect(resolveOverlayGridWorkloadScale("passfail", 2)).toBe(1);
     expect(resolveOverlayGridWorkloadScale("relay", 2)).toBe(1);
-    expect(resolveOverlayGridWorkloadScale("heatmap", 1)).toBe(1);
-    expect(resolveOverlayGridWorkloadScale("heatmap", 4)).toBe(1);
-    expect(resolveOverlayGridWorkloadScale("weakest", 4)).toBe(1);
-    expect(resolveOverlayGridWorkloadScale("contours", 4)).toBe(1);
+    expect(resolveOverlayGridWorkloadScale("heatmap", 1)).toBe(0.5);
+    expect(resolveOverlayGridWorkloadScale("heatmap", 4)).toBe(0.5);
+    expect(resolveOverlayGridWorkloadScale("weakest", 4)).toBe(0.5);
+    expect(resolveOverlayGridWorkloadScale("contours", 4)).toBe(0.5);
     expect(resolveOverlayGridWorkloadScale("mesh-extension", 2)).toBe(1);
     expect(resolveOverlayGridWorkloadScale("mesh-extension", 4)).toBe(1);
   });
 
-  it("returns the same honest logical grid size for Pass/Fail and coverage modes", () => {
-    const bounds = { minLat: 59.8, maxLat: 60, minLon: 10.6, maxLon: 10.8 };
+  it("turns a 317x317 Pass/Fail grid into a 158x158 smooth coverage grid", () => {
+    const bounds = { minLat: 59.8, maxLat: 60, minLon: 10.6, maxLon: 11.0 };
     const passFail = computeCalibratedOverlayGridDimensions(24, bounds, "passfail", 1, 2);
     const heatmap = computeCalibratedOverlayGridDimensions(24, bounds, "heatmap", 1, 4);
+    const weakest = computeCalibratedOverlayGridDimensions(24, bounds, "weakest", 1, 4);
+    const contours = computeCalibratedOverlayGridDimensions(24, bounds, "contours", 1, 4);
 
     expect(passFail).toEqual(computeCanonicalOverlayGridDimensions(24, bounds, 1));
-    expect(heatmap).toEqual(passFail);
+    expect(passFail).toMatchObject({ width: 317, height: 317 });
+    expect(heatmap).toMatchObject({ width: 158, height: 158, totalSamples: 24_964 });
+    expect(weakest).toEqual(heatmap);
+    expect(contours).toEqual(heatmap);
   });
 
   it("uses selected sites as coverage contributors and all sites for an empty selection", () => {
@@ -116,6 +122,34 @@ describe("buildCoverage", () => {
     expect(selectedEvaluators[0].evaluatePoint(59.95, 10.85)).toBe(
       singleMembershipEvaluators[0].evaluatePoint(59.95, 10.85),
     );
+  });
+
+  it("discards stale terrain-loss entries when the coverage selection scope changes", () => {
+    clearTerrainLossCache();
+    let terrainReads = 0;
+    const terrainSampler = () => {
+      terrainReads += 1;
+      return 120;
+    };
+    const createForScope = (terrainCacheKey: string) => createCoverageContributorEvaluators(
+      network,
+      [sites[0]],
+      systems,
+      defaultPropagationEnvironment(),
+      terrainSampler,
+      { terrainSamples: 20, terrainCacheKey, requireCompleteTerrain: true },
+    )[0];
+
+    createForScope("selection-one").evaluatePoint(59.95, 10.85);
+    terrainReads = 0;
+    createForScope("selection-one").evaluatePoint(59.95, 10.85);
+    expect(terrainReads).toBe(1);
+
+    createForScope("selection-two").evaluatePoint(59.96, 10.86);
+    terrainReads = 0;
+    createForScope("selection-one").evaluatePoint(59.95, 10.85);
+
+    expect(terrainReads).toBeGreaterThan(1);
   });
 
   it("keeps Mesh Extension's nested comparison grid at the selected resolution", () => {

--- a/src/lib/coverage.ts
+++ b/src/lib/coverage.ts
@@ -79,17 +79,16 @@ export type CalibratedOverlayGridMode =
   | "mesh-extension";
 
 /**
- * Every area overlay shares Pass/Fail's logical grid so the selected
- * resolution always means the same thing. Adaptive evaluation can still
- * reduce the number of expensive RF calculations underneath that grid.
+ * Smooth coverage surfaces render at half the Pass/Fail resolution per axis.
+ * Adaptive evaluation can still reduce the expensive RF calculations beneath
+ * each mode's honest logical output grid.
  */
 export const resolveOverlayGridWorkloadScale = (
   mode: CalibratedOverlayGridMode,
   participantCount = 1,
 ): number => {
-  void mode;
   void participantCount;
-  return 1;
+  return mode === "heatmap" || mode === "weakest" || mode === "contours" ? 0.5 : 1;
 };
 
 export const resolveMeshExtensionCoverageBudgetGridSize = (gridSize: number): number =>
@@ -181,6 +180,8 @@ const nUnitsToKFactor = (nUnits: number): number => {
 
 const TERRAIN_LOSS_CACHE_LIMIT = 100_000;
 const terrainLossMemo = new Map<string, number>();
+let terrainLossMemoScope = "";
+let terrainLossMemoScopeVersion = 0;
 
 const quantize = (value: number): string => value.toFixed(5);
 
@@ -217,16 +218,24 @@ const getMemoizedTerrainLoss = (
   const cached = terrainLossMemo.get(key);
   if (typeof cached === "number") return cached;
   const value = compute();
+  if (terrainLossMemo.size >= TERRAIN_LOSS_CACHE_LIMIT) return value;
   terrainLossMemo.set(key, value);
-  if (terrainLossMemo.size > TERRAIN_LOSS_CACHE_LIMIT) {
-    const oldest = terrainLossMemo.keys().next().value;
-    if (typeof oldest === "string") terrainLossMemo.delete(oldest);
-  }
   return value;
 };
 
 export const clearTerrainLossCache = (): void => {
   terrainLossMemo.clear();
+  terrainLossMemoScope = "";
+  terrainLossMemoScopeVersion += 1;
+};
+
+const prepareTerrainLossCacheScope = (scope: string): string => {
+  if (scope !== terrainLossMemoScope) {
+    terrainLossMemo.clear();
+    terrainLossMemoScope = scope;
+    terrainLossMemoScopeVersion += 1;
+  }
+  return `coverage-${terrainLossMemoScopeVersion}`;
 };
 
 const evalRx = (
@@ -349,6 +358,7 @@ export const createCoverageContributorEvaluators = (
   terrainSampler?: (coordinates: Coordinates) => number | null,
   options?: Pick<BuildCoverageOptions, "terrainSamples" | "terrainCacheKey" | "requireCompleteTerrain">,
 ): CoverageContributorEvaluator[] => {
+  const terrainCacheNamespace = prepareTerrainLossCacheScope(options?.terrainCacheKey ?? "global");
   const memberships = resolveCoverageMemberships(network, sites, systems);
   const frequencyMHz = network.frequencyOverrideMHz ?? network.frequencyMHz;
   const terrainSamples = Math.max(16, Math.round(options?.terrainSamples ?? 20));
@@ -368,7 +378,7 @@ export const createCoverageContributorEvaluators = (
         terrainSamples,
         environment,
         effectiveTerrainSampler,
-        options?.terrainCacheKey,
+        terrainCacheNamespace,
       ),
   }));
 };

--- a/src/lib/overlayModeTiming.test.ts
+++ b/src/lib/overlayModeTiming.test.ts
@@ -12,6 +12,7 @@ import {
   buildRelayCandidateOverlayPixelsAsync,
   buildSourcePassFailOverlayPixelsAsync,
 } from "./overlayRaster";
+import { simulationAreaBoundsForSites } from "./simulationArea";
 import type { Link, Network, PropagationEnvironment, RadioSystem, Site } from "../types/radio";
 
 const bounds = { minLat: 59.8, maxLat: 60, minLon: 10.6, maxLon: 10.8 };
@@ -161,6 +162,56 @@ describe("overlay mode timing calibration", () => {
     const productionPathBudget = buildCoverageGridPoints(24, bounds).length * sites.length;
     expect(adaptivePathCounts.every((count) => count <= productionPathBudget * 3.5)).toBe(true);
     expect(adaptiveDurations[1]).toBeLessThanOrEqual(productionDurations[1] * 2);
+  }, 120_000);
+
+  it("keeps rolling-terrain Heatmap work progressive as the third and fourth Sites expand the area", async () => {
+    const measurements: Array<{ sites: number; pixels: number; paths: number; terrainReads: number }> = [];
+    for (let siteCount = 1; siteCount <= 4; siteCount += 1) {
+      const selectedSites = sites.slice(0, siteCount);
+      const selectedBounds = simulationAreaBoundsForSites(selectedSites, { overlayRadiusKm: 20 })!;
+      const dimensions = computeCalibratedOverlayGridDimensions(24, selectedBounds, "heatmap");
+      let terrainReads = 0;
+      const contributors = createCoverageContributorEvaluators(
+        network,
+        selectedSites,
+        [system],
+        environment,
+        ({ lat, lon }) => {
+          terrainReads += 1;
+          return 125
+            + Math.sin(lat * 240) * 55
+            + Math.cos(lon * 190) * 35
+            + Math.sin((lat + lon) * 410) * 20;
+        },
+        {
+          terrainSamples: 20,
+          terrainCacheKey: `rolling-terrain-${siteCount}`,
+          requireCompleteTerrain: true,
+        },
+      );
+      const result = await buildAdaptiveCoverageOverlayPixelsAsync({
+        bounds: selectedBounds,
+        dimensions,
+        initialGridSize: 24,
+        mode: "heatmap",
+        rxTargetDbm: -118,
+        contributors,
+        context: context(`rolling-terrain-${siteCount}`),
+        adaptive: true,
+      });
+      measurements.push({
+        sites: siteCount,
+        pixels: dimensions.totalSamples,
+        paths: result?.analysisStats?.evaluatedPaths ?? Number.POSITIVE_INFINITY,
+        terrainReads,
+      });
+    }
+    const singleSitePaths = measurements[0].paths;
+    measurements.forEach((measurement) => {
+      expect(measurement.pixels).toBeLessThanOrEqual(25_500);
+      expect(measurement.paths).toBeLessThanOrEqual(singleSitePaths * measurement.sites * 1.05);
+      expect(measurement.terrainReads).toBeLessThanOrEqual(measurement.paths * 22);
+    });
   }, 120_000);
 
 });


### PR DESCRIPTION
## Summary

- halve Heatmap, Weakest Site, and Contours resolution per axis (`317x317` becomes `158x158` at the representative 1x setting)
- leave Pass/Fail, Relay, and Mesh Extension dimensions unchanged
- scope terrain-loss caching to the current coverage selection and stop cache churn at capacity

## Third-Site investigation

Rough terrain makes the adaptive surface approach the full logical grid, with about 21 terrain reads per radio path. Sequential selections also retained selection-specific entries in a global 100k cache; the third calculation crossed the limit and repeatedly inserted/evicted unique entries.

The fix clears stale selection scopes, uses short generation keys, and computes without insertion after the cap. The same rolling-terrain 1–4 Site investigation dropped from about 5.45s to 1.13s without changing results.

## Regression coverage

- explicit `317x317` -> `158x158` mode dimensions
- UI sample label shows `158x158` and about `25k` points
- same-scope terrain results remain reusable while changed selection scopes discard stale entries
- rolling-terrain paths and terrain reads remain within 5% of linear through 1–4 Sites

## Validation

- `npm test` — 135 files, 797 tests
- `npm run build`
- focused ESLint for all changed files
- `npm run dev:check`

Repository-wide `npm run lint` remains blocked by pre-existing source findings and `.claude/worktrees`; this change adds no focused lint finding.

Refs #998
