### PR TITLE
Fix radio preset autosave and modal stacking

### DIFF
--- a/src/components/AppShell.deeplink.test.ts
+++ b/src/components/AppShell.deeplink.test.ts
@@ -132,7 +132,14 @@ vi.mock("./LinkProfileChart", () => ({ LinkProfileChart: () => null }));
 vi.mock("./PanoramaChart", () => ({ PanoramaChart: () => null }));
 vi.mock("./ActionButton", () => ({ ActionButton: ({ children, variant, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement> & { variant?: string }) => React.createElement("button", { ...props, "data-variant": variant }, children) }));
 vi.mock("./InlineCloseIconButton", () => ({ InlineCloseIconButton: () => null }));
-vi.mock("./ModalOverlay", () => ({ ModalOverlay: ({ children }: { children?: React.ReactNode }) => children ?? null }));
+vi.mock("./ModalOverlay", () => ({
+  ModalOverlay: ({ children, suspended, ...props }: { children?: React.ReactNode; suspended?: boolean; "aria-label": string }) =>
+    React.createElement("div", {
+      "aria-hidden": suspended || undefined,
+      "aria-label": props["aria-label"],
+      "data-modal-overlay": "true",
+    }, children),
+}));
 vi.mock("./app-shell/MobileWorkspaceTabs", () => ({ MobileWorkspaceTabs: () => null }));
 vi.mock("./app-shell/useOnboardingFlow", () => ({
   useOnboardingFlow: () => ({
@@ -312,6 +319,23 @@ describe("AppShell deeplink cold-load flow", () => {
       expect(document.body.textContent).toContain("869.4 MHz");
       expect(document.body.textContent).toContain("-127 dBm");
       expect(document.body.textContent).toContain("Sign in to save");
+    } finally {
+      unmountAppShell(view);
+    }
+  });
+
+  it("renders the preset import above and suspends the Settings dialog", async () => {
+    const defaults = { ...simulationDefaultsFromPreset("mt-eu_868"), autoPropagationEnvironment: false };
+    window.history.replaceState(null, "", `/settings/preferences${buildRadioPresetShareHash({ name: "Alpine Mesh", defaults })}`);
+
+    const view = await renderAppShell();
+    try {
+      const settings = document.querySelector<HTMLElement>('[data-modal-overlay="true"][aria-label="Settings"]');
+      const presetImport = document.querySelector<HTMLElement>('[data-modal-overlay="true"][aria-label="Import radio preset"]');
+      expect(settings).not.toBeNull();
+      expect(presetImport).not.toBeNull();
+      expect(settings).toHaveAttribute("aria-hidden", "true");
+      expect((settings as Node).compareDocumentPosition(presetImport as Node) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     } finally {
       unmountAppShell(view);
     }

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -2393,6 +2393,19 @@ export function AppShell() {
           </div>
         </ModalOverlay>
       ) : null}
+      {settingsRoute ? (
+        <ModalOverlay
+          aria-label="Settings"
+          className="settings-overlay"
+          onClose={closeSettings}
+          suspended={Boolean(presetImport)}
+          tier="raised"
+        >
+          <div className="library-manager-card settings-panel-wrapper">
+            <SettingsPanel initialSection={settingsRoute.section} onClose={closeSettings} suspended={Boolean(presetImport)} />
+          </div>
+        </ModalOverlay>
+      ) : null}
       {presetImport ? (
         <ModalOverlay aria-label="Import radio preset" onClose={clearPresetImport} tier="raised">
           <div className="library-manager-card radio-preset-import-card">
@@ -2640,13 +2653,6 @@ export function AppShell() {
         </ModalOverlay>
       ) : null}
       <UserProfilePopover onClose={() => setProfileTarget(null)} target={profileTarget} viewer={currentUser} />
-      {settingsRoute ? (
-        <ModalOverlay aria-label="Settings" onClose={closeSettings} tier="raised" className="settings-overlay">
-          <div className="library-manager-card settings-panel-wrapper">
-            <SettingsPanel initialSection={settingsRoute.section} onClose={closeSettings} />
-          </div>
-        </ModalOverlay>
-      ) : null}
       <MapEditorPanel isMobile={isMobileViewport} />
     </main>
   );

--- a/src/components/settings/SettingsPanel.test.tsx
+++ b/src/components/settings/SettingsPanel.test.tsx
@@ -128,6 +128,20 @@ describe("SettingsPanel", () => {
     expect(onClose).toHaveBeenCalledOnce();
   });
 
+  it("does not close or steal focus while suspended under another modal", () => {
+    const onClose = vi.fn();
+    const outsideButton = document.createElement("button");
+    document.body.append(outsideButton);
+    outsideButton.focus();
+    render(<SettingsPanel initialSection={null} onClose={onClose} suspended />);
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(outsideButton);
+    outsideButton.remove();
+  });
+
   it("clears the authenticated-session marker on explicit sign out", () => {
     mockState.currentUser = {
       id: "u1",

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -16,6 +16,8 @@ type SettingsPanelProps = {
   /** Active section resolved from the URL; null → default to "profile". */
   initialSection: SettingsSectionId | null;
   onClose: () => void;
+  /** Disable panel-level focus and keyboard handling while a raised child modal is active. */
+  suspended?: boolean;
 };
 
 const useIsNarrow = () => {
@@ -33,7 +35,7 @@ const useIsNarrow = () => {
   return isNarrow;
 };
 
-export function SettingsPanel({ initialSection, onClose }: SettingsPanelProps) {
+export function SettingsPanel({ initialSection, onClose, suspended = false }: SettingsPanelProps) {
   const currentUser = useAppStore((state) => state.currentUser);
   const setCurrentUser = useAppStore((state) => state.setCurrentUser);
   const authState = useAppStore((state) => state.authState);
@@ -92,6 +94,7 @@ export function SettingsPanel({ initialSection, onClose }: SettingsPanelProps) {
 
   // Escape key closes the panel.
   useEffect(() => {
+    if (suspended) return;
     const onKey = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         event.preventDefault();
@@ -100,12 +103,13 @@ export function SettingsPanel({ initialSection, onClose }: SettingsPanelProps) {
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [onClose]);
+  }, [onClose, suspended]);
 
   useEffect(() => {
     // Focus the close button when opening for a11y.
+    if (suspended) return;
     closeButtonRef.current?.focus();
-  }, []);
+  }, [suspended]);
 
   const handleMeUpdated = useCallback(
     (user: CloudUser) => {

--- a/src/components/settings/sections/PreferencesSection.test.tsx
+++ b/src/components/settings/sections/PreferencesSection.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { simulationDefaultsFromPreset, type UserSimulationDefaultsPreference } from "../../../lib/simulationDefaults";
 import type { CloudUser } from "../../../lib/cloudUser";
 import { parseRadioPresetShareHash } from "../../../lib/radioPresetShare";
@@ -59,6 +59,10 @@ describe("PreferencesSection custom radio presets", () => {
     hoisted.clipboardWriteText.mockResolvedValue(undefined);
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("shows the migrated legacy custom preset and blocks deleting the active default", async () => {
     const me = userWithPreference({
       mode: "custom",
@@ -110,5 +114,130 @@ describe("PreferencesSection custom radio presets", () => {
       presetId: "mt-us",
       customPresets: [expect.objectContaining({ name: "Field Mesh" })],
     });
+  });
+
+  it("keeps multi-character value edits optimistic and debounces the final draft", async () => {
+    vi.useFakeTimers();
+    const defaults = { ...simulationDefaultsFromPreset("mt-eu_868"), frequencyPresetId: "radio-alpine" };
+    const me = userWithPreference({
+      mode: "custom",
+      presetId: "mt-eu_868",
+      customPresetId: "radio-alpine",
+      customPresets: [{ id: "radio-alpine", name: "Alpine Mesh", defaults }],
+      overridePresetDefaults: false,
+    });
+    hoisted.updateMyProfile.mockImplementation(() => new Promise(() => {}));
+    render(<PreferencesSection me={me} onMeUpdated={vi.fn()} />);
+
+    const frequency = screen.getByRole("spinbutton", { name: "Frequency (MHz)" });
+    fireEvent.change(frequency, { target: { value: "9" } });
+    fireEvent.change(frequency, { target: { value: "91" } });
+    fireEvent.change(frequency, { target: { value: "915" } });
+
+    expect(frequency).toHaveValue(915);
+    expect(hoisted.updateMyProfile).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Share custom preset: Alpine Mesh" })).toBeDisabled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
+    expect(hoisted.updateMyProfile).toHaveBeenCalledTimes(1);
+    expect(hoisted.updateMyProfile.mock.calls[0]?.[0].simulationDefaultsPreference.customPresets[0].defaults.frequencyMHz).toBe(915);
+    vi.useRealTimers();
+  });
+
+  it("serializes overlapping saves and sends the newest complete draft", async () => {
+    vi.useFakeTimers();
+    const defaults = { ...simulationDefaultsFromPreset("mt-eu_868"), frequencyPresetId: "radio-alpine" };
+    const me = userWithPreference({
+      mode: "custom",
+      presetId: "mt-eu_868",
+      customPresetId: "radio-alpine",
+      customPresets: [{ id: "radio-alpine", name: "Alpine Mesh", defaults }],
+      overridePresetDefaults: false,
+    });
+    const resolvers: Array<(user: CloudUser) => void> = [];
+    hoisted.updateMyProfile.mockImplementation(() => new Promise<CloudUser>((resolve) => resolvers.push(resolve)));
+    render(<PreferencesSection me={me} onMeUpdated={vi.fn()} />);
+
+    const frequency = screen.getByRole("spinbutton", { name: "Frequency (MHz)" });
+    const bandwidth = screen.getByRole("spinbutton", { name: "Bandwidth (kHz)" });
+    fireEvent.change(frequency, { target: { value: "915" } });
+    await act(async () => { vi.advanceTimersByTime(300); await Promise.resolve(); });
+    expect(hoisted.updateMyProfile).toHaveBeenCalledTimes(1);
+
+    fireEvent.change(bandwidth, { target: { value: "125" } });
+    await act(async () => { vi.advanceTimersByTime(300); await Promise.resolve(); });
+    expect(hoisted.updateMyProfile).toHaveBeenCalledTimes(1);
+    expect(frequency).toHaveValue(915);
+    expect(bandwidth).toHaveValue(125);
+
+    const firstPatch = hoisted.updateMyProfile.mock.calls[0]?.[0];
+    await act(async () => {
+      resolvers[0]?.({ ...me, simulationDefaultsPreference: firstPatch.simulationDefaultsPreference });
+      await Promise.resolve();
+    });
+    expect(hoisted.updateMyProfile).toHaveBeenCalledTimes(2);
+    const secondDefaults = hoisted.updateMyProfile.mock.calls[1]?.[0].simulationDefaultsPreference.customPresets[0].defaults;
+    expect(secondDefaults).toMatchObject({ frequencyMHz: 915, bandwidthKhz: 125 });
+    expect(frequency).toHaveValue(915);
+    expect(bandwidth).toHaveValue(125);
+    vi.useRealTimers();
+  });
+
+  it("retains the optimistic draft and disables sharing after a save failure", async () => {
+    vi.useFakeTimers();
+    const defaults = { ...simulationDefaultsFromPreset("mt-eu_868"), frequencyPresetId: "radio-alpine" };
+    const me = userWithPreference({
+      mode: "custom",
+      presetId: "mt-eu_868",
+      customPresetId: "radio-alpine",
+      customPresets: [{ id: "radio-alpine", name: "Alpine Mesh", defaults }],
+      overridePresetDefaults: false,
+    });
+    hoisted.updateMyProfile.mockRejectedValue(new Error("Preset save failed"));
+    render(<PreferencesSection me={me} onMeUpdated={vi.fn()} />);
+
+    const frequency = screen.getByRole("spinbutton", { name: "Frequency (MHz)" });
+    fireEvent.change(frequency, { target: { value: "915" } });
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(frequency).toHaveValue(915);
+    expect(screen.getAllByText("Preset save failed")).not.toHaveLength(0);
+    expect(screen.getByRole("button", { name: "Share custom preset: Alpine Mesh" })).toBeDisabled();
+    vi.useRealTimers();
+  });
+
+  it("edits and saves polarization as part of the complete manual defaults", async () => {
+    vi.useFakeTimers();
+    const defaults = {
+      ...simulationDefaultsFromPreset("mt-eu_868"),
+      frequencyPresetId: "radio-alpine",
+      autoPropagationEnvironment: false,
+    };
+    const me = userWithPreference({
+      mode: "custom",
+      presetId: "mt-eu_868",
+      customPresetId: "radio-alpine",
+      customPresets: [{ id: "radio-alpine", name: "Alpine Mesh", defaults }],
+      overridePresetDefaults: false,
+    });
+    hoisted.updateMyProfile.mockImplementation(async (patch: { simulationDefaultsPreference: UserSimulationDefaultsPreference }) => ({
+      ...me,
+      simulationDefaultsPreference: patch.simulationDefaultsPreference,
+    }));
+    render(<PreferencesSection me={me} onMeUpdated={vi.fn()} />);
+
+    const polarization = screen.getByRole("combobox", { name: "Polarization" });
+    fireEvent.change(polarization, { target: { value: "Horizontal" } });
+    expect(polarization).toHaveValue("Horizontal");
+    await act(async () => { vi.advanceTimersByTime(300); await Promise.resolve(); });
+    expect(hoisted.updateMyProfile.mock.calls[0]?.[0].simulationDefaultsPreference.customPresets[0].defaults.propagationEnvironment.polarization).toBe("Horizontal");
+    vi.useRealTimers();
   });
 });

--- a/src/components/settings/sections/PreferencesSection.tsx
+++ b/src/components/settings/sections/PreferencesSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Copy, Plus, Trash2 } from "lucide-react";
 import { updateMyProfile, type CloudUser } from "../../../lib/cloudUser";
 import { FREQUENCY_PRESETS, frequencyPresetGroups } from "../../../lib/frequencyPlans";
@@ -34,8 +34,18 @@ type SelectFieldState = {
 };
 
 const IDLE_SELECT: SelectFieldState = { state: "idle", error: null };
+const PRESET_VALUE_SAVE_DEBOUNCE_MS = 300;
 
 export function PreferencesSection({ me, onMeUpdated }: PreferencesSectionProps) {
+  const preferenceKey = JSON.stringify([
+    me?.id ?? null,
+    me?.defaultFrequencyPresetId ?? null,
+    me?.simulationDefaultsPreference ?? null,
+  ]);
+  return <PreferencesSectionContent key={preferenceKey} me={me} onMeUpdated={onMeUpdated} />;
+}
+
+function PreferencesSectionContent({ me, onMeUpdated }: PreferencesSectionProps) {
   const uiThemePreference = useAppStore((state) => state.uiThemePreference);
   const setUiThemePreference = useAppStore((state) => state.setUiThemePreference);
   const uiColorTheme = useAppStore((state) => state.uiColorTheme);
@@ -44,22 +54,31 @@ export function PreferencesSection({ me, onMeUpdated }: PreferencesSectionProps)
   const setAuthState = useAppStore((state) => state.setAuthState);
   const { activeHolidayTheme, holidayThemesVisible } = useThemeVariant();
 
-  const preference = useMemo(
+  const initialPreference = useMemo(
     () => normalizeUserSimulationDefaultsPreference(
       me?.simulationDefaultsPreference,
       me?.defaultFrequencyPresetId,
     ),
     [me?.defaultFrequencyPresetId, me?.simulationDefaultsPreference],
   );
+  const [preference, setPreference] = useState(initialPreference);
   const customPresets = useMemo(() => preference.customPresets ?? [], [preference.customPresets]);
 
   const [presetState, setPresetState] = useState<SelectFieldState>(IDLE_SELECT);
   const [managedPresetId, setManagedPresetId] = useState(
-    preference.mode === "custom" ? preference.customPresetId ?? customPresets[0]?.id ?? "" : "",
+    initialPreference.mode === "custom" ? initialPreference.customPresetId ?? initialPreference.customPresets?.[0]?.id ?? "" : "",
   );
   const [newPresetName, setNewPresetName] = useState("");
   const [renameDraft, setRenameDraft] = useState<{ presetId: string; value: string } | null>(null);
   const [presetActionStatus, setPresetActionStatus] = useState("");
+  const latestRevisionRef = useRef(0);
+  const persistedRevisionRef = useRef(0);
+  const pendingSaveRef = useRef<{ preference: UserSimulationDefaultsPreference; revision: number } | null>(null);
+  const queuedSaveRef = useRef<{ preference: UserSimulationDefaultsPreference; revision: number } | null>(null);
+  const saveInFlightRef = useRef(false);
+  const debounceTimerRef = useRef<number | null>(null);
+  const savedTimerRef = useRef<number | null>(null);
+  const mountedRef = useRef(true);
 
   const resolvedManagedPresetId = customPresets.some((preset) => preset.id === managedPresetId)
     ? managedPresetId
@@ -75,47 +94,118 @@ export function PreferencesSection({ me, onMeUpdated }: PreferencesSectionProps)
   const holidayThemes = getHolidayThemeCatalog();
   const selectedColorThemeValue = activeHolidayTheme?.key ? `holiday:${activeHolidayTheme.key}` : uiColorTheme;
 
-  const saveSimulationDefaultsPreference = useCallback(
-    async (nextPreference: UserSimulationDefaultsPreference) => {
-      setPresetState({ state: "saving", error: null });
+  const drainPreferenceSaveQueue = useCallback(
+    async function drainPreferenceSaveQueue(): Promise<void> {
+      if (saveInFlightRef.current || !queuedSaveRef.current) return;
+      const request = queuedSaveRef.current;
+      queuedSaveRef.current = null;
+      saveInFlightRef.current = true;
       try {
-        const normalized = normalizeUserSimulationDefaultsPreference(nextPreference);
         const updated = await updateMyProfile({
-          defaultFrequencyPresetId: normalized.presetId,
-          simulationDefaultsPreference: normalized,
+          defaultFrequencyPresetId: request.preference.presetId,
+          simulationDefaultsPreference: request.preference,
         });
-        onMeUpdated(updated);
-        setCurrentUser(updated);
-        setAuthState("signed_in");
-        setPresetState({ state: "saved", error: null });
-        window.setTimeout(() => {
-          setPresetState((current) => (current.state === "saved" ? IDLE_SELECT : current));
-        }, 1800);
+        const isLatest = request.revision === latestRevisionRef.current
+          && !pendingSaveRef.current
+          && !queuedSaveRef.current;
+        if (isLatest) {
+          persistedRevisionRef.current = request.revision;
+          if (mountedRef.current) {
+            onMeUpdated(updated);
+            setCurrentUser(updated);
+            setAuthState("signed_in");
+            setPresetState({ state: "saved", error: null });
+            if (savedTimerRef.current != null) window.clearTimeout(savedTimerRef.current);
+            savedTimerRef.current = window.setTimeout(() => {
+              if (mountedRef.current) setPresetState((current) => (current.state === "saved" ? IDLE_SELECT : current));
+            }, 1800);
+          }
+        }
       } catch (error) {
-        setPresetState({ state: "error", error: getUiErrorMessage(error) });
+        const isLatest = request.revision === latestRevisionRef.current
+          && !pendingSaveRef.current
+          && !queuedSaveRef.current;
+        if (isLatest && mountedRef.current) {
+          setPresetState({ state: "error", error: getUiErrorMessage(error) });
+        }
+      } finally {
+        saveInFlightRef.current = false;
+        if (queuedSaveRef.current) await drainPreferenceSaveQueue();
       }
     },
     [onMeUpdated, setAuthState, setCurrentUser],
   );
 
+  const flushPendingPreferenceSave = useCallback(() => {
+    if (debounceTimerRef.current != null) {
+      window.clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
+    }
+    if (!pendingSaveRef.current) return;
+    queuedSaveRef.current = pendingSaveRef.current;
+    pendingSaveRef.current = null;
+    void drainPreferenceSaveQueue();
+  }, [drainPreferenceSaveQueue]);
+
+  const saveSimulationDefaultsPreference = useCallback(
+    (nextPreference: UserSimulationDefaultsPreference, debounce = false) => {
+      const normalized = normalizeUserSimulationDefaultsPreference(nextPreference);
+      const revision = latestRevisionRef.current + 1;
+      latestRevisionRef.current = revision;
+      setPreference(normalized);
+      setPresetState({ state: "saving", error: null });
+      if (savedTimerRef.current != null) {
+        window.clearTimeout(savedTimerRef.current);
+        savedTimerRef.current = null;
+      }
+
+      // A newer complete draft supersedes any queued snapshot that has not started.
+      queuedSaveRef.current = null;
+      pendingSaveRef.current = { preference: normalized, revision };
+      if (!debounce) {
+        flushPendingPreferenceSave();
+        return;
+      }
+      if (debounceTimerRef.current != null) window.clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = window.setTimeout(() => {
+        debounceTimerRef.current = null;
+        flushPendingPreferenceSave();
+      }, PRESET_VALUE_SAVE_DEBOUNCE_MS);
+    },
+    [flushPendingPreferenceSave],
+  );
+
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+      if (debounceTimerRef.current != null) window.clearTimeout(debounceTimerRef.current);
+      if (savedTimerRef.current != null) window.clearTimeout(savedTimerRef.current);
+      if (pendingSaveRef.current) {
+        queuedSaveRef.current = pendingSaveRef.current;
+        pendingSaveRef.current = null;
+        void drainPreferenceSaveQueue();
+      }
+    };
+  }, [drainPreferenceSaveQueue]);
+
   const patchPreferenceDefaults = (patch: Partial<SimulationDefaults>) => {
     if (managedPreset) {
       const nextDefaults = { ...managedPreset.defaults, ...patch, frequencyPresetId: managedPreset.id };
-      void saveSimulationDefaultsPreference({
+      saveSimulationDefaultsPreference({
         ...preference,
         customPresets: customPresets.map((preset) =>
           preset.id === managedPreset.id ? { ...preset, defaults: nextDefaults } : preset,
         ),
-      });
+      }, true);
       return;
     }
     const base = simulationDefaultsFromPreset(preference.presetId);
     const nextDefaults = { ...base, ...activeDefaults, ...patch };
-    void saveSimulationDefaultsPreference({
+    saveSimulationDefaultsPreference({
       ...preference,
       overridePresetDefaults: true,
       overrides: nextDefaults,
-    });
+    }, true);
   };
 
   const createCustomPreset = () => {
@@ -133,7 +223,7 @@ export function PreferencesSection({ me, onMeUpdated }: PreferencesSectionProps)
       return;
     }
     const id = `radio-${crypto.randomUUID()}`;
-    void saveSimulationDefaultsPreference({
+    saveSimulationDefaultsPreference({
       ...preference,
       customPresets: [...customPresets, { id, name, defaults: { ...activeDefaults, frequencyPresetId: id } }],
     });
@@ -153,7 +243,7 @@ export function PreferencesSection({ me, onMeUpdated }: PreferencesSectionProps)
       setPresetActionStatus("Preset names must be unique.");
       return;
     }
-    void saveSimulationDefaultsPreference({
+    saveSimulationDefaultsPreference({
       ...preference,
       customPresets: customPresets.map((preset) => preset.id === managedPreset.id ? { ...preset, name } : preset),
     });
@@ -162,7 +252,7 @@ export function PreferencesSection({ me, onMeUpdated }: PreferencesSectionProps)
 
   const deleteManagedPreset = () => {
     if (!managedPreset || preference.mode === "custom" && preference.customPresetId === managedPreset.id) return;
-    void saveSimulationDefaultsPreference({
+    saveSimulationDefaultsPreference({
       ...preference,
       customPresets: customPresets.filter((preset) => preset.id !== managedPreset.id),
     });
@@ -171,7 +261,7 @@ export function PreferencesSection({ me, onMeUpdated }: PreferencesSectionProps)
   };
 
   const shareManagedPreset = async () => {
-    if (!managedPreset || presetState.state === "saving" || presetState.state === "error") return;
+    if (!managedPreset || latestRevisionRef.current !== persistedRevisionRef.current || presetState.state === "error") return;
     try {
       await navigator.clipboard.writeText(buildRadioPresetShareUrl(managedPreset, window.location));
       setPresetActionStatus("Preset link copied.");
@@ -278,7 +368,7 @@ export function PreferencesSection({ me, onMeUpdated }: PreferencesSectionProps)
               const next = event.target.value;
               if (next.startsWith("custom:")) {
                 const customPresetId = next.slice("custom:".length);
-                void saveSimulationDefaultsPreference({
+                saveSimulationDefaultsPreference({
                   ...preference,
                   mode: "custom",
                   customPresetId,
@@ -288,7 +378,7 @@ export function PreferencesSection({ me, onMeUpdated }: PreferencesSectionProps)
                 return;
               }
               setManagedPresetId("");
-              void saveSimulationDefaultsPreference({ ...preference, mode: "preset", presetId: next, overridePresetDefaults: false });
+              saveSimulationDefaultsPreference({ ...preference, mode: "preset", presetId: next, overridePresetDefaults: false });
             }}
           >
             {frequencyPresetGroups(FREQUENCY_PRESETS).map((groupEntry) => (
@@ -348,7 +438,7 @@ export function PreferencesSection({ me, onMeUpdated }: PreferencesSectionProps)
                   <div className="custom-radio-preset-actions">
                     <Button
                       aria-label={`Share custom preset: ${managedPreset.name}`}
-                      disabled={presetState.state === "saving" || presetState.state === "error"}
+                      disabled={latestRevisionRef.current !== persistedRevisionRef.current || presetState.state === "error"}
                       onClick={() => void shareManagedPreset()}
                       title="Copy share link"
                       type="button"
@@ -378,7 +468,7 @@ export function PreferencesSection({ me, onMeUpdated }: PreferencesSectionProps)
               checked={preference.overridePresetDefaults}
               onChange={(event) => {
                 setManagedPresetId("");
-                void saveSimulationDefaultsPreference({
+                saveSimulationDefaultsPreference({
                   ...preference,
                   overridePresetDefaults: event.target.checked,
                   overrides: event.target.checked ? activeDefaults : undefined,
@@ -390,7 +480,7 @@ export function PreferencesSection({ me, onMeUpdated }: PreferencesSectionProps)
         ) : null}
 
         {managedPreset || preference.overridePresetDefaults ? (
-          <div className="autosave-field">
+          <div className="autosave-field" onBlur={flushPendingPreferenceSave}>
             <label className="field-grid">
               <span>Frequency (MHz)</span>
               <input type="number" value={editableDefaults.frequencyMHz} onChange={(event) => patchPreferenceDefaults({ frequencyMHz: Number(event.target.value) })} />
@@ -437,6 +527,13 @@ export function PreferencesSection({ me, onMeUpdated }: PreferencesSectionProps)
                     <option value="Equatorial">Equatorial</option>
                     <option value="Continental Subtropical">Continental Subtropical</option>
                     <option value="Maritime Subtropical">Maritime Subtropical</option>
+                  </select>
+                </label>
+                <label className="field-grid">
+                  <span>Polarization</span>
+                  <select className="locale-select" value={editableDefaults.propagationEnvironment.polarization} onChange={(event) => patchPreferenceDefaults({ propagationEnvironment: { ...editableDefaults.propagationEnvironment, polarization: event.target.value as SimulationDefaults["propagationEnvironment"]["polarization"] } })}>
+                    <option value="Vertical">Vertical</option>
+                    <option value="Horizontal">Horizontal</option>
                   </select>
                 </label>
                 <label className="field-grid">


### PR DESCRIPTION
## Summary

- keep preset/default values in an optimistic complete preference draft
- debounce value edits and serialize `/api/me` PATCH requests so stale responses cannot overwrite newer input
- retain failed drafts and gate Share until the latest revision is persisted
- add the missing manual propagation Polarization control
- render preset Import above Settings and suspend Settings keyboard/focus behavior underneath

Refs #864

## Root cause

Preset inputs were controlled by the last server-backed preference while each keystroke launched an independent whole-preference PATCH. Settings and Import also used the same raised modal tier, with Settings mounted later and therefore receiving the higher generated layer.

## Verification

- `npm test` — 139 files, 818 tests passed
- `npm run build` — passed (existing chunk-size warning only)
- preset/modal focused suite — 74 tests passed
- required deep-link, calculate API, and app-store suites — passed
- TypeScript and scoped lint — passed
- `npm run dev:check` — no LinkSim dev/watch servers found

`SettingsPanel.tsx` retains its unrelated pre-existing repository lint finding for synchronous state adjustment in the admin fallback effect.