### PR TITLE
Add named, shareable radio presets

### DIFF
--- a/functions/_lib/db.ts
+++ b/functions/_lib/db.ts
@@ -1,6 +1,9 @@
 import type { CloudResourceRecord, DbVisibility, Env, Grant, ResourceRole, UserRole, Visibility } from "./types";
 import { findPresetById } from "../../src/lib/frequencyPlans";
-import { normalizeSimulationDefaults, type UserSimulationDefaultsPreference } from "../../src/lib/simulationDefaults";
+import {
+  normalizeUserSimulationDefaultsPreference,
+  type UserSimulationDefaultsPreference,
+} from "../../src/lib/simulationDefaults";
 
 const VISIBILITIES: Visibility[] = ["private", "public", "shared"];
 const DB_VISIBILITIES: DbVisibility[] = ["private", "public_read", "public_write"];
@@ -177,16 +180,8 @@ const sanitizeSimulationDefaultsPreference = (value: unknown): string | null | u
   if (value === undefined) return undefined;
   if (value === null) return null;
   if (typeof value !== "object" || Array.isArray(value)) throw new Error("Simulation defaults preference must be an object or null.");
-  const raw = value as Partial<UserSimulationDefaultsPreference>;
-  const mode = raw.mode === "custom" ? "custom" : "preset";
-  const presetId = typeof raw.presetId === "string" && findPresetById(raw.presetId) ? raw.presetId : "oslo-local-869618";
-  const normalized: UserSimulationDefaultsPreference = {
-    mode,
-    presetId,
-    overridePresetDefaults: Boolean(raw.overridePresetDefaults),
-    ...(raw.overrides ? { overrides: normalizeSimulationDefaults(raw.overrides) } : {}),
-    ...(raw.custom ? { custom: normalizeSimulationDefaults(raw.custom) } : {}),
-  };
+  const raw = value as UserSimulationDefaultsPreference;
+  const normalized = normalizeUserSimulationDefaultsPreference(raw);
   return JSON.stringify(normalized);
 };
 

--- a/src/components/AppShell.deeplink.test.ts
+++ b/src/components/AppShell.deeplink.test.ts
@@ -130,7 +130,7 @@ vi.mock("./WelcomeModal", () => ({ default: () => null }));
 vi.mock("./OnboardingTutorialModal", () => ({ default: () => null }));
 vi.mock("./LinkProfileChart", () => ({ LinkProfileChart: () => null }));
 vi.mock("./PanoramaChart", () => ({ PanoramaChart: () => null }));
