### PR TITLE
Add Forge PR and bounded CI skills

### DIFF
--- a/.agents/skills/linksim-ci-shepherd/SKILL.md
+++ b/.agents/skills/linksim-ci-shepherd/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: linksim-ci-shepherd
+description: Monitor a LinkSim pull request, retrieve targeted GitHub Actions failures, apply explicitly authorized fixes, and resolve review feedback within a bounded cycle count. Use after a LinkSim PR is open and Codex must shepherd required checks without merging, approving, rerunning workflows blindly, or expanding scope.
+---
+
+# LinkSim CI Shepherd
+
+Shepherd one PR to a truthful handoff. Never merge or approve the PR.
+
+## Monitor compactly
+
+1. Read `AGENTS.md` and confirm the PR targets `staging` from an allowed branch.
+2. Verify the local branch and PR head SHA match before changing anything.
+3. Run
+   `python3 scripts/watch-ci <pr-number> --repo wilhel1812/LinkSim`. It emits
+   one final JSON result and a meaningful exit code instead of streaming logs
+   into model context.
+4. If checks pass, inspect unresolved review threads and hand off. Do not invent
+   work merely to consume the cycle budget.
+
+## Fix failures deliberately
+
+Use at most three fix cycles per PR head lineage.
+
+For each cycle:
+
+1. Identify the failed check from the watcher result.
+2. Retrieve only its failed-step log with `gh run view <run-id> --log-failed`.
+3. Reproduce locally when practical and determine the root cause.
+4. Change only what is within the approved issue scope. Ask before broadening
+   behavior, policy, dependencies, or UI.
+5. Add or update a regression test where the failure exposes a defect.
+6. Run targeted verification, then `npm test`, `npm run build`,
+   `npm run dev:check`, and `git diff --check` as applicable.
+7. Commit with Forge trailers and push. Never use a blind workflow rerun as a
+   substitute for a fix.
+
+Stop after three cycles, two equivalent repeated failures, missing authority,
+or a failure outside LinkSim control. Return a signed `needs-human` summary with
+the failing check, evidence, attempted fixes, and safest next action.
+
+## Address review feedback
+
+- Read unresolved thread state, not only flat comments.
+- Implement actionable feedback within scope; explain concretely when feedback
+  conflicts with verified behavior or policy.
+- Reply with evidence and mark a thread resolved only after its concern is
+  actually addressed.
+- Re-run the watcher after every pushed fix.
+
+## Handoff
+
+Report the final head SHA, check result, fix-cycle count, unresolved threads,
+and verification performed. A green PR remains unmerged until the user or an
+authorized maintainer explicitly merges it.

--- a/.agents/skills/linksim-ci-shepherd/agents/openai.yaml
+++ b/.agents/skills/linksim-ci-shepherd/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "LinkSim CI Shepherd"
+  short_description: "Monitor and fix LinkSim pull request CI"
+  default_prompt: "Use $linksim-ci-shepherd to monitor this LinkSim pull request and resolve bounded CI failures."

