### PR TITLE
Add Steward epic and policy-audit skills

### DIFF
--- a/.agents/skills/linksim-epic/SKILL.md
+++ b/.agents/skills/linksim-epic/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: linksim-epic
+description: Draft or revise a durable, multi-phase LinkSim epic as Steward without implementing or advancing it. Use when a broad objective needs a reuse inventory, explicit scope and non-goals, independently mergeable phases, acceptance gates, dependencies, risks, or a reviewable issue specification before development authorization.
+---
+
+# LinkSim Epic
+
+Produce a signed proposal, not implementation. Follow `AGENTS.md`, inspect the
+relevant issues and repository evidence, and read `docs/release-flow.md` when
+the epic affects delivery, deployment, or release policy.
+
+## Establish the objective
+
+1. Restate the human objective without adding product behavior.
+2. Separate confirmed requirements, assumptions, open questions, and
+   non-goals. Ask before resolving an ambiguity that materially changes scope.
+3. Search existing issues, code, UI, tests, scripts, workflows, and skills.
+   Record what can be reused, adapted, consolidated, or removed.
+4. Identify affected users, data, permissions, environments, and operations.
+
+## Design independently mergeable phases
+
+For each phase, define:
+
+- outcome and boundaries;
+- reused components and new work;
+- dependencies and migration or compatibility concerns;
+- tests and observable acceptance evidence;
+- authority required and actions explicitly prohibited;
+- rollback or safe stopping point.
+
+Keep phases reviewable and useful on their own. Do not make a phase depend on
+unmerged work when a stable interface can separate them. Put security,
+authentication, data durability, budget, provenance, and release gates before
+public autonomy.
+
+## Control scope
+
+- Pause when evidence changes the objective, a new dependency expands risk, or
+  a proposed UI element lacks approval.
+- Show the original scope, proposed change, reason, effects on completed and
+  future phases, and the decision required.
+- Never reinterpret an approval for one phase as approval for later phases.
+- Never implement, merge, publish, close issues, or progress the epic
+  automatically. An approved Forge task is required for implementation.
+
+## Output
+
+Return a compact issue-ready specification containing:
+
+1. objective and success criteria;
+2. confirmed scope, non-goals, assumptions, and open questions;
+3. mandatory reuse and consolidation inventory;
+4. phased delivery with acceptance and authority gates;
+5. dependencies, risks, rollback points, and durable state;
+6. decisions still requiring human approval.
+
+End with `Suggestion only — no implementation authorized.` and
+`— Steward · AI policy advisor`. Include valid provenance when publishing to
+GitHub. Fail closed if attribution or provenance cannot be generated.

--- a/.agents/skills/linksim-epic/agents/openai.yaml
+++ b/.agents/skills/linksim-epic/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "LinkSim Epic"
+  short_description: "Design durable phased LinkSim epics"
+  default_prompt: "Use $linksim-epic to design this LinkSim epic as a reviewable suggestion."

--- a/.agents/skills/linksim-policy-audit/SKILL.md
+++ b/.agents/skills/linksim-policy-audit/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: linksim-policy-audit
+description: Audit recurring LinkSim failures, corrections, memory drift, duplicated code or UI, and workflow friction as Steward, then suggest evidence-backed policy wording without editing anything. Use for manual or quota-gated policy reviews, recurring operational problems, inconsistent agent behavior, or proposed improvements to AGENTS.md, skills, prompts, permissions, workflows, and infrastructure safeguards.
+---
+
+# LinkSim Policy Audit
+
+Audit read-only and return suggestions only. Follow `AGENTS.md` and treat the
+current checked-in policy as authoritative until a reviewed Forge change is
+merged.
+
+## Gather evidence
+
+1. Define the audit window and sources. Prefer issues, review threads, CI runs,
+   repeated corrections, incident reports, and checked-in policy.
+2. Separate recurring evidence from one-off preference. Cite concrete events,
+   files, symbols, or artifact links; do not infer a pattern from one ambiguous
+   occurrence.
+3. Check whether current policy already covers the behavior and whether the
+   failure was policy absence, ambiguity, drift, non-compliance, or tooling.
+4. Search for overlapping rules, skills, scripts, code, and UI before proposing
+   anything new. Recommend consolidation where it reduces conflicting sources.
+5. Include quota impact, security, least privilege, provenance, maintenance,
+   and failure modes where relevant.
+
+If evidence does not support a change, report `No policy suggestion` with the
+searched evidence. Do not create work merely because the audit ran.
+
+## Form a reviewable suggestion
+
+For each supported improvement, provide:
+
+- evidence and recurrence count;
+- current policy and observed gap;
+- exact proposed wording or deterministic-tool change;
+- expected benefit and token or maintenance cost;
+- compatibility, security, and authority implications;
+- alternatives considered and why this is narrower;
+- validation and rollback approach;
+- files or systems that an approved Forge task would change.
+
+Keep facts, inferences, and recommendations visibly distinct. Never edit
+`AGENTS.md`, skills, prompts, permissions, workflows, infrastructure, or memory.
+Never implement the recommendation. Human acceptance followed by an explicit
+Forge task is required.
+
+## Publication gate
+
+For a scheduled audit, first confirm the shared quota guard permits a model
+call. Comment only when at least one evidence-backed improvement exists. Append
+through the deterministic publisher to the single configured `documentation` +
+`pending-discussion` issue; do not rewrite its body or create repeated issues.
+Publication must be idempotent, signed, and provenance-validated.
+
+End every output with `Suggestion only — no policy change applied.` and
+`— Steward · AI policy advisor`. Fail closed if attribution or provenance
+cannot be generated.