-vi.mock("./ActionButton", () => ({ ActionButton: () => null }));
+vi.mock("./ActionButton", () => ({ ActionButton: ({ children, variant, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement> & { variant?: string }) => React.createElement("button", { ...props, "data-variant": variant }, children) }));
 vi.mock("./InlineCloseIconButton", () => ({ InlineCloseIconButton: () => null }));
 vi.mock("./ModalOverlay", () => ({ ModalOverlay: ({ children }: { children?: React.ReactNode }) => children ?? null }));
 vi.mock("./app-shell/MobileWorkspaceTabs", () => ({ MobileWorkspaceTabs: () => null }));
@@ -149,6 +149,8 @@ vi.mock("./app-shell/useOnboardingFlow", () => ({
 }));
 
 import { AppShell, buildAuthStartPath } from "./AppShell";
+import { buildRadioPresetShareHash } from "../lib/radioPresetShare";
+import { simulationDefaultsFromPreset } from "../lib/simulationDefaults";
 
 const waitForCondition = async (check: () => boolean, timeoutMs = 2500): Promise<void> => {
   const started = Date.now();
@@ -290,6 +292,29 @@ describe("AppShell deeplink cold-load flow", () => {
     expect(buildAuthStartPath({ pathname: "/sim/site", search: "?mode=demo", hash: "#panel" })).toBe(
       "/api/auth-start?returnTo=%2Fsim%2Fsite%3Fmode%3Ddemo%23panel",
     );
+  });
+
+  it("previews every shared radio preset value before an anonymous import", async () => {
+    const defaults = {
+      ...simulationDefaultsFromPreset("mt-eu_868"),
+      frequencyMHz: 869.4,
+      rxSensitivityTargetDbm: -127,
+      autoPropagationEnvironment: false,
+    };
+    window.history.replaceState(null, "", `/${buildRadioPresetShareHash({ name: "Alpine Mesh", defaults })}`);
+    hoisted.fetchMe.mockRejectedValue(new Error("Unauthorized"));
+    hoisted.fetchAuthStatus.mockResolvedValue({ authenticated: false, authState: "guest" });
+
+    const view = await renderAppShell();
+    try {
+      expect(document.body.textContent).toContain("Import Radio Preset");
+      expect(document.body.textContent).toContain("Alpine Mesh");
+      expect(document.body.textContent).toContain("869.4 MHz");
+      expect(document.body.textContent).toContain("-127 dBm");
+      expect(document.body.textContent).toContain("Sign in to save");
+    } finally {
+      unmountAppShell(view);
+    }
   });
 
   it("loads the resolved simulation id and does not emit unavailable", async () => {

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,6 +1,6 @@
 import { type CSSProperties, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CircleAlert, CircleCheck, CircleX, Copy, Globe, Info, PanelBottomClose, PanelBottomOpen, PanelLeftClose, PanelLeftOpen, PanelRightClose, PanelRightOpen, Share, UserRoundPlus, UserRoundSearch, Users, X } from "lucide-react";
-import { CloudApiError, type CloudUser, type CollaboratorDirectoryUser, fetchAuthStatus, fetchCollaboratorDirectory, fetchDeepLinkStatus, fetchMe } from "../lib/cloudUser";
+import { CloudApiError, type CloudUser, type CollaboratorDirectoryUser, fetchAuthStatus, fetchCollaboratorDirectory, fetchDeepLinkStatus, fetchMe, updateMyProfile } from "../lib/cloudUser";
 import { fetchCloudLibrary, fetchPublicSimulationLibrary, pushCloudLibrary } from "../lib/cloudLibrary";
 import { buildDeepLinkPathname, buildDeepLinkUrl, buildSettingsPath, canonicalizeDeepLinkKey, matchSettingsPath, parseDeepLinkFromLocation, slugifyName, type SettingsSectionId } from "../lib/deepLink";
 import { canRunDeepLinkApply } from "../lib/deepLinkApplyGate";
@@ -14,6 +14,9 @@ import {
 import { emptyWorkspaceState } from "../lib/emptyWorkspaceState";
 import { getCurrentRuntimeEnvironment } from "../lib/environment";
 import { getUiErrorMessage } from "../lib/uiError";
+import { parseRadioPresetShareHash, type RadioPresetShareParseResult } from "../lib/radioPresetShare";
+import { normalizeUserSimulationDefaultsPreference } from "../lib/simulationDefaults";
+import { buildImportedRadioPresetPreference } from "../lib/radioPresetImport";
 import {
   clearUiNotifications,
   dismissUiNotification,
@@ -236,6 +239,20 @@ export function AppShell() {
   }, []);
   const [libraryAutoOpened, setLibraryAutoOpened] = useState(false);
   const [showShareModal, setShowShareModal] = useState(false);
+  const [presetImport, setPresetImport] = useState<RadioPresetShareParseResult | null>(() => {
+    if (typeof window === "undefined") return null;
+    const parsed = parseRadioPresetShareHash(window.location.hash);
+    return parsed.ok || parsed.reason !== "missing" ? parsed : null;
+  });
+  const [presetImportName, setPresetImportName] = useState(() => {
+    if (typeof window === "undefined") return "";
+    const parsed = parseRadioPresetShareHash(window.location.hash);
+    return parsed.ok ? parsed.preset.name : "";
+  });
+  const [presetImportMakeDefault, setPresetImportMakeDefault] = useState(false);
+  const [presetImportConflictMode, setPresetImportConflictMode] = useState<"replace" | "rename" | null>(null);
+  const [presetImportBusy, setPresetImportBusy] = useState(false);
+  const [presetImportStatus, setPresetImportStatus] = useState("");
   const [profileTarget, setProfileTarget] = useState<UserProfilePopoverTarget | null>(null);
   const [shareBusy, setShareBusy] = useState(false);
   const [shareDirectory, setShareDirectory] = useState<CollaboratorDirectoryUser[]>([]);
@@ -582,6 +599,54 @@ export function AppShell() {
     clearAuthRetryTimer();
     window.location.href = buildAuthStartPath(window.location);
   }, [clearAuthRetryTimer]);
+
+  const clearPresetImport = useCallback(() => {
+    setPresetImport(null);
+    setPresetImportStatus("");
+    setPresetImportConflictMode(null);
+    if (typeof window !== "undefined" && window.location.hash.startsWith("#preset=")) {
+      window.history.replaceState(null, "", `${window.location.pathname}${window.location.search}`);
+    }
+  }, []);
+
+  const importSharedRadioPreset = useCallback(async () => {
+    if (!presetImport?.ok || !currentUser?.id) return;
+    const preference = normalizeUserSimulationDefaultsPreference(
+      currentUser.simulationDefaultsPreference,
+      currentUser.defaultFrequencyPresetId,
+    );
+    let importResult: ReturnType<typeof buildImportedRadioPresetPreference>;
+    try {
+      importResult = buildImportedRadioPresetPreference({
+        preference,
+        sharedPreset: presetImport.preset,
+        requestedName: presetImportName,
+        conflictMode: presetImportConflictMode,
+        makeDefault: presetImportMakeDefault,
+        createId: () => `radio-${crypto.randomUUID()}`,
+      });
+    } catch (error) {
+      setPresetImportStatus(getUiErrorMessage(error));
+      return;
+    }
+
+    setPresetImportBusy(true);
+    setPresetImportStatus("");
+    try {
+      const updated = await updateMyProfile({
+        defaultFrequencyPresetId: importResult.preference.presetId,
+        simulationDefaultsPreference: importResult.preference,
+      });
+      setCurrentUser(updated);
+      setAuthState("signed_in");
+      clearPresetImport();
+      pushNotification({ id: "radio-preset-imported", message: `Saved radio preset: ${importResult.importedName}`, tone: "info" });
+    } catch (error) {
+      setPresetImportStatus(getUiErrorMessage(error));
+    } finally {
+      setPresetImportBusy(false);
+    }
+  }, [clearPresetImport, currentUser, presetImport, presetImportConflictMode, presetImportMakeDefault, presetImportName, pushNotification, setAuthState]);
 
   const scheduleAuthRecoveryRetry = useCallback(
     (source: "timeout" | "failure"): boolean => {
@@ -2325,6 +2390,97 @@ export function AppShell() {
               onOpenUserProfile={(userId, anchor) => setProfileTarget({ anchor, userId })}
               readOnly={!canPersistWorkspace}
             />
+          </div>
+        </ModalOverlay>
+      ) : null}
+      {presetImport ? (
+        <ModalOverlay aria-label="Import radio preset" onClose={clearPresetImport} tier="raised">
+          <div className="library-manager-card radio-preset-import-card">
+            <div className="library-manager-header">
+              <h2>Import Radio Preset</h2>
+              <InlineCloseIconButton onClick={clearPresetImport} />
+            </div>
+            {!presetImport.ok ? (
+              <>
+                <p className="field-help field-help-error">This preset link is invalid or unsupported.</p>
+                <ActionButton onClick={clearPresetImport} type="button">Close</ActionButton>
+              </>
+            ) : (() => {
+              const preference = normalizeUserSimulationDefaultsPreference(
+                currentUser?.simulationDefaultsPreference,
+                currentUser?.defaultFrequencyPresetId,
+              );
+              const conflict = preference.customPresets?.find(
+                (preset) => preset.name.toLocaleLowerCase() === presetImport.preset.name.toLocaleLowerCase(),
+              );
+              const defaults = presetImport.preset.defaults;
+              const replacingActiveDefault = Boolean(
+                conflict && preference.mode === "custom" && preference.customPresetId === conflict.id,
+              );
+              return (
+                <>
+                  <p className="field-help">Review every value before saving an independent copy to your account.</p>
+                  <div className="panel-section compact-panel radio-preset-import-values">
+                    <strong>{presetImport.preset.name}</strong>
+                    <dl>
+                      <dt>Frequency</dt><dd>{defaults.frequencyMHz} MHz</dd>
+                      <dt>Bandwidth</dt><dd>{defaults.bandwidthKhz} kHz</dd>
+                      <dt>Spread factor</dt><dd>{defaults.spreadFactor}</dd>
+                      <dt>Coding rate</dt><dd>{defaults.codingRate}</dd>
+                      <dt>Region code</dt><dd>{defaults.regionCode || "—"}</dd>
+                      <dt>RX target</dt><dd>{defaults.rxSensitivityTargetDbm} dBm</dd>
+                      <dt>Environment loss</dt><dd>{defaults.environmentLossDb} dB</dd>
+                      <dt>Environment mode</dt><dd>{defaults.autoPropagationEnvironment ? "Automatic" : "Manual"}</dd>
+                      <dt>Radio climate</dt><dd>{defaults.propagationEnvironment.radioClimate}</dd>
+                      <dt>Polarization</dt><dd>{defaults.propagationEnvironment.polarization}</dd>
+                      <dt>Clutter height</dt><dd>{defaults.propagationEnvironment.clutterHeightM} m</dd>
+                      <dt>Ground dielectric</dt><dd>{defaults.propagationEnvironment.groundDielectric}</dd>
+                      <dt>Ground conductivity</dt><dd>{defaults.propagationEnvironment.groundConductivity}</dd>
+                      <dt>Atmospheric bending</dt><dd>{defaults.propagationEnvironment.atmosphericBendingNUnits} N-units</dd>
+                    </dl>
+                  </div>
+                  {!currentUser ? (
+                    <ActionButton onClick={handleUserSignInRequested} type="button">Sign in to save</ActionButton>
+                  ) : (
+                    <>
+                      {conflict ? (
+                        <fieldset className="resource-edit-fieldset radio-preset-conflict-options">
+                          <legend>A preset named “{conflict.name}” already exists</legend>
+                          <label>
+                            <input checked={presetImportConflictMode === "replace"} name="preset-import-conflict" onChange={() => { setPresetImportConflictMode("replace"); setPresetImportName(conflict.name); setPresetImportStatus(""); }} type="radio" />
+                            Replace the existing preset
+                          </label>
+                          <label>
+                            <input checked={presetImportConflictMode === "rename"} name="preset-import-conflict" onChange={() => { setPresetImportConflictMode("rename"); setPresetImportName(`${presetImport.preset.name} copy`); setPresetImportStatus(""); }} type="radio" />
+                            Save as a new preset
+                          </label>
+                          {replacingActiveDefault && presetImportConflictMode === "replace" ? (
+                            <p className="field-help field-help-error">This replaces your active account default and changes inheriting Simulations.</p>
+                          ) : null}
+                        </fieldset>
+                      ) : null}
+                      {(!conflict || presetImportConflictMode === "rename") ? (
+                        <label className="field-grid">
+                          <span>Preset name</span>
+                          <input maxLength={80} onChange={(event) => setPresetImportName(event.target.value)} type="text" value={presetImportName} />
+                        </label>
+                      ) : null}
+                      <label className="field-grid">
+                        <span>Use as my account default</span>
+                        <input aria-label="Use imported preset as my account default" checked={presetImportMakeDefault} onChange={(event) => setPresetImportMakeDefault(event.target.checked)} type="checkbox" />
+                      </label>
+                      <div className="radio-preset-import-actions">
+                        <ActionButton disabled={presetImportBusy || Boolean(conflict && !presetImportConflictMode)} onClick={() => void importSharedRadioPreset()} type="button">
+                          {presetImportBusy ? "Saving…" : "Save preset"}
+                        </ActionButton>
+                        <ActionButton onClick={clearPresetImport} type="button" variant="ghost">Cancel</ActionButton>
+                      </div>
+                      {presetImportStatus ? <p className="field-help field-help-error" role="alert">{presetImportStatus}</p> : null}
+                    </>
+                  )}
+                </>
+              );
+            })()}
           </div>
         </ModalOverlay>
       ) : null}

--- a/src/components/settings/sections/PreferencesSection.test.tsx
+++ b/src/components/settings/sections/PreferencesSection.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { simulationDefaultsFromPreset, type UserSimulationDefaultsPreference } from "../../../lib/simulationDefaults";
+import type { CloudUser } from "../../../lib/cloudUser";
+import { parseRadioPresetShareHash } from "../../../lib/radioPresetShare";
+
+const hoisted = vi.hoisted(() => ({
+  updateMyProfile: vi.fn(),
+  setCurrentUser: vi.fn(),
+  setAuthState: vi.fn(),
+  clipboardWriteText: vi.fn(),
+  store: {
+    uiThemePreference: "system",
+    setUiThemePreference: vi.fn(),
+    uiColorTheme: "blue",
+    setUiColorTheme: vi.fn(),
+    setCurrentUser: vi.fn(),
+    setAuthState: vi.fn(),
+  } as Record<string, unknown>,
+}));
+
+vi.mock("../../../lib/cloudUser", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../../lib/cloudUser")>();
+  return { ...original, updateMyProfile: hoisted.updateMyProfile };
+});
+
+vi.mock("../../../store/appStore", () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) => selector(hoisted.store),
+}));
+
+vi.mock("../../../hooks/useThemeVariant", () => ({
+  useThemeVariant: () => ({ activeHolidayTheme: null, holidayThemesVisible: false }),
+}));
+
+import { PreferencesSection } from "./PreferencesSection";
+
+const userWithPreference = (preference: UserSimulationDefaultsPreference): CloudUser => ({
+  id: "user-1",
+  username: "Owner",
+  bio: "",
+  avatarUrl: "",
+  isAdmin: false,
+  isApproved: true,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  defaultFrequencyPresetId: preference.presetId,
+  simulationDefaultsPreference: preference,
+});
+
+describe("PreferencesSection custom radio presets", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: hoisted.clipboardWriteText },
+    });
+    hoisted.clipboardWriteText.mockResolvedValue(undefined);
+  });
+
+  it("shows the migrated legacy custom preset and blocks deleting the active default", async () => {
+    const me = userWithPreference({
+      mode: "custom",
+      presetId: "mt-us",
+      overridePresetDefaults: false,
+      custom: { ...simulationDefaultsFromPreset("mt-us"), frequencyMHz: 906.875 },
+    });
+    render(<PreferencesSection me={me} onMeUpdated={vi.fn()} />);
+
+    expect((await screen.findAllByRole("option", { name: "My custom preset" })).length).toBe(2);
+    expect(screen.getByRole("button", { name: "Delete custom preset: My custom preset" })).toBeDisabled();
+  });
+
+  it("copies a saved preset as a valid self-contained fragment", async () => {
+    const defaults = { ...simulationDefaultsFromPreset("mt-eu_868"), frequencyPresetId: "radio-alpine", frequencyMHz: 869.4 };
+    const me = userWithPreference({
+      mode: "custom",
+      presetId: "mt-eu_868",
+      customPresetId: "radio-alpine",
+      customPresets: [{ id: "radio-alpine", name: "Alpine Mesh", defaults }],
+      overridePresetDefaults: false,
+    });
+    render(<PreferencesSection me={me} onMeUpdated={vi.fn()} />);
+    await userEvent.click(await screen.findByRole("button", { name: "Share custom preset: Alpine Mesh" }));
+
+    await waitFor(() => expect(hoisted.clipboardWriteText).toHaveBeenCalledTimes(1));
+    const url = new URL(String(hoisted.clipboardWriteText.mock.calls[0]?.[0]));
+    expect(parseRadioPresetShareHash(url.hash)).toMatchObject({
+      ok: true,
+      preset: { name: "Alpine Mesh", defaults: { frequencyMHz: 869.4 } },
+    });
+  });
+
+  it("creates a uniquely named preset without changing the active default", async () => {
+    const me = userWithPreference({ mode: "preset", presetId: "mt-us", overridePresetDefaults: false });
+    hoisted.updateMyProfile.mockImplementation(async (patch: { simulationDefaultsPreference: UserSimulationDefaultsPreference }) => ({
+      ...me,
+      simulationDefaultsPreference: patch.simulationDefaultsPreference,
+    }));
+    render(<PreferencesSection me={me} onMeUpdated={vi.fn()} />);
+
+    await userEvent.type(screen.getByRole("textbox", { name: "New custom preset name" }), "Field Mesh");
+    await userEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => expect(hoisted.updateMyProfile).toHaveBeenCalledTimes(1));
+    const patch = hoisted.updateMyProfile.mock.calls[0]?.[0];
+    expect(patch.simulationDefaultsPreference).toMatchObject({
+      mode: "preset",
+      presetId: "mt-us",
+      customPresets: [expect.objectContaining({ name: "Field Mesh" })],
+    });
+  });
+});

