### PR TITLE
Add Beacon protected-release skill

### DIFF
--- a/.agents/skills/linksim-release/SKILL.md
+++ b/.agents/skills/linksim-release/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: linksim-release
+description: Prepare, verify, monitor, and report a protected LinkSim release as Beacon. Use when a maintainer asks to assemble release artifacts, evaluate staging readiness, open a production promotion pull request, execute an explicitly approved production promotion, monitor its deployment, or complete the issue and milestone release sweep.
+---
+
+# LinkSim Release
+
+Follow `AGENTS.md`, `docs/release-flow.md`, and
+`docs/milestone-release-checklist.md` as the sources of truth. Do not copy their
+policy into release artifacts.
+
+Beacon may prepare a release before production approval. Beacon must not tag,
+merge, promote, dispatch a production workflow, or publish a GitHub release
+until the user explicitly approves production in the current task.
+
+## Prepare the release candidate
+
+1. Fetch and prune, then report the branch comparisons required by `AGENTS.md`.
+2. Confirm every proposed change is already on `origin/staging`. Inventory the
+   milestone, issue states, open release blockers, and staging-only drift.
+3. Choose the SemVer bump from current policy and explain the reason. Prepare
+   the version and human-readable `CHANGELOG.md` entry on an approved
+   `chore/release-X-Y-Z` branch from current `origin/staging`.
+4. Run `npm test`, `npm run build`, the relevant targeted checks, and
+   `npm run dev:check`. Do not run a local production deploy.
+5. Deliver release-preparation changes through a signed PR to `staging` using
+   `$linksim-create-pr` and `$linksim-ci-shepherd`.
+6. Monitor the automatic staging deployment and report its exact commit and
+   build label. Obtain explicit staging sign-off and freeze the release scope.
+7. Complete `docs/milestone-release-checklist.md` as an attestation; do not edit
+   its reusable template merely to record one release.
+
+If any release-tree content changes after sign-off, stop and restart staging
+verification.
+
+## Establish the exact release tree
+
+1. Record the verified staging tree with `git rev-parse origin/staging^{tree}`.
+2. Confirm the intended `vX.Y.Z` tag targets that verified release tree and
+   that the application version changed from the prior release.
+3. Prefer a `staging` to `main` promotion PR. If squash history causes a real
+   conflict, use only the `release/vX.Y.Z` fallback documented in
+   `docs/release-flow.md`; preserve the verified staging tree exactly.
+4. Include the required checked milestone-attestation line in the promotion PR.
+5. Before seeking approval, show the version, changelog, source and target,
+   verified staging commit and tree, tag target, checks, unresolved issues, and
+   exact actions approval would authorize.
+
+Preparation stops here unless explicit production approval is present.
+
+## Execute an approved production release
+
+After explicit approval in the current task:
+
+1. Re-fetch and prove the candidate, tag, PR head, and verified staging tree
+   have not changed. A mismatch invalidates approval and requires new sign-off.
+2. Use the protected GitHub PR and production-environment flow. Never push
+   directly to `main`, bypass required reviewers, run raw Wrangler deployment,
+   or use the disabled local release script.
+3. Let CI probe, conditionally migrate, and re-probe production D1 using the
+   tracked deployment workflow. Do not apply an improvised migration.
+4. Monitor the production run with
+   `python3 scripts/watch-release <run-id> --expected-sha <main-sha>`.
+5. On failure, retrieve only the failed-step log and stop production retries
+   until the cause and authorization are clear.
+
+## Report and sweep
+
+- Sign deployment reports and GitHub release bodies as Beacon. Name the human
+  production approver and include the Beacon run ID and deployed commit.
+- Preserve the user-facing changelog format; provenance belongs in a footer or
+  hidden marker.
+- After verified production deployment, reconcile issue and milestone state,
+  apply `released` to shipped issues, and report exclusions explicitly.
+- Do not close an issue merely because a deployment job is green. Follow the
+  issue sign-off and milestone rules in `docs/release-flow.md`.
+
+Use the visible signature `— Beacon · AI release agent` and the provenance
+contract in `config/ai-agents.json`. Fail closed if provenance validation fails.

--- a/.agents/skills/linksim-release/agents/openai.yaml
+++ b/.agents/skills/linksim-release/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "LinkSim Release"
+  short_description: "Prepare and monitor protected LinkSim releases"
+  default_prompt: "Use $linksim-release to prepare this LinkSim release and stop before production unless explicit approval is present."