--- a/.agents/skills/linksim-ci-shepherd/scripts/watch-ci
+++ b/.agents/skills/linksim-ci-shepherd/scripts/watch-ci
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Wait for LinkSim PR checks and emit one compact JSON result."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import time
+from typing import Any
+
+
+FAIL_BUCKETS = {"cancel", "fail"}
+PENDING_BUCKETS = {"pending"}
+
+
+def read_checks(pr: int, repository: str) -> list[dict[str, Any]]:
+    process = subprocess.run(
+        [
+            "gh", "pr", "checks", str(pr), "--repo", repository,
+            "--json", "name,state,bucket,link,workflow",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if process.returncode not in {0, 1, 8}:
+        raise RuntimeError(process.stderr.strip() or "gh pr checks failed")
+    data = json.loads(process.stdout or "[]")
+    if not isinstance(data, list):
+        raise ValueError("gh pr checks returned non-list JSON")
+    return [item for item in data if isinstance(item, dict)]
+
+
+def result_payload(
+    result: str,
+    pr: int,
+    repository: str,
+    checks: list[dict[str, Any]],
+    started: float,
+    *,
+    error: str = "",
+) -> dict[str, Any]:
+    failed = [item for item in checks if str(item.get("bucket")) in FAIL_BUCKETS]
+    return {
+        "result": result,
+        "repository": repository,
+        "pull_request": pr,
+        "elapsed_seconds": int(time.monotonic() - started),
+        "check_count": len(checks),
+        "failed": failed,
+        "checks": checks,
+        **({"error": error[:500]} if error else {}),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("pull_request", type=int)
+    parser.add_argument("--repo", default="wilhel1812/LinkSim")
+    parser.add_argument("--interval", type=int, default=15)
+    parser.add_argument("--timeout", type=int, default=1800)
+    args = parser.parse_args()
+
+    if args.interval < 1 or args.timeout < 1:
+        parser.error("interval and timeout must be positive")
+
+    started = time.monotonic()
+    checks: list[dict[str, Any]] = []
+    while True:
+        try:
+            checks = read_checks(args.pull_request, args.repo)
+        except (RuntimeError, ValueError, json.JSONDecodeError) as error:
+            payload = result_payload(
+                "error",
+                args.pull_request,
+                args.repo,
+                checks,
+                started,
+                error=str(error),
+            )
+            print(json.dumps(payload, separators=(",", ":")))
+            return 2
+
+        buckets = {str(item.get("bucket", "")) for item in checks}
+        if buckets & FAIL_BUCKETS:
+            payload = result_payload(
+                "fail", args.pull_request, args.repo, checks, started
+            )
+            print(json.dumps(payload, separators=(",", ":")))
+            return 1
+        if checks and not (buckets & PENDING_BUCKETS):
+            payload = result_payload(
+                "pass", args.pull_request, args.repo, checks, started
+            )
+            print(json.dumps(payload, separators=(",", ":")))
+            return 0
+        if time.monotonic() - started >= args.timeout:
+            payload = result_payload(
+                "timeout", args.pull_request, args.repo, checks, started
+            )
+            print(json.dumps(payload, separators=(",", ":")))
+            return 2
+        time.sleep(args.interval)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/linksim-create-pr/SKILL.md
+++ b/.agents/skills/linksim-create-pr/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: linksim-create-pr
+description: Implement an explicitly approved LinkSim issue and deliver it as a tested, signed pull request to staging. Use when Codex is authorized to change LinkSim code, tests, documentation, workflows, or repository-scoped automation and must follow the project's issue, branch, validation, provenance, and handoff policy.
+---
+
+# LinkSim Create PR
+
+Deliver one approved, reviewable change. Never merge the pull request or promote
+production.
+
+## Prepare the work
+
+1. Read `AGENTS.md`, the relevant GitHub issue, `docs/release-flow.md`, and
+   `docs/milestone-release-checklist.md` completely.
+2. Confirm explicit implementation approval in the current task. Linky filing,
+   an issue label, or prior investigation is insufficient.
+3. Fetch and prune. Report the branch comparisons required by `AGENTS.md`.
+4. Update the issue to `in-progress` and post a signed implementation-batch
+   comment before editing.
+5. Create `issue/<id>-<slug>` from current `origin/staging`. Do not commit to
+   `staging` or `main`.
+
+## Implement narrowly
+
+1. Reuse the investigator's evidence or run `$linksim-issue-investigator` when
+   evidence is incomplete.
+2. Inventory reusable and overlapping code or UI before adding anything.
+3. Write or update a failing test first when runtime behavior changes. Implement
+   the smallest fix, then refactor with tests green.
+4. Preserve unrelated user changes. Stop if safe isolation is impossible.
+5. Follow the accessibility, error-handling, modal-tier, terminology, theme,
+   auth, database, deep-link, and deployment rules in `AGENTS.md`.
+6. Update documentation only where behavior or operator guidance changed.
+   Automation-only repository assets do not independently bump the application
+   version unless current policy or the user requires it.
+
+## Verify
+
+1. Run targeted tests while iterating.
+2. Run `npm test` and `npm run build` before committing.
+3. Run the additional deep-link/API tests from `AGENTS.md` when applicable.
+4. Run `npm run dev:check`; stop any LinkSim dev/watch server unless the user
+   explicitly asked to keep it running.
+5. Run `git diff --check` and review the complete diff for scope, secrets, debug
+   output, duplicated policy, and accidental generated files.
+
+## Publish with provenance
+
+1. Stage only intended files.
+2. Commit with these trailers, using the real values:
+
+   ```text
+   AI-Agent: Forge
+   AI-Agent-Type: bot
+   AI-Run-ID: <uuid>
+   Human-Authorized-By: <github-login>
+   ```
+
+3. Push the issue branch and open a PR to `staging`.
+4. Add the `ai-assisted` label. Sign the PR body visibly as Forge and include a
+   valid hidden provenance marker from `config/ai-agents.json`.
+5. Describe scope, authority boundary, tests, documentation impact, versioning
+   decision, and linked issue. Do not claim unperformed verification.
+6. Hand the PR to `$linksim-ci-shepherd`. Do not merge it.
+
+After a human-authorized merge, monitor the automatic staging deployment,
+report its commit SHA, update the issue to `in-staging`, and request explicit
+staging sign-off. Production remains a separate Beacon workflow and approval.

--- a/.agents/skills/linksim-create-pr/agents/openai.yaml
+++ b/.agents/skills/linksim-create-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "LinkSim Create PR"
+  short_description: "Create policy-compliant LinkSim pull requests"
+  default_prompt: "Use $linksim-create-pr to deliver this approved LinkSim change as a tested pull request to staging."


### PR DESCRIPTION
Closes part of #1014.

## Scope
- add the repository-scoped `linksim-create-pr` Forge skill
- add the bounded `linksim-ci-shepherd` Forge skill
- add a deterministic CI watcher that emits one final JSON result and stops with meaningful exit codes

## Authority boundaries
Forge still requires explicit implementation approval and cannot merge or release production. The CI shepherd is limited to three fix cycles and stops on repeated failures or missing authority.

## Verification
- official skill validator: both skills passed
- watcher exercised against PR #1019: 8 checks, final result `pass`, exit 0
- `npm test`: 142 files / 843 tests passed
- `npm run build`: passed
- `npm run dev:check`: no LinkSim dev/watch servers found
- `git diff --check`: passed

## Documentation and versioning
This adds repository-scoped automation guidance only. It does not change LinkSim runtime behavior or independently bump the application version.

— Forge · AI coding agent

<!-- linksim-ai:v1 agent=Forge bot=true run=019fd694-2310-7f92-a608-dd6dc4d730cb source=LinkSim-1014 commit=14fc2ea945e87e472b38cfe458ba3a8df1851ae6 -->