--- a/src/components/settings/sections/PreferencesSection.tsx
+++ b/src/components/settings/sections/PreferencesSection.tsx
@@ -1,12 +1,18 @@
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
+import { Copy, Plus, Trash2 } from "lucide-react";
 import { updateMyProfile, type CloudUser } from "../../../lib/cloudUser";
 import { FREQUENCY_PRESETS, frequencyPresetGroups } from "../../../lib/frequencyPlans";
 import {
+  MAX_CUSTOM_RADIO_PRESETS,
+  findCustomRadioPreset,
+  normalizeCustomRadioPresetName,
+  normalizeUserSimulationDefaultsPreference,
   resolveUserSimulationDefaults,
   simulationDefaultsFromPreset,
   type SimulationDefaults,
   type UserSimulationDefaultsPreference,
 } from "../../../lib/simulationDefaults";
+import { buildRadioPresetShareUrl } from "../../../lib/radioPresetShare";
 import { getUiErrorMessage } from "../../../lib/uiError";
 import { useAppStore } from "../../../store/appStore";
 import { useThemeVariant } from "../../../hooks/useThemeVariant";
@@ -15,6 +21,7 @@ import { setHolidayThemePreview } from "../../../themes/holidayThemeDev";
 import type { HolidayThemeKey, UiColorTheme } from "../../../themes/types";
 import { AutoSaveIndicator, type AutoSaveState } from "../../ui/AutoSaveIndicator";
 import { InfoTip } from "../../InfoTip";