--- a/.agents/skills/linksim-release/scripts/watch-release
+++ b/.agents/skills/linksim-release/scripts/watch-release
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Wait for one LinkSim release workflow and emit one compact JSON result."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import time
+from typing import Any
+
+
+def read_run(run_id: int, repository: str) -> dict[str, Any]:
+    process = subprocess.run(
+        [
+            "gh",
+            "run",
+            "view",
+            str(run_id),
+            "--repo",
+            repository,
+            "--json",
+            "status,conclusion,headSha,url,workflowName,event",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if process.returncode != 0:
+        raise RuntimeError(process.stderr.strip() or "gh run view failed")
+    data = json.loads(process.stdout or "{}")
+    if not isinstance(data, dict):
+        raise ValueError("gh run view returned non-object JSON")
+    return data
+
+
+def result_payload(
+    result: str,
+    run_id: int,
+    repository: str,
+    run: dict[str, Any],
+    started: float,
+    *,
+    error: str = "",
+) -> dict[str, Any]:
+    return {
+        "result": result,
+        "repository": repository,
+        "run_id": run_id,
+        "elapsed_seconds": int(time.monotonic() - started),
+        "workflow": run.get("workflowName", ""),
+        "event": run.get("event", ""),
+        "status": run.get("status", ""),
+        "conclusion": run.get("conclusion", ""),
+        "head_sha": run.get("headSha", ""),
+        "url": run.get("url", ""),
+        **({"error": error[:500]} if error else {}),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("run_id", type=int)
+    parser.add_argument("--repo", default="wilhel1812/LinkSim")
+    parser.add_argument("--expected-sha", default="")
+    parser.add_argument("--interval", type=int, default=15)
+    parser.add_argument("--timeout", type=int, default=1800)
+    args = parser.parse_args()
+
+    if args.interval < 1 or args.timeout < 1:
+        parser.error("interval and timeout must be positive")
+
+    started = time.monotonic()
+    run: dict[str, Any] = {}
+    while True:
+        try:
+            run = read_run(args.run_id, args.repo)
+        except (RuntimeError, ValueError, json.JSONDecodeError) as error:
+            payload = result_payload(
+                "error",
+                args.run_id,
+                args.repo,
+                run,
+                started,
+                error=str(error),
+            )
+            print(json.dumps(payload, separators=(",", ":")))
+            return 2
+
+        head_sha = str(run.get("headSha", ""))
+        if args.expected_sha and head_sha != args.expected_sha:
+            payload = result_payload(
+                "error",
+                args.run_id,
+                args.repo,
+                run,
+                started,
+                error="workflow head SHA does not match expected release commit",
+            )
+            print(json.dumps(payload, separators=(",", ":")))
+            return 2
+
+        if str(run.get("status")) == "completed":
+            result = "pass" if str(run.get("conclusion")) == "success" else "fail"
+            payload = result_payload(
+                result, args.run_id, args.repo, run, started
+            )
+            print(json.dumps(payload, separators=(",", ":")))
+            return 0 if result == "pass" else 1
+
+        if time.monotonic() - started >= args.timeout:
+            payload = result_payload(
+                "timeout", args.run_id, args.repo, run, started
+            )
+            print(json.dumps(payload, separators=(",", ":")))
+            return 2
+        time.sleep(args.interval)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes part of #1014.

## Scope
- add the repository-scoped `linksim-release` Beacon skill
- codify release preparation separately from explicit production authorization
- add a deterministic release watcher that validates the expected deployment SHA and emits one final JSON result

## Authority boundaries
Beacon may prepare release artifacts, but it cannot tag, merge, promote, dispatch production, or publish a GitHub release without explicit production approval in the current task. Production remains on the protected PR and GitHub environment path.

## Verification
- official skill validator: passed
- watcher accepted staging deployment run 31305892397 for exact SHA `a6b1d7fd09d97a431f1df6ffa6081a3200fa5f57`
- watcher rejected a mismatched expected SHA with exit code 2
- `npm test`: 142 files / 843 tests passed
- `npm run build`: passed
- `npm run dev:check`: no LinkSim dev/watch servers found
- `git diff --check`: passed

## Documentation and versioning
This adds repository-scoped automation guidance only. It does not change LinkSim runtime behavior or independently bump the application version.

— Forge · AI coding agent

<!-- linksim-ai:v1 agent=Forge bot=true run=019fd694-2310-7f92-a608-dd6dc4d730cb source=LinkSim-1014 commit=87f74a822fff162ac20e72d23c8434e47f7dd4c1 -->