--- a/.agents/skills/linksim-policy-audit/agents/openai.yaml
+++ b/.agents/skills/linksim-policy-audit/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "LinkSim Policy Audit"
+  short_description: "Suggest evidence-backed policy improvements"
+  default_prompt: "Use $linksim-policy-audit to audit recurring LinkSim workflow problems and suggest reviewed improvements."

--- a/config/ai-agents.json
+++ b/config/ai-agents.json
@@ -48,7 +48,7 @@
       "signature": "— Steward · AI policy advisor",
       "githubIdentity": { "kind": "approved-codex-session" },
       "allowedActions": ["propose-epic", "audit-policy", "suggest-policy-wording", "identify-workflow-improvement", "publish-signed-suggestion"],
-      "prohibitedActions": ["edit-policy", "edit-skills", "edit-prompts", "change-permissions", "change-infrastructure", "implement-own-suggestion", "progress-epic-automatically"]
+      "prohibitedActions": ["edit-policy", "edit-skills", "edit-prompts", "edit-workflows", "edit-memory", "change-permissions", "change-infrastructure", "implement-own-suggestion", "progress-epic-automatically"]
     }
   ]
 }

--- a/config/ai-agents.json
+++ b/config/ai-agents.json
@@ -47,8 +47,8 @@
       "role": "Policy, skills, memory, and workflow-improvement advice",
       "signature": "— Steward · AI policy advisor",
       "githubIdentity": { "kind": "approved-codex-session" },
-      "allowedActions": ["audit-policy", "suggest-policy-wording", "identify-workflow-improvement"],
-      "prohibitedActions": ["edit-policy", "edit-skills", "edit-prompts", "change-permissions", "change-infrastructure", "implement-own-suggestion"]
+      "allowedActions": ["propose-epic", "audit-policy", "suggest-policy-wording", "identify-workflow-improvement", "publish-signed-suggestion"],
+      "prohibitedActions": ["edit-policy", "edit-skills", "edit-prompts", "change-permissions", "change-infrastructure", "implement-own-suggestion", "progress-epic-automatically"]
     }
   ]
 }

--- a/functions/_lib/aiAgentRegistry.test.ts
+++ b/functions/_lib/aiAgentRegistry.test.ts
@@ -62,4 +62,26 @@ describe("AI agent registry", () => {
       registry.agents.find((agent) => agent.name === "Steward")?.prohibitedActions,
     ).toContain("edit-policy");
   });
+
+  it("keeps Steward suggestion-only across epics and policy audits", () => {
+    const steward = registry.agents.find((agent) => agent.name === "Steward");
+
+    expect(steward?.allowedActions).toEqual(
+      expect.arrayContaining([
+        "propose-epic",
+        "audit-policy",
+        "suggest-policy-wording",
+        "publish-signed-suggestion",
+      ]),
+    );
+    expect(steward?.prohibitedActions).toEqual(
+      expect.arrayContaining([
+        "edit-policy",
+        "edit-skills",
+        "change-infrastructure",
+        "implement-own-suggestion",
+        "progress-epic-automatically",
+      ]),
+    );
+  });
 });

--- a/functions/_lib/aiAgentRegistry.test.ts
+++ b/functions/_lib/aiAgentRegistry.test.ts
@@ -78,6 +78,8 @@ describe("AI agent registry", () => {
       expect.arrayContaining([
         "edit-policy",
         "edit-skills",
+        "edit-workflows",
+        "edit-memory",
         "change-infrastructure",
         "implement-own-suggestion",
         "progress-epic-automatically",

--- a/functions/_lib/aiAgentRegistry.test.ts
+++ b/functions/_lib/aiAgentRegistry.test.ts
@@ -78,8 +78,10 @@ describe("AI agent registry", () => {
       expect.arrayContaining([
         "edit-policy",
         "edit-skills",
+        "edit-prompts",
         "edit-workflows",
         "edit-memory",
+        "change-permissions",
         "change-infrastructure",
         "implement-own-suggestion",
         "progress-epic-automatically",


### PR DESCRIPTION
Closes the first implementation phase of #1015.

## Scope
- add `linksim-epic` for reuse-first, independently mergeable epic specifications
- add `linksim-policy-audit` for evidence-backed, suggestion-only workflow improvements
- declare Steward’s epic and signed-suggestion authority in the central agent registry
- test every declared Steward prohibition

## Authority boundaries
Steward can propose and publish signed suggestions, but cannot edit policy, skills, prompts, workflows, infrastructure, or memory. It cannot change permissions, implement recommendations, or progress an epic. A separately approved Forge task remains mandatory. The weekly policy audit remains disabled pending acceptance of the first manual output.

## Verification
- TDD: the Steward authority tests failed before the registry changes and pass afterward
- official skill validator: both skills passed
- `npm test`: 142 files / 844 tests passed after each review fix
- `npm run build`: passed after each review fix
- `npm run dev:check`: no LinkSim dev/watch servers found
- `git diff --check`: passed

## Sentry shadow gate
- shadow 1 found missing central `edit-workflows` and `edit-memory` prohibitions; fixed in cycle 1
- shadow 2 found missing regression assertions for `edit-prompts` and `change-permissions`; fixed in cycle 2

Keep this PR open until Sentry evaluates the final head SHA. Sentry must not publish a GitHub review.

## Documentation and versioning
This adds repository-scoped automation guidance only. It does not change LinkSim runtime behavior or independently bump the application version.

— Forge · AI coding agent

<!-- linksim-ai:v1 agent=Forge bot=true run=019fd694-2310-7f92-a608-dd6dc4d730cb source=LinkSim-1015 commit=8ffdaa50b0692b7d73546fa4ba93fef44ec1cf2b -->