+import { Button } from "../../ui/Button";
 
 type PreferencesSectionProps = {
   me: CloudUser | null;
@@ -37,14 +44,34 @@ export function PreferencesSection({ me, onMeUpdated }: PreferencesSectionProps)
   const setAuthState = useAppStore((state) => state.setAuthState);
   const { activeHolidayTheme, holidayThemesVisible } = useThemeVariant();
 
-  const [presetState, setPresetState] = useState<SelectFieldState>(IDLE_SELECT);
+  const preference = useMemo(
+    () => normalizeUserSimulationDefaultsPreference(
+      me?.simulationDefaultsPreference,
+      me?.defaultFrequencyPresetId,
+    ),
+    [me?.defaultFrequencyPresetId, me?.simulationDefaultsPreference],
+  );
+  const customPresets = useMemo(() => preference.customPresets ?? [], [preference.customPresets]);
 
-  const preference: UserSimulationDefaultsPreference = me?.simulationDefaultsPreference ?? {
-    mode: "preset",
-    presetId: me?.defaultFrequencyPresetId ?? "oslo-local-869618",
-    overridePresetDefaults: false,
-  };
+  const [presetState, setPresetState] = useState<SelectFieldState>(IDLE_SELECT);
+  const [managedPresetId, setManagedPresetId] = useState(
+    preference.mode === "custom" ? preference.customPresetId ?? customPresets[0]?.id ?? "" : "",
+  );
+  const [newPresetName, setNewPresetName] = useState("");
+  const [renameDraft, setRenameDraft] = useState<{ presetId: string; value: string } | null>(null);
+  const [presetActionStatus, setPresetActionStatus] = useState("");
+
+  const resolvedManagedPresetId = customPresets.some((preset) => preset.id === managedPresetId)
+    ? managedPresetId
+    : preference.mode === "custom"
+      ? preference.customPresetId ?? customPresets[0]?.id ?? ""
+      : "";
+  const managedPreset = findCustomRadioPreset(preference, resolvedManagedPresetId);
+  const renameValue = renameDraft && renameDraft.presetId === managedPreset?.id
+    ? renameDraft.value
+    : managedPreset?.name ?? "";
   const activeDefaults = resolveUserSimulationDefaults(preference, me?.defaultFrequencyPresetId);
+  const editableDefaults = managedPreset?.defaults ?? activeDefaults;
   const holidayThemes = getHolidayThemeCatalog();
   const selectedColorThemeValue = activeHolidayTheme?.key ? `holiday:${activeHolidayTheme.key}` : uiColorTheme;
 
@@ -52,9 +79,10 @@ export function PreferencesSection({ me, onMeUpdated }: PreferencesSectionProps)
     async (nextPreference: UserSimulationDefaultsPreference) => {
       setPresetState({ state: "saving", error: null });
       try {
+        const normalized = normalizeUserSimulationDefaultsPreference(nextPreference);
         const updated = await updateMyProfile({
-          defaultFrequencyPresetId: nextPreference.presetId,
-          simulationDefaultsPreference: nextPreference,
+          defaultFrequencyPresetId: normalized.presetId,
+          simulationDefaultsPreference: normalized,
         });
         onMeUpdated(updated);
         setCurrentUser(updated);
@@ -71,13 +99,85 @@ export function PreferencesSection({ me, onMeUpdated }: PreferencesSectionProps)
   );
 
   const patchPreferenceDefaults = (patch: Partial<SimulationDefaults>) => {
-    const base = preference.mode === "custom" ? activeDefaults : simulationDefaultsFromPreset(preference.presetId);
+    if (managedPreset) {
+      const nextDefaults = { ...managedPreset.defaults, ...patch, frequencyPresetId: managedPreset.id };
+      void saveSimulationDefaultsPreference({
+        ...preference,
+        customPresets: customPresets.map((preset) =>
+          preset.id === managedPreset.id ? { ...preset, defaults: nextDefaults } : preset,
+        ),
+      });
+      return;
+    }
+    const base = simulationDefaultsFromPreset(preference.presetId);
     const nextDefaults = { ...base, ...activeDefaults, ...patch };
     void saveSimulationDefaultsPreference({
       ...preference,
-      overridePresetDefaults: preference.mode === "custom" ? preference.overridePresetDefaults : true,
-      ...(preference.mode === "custom" ? { custom: nextDefaults } : { overrides: nextDefaults }),
+      overridePresetDefaults: true,
+      overrides: nextDefaults,
     });
+  };
+
+  const createCustomPreset = () => {
+    const name = normalizeCustomRadioPresetName(newPresetName);
+    if (!name) {
+      setPresetActionStatus("Enter a preset name.");
+      return;
+    }
+    if (customPresets.some((preset) => preset.name.toLocaleLowerCase() === name.toLocaleLowerCase())) {
+      setPresetActionStatus("Preset names must be unique.");
+      return;
+    }
+    if (customPresets.length >= MAX_CUSTOM_RADIO_PRESETS) {
+      setPresetActionStatus(`You can save up to ${MAX_CUSTOM_RADIO_PRESETS} custom presets.`);
+      return;
+    }
+    const id = `radio-${crypto.randomUUID()}`;
+    void saveSimulationDefaultsPreference({
+      ...preference,
+      customPresets: [...customPresets, { id, name, defaults: { ...activeDefaults, frequencyPresetId: id } }],
+    });
+    setManagedPresetId(id);
+    setNewPresetName("");
+    setPresetActionStatus("Custom preset created.");
+  };
+
+  const renameManagedPreset = () => {
+    if (!managedPreset) return;
+    const name = normalizeCustomRadioPresetName(renameValue);
+    if (!name) {
+      setPresetActionStatus("Enter a preset name.");
+      return;
+    }
+    if (customPresets.some((preset) => preset.id !== managedPreset.id && preset.name.toLocaleLowerCase() === name.toLocaleLowerCase())) {
+      setPresetActionStatus("Preset names must be unique.");
+      return;
+    }
+    void saveSimulationDefaultsPreference({
+      ...preference,
+      customPresets: customPresets.map((preset) => preset.id === managedPreset.id ? { ...preset, name } : preset),
+    });
+    setPresetActionStatus("Preset renamed.");
+  };
+
+  const deleteManagedPreset = () => {
+    if (!managedPreset || preference.mode === "custom" && preference.customPresetId === managedPreset.id) return;
+    void saveSimulationDefaultsPreference({
+      ...preference,
+      customPresets: customPresets.filter((preset) => preset.id !== managedPreset.id),
+    });
+    setManagedPresetId("");
+    setPresetActionStatus("Preset deleted.");
+  };
+
+  const shareManagedPreset = async () => {
+    if (!managedPreset || presetState.state === "saving" || presetState.state === "error") return;
+    try {
+      await navigator.clipboard.writeText(buildRadioPresetShareUrl(managedPreset, window.location));
+      setPresetActionStatus("Preset link copied.");
+    } catch (error) {
+      setPresetActionStatus(`Unable to copy preset link: ${getUiErrorMessage(error)}`);
+    }
   };
 
   const setHolidayThemeSelection = (holidayThemeKey: HolidayThemeKey | null) => {
@@ -173,22 +273,24 @@ export function PreferencesSection({ me, onMeUpdated }: PreferencesSectionProps)
           <select
             id="pref-default-preset"
             className="locale-select"
-            value={preference.mode === "custom" ? "custom" : preference.presetId}
+            value={preference.mode === "custom" ? `custom:${preference.customPresetId}` : preference.presetId}
             onChange={(event) => {
               const next = event.target.value;
-              if (next === "custom") {
+              if (next.startsWith("custom:")) {
+                const customPresetId = next.slice("custom:".length);
                 void saveSimulationDefaultsPreference({
+                  ...preference,
                   mode: "custom",
-                  presetId: preference.presetId,
+                  customPresetId,
                   overridePresetDefaults: false,
-                  custom: activeDefaults,
                 });
+                setManagedPresetId(customPresetId);
                 return;
               }
-              void saveSimulationDefaultsPreference({ mode: "preset", presetId: next, overridePresetDefaults: false });
+              setManagedPresetId("");
+              void saveSimulationDefaultsPreference({ ...preference, mode: "preset", presetId: next, overridePresetDefaults: false });
             }}
           >
-            <option value="custom">Custom preset</option>
             {frequencyPresetGroups(FREQUENCY_PRESETS).map((groupEntry) => (
               <optgroup key={groupEntry.group} label={groupEntry.group}>
                 {groupEntry.presets.map((preset) => (
@@ -198,7 +300,74 @@ export function PreferencesSection({ me, onMeUpdated }: PreferencesSectionProps)
                 ))}
               </optgroup>
             ))}
+            {customPresets.length ? (
+              <optgroup label="My presets">
+                {customPresets.map((preset) => (
+                  <option key={preset.id} value={`custom:${preset.id}`}>{preset.name}</option>
+                ))}
+              </optgroup>
+            ) : null}
           </select>
+        </div>
+
+        <div className="autosave-field custom-radio-preset-manager">
+          <label className="autosave-field-label" htmlFor="pref-custom-preset-manager">
+            <span>Custom radio presets <InfoTip text="Create named presets, edit their complete Simulation defaults, or copy a portable share link." /></span>
+          </label>
+          <div className="custom-radio-preset-create-row">
+            <input
+              aria-label="New custom preset name"
+              maxLength={80}
+              onChange={(event) => setNewPresetName(event.target.value)}
+              placeholder="New preset name"
+              type="text"
+              value={newPresetName}
+            />
+            <Button disabled={customPresets.length >= MAX_CUSTOM_RADIO_PRESETS} onClick={createCustomPreset} type="button">
+              <Plus aria-hidden="true" size={14} /> Create
+            </Button>
+          </div>
+          {customPresets.length ? (
+            <>
+              <select
+                aria-label="Custom preset to manage"
+                className="locale-select"
+                id="pref-custom-preset-manager"
+                onChange={(event) => { setManagedPresetId(event.target.value); setPresetActionStatus(""); }}
+                value={resolvedManagedPresetId}
+              >
+                <option value="">Select a custom preset to manage</option>
+                {customPresets.map((preset) => <option key={preset.id} value={preset.id}>{preset.name}</option>)}
+              </select>
+              {managedPreset ? (
+                <>
+                  <div className="custom-radio-preset-create-row">
+                    <input aria-label="Custom preset name" maxLength={80} onChange={(event) => setRenameDraft({ presetId: managedPreset.id, value: event.target.value })} type="text" value={renameValue} />
+                    <Button disabled={renameValue.trim() === managedPreset.name} onClick={renameManagedPreset} type="button" variant="ghost">Rename</Button>
+                  </div>
+                  <div className="custom-radio-preset-actions">
+                    <Button
+                      aria-label={`Share custom preset: ${managedPreset.name}`}
+                      disabled={presetState.state === "saving" || presetState.state === "error"}
+                      onClick={() => void shareManagedPreset()}
+                      title="Copy share link"
+                      type="button"
+                      variant="ghost"
+                    ><Copy aria-hidden="true" size={14} /> Share</Button>
+                    <Button
+                      aria-label={`Delete custom preset: ${managedPreset.name}`}
+                      disabled={preference.mode === "custom" && preference.customPresetId === managedPreset.id}
+                      onClick={deleteManagedPreset}
+                      title={preference.mode === "custom" && preference.customPresetId === managedPreset.id ? "Select another account default before deleting" : "Delete custom preset"}
+                      type="button"
+                      variant="danger"
+                    ><Trash2 aria-hidden="true" size={14} /> Delete</Button>
+                  </div>
+                </>
+              ) : null}
+            </>
+          ) : <p className="field-help">No custom presets saved yet.</p>}
+          {presetActionStatus ? <p className="field-help" role="status">{presetActionStatus}</p> : null}
         </div>
 
         {preference.mode === "preset" ? (
@@ -208,6 +377,7 @@ export function PreferencesSection({ me, onMeUpdated }: PreferencesSectionProps)
               aria-label="Override preset settings"
               checked={preference.overridePresetDefaults}
               onChange={(event) => {
+                setManagedPresetId("");
                 void saveSimulationDefaultsPreference({
                   ...preference,
                   overridePresetDefaults: event.target.checked,
@@ -219,47 +389,47 @@ export function PreferencesSection({ me, onMeUpdated }: PreferencesSectionProps)
           </label>
         ) : null}
 
-        {preference.mode === "custom" || preference.overridePresetDefaults ? (
+        {managedPreset || preference.overridePresetDefaults ? (
           <div className="autosave-field">
             <label className="field-grid">
               <span>Frequency (MHz)</span>
-              <input type="number" value={activeDefaults.frequencyMHz} onChange={(event) => patchPreferenceDefaults({ frequencyMHz: Number(event.target.value), frequencyPresetId: preference.presetId })} />
+              <input type="number" value={editableDefaults.frequencyMHz} onChange={(event) => patchPreferenceDefaults({ frequencyMHz: Number(event.target.value) })} />
             </label>
             <label className="field-grid">
               <span>Bandwidth (kHz)</span>
-              <input type="number" value={activeDefaults.bandwidthKhz} onChange={(event) => patchPreferenceDefaults({ bandwidthKhz: Number(event.target.value) })} />
+              <input type="number" value={editableDefaults.bandwidthKhz} onChange={(event) => patchPreferenceDefaults({ bandwidthKhz: Number(event.target.value) })} />
             </label>
             <label className="field-grid">
               <span>Spread factor</span>
-              <input type="number" value={activeDefaults.spreadFactor} onChange={(event) => patchPreferenceDefaults({ spreadFactor: Number(event.target.value) })} />
+              <input type="number" value={editableDefaults.spreadFactor} onChange={(event) => patchPreferenceDefaults({ spreadFactor: Number(event.target.value) })} />
             </label>
             <label className="field-grid">
               <span>Coding rate</span>
-              <input type="number" value={activeDefaults.codingRate} onChange={(event) => patchPreferenceDefaults({ codingRate: Number(event.target.value) })} />
+              <input type="number" value={editableDefaults.codingRate} onChange={(event) => patchPreferenceDefaults({ codingRate: Number(event.target.value) })} />
             </label>
             <label className="field-grid">
               <span>Region code</span>
-              <input type="text" value={activeDefaults.regionCode ?? ""} onChange={(event) => patchPreferenceDefaults({ regionCode: event.target.value || undefined })} />
+              <input type="text" value={editableDefaults.regionCode ?? ""} onChange={(event) => patchPreferenceDefaults({ regionCode: event.target.value || undefined })} />
             </label>
             <label className="field-grid">
               <span>RX target (dBm)</span>
-              <input type="number" value={activeDefaults.rxSensitivityTargetDbm} onChange={(event) => patchPreferenceDefaults({ rxSensitivityTargetDbm: Number(event.target.value) })} />
+              <input type="number" value={editableDefaults.rxSensitivityTargetDbm} onChange={(event) => patchPreferenceDefaults({ rxSensitivityTargetDbm: Number(event.target.value) })} />
             </label>
             <label className="field-grid">
               <span>Env loss (dB)</span>
-              <input min={0} type="number" value={activeDefaults.environmentLossDb} onChange={(event) => patchPreferenceDefaults({ environmentLossDb: Number(event.target.value) })} />
+              <input min={0} type="number" value={editableDefaults.environmentLossDb} onChange={(event) => patchPreferenceDefaults({ environmentLossDb: Number(event.target.value) })} />
             </label>
             <label className="field-grid">
               <span>Auto environment defaults</span>
-              <input aria-label="Auto environment defaults" checked={activeDefaults.autoPropagationEnvironment} onChange={(event) => patchPreferenceDefaults({ autoPropagationEnvironment: event.target.checked })} type="checkbox" />
+              <input aria-label="Auto environment defaults" checked={editableDefaults.autoPropagationEnvironment} onChange={(event) => patchPreferenceDefaults({ autoPropagationEnvironment: event.target.checked })} type="checkbox" />
             </label>
-            {activeDefaults.autoPropagationEnvironment ? (
+            {editableDefaults.autoPropagationEnvironment ? (
               <p className="field-help">Auto derives climate and clutter from terrain for each path. Turn it off to use fixed manual environment values.</p>
             ) : (
               <>
                 <label className="field-grid">
                   <span>Radio climate</span>
-                  <select className="locale-select" value={activeDefaults.propagationEnvironment.radioClimate} onChange={(event) => patchPreferenceDefaults({ propagationEnvironment: { ...activeDefaults.propagationEnvironment, radioClimate: event.target.value as SimulationDefaults["propagationEnvironment"]["radioClimate"] } })}>
+                  <select className="locale-select" value={editableDefaults.propagationEnvironment.radioClimate} onChange={(event) => patchPreferenceDefaults({ propagationEnvironment: { ...editableDefaults.propagationEnvironment, radioClimate: event.target.value as SimulationDefaults["propagationEnvironment"]["radioClimate"] } })}>
                     <option value="Continental Temperate">Continental Temperate</option>
                     <option value="Maritime Temperate (Land)">Maritime Temperate (Land)</option>
                     <option value="Maritime Temperate (Sea)">Maritime Temperate (Sea)</option>
@@ -271,19 +441,19 @@ export function PreferencesSection({ me, onMeUpdated }: PreferencesSectionProps)
                 </label>
                 <label className="field-grid">
                   <span>Clutter height (m)</span>
-                  <input type="number" value={activeDefaults.propagationEnvironment.clutterHeightM} onChange={(event) => patchPreferenceDefaults({ propagationEnvironment: { ...activeDefaults.propagationEnvironment, clutterHeightM: Number(event.target.value) } })} />
+                  <input type="number" value={editableDefaults.propagationEnvironment.clutterHeightM} onChange={(event) => patchPreferenceDefaults({ propagationEnvironment: { ...editableDefaults.propagationEnvironment, clutterHeightM: Number(event.target.value) } })} />
                 </label>
                 <label className="field-grid">
                   <span>Ground dielectric</span>
-                  <input type="number" value={activeDefaults.propagationEnvironment.groundDielectric} onChange={(event) => patchPreferenceDefaults({ propagationEnvironment: { ...activeDefaults.propagationEnvironment, groundDielectric: Number(event.target.value) } })} />
+                  <input type="number" value={editableDefaults.propagationEnvironment.groundDielectric} onChange={(event) => patchPreferenceDefaults({ propagationEnvironment: { ...editableDefaults.propagationEnvironment, groundDielectric: Number(event.target.value) } })} />
                 </label>
                 <label className="field-grid">
                   <span>Ground conductivity</span>
-                  <input type="number" value={activeDefaults.propagationEnvironment.groundConductivity} onChange={(event) => patchPreferenceDefaults({ propagationEnvironment: { ...activeDefaults.propagationEnvironment, groundConductivity: Number(event.target.value) } })} />
+                  <input type="number" value={editableDefaults.propagationEnvironment.groundConductivity} onChange={(event) => patchPreferenceDefaults({ propagationEnvironment: { ...editableDefaults.propagationEnvironment, groundConductivity: Number(event.target.value) } })} />
                 </label>
                 <label className="field-grid">
                   <span>Atmospheric bending (N-units)</span>
-                  <input type="number" value={activeDefaults.propagationEnvironment.atmosphericBendingNUnits} onChange={(event) => patchPreferenceDefaults({ propagationEnvironment: { ...activeDefaults.propagationEnvironment, atmosphericBendingNUnits: Number(event.target.value) } })} />
+                  <input type="number" value={editableDefaults.propagationEnvironment.atmosphericBendingNUnits} onChange={(event) => patchPreferenceDefaults({ propagationEnvironment: { ...editableDefaults.propagationEnvironment, atmosphericBendingNUnits: Number(event.target.value) } })} />
                 </label>
               </>
             )}

--- a/src/index.css
+++ b/src/index.css
@@ -6125,6 +6125,62 @@ html.panorama-gesture-lock body {
   font-size: 0.85rem;
 }
 
+.custom-radio-preset-manager {
+  gap: 0.65rem;
+}
+
+.custom-radio-preset-create-row,
+.custom-radio-preset-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.custom-radio-preset-create-row > input {
+  flex: 1;
+  min-width: 0;
+}
+
+.custom-radio-preset-create-row .btn,
+.custom-radio-preset-create-row .btn-ghost,
+.custom-radio-preset-actions .btn,
+.custom-radio-preset-actions .btn-ghost,
+.custom-radio-preset-actions .btn-danger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.radio-preset-import-card {
+  max-width: 36rem;
+}
+
+.radio-preset-import-values dl {
+  display: grid;
+  grid-template-columns: minmax(9rem, 1fr) minmax(8rem, 1fr);
+  gap: 0.35rem 1rem;
+  margin: 0.75rem 0 0;
+}
+
+.radio-preset-import-values dt {
+  color: var(--muted);
+}
+
+.radio-preset-import-values dd {
+  margin: 0;
+  text-align: right;
+}
+
+.radio-preset-conflict-options {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.radio-preset-import-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
 /* Auto-save indicator */
 .autosave-indicator {
   display: inline-flex;

--- a/src/lib/radioPresetImport.test.ts
+++ b/src/lib/radioPresetImport.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { buildImportedRadioPresetPreference } from "./radioPresetImport";
+import { simulationDefaultsFromPreset, type UserSimulationDefaultsPreference } from "./simulationDefaults";
+
+const defaults = simulationDefaultsFromPreset("mt-eu_868");
+const preference: UserSimulationDefaultsPreference = {
+  mode: "custom",
+  presetId: "mt-eu_868",
+  customPresetId: "radio-existing",
+  customPresets: [{ id: "radio-existing", name: "Alpine Mesh", defaults: { ...defaults, frequencyPresetId: "radio-existing" } }],
+  overridePresetDefaults: false,
+};
+
+describe("buildImportedRadioPresetPreference", () => {
+  it("imports an independent copy and optionally selects it as default", () => {
+    const result = buildImportedRadioPresetPreference({
+      preference,
+      sharedPreset: { name: "Field Mesh", defaults },
+      requestedName: "Field Mesh",
+      conflictMode: null,
+      makeDefault: true,
+      createId: () => "radio-imported",
+    });
+    expect(result.preference).toMatchObject({ mode: "custom", customPresetId: "radio-imported" });
+    expect(result.preference.customPresets).toContainEqual(expect.objectContaining({ id: "radio-imported", name: "Field Mesh" }));
+  });
+
+  it("replaces a conflicting preset while preserving its stable id", () => {
+    const result = buildImportedRadioPresetPreference({
+      preference,
+      sharedPreset: { name: "Alpine Mesh", defaults: { ...defaults, frequencyMHz: 869.4 } },
+      requestedName: "Alpine Mesh",
+      conflictMode: "replace",
+      makeDefault: false,
+      createId: () => "unused",
+    });
+    expect(result.importedId).toBe("radio-existing");
+    expect(result.preference.customPresets).toHaveLength(1);
+    expect(result.preference.customPresets?.[0]?.defaults.frequencyMHz).toBe(869.4);
+    expect(result.preference.customPresetId).toBe("radio-existing");
+  });
+
+  it("requires an explicit conflict choice and a unique rename", () => {
+    expect(() => buildImportedRadioPresetPreference({
+      preference,
+      sharedPreset: { name: "Alpine Mesh", defaults },
+      requestedName: "Alpine Mesh",
+      conflictMode: null,
+      makeDefault: false,
+      createId: () => "new",
+    })).toThrow(/choose whether/i);
+    expect(() => buildImportedRadioPresetPreference({
+      preference,
+      sharedPreset: { name: "Alpine Mesh", defaults },
+      requestedName: "Alpine Mesh",
+      conflictMode: "rename",
+      makeDefault: false,
+      createId: () => "new",
+    })).toThrow(/unique/i);
+  });
+});

--- a/src/lib/radioPresetImport.ts
+++ b/src/lib/radioPresetImport.ts
@@ -1,0 +1,68 @@
+import {
+  MAX_CUSTOM_RADIO_PRESETS,
+  normalizeCustomRadioPresetName,
+  normalizeUserSimulationDefaultsPreference,
+  type UserSimulationDefaultsPreference,
+} from "./simulationDefaults";
+import type { SharedRadioPreset } from "./radioPresetShare";
+
+export type RadioPresetImportConflictMode = "replace" | "rename" | null;
+
+export const findRadioPresetImportConflict = (
+  preference: UserSimulationDefaultsPreference,
+  sharedPresetName: string,
+) => preference.customPresets?.find(
+  (preset) => preset.name.toLocaleLowerCase() === sharedPresetName.trim().toLocaleLowerCase(),
+);
+
+export const buildImportedRadioPresetPreference = (input: {
+  preference: UserSimulationDefaultsPreference;
+  sharedPreset: SharedRadioPreset;
+  requestedName: string;
+  conflictMode: RadioPresetImportConflictMode;
+  makeDefault: boolean;
+  createId: () => string;
+}): { preference: UserSimulationDefaultsPreference; importedName: string; importedId: string } => {
+  const preference = normalizeUserSimulationDefaultsPreference(input.preference);
+  const customPresets = preference.customPresets ?? [];
+  const requestedName = normalizeCustomRadioPresetName(input.requestedName);
+  if (!requestedName) throw new Error("Enter a preset name.");
+
+  const conflict = findRadioPresetImportConflict(preference, input.sharedPreset.name);
+  if (conflict && !input.conflictMode) {
+    throw new Error("Choose whether to replace the existing preset or save with a new name.");
+  }
+  const replacing = Boolean(conflict && input.conflictMode === "replace");
+  const nameCollision = customPresets.find(
+    (preset) => preset.name.toLocaleLowerCase() === requestedName.toLocaleLowerCase() && preset.id !== conflict?.id,
+  );
+  if (!replacing && (nameCollision || requestedName.toLocaleLowerCase() === conflict?.name.toLocaleLowerCase())) {
+    throw new Error("Choose a unique preset name.");
+  }
+  if (!replacing && customPresets.length >= MAX_CUSTOM_RADIO_PRESETS) {
+    throw new Error(`You can save up to ${MAX_CUSTOM_RADIO_PRESETS} custom presets.`);
+  }
+
+  const importedId = replacing ? conflict!.id : input.createId();
+  const importedName = replacing ? conflict!.name : requestedName;
+  const imported = {
+    id: importedId,
+    name: importedName,
+    defaults: { ...input.sharedPreset.defaults, frequencyPresetId: importedId },
+  };
+  const nextCustomPresets = replacing
+    ? customPresets.map((preset) => preset.id === importedId ? imported : preset)
+    : [...customPresets, imported];
+
+  return {
+    importedId,
+    importedName,
+    preference: normalizeUserSimulationDefaultsPreference({
+      ...preference,
+      ...(input.makeDefault
+        ? { mode: "custom" as const, customPresetId: importedId, overridePresetDefaults: false }
+        : {}),
+      customPresets: nextCustomPresets,
+    }),
+  };
+};

--- a/src/lib/radioPresetShare.test.ts
+++ b/src/lib/radioPresetShare.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { defaultPropagationEnvironment } from "./propagationEnvironment";
+import {
+  buildRadioPresetShareHash,
+  parseRadioPresetShareHash,
+  RADIO_PRESET_SHARE_MAX_ENCODED_LENGTH,
+} from "./radioPresetShare";
+
+const defaults = {
+  frequencyPresetId: "custom-source",
+  frequencyMHz: 869.618,
+  bandwidthKhz: 62.5,
+  spreadFactor: 8,
+  codingRate: 5,
+  regionCode: "EU_868",
+  rxSensitivityTargetDbm: -130,
+  environmentLossDb: 3,
+  propagationEnvironment: defaultPropagationEnvironment(),
+  autoPropagationEnvironment: false,
+};
+
+describe("radioPresetShare", () => {
+  it("round trips a complete preset with a unicode name", () => {
+    const hash = buildRadioPresetShareHash({ name: "Høgevarde 📡", defaults });
+    expect(hash).toMatch(/^#preset=[A-Za-z0-9_-]+$/);
+    expect(parseRadioPresetShareHash(hash)).toEqual({
+      ok: true,
+      preset: { name: "Høgevarde 📡", defaults: { ...defaults, frequencyPresetId: "custom" } },
+    });
+  });
+
+  it("rejects malformed, oversized, and unsupported payloads", () => {
+    expect(parseRadioPresetShareHash("#preset=not-json")).toMatchObject({ ok: false });
+    expect(parseRadioPresetShareHash(`#preset=${"a".repeat(RADIO_PRESET_SHARE_MAX_ENCODED_LENGTH + 1)}`)).toEqual({
+      ok: false,
+      reason: "too_large",
+    });
+    const unsupported = btoa(JSON.stringify({ v: 2, name: "Future", defaults }))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/g, "");
+    expect(parseRadioPresetShareHash(`#preset=${unsupported}`)).toEqual({ ok: false, reason: "unsupported_version" });
+  });
+
+  it("strictly validates names and radio/environment values", () => {
+    expect(() => buildRadioPresetShareHash({ name: " ", defaults })).toThrow(/name/i);
+    expect(() => buildRadioPresetShareHash({ name: "x".repeat(81), defaults })).toThrow(/name/i);
+    expect(() => buildRadioPresetShareHash({ name: "Bad frequency", defaults: { ...defaults, frequencyMHz: 0 } })).toThrow(/frequency/i);
+    expect(() => buildRadioPresetShareHash({ name: "Bad SF", defaults: { ...defaults, spreadFactor: 13 } })).toThrow(/spread factor/i);
+    expect(() => buildRadioPresetShareHash({ name: "Bad CR", defaults: { ...defaults, codingRate: 4 } })).toThrow(/coding rate/i);
+    expect(() => buildRadioPresetShareHash({ name: "Bad climate", defaults: { ...defaults, propagationEnvironment: { ...defaults.propagationEnvironment, radioClimate: "Moon" as never } } })).toThrow(/climate/i);
+    expect(() => buildRadioPresetShareHash({ name: "Bad automatic mode", defaults: { ...defaults, autoPropagationEnvironment: "yes" as never } })).toThrow(/automatic environment/i);
+  });
+});

--- a/src/lib/radioPresetShare.ts
+++ b/src/lib/radioPresetShare.ts
@@ -1,0 +1,128 @@
+import type { RadioClimate, Polarization, PropagationEnvironment } from "../types/radio";
+import type { SimulationDefaults } from "./simulationDefaults";
+import { MAX_CUSTOM_RADIO_PRESET_NAME_LENGTH } from "./simulationDefaults";
+
+export const RADIO_PRESET_SHARE_MAX_ENCODED_LENGTH = 8 * 1024;
+
+export type SharedRadioPreset = {
+  name: string;
+  defaults: SimulationDefaults;
+};
+
+export type RadioPresetShareParseResult =
+  | { ok: true; preset: SharedRadioPreset }
+  | { ok: false; reason: "missing" | "too_large" | "malformed" | "unsupported_version" | "invalid" };
+
+const RADIO_CLIMATES = new Set<RadioClimate>([
+  "Equatorial",
+  "Continental Subtropical",
+  "Maritime Subtropical",
+  "Desert",
+  "Continental Temperate",
+  "Maritime Temperate (Land)",
+  "Maritime Temperate (Sea)",
+]);
+const POLARIZATIONS = new Set<Polarization>(["Vertical", "Horizontal"]);
+
+const requireFinite = (value: unknown, label: string): number => {
+  if (typeof value !== "number" || !Number.isFinite(value)) throw new Error(`${label} must be a finite number.`);
+  return value;
+};
+
+const validateEnvironment = (value: unknown): PropagationEnvironment => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Propagation environment is invalid.");
+  const raw = value as Partial<PropagationEnvironment>;
+  if (!RADIO_CLIMATES.has(raw.radioClimate as RadioClimate)) throw new Error("Radio climate is invalid.");
+  if (!POLARIZATIONS.has(raw.polarization as Polarization)) throw new Error("Polarization is invalid.");
+  const clutterHeightM = requireFinite(raw.clutterHeightM, "Clutter height");
+  const groundDielectric = requireFinite(raw.groundDielectric, "Ground dielectric");
+  const groundConductivity = requireFinite(raw.groundConductivity, "Ground conductivity");
+  const atmosphericBendingNUnits = requireFinite(raw.atmosphericBendingNUnits, "Atmospheric bending");
+  if (clutterHeightM < 0 || groundDielectric <= 0 || groundConductivity < 0 || atmosphericBendingNUnits <= 0) {
+    throw new Error("Propagation environment values are outside the supported range.");
+  }
+  return {
+    radioClimate: raw.radioClimate as RadioClimate,
+    polarization: raw.polarization as Polarization,
+    clutterHeightM,
+    groundDielectric,
+    groundConductivity,
+    atmosphericBendingNUnits,
+  };
+};
+
+export const validateSharedRadioPreset = (value: unknown): SharedRadioPreset => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Preset payload is invalid.");
+  const raw = value as { name?: unknown; defaults?: unknown };
+  const name = typeof raw.name === "string" ? raw.name.trim() : "";
+  if (!name || name.length > MAX_CUSTOM_RADIO_PRESET_NAME_LENGTH) throw new Error("Preset name must be 1-80 characters.");
+  if (!raw.defaults || typeof raw.defaults !== "object" || Array.isArray(raw.defaults)) throw new Error("Preset defaults are invalid.");
+  const defaults = raw.defaults as Partial<SimulationDefaults>;
+  const frequencyMHz = requireFinite(defaults.frequencyMHz, "Frequency");
+  const bandwidthKhz = requireFinite(defaults.bandwidthKhz, "Bandwidth");
+  const spreadFactor = requireFinite(defaults.spreadFactor, "Spread factor");
+  const codingRate = requireFinite(defaults.codingRate, "Coding rate");
+  const rxSensitivityTargetDbm = requireFinite(defaults.rxSensitivityTargetDbm, "RX target");
+  const environmentLossDb = requireFinite(defaults.environmentLossDb, "Environment loss");
+  if (frequencyMHz <= 0) throw new Error("Frequency must be greater than zero.");
+  if (bandwidthKhz <= 0) throw new Error("Bandwidth must be greater than zero.");
+  if (!Number.isInteger(spreadFactor) || spreadFactor < 5 || spreadFactor > 12) throw new Error("Spread factor must be an integer from 5 to 12.");
+  if (!Number.isInteger(codingRate) || codingRate < 5 || codingRate > 8) throw new Error("Coding rate must be an integer from 5 to 8.");
+  if (environmentLossDb < 0) throw new Error("Environment loss cannot be negative.");
+  if (typeof defaults.autoPropagationEnvironment !== "boolean") throw new Error("Automatic environment mode must be a boolean.");
+  const regionCode = typeof defaults.regionCode === "string" ? defaults.regionCode.trim().slice(0, 32) : undefined;
+  return {
+    name,
+    defaults: {
+      // Internal account preset IDs are deliberately excluded from portable links.
+      frequencyPresetId: "custom",
+      frequencyMHz,
+      bandwidthKhz,
+      spreadFactor,
+      codingRate,
+      ...(regionCode ? { regionCode } : {}),
+      rxSensitivityTargetDbm,
+      environmentLossDb,
+      propagationEnvironment: validateEnvironment(defaults.propagationEnvironment),
+      autoPropagationEnvironment: defaults.autoPropagationEnvironment,
+    },
+  };
+};
+
+const encodeBase64Url = (value: string): string => {
+  const bytes = new TextEncoder().encode(value);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+};
+
+const decodeBase64Url = (value: string): string => {
+  const base64 = value.replace(/-/g, "+").replace(/_/g, "/").padEnd(Math.ceil(value.length / 4) * 4, "=");
+  const binary = atob(base64);
+  return new TextDecoder().decode(Uint8Array.from(binary, (character) => character.charCodeAt(0)));
+};
+
+export const buildRadioPresetShareHash = (preset: SharedRadioPreset): string => {
+  const validated = validateSharedRadioPreset(preset);
+  const encoded = encodeBase64Url(JSON.stringify({ v: 1, ...validated }));
+  if (encoded.length > RADIO_PRESET_SHARE_MAX_ENCODED_LENGTH) throw new Error("Preset share payload is too large.");
+  return `#preset=${encoded}`;
+};
+
+export const buildRadioPresetShareUrl = (preset: SharedRadioPreset, location: Pick<Location, "origin" | "pathname" | "search">): string =>
+  `${location.origin}${location.pathname}${location.search}${buildRadioPresetShareHash(preset)}`;
+
+export const parseRadioPresetShareHash = (hash: string): RadioPresetShareParseResult => {
+  if (!hash.startsWith("#preset=")) return { ok: false, reason: "missing" };
+  const encoded = hash.slice("#preset=".length);
+  if (!encoded || encoded.length > RADIO_PRESET_SHARE_MAX_ENCODED_LENGTH) {
+    return { ok: false, reason: encoded ? "too_large" : "missing" };
+  }
+  try {
+    const raw = JSON.parse(decodeBase64Url(encoded)) as { v?: unknown };
+    if (raw.v !== 1) return { ok: false, reason: "unsupported_version" };
+    return { ok: true, preset: validateSharedRadioPreset(raw) };
+  } catch {
+    return { ok: false, reason: "malformed" };
+  }
+};

--- a/src/lib/simulationDefaults.test.ts
+++ b/src/lib/simulationDefaults.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  LEGACY_CUSTOM_RADIO_PRESET_ID,
+  MAX_CUSTOM_RADIO_PRESETS,
+  normalizeUserSimulationDefaultsPreference,
+  resolveUserSimulationDefaults,
+  simulationDefaultsFromPreset,
+} from "./simulationDefaults";
+
+describe("custom radio presets", () => {
+  it("migrates the legacy unnamed custom defaults without changing values", () => {
+    const legacy = {
+      mode: "custom" as const,
+      presetId: "mt-us",
+      overridePresetDefaults: false,
+      custom: { ...simulationDefaultsFromPreset("mt-us"), frequencyMHz: 906.875, rxSensitivityTargetDbm: -126 },
+    };
+    const normalized = normalizeUserSimulationDefaultsPreference(legacy);
+    expect(normalized.customPresetId).toBe(LEGACY_CUSTOM_RADIO_PRESET_ID);
+    expect(normalized.customPresets).toHaveLength(1);
+    expect(normalized.customPresets?.[0]).toMatchObject({
+      id: LEGACY_CUSTOM_RADIO_PRESET_ID,
+      name: "My custom preset",
+      defaults: { frequencyMHz: 906.875, rxSensitivityTargetDbm: -126 },
+    });
+    expect(resolveUserSimulationDefaults(normalized).frequencyMHz).toBe(906.875);
+  });
+
+  it("resolves a selected named preset and keeps its stable id", () => {
+    const base = simulationDefaultsFromPreset("mt-eu_868");
+    const preference = normalizeUserSimulationDefaultsPreference({
+      mode: "custom",
+      presetId: "mt-eu_868",
+      customPresetId: "radio-alpine",
+      customPresets: [{ id: "radio-alpine", name: "Alpine Mesh", defaults: { ...base, frequencyMHz: 869.4 } }],
+      overridePresetDefaults: false,
+    });
+    expect(resolveUserSimulationDefaults(preference)).toMatchObject({
+      frequencyPresetId: "radio-alpine",
+      frequencyMHz: 869.4,
+    });
+  });
+
+  it("deduplicates names and caps the normalized collection", () => {
+    const base = simulationDefaultsFromPreset("mt-us");
+    const customPresets = Array.from({ length: MAX_CUSTOM_RADIO_PRESETS + 5 }, (_, index) => ({
+      id: `radio-${index}`,
+      name: index === 1 ? " mesh 0 " : `Mesh ${index}`,
+      defaults: base,
+    }));
+    const normalized = normalizeUserSimulationDefaultsPreference({
+      mode: "preset",
+      presetId: "mt-us",
+      overridePresetDefaults: false,
+      customPresets,
+    });
+    expect(normalized.customPresets).toHaveLength(MAX_CUSTOM_RADIO_PRESETS);
+    expect(normalized.customPresets?.filter((preset) => preset.name.toLowerCase() === "mesh 0")).toHaveLength(1);
+  });
+
+  it("ignores malformed collection entries during server-safe normalization", () => {
+    const malformed = {
+      mode: "custom",
+      presetId: "mt-us",
+      overridePresetDefaults: false,
+      customPresetId: "valid",
+      customPresets: [null, "bad", { id: "valid", name: "Valid", defaults: simulationDefaultsFromPreset("mt-us") }],
+    } as unknown as Parameters<typeof normalizeUserSimulationDefaultsPreference>[0];
+    const normalized = normalizeUserSimulationDefaultsPreference(malformed);
+    expect(normalized.customPresets).toHaveLength(1);
+    expect(normalized.customPresetId).toBe("valid");
+  });
+});

--- a/src/lib/simulationDefaults.ts
+++ b/src/lib/simulationDefaults.ts
@@ -15,9 +15,21 @@ export type SimulationDefaults = {
   autoPropagationEnvironment: boolean;
 };
 
+export type CustomRadioPreset = {
+  id: string;
+  name: string;
+  defaults: SimulationDefaults;
+};
+
+export const MAX_CUSTOM_RADIO_PRESETS = 50;
+export const MAX_CUSTOM_RADIO_PRESET_NAME_LENGTH = 80;
+export const LEGACY_CUSTOM_RADIO_PRESET_ID = "radio-legacy-custom";
+
 export type UserSimulationDefaultsPreference = {
   mode: "preset" | "custom";
   presetId: string;
+  customPresetId?: string;
+  customPresets?: CustomRadioPreset[];
   overridePresetDefaults: boolean;
   overrides?: Partial<SimulationDefaults>;
   custom?: Partial<SimulationDefaults>;
@@ -78,16 +90,102 @@ const mergeDefaults = (base: SimulationDefaults, patch?: Partial<SimulationDefau
       : base.autoPropagationEnvironment,
 });
 
+const normalizeCustomRadioPresetId = (value: unknown): string =>
+  typeof value === "string" ? value.trim().slice(0, 120) : "";
+
+export const normalizeCustomRadioPresetName = (value: unknown): string =>
+  typeof value === "string" ? value.trim().slice(0, MAX_CUSTOM_RADIO_PRESET_NAME_LENGTH) : "";
+
+export const findCustomRadioPreset = (
+  preference: UserSimulationDefaultsPreference | null | undefined,
+  id: string | null | undefined,
+): CustomRadioPreset | undefined =>
+  preference?.customPresets?.find((preset) => preset.id === id);
+
+export const normalizeUserSimulationDefaultsPreference = (
+  value?: UserSimulationDefaultsPreference | null,
+  legacyPresetId?: string | null,
+): UserSimulationDefaultsPreference => {
+  const raw = value ?? {
+    mode: "preset" as const,
+    presetId: legacyPresetId ?? FALLBACK_SIMULATION_PRESET_ID,
+    overridePresetDefaults: false,
+  };
+  const presetId = findPresetById(raw.presetId)
+    ? raw.presetId
+    : findPresetById(legacyPresetId ?? "")
+      ? String(legacyPresetId)
+      : FALLBACK_SIMULATION_PRESET_ID;
+  const customPresets: CustomRadioPreset[] = [];
+  const ids = new Set<string>();
+  const names = new Set<string>();
+
+  const addPreset = (candidate: unknown, preserveDefaultsPresetId = false) => {
+    if (customPresets.length >= MAX_CUSTOM_RADIO_PRESETS) return;
+    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return;
+    const rawCandidate = candidate as Partial<CustomRadioPreset>;
+    const id = normalizeCustomRadioPresetId(rawCandidate.id);
+    const name = normalizeCustomRadioPresetName(rawCandidate.name);
+    const nameKey = name.toLocaleLowerCase();
+    if (!id || !name || ids.has(id) || names.has(nameKey) || !rawCandidate.defaults) return;
+    const normalizedDefaults = normalizeSimulationDefaults(rawCandidate.defaults);
+    ids.add(id);
+    names.add(nameKey);
+    customPresets.push({
+      id,
+      name,
+      defaults: {
+        ...normalizedDefaults,
+        frequencyPresetId: preserveDefaultsPresetId
+          ? normalizedDefaults.frequencyPresetId
+          : id,
+      },
+    });
+  };
+
+  if (Array.isArray(raw.customPresets)) {
+    for (const candidate of raw.customPresets) addPreset(candidate);
+  }
+  if (raw.mode === "custom" && raw.custom && !customPresets.length) {
+    addPreset({
+      id: LEGACY_CUSTOM_RADIO_PRESET_ID,
+      name: "My custom preset",
+      defaults: normalizeSimulationDefaults(raw.custom, simulationDefaultsFromPreset(presetId)),
+    }, true);
+  }
+
+  const requestedCustomId = normalizeCustomRadioPresetId(raw.customPresetId);
+  const selectedCustom = customPresets.find((preset) => preset.id === requestedCustomId)
+    ?? (raw.mode === "custom" ? customPresets[0] : undefined);
+
+  return {
+    mode: raw.mode === "custom" && selectedCustom ? "custom" : "preset",
+    presetId,
+    ...(selectedCustom ? { customPresetId: selectedCustom.id } : {}),
+    ...(customPresets.length ? { customPresets } : {}),
+    overridePresetDefaults: Boolean(raw.overridePresetDefaults),
+    ...(raw.overrides ? { overrides: normalizeSimulationDefaults(raw.overrides, simulationDefaultsFromPreset(presetId)) } : {}),
+  };
+};
+
 export const resolveUserSimulationDefaults = (
   preference?: UserSimulationDefaultsPreference | null,
   legacyPresetId?: string | null,
 ): SimulationDefaults => {
-  const presetId = preference?.presetId || legacyPresetId || FALLBACK_SIMULATION_PRESET_ID;
+  const normalizedPreference = normalizeUserSimulationDefaultsPreference(preference, legacyPresetId);
+  const presetId = normalizedPreference.presetId || legacyPresetId || FALLBACK_SIMULATION_PRESET_ID;
   const presetDefaults = simulationDefaultsFromPreset(presetId);
-  if (preference?.mode === "custom") {
-    return mergeDefaults(presetDefaults, preference.custom);
+  if (normalizedPreference.mode === "custom") {
+    const customPreset = findCustomRadioPreset(normalizedPreference, normalizedPreference.customPresetId);
+    if (customPreset) {
+      return customPreset.id === LEGACY_CUSTOM_RADIO_PRESET_ID
+        ? customPreset.defaults
+        : { ...customPreset.defaults, frequencyPresetId: customPreset.id };
+    }
   }
-  return preference?.overridePresetDefaults ? mergeDefaults(presetDefaults, preference.overrides) : presetDefaults;
+  return normalizedPreference.overridePresetDefaults
+    ? mergeDefaults(presetDefaults, normalizedPreference.overrides)
+    : presetDefaults;
 };
 
 export const normalizeSimulationDefaults = (

--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -48,6 +48,7 @@ vi.mock("../lib/cloudLibrary", async () => {
 import { useAppStore } from "./appStore";
 import { fetchElevations } from "../lib/elevationService";
 import { deleteCloudSimulation, restoreCloudSimulation } from "../lib/cloudLibrary";
+import { simulationDefaultsFromPreset } from "../lib/simulationDefaults";
 
 describe("appStore auth session state", () => {
   beforeEach(() => {
@@ -834,6 +835,37 @@ describe("appStore new simulation default frequency preset", () => {
     expect(created?.snapshot.environmentLossDb).toBe(4);
     expect(created?.snapshot.autoPropagationEnvironment).toBe(false);
     expect(created?.snapshot.simulationDefaultsOverrideEnabled).toBe(false);
+  });
+
+  it("uses a selected named custom preset when creating a blank simulation", () => {
+    const defaults = {
+      ...simulationDefaultsFromPreset("mt-eu_868"),
+      frequencyPresetId: "radio-field-mesh",
+      frequencyMHz: 869.4,
+      rxSensitivityTargetDbm: -127,
+    };
+    useAppStore.setState((state) => ({
+      currentUser: state.currentUser ? {
+        ...state.currentUser,
+        simulationDefaultsPreference: {
+          mode: "custom",
+          presetId: "mt-eu_868",
+          customPresetId: "radio-field-mesh",
+          customPresets: [{ id: "radio-field-mesh", name: "Field Mesh", defaults }],
+          overridePresetDefaults: false,
+        },
+      } : null,
+    }));
+
+    const createdId = useAppStore.getState().createBlankSimulationPreset("Named custom", {
+      visibility: "private",
+      ownerUserId: "owner-1",
+    });
+    const created = useAppStore.getState().simulationPresets.find((entry) => entry.id === createdId);
+    expect(created?.snapshot).toMatchObject({
+      selectedFrequencyPresetId: "radio-field-mesh",
+      rxSensitivityTargetDbm: -127,
+    });
   });
 
   it("falls back to app default when cloud default is invalid", () => {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -4,6 +4,7 @@ import { setAppStoreBridge, useCoverageStore } from "./coverageStore";
 import { findPresetById } from "../lib/frequencyPlans";
 import {
   FALLBACK_SIMULATION_PRESET_ID,
+  findCustomRadioPreset,
   normalizeSimulationDefaults,
   resolveUserSimulationDefaults,
   simulationDefaultsFromPreset,
@@ -160,9 +161,10 @@ const requireAuth = (currentUser: CloudUser | null, action: string): CloudUser |
 };
 
 const resolveDefaultFrequencyPresetIdForNewSimulation = (currentUser: CloudUser | null): string => {
-  const preferred = currentUser?.simulationDefaultsPreference?.presetId ?? currentUser?.defaultFrequencyPresetId;
-  if (typeof preferred === "string" && findPresetById(preferred)) return preferred;
-  return FALLBACK_SIMULATION_PRESET_ID;
+  return resolveUserSimulationDefaults(
+    currentUser?.simulationDefaultsPreference,
+    currentUser?.defaultFrequencyPresetId,
+  ).frequencyPresetId;
 };
 
 const resolveEffectiveSimulationDefaultsForSnapshot = (
@@ -2928,8 +2930,9 @@ export const useAppStore = create<AppState>((set, get) => ({
     if (hasDuplicateSimulationName(get().simulationPresets, presetName)) return null;
     const inheritedDefaults = resolveUserSimulationDefaults(user.simulationDefaultsPreference, user.defaultFrequencyPresetId);
     const defaultPresetId = inheritedDefaults.frequencyPresetId;
+    const requestedCustomPreset = findCustomRadioPreset(user.simulationDefaultsPreference, options?.frequencyPresetId);
     const selectedPresetId =
-      typeof options?.frequencyPresetId === "string" && findPresetById(options.frequencyPresetId)
+      typeof options?.frequencyPresetId === "string" && (findPresetById(options.frequencyPresetId) || requestedCustomPreset)
         ? options.frequencyPresetId
         : defaultPresetId;
     set((current) => {
@@ -3641,24 +3644,25 @@ export const useAppStore = create<AppState>((set, get) => ({
     }
     const { selectedFrequencyPresetId, selectedNetworkId } = get();
     const preset = findPresetById(selectedFrequencyPresetId);
-    if (!preset) return;
-    const defaults = simulationDefaultsFromPreset(preset.id);
+    const customPreset = findCustomRadioPreset(user.simulationDefaultsPreference, selectedFrequencyPresetId);
+    if (!preset && !customPreset) return;
+    const defaults = customPreset?.defaults ?? simulationDefaultsFromPreset(preset?.id ?? FALLBACK_SIMULATION_PRESET_ID);
 
     set((state) => ({
       networks: state.networks.map((network) =>
         network.id === selectedNetworkId
           ? {
               ...network,
-              frequencyMHz: preset.frequencyMHz,
-              bandwidthKhz: preset.bandwidthKhz,
-              spreadFactor: preset.spreadFactor,
-              codingRate: preset.codingRate,
-              frequencyOverrideMHz: preset.frequencyMHz,
-              regionCode: preset.regionCode,
+              frequencyMHz: defaults.frequencyMHz,
+              bandwidthKhz: defaults.bandwidthKhz,
+              spreadFactor: defaults.spreadFactor,
+              codingRate: defaults.codingRate,
+              frequencyOverrideMHz: defaults.frequencyMHz,
+              regionCode: defaults.regionCode,
             }
           : network,
       ),
-      links: state.links.map((link) => ({ ...link, frequencyMHz: preset.frequencyMHz })),
+      links: state.links.map((link) => ({ ...link, frequencyMHz: defaults.frequencyMHz })),
       rxSensitivityTargetDbm: defaults.rxSensitivityTargetDbm,
       environmentLossDb: defaults.environmentLossDb,
       propagationEnvironment: defaults.propagationEnvironment,


### PR DESCRIPTION
## Summary

- add account-synced named custom radio presets with legacy custom migration and consistent resolution
- add Preferences management with autosaved full defaults editing and portable share links
- add strict versioned preset link codec plus raised anonymous/authenticated import preview and conflict handling
- preserve the existing `/api/me` shape and store the collection inside the JSON preference without a D1 migration

Refs #864

## Verification

- `npm test` — 139 files, 812 tests passed
- `npm run build` — passed (existing chunk-size warning only)
- `npm run test -- --run src/lib/deepLink.test.ts` — passed
- `npm run test -- --run functions/api/v1/calculate.test.ts` — passed
- `npm run test -- --run src/store/appStore.test.ts` — passed
- scoped ESLint for the preset implementation/tests — passed
- `npm run dev:check` — no LinkSim dev/watch servers found

Repository-wide lint retains unrelated pre-existing baseline findings.