### PR TITLE
chore(agents): gate Sentry shadow reviews by exact SHA

### DIFF
--- a/.agents/skills/linksim-ci-shepherd/SKILL.md
+++ b/.agents/skills/linksim-ci-shepherd/SKILL.md
@@ -12,11 +12,29 @@ Shepherd one PR to a truthful handoff. Never merge or approve the PR.
 1. Read `AGENTS.md` and confirm the PR targets `staging` from an allowed branch.
 2. Verify the local branch and PR head SHA match before changing anything.
 3. Run
-   `python3 scripts/watch-ci <pr-number> --repo wilhel1812/LinkSim`. It emits
+   `python3 .agents/skills/linksim-ci-shepherd/scripts/watch-ci <pr-number> --repo wilhel1812/LinkSim`. It emits
    one final JSON result and a meaningful exit code instead of streaming logs
    into model context.
 4. If checks pass, inspect unresolved review threads and hand off. Do not invent
    work merely to consume the cycle budget.
+
+## Hold for private Sentry shadow evaluation
+
+While the Sentry shadow-evaluation gate is active, a green CI result is not yet
+merge-ready. Run:
+
+`python3 .agents/skills/linksim-ci-shepherd/scripts/watch-sentry <pr-number> --repo wilhel1812/LinkSim`
+
+Set `LINKSIM_SENTRY_HOST` to the approved SSH target for the private runtime.
+The watcher reads deterministic SQLite state through the isolated
+`sentry-reviewer` container. It cannot enqueue a review, trigger a model call,
+publish a result, or rerun CI.
+
+Do not hand off a PR as merge-ready until the watcher returns `pass` for the
+exact current head SHA. A review of a superseded SHA does not satisfy the gate.
+`needs-human`, timeout, missing access, or malformed state fails closed. Re-run
+both watchers after every pushed fix. Reassess and remove this temporary hold
+when private shadow evaluation is replaced by an accepted public-review flow.
 
 ## Fix failures deliberately
 

--- a/.agents/skills/linksim-ci-shepherd/scripts/watch-sentry
+++ b/.agents/skills/linksim-ci-shepherd/scripts/watch-sentry
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import time
 from typing import Any
@@ -16,13 +17,15 @@ PENDING_STATES = {"missing", "queued", "running"}
 PROCESS_TIMEOUT_SECONDS = 30
 
 
-def read_pr_head(pr: int, repository: str) -> str:
+def read_pr_head(
+    pr: int, repository: str, *, timeout_seconds: float = PROCESS_TIMEOUT_SECONDS
+) -> str:
     process = subprocess.run(
         ["gh", "pr", "view", str(pr), "--repo", repository, "--json", "headRefOid", "--jq", ".headRefOid"],
         check=False,
         capture_output=True,
         text=True,
-        timeout=PROCESS_TIMEOUT_SECONDS,
+        timeout=timeout_seconds,
     )
     if process.returncode != 0:
         raise RuntimeError(process.stderr.strip() or "gh pr view failed")
@@ -32,10 +35,17 @@ def read_pr_head(pr: int, repository: str) -> str:
     return head_sha
 
 
-def read_review_status(host: str, pr: int, head_sha: str) -> dict[str, Any]:
+def read_review_status(
+    host: str,
+    pr: int,
+    head_sha: str,
+    *,
+    timeout_seconds: float = PROCESS_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
     process = subprocess.run(
         [
             "ssh",
+            "--",
             host,
             "docker",
             "exec",
@@ -49,7 +59,7 @@ def read_review_status(host: str, pr: int, head_sha: str) -> dict[str, Any]:
         check=False,
         capture_output=True,
         text=True,
-        timeout=PROCESS_TIMEOUT_SECONDS,
+        timeout=timeout_seconds,
     )
     if process.returncode != 0:
         raise RuntimeError(process.stderr.strip() or "Sentry status query failed")
@@ -76,21 +86,34 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("pull_request", type=int)
     parser.add_argument("--repo", default="wilhel1812/LinkSim")
-    parser.add_argument("--host", default=os.environ.get("LINKSIM_SENTRY_HOST", ""))
+    parser.add_argument("--host")
     parser.add_argument("--head-sha")
     parser.add_argument("--interval", type=int, default=15)
     parser.add_argument("--timeout", type=int, default=900)
     args = parser.parse_args(argv)
 
-    if not args.host:
-        parser.error("--host or LINKSIM_SENTRY_HOST is required")
     if args.interval < 1 or args.timeout < 1:
         parser.error("interval and timeout must be positive")
 
     started = time.monotonic()
+    deadline = started + args.timeout
     head_sha = args.head_sha or ""
     try:
-        current_head = read_pr_head(args.pull_request, args.repo)
+        approved_host = os.environ.get("LINKSIM_SENTRY_HOST", "").strip()
+        host = args.host or approved_host
+        if not approved_host or host != approved_host:
+            raise ValueError("Sentry host is not in the configured allowlist")
+        if not re.fullmatch(r"[A-Za-z0-9._-]+@[A-Za-z0-9._:-]+", host):
+            raise ValueError("Sentry host has an invalid SSH destination format")
+
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return emit("timeout", args.pull_request, args.repo, head_sha, started)
+        current_head = read_pr_head(
+            args.pull_request,
+            args.repo,
+            timeout_seconds=min(PROCESS_TIMEOUT_SECONDS, remaining),
+        )
         head_sha = args.head_sha or current_head
         if current_head != head_sha:
             return emit(
@@ -103,12 +126,27 @@ def main(argv: list[str] | None = None) -> int:
             )
 
         while True:
-            status = read_review_status(args.host, args.pull_request, head_sha)
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return emit("timeout", args.pull_request, args.repo, head_sha, started)
+            status = read_review_status(
+                host,
+                args.pull_request,
+                head_sha,
+                timeout_seconds=min(PROCESS_TIMEOUT_SECONDS, remaining),
+            )
             if status.get("target") != f"pr:{args.pull_request}" or status.get("revision") != head_sha:
                 raise ValueError("Sentry status did not match the requested PR head SHA")
             state = str(status.get("state", ""))
             if state == "completed":
-                current_head = read_pr_head(args.pull_request, args.repo)
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return emit("timeout", args.pull_request, args.repo, head_sha, started)
+                current_head = read_pr_head(
+                    args.pull_request,
+                    args.repo,
+                    timeout_seconds=min(PROCESS_TIMEOUT_SECONDS, remaining),
+                )
                 if current_head != head_sha:
                     return emit(
                         "head-changed",
@@ -138,7 +176,8 @@ def main(argv: list[str] | None = None) -> int:
                 )
             if state not in PENDING_STATES:
                 raise ValueError(f"unknown Sentry review state: {state or '<empty>'}")
-            if time.monotonic() - started >= args.timeout:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
                 return emit(
                     "timeout",
                     args.pull_request,
@@ -147,13 +186,23 @@ def main(argv: list[str] | None = None) -> int:
                     started,
                     state=state,
                 )
-            time.sleep(args.interval)
+            time.sleep(min(float(args.interval), remaining))
+    except subprocess.TimeoutExpired as error:
+        if time.monotonic() >= deadline:
+            return emit("timeout", args.pull_request, args.repo, head_sha, started)
+        return emit(
+            "error",
+            args.pull_request,
+            args.repo,
+            head_sha,
+            started,
+            error=str(error)[:500],
+        )
     except (
         OSError,
         RuntimeError,
         ValueError,
         json.JSONDecodeError,
-        subprocess.TimeoutExpired,
     ) as error:
         return emit(
             "error",

--- a/.agents/skills/linksim-ci-shepherd/scripts/watch-sentry
+++ b/.agents/skills/linksim-ci-shepherd/scripts/watch-sentry
@@ -13,6 +13,7 @@ from typing import Any
 
 TERMINAL_FAILURE_STATES = {"cancelled", "failed", "needs-human"}
 PENDING_STATES = {"missing", "queued", "running"}
+PROCESS_TIMEOUT_SECONDS = 30
 
 
 def read_pr_head(pr: int, repository: str) -> str:
@@ -21,6 +22,7 @@ def read_pr_head(pr: int, repository: str) -> str:
         check=False,
         capture_output=True,
         text=True,
+        timeout=PROCESS_TIMEOUT_SECONDS,
     )
     if process.returncode != 0:
         raise RuntimeError(process.stderr.strip() or "gh pr view failed")
@@ -47,6 +49,7 @@ def read_review_status(host: str, pr: int, head_sha: str) -> dict[str, Any]:
         check=False,
         capture_output=True,
         text=True,
+        timeout=PROCESS_TIMEOUT_SECONDS,
     )
     if process.returncode != 0:
         raise RuntimeError(process.stderr.strip() or "Sentry status query failed")
@@ -85,6 +88,7 @@ def main(argv: list[str] | None = None) -> int:
         parser.error("interval and timeout must be positive")
 
     started = time.monotonic()
+    head_sha = args.head_sha or ""
     try:
         current_head = read_pr_head(args.pull_request, args.repo)
         head_sha = args.head_sha or current_head
@@ -100,6 +104,8 @@ def main(argv: list[str] | None = None) -> int:
 
         while True:
             status = read_review_status(args.host, args.pull_request, head_sha)
+            if status.get("target") != f"pr:{args.pull_request}" or status.get("revision") != head_sha:
+                raise ValueError("Sentry status did not match the requested PR head SHA")
             state = str(status.get("state", ""))
             if state == "completed":
                 current_head = read_pr_head(args.pull_request, args.repo)
@@ -142,12 +148,18 @@ def main(argv: list[str] | None = None) -> int:
                     state=state,
                 )
             time.sleep(args.interval)
-    except (RuntimeError, ValueError, json.JSONDecodeError) as error:
+    except (
+        OSError,
+        RuntimeError,
+        ValueError,
+        json.JSONDecodeError,
+        subprocess.TimeoutExpired,
+    ) as error:
         return emit(
             "error",
             args.pull_request,
             args.repo,
-            args.head_sha or "",
+            head_sha,
             started,
             error=str(error)[:500],
         )

--- a/.agents/skills/linksim-ci-shepherd/scripts/watch-sentry
+++ b/.agents/skills/linksim-ci-shepherd/scripts/watch-sentry
@@ -15,6 +15,13 @@ from typing import Any
 TERMINAL_FAILURE_STATES = {"cancelled", "failed", "needs-human"}
 PENDING_STATES = {"missing", "queued", "running"}
 PROCESS_TIMEOUT_SECONDS = 30
+HEAD_SHA_PATTERN = re.compile(r"[0-9a-fA-F]{40}")
+
+
+def validate_head_sha(value: str) -> str:
+    if not HEAD_SHA_PATTERN.fullmatch(value):
+        raise ValueError("GitHub returned an invalid PR head SHA")
+    return value.lower()
 
 
 def read_pr_head(
@@ -29,10 +36,7 @@ def read_pr_head(
     )
     if process.returncode != 0:
         raise RuntimeError(process.stderr.strip() or "gh pr view failed")
-    head_sha = process.stdout.strip()
-    if len(head_sha) != 40:
-        raise ValueError("GitHub returned an invalid PR head SHA")
-    return head_sha
+    return validate_head_sha(process.stdout.strip())
 
 
 def read_review_status(
@@ -105,6 +109,7 @@ def main(argv: list[str] | None = None) -> int:
             raise ValueError("Sentry host is not in the configured allowlist")
         if not re.fullmatch(r"[A-Za-z0-9._-]+@[A-Za-z0-9._:-]+", host):
             raise ValueError("Sentry host has an invalid SSH destination format")
+        requested_head = validate_head_sha(args.head_sha) if args.head_sha else ""
 
         remaining = deadline - time.monotonic()
         if remaining <= 0:
@@ -114,7 +119,7 @@ def main(argv: list[str] | None = None) -> int:
             args.repo,
             timeout_seconds=min(PROCESS_TIMEOUT_SECONDS, remaining),
         )
-        head_sha = args.head_sha or current_head
+        head_sha = requested_head or current_head
         if current_head != head_sha:
             return emit(
                 "head-changed",

--- a/.agents/skills/linksim-ci-shepherd/scripts/watch-sentry
+++ b/.agents/skills/linksim-ci-shepherd/scripts/watch-sentry
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Wait for one exact private Sentry shadow review without triggering a model call."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import time
+from typing import Any
+
+
+TERMINAL_FAILURE_STATES = {"cancelled", "failed", "needs-human"}
+PENDING_STATES = {"missing", "queued", "running"}
+
+
+def read_pr_head(pr: int, repository: str) -> str:
+    process = subprocess.run(
+        ["gh", "pr", "view", str(pr), "--repo", repository, "--json", "headRefOid", "--jq", ".headRefOid"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if process.returncode != 0:
+        raise RuntimeError(process.stderr.strip() or "gh pr view failed")
+    head_sha = process.stdout.strip()
+    if len(head_sha) != 40:
+        raise ValueError("GitHub returned an invalid PR head SHA")
+    return head_sha
+
+
+def read_review_status(host: str, pr: int, head_sha: str) -> dict[str, Any]:
+    process = subprocess.run(
+        [
+            "ssh",
+            host,
+            "docker",
+            "exec",
+            "sentry-reviewer",
+            "/opt/hermes/.venv/bin/python3",
+            "/opt/linky/linky_runtime.py",
+            "review-status",
+            f"pr:{pr}",
+            head_sha,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if process.returncode != 0:
+        raise RuntimeError(process.stderr.strip() or "Sentry status query failed")
+    value = json.loads(process.stdout)
+    if not isinstance(value, dict):
+        raise ValueError("Sentry status query returned non-object JSON")
+    return value
+
+
+def emit(result: str, pr: int, repository: str, head_sha: str, started: float, **extra: Any) -> int:
+    payload = {
+        "result": result,
+        "repository": repository,
+        "pull_request": pr,
+        "head_sha": head_sha,
+        "elapsed_seconds": int(time.monotonic() - started),
+        **extra,
+    }
+    print(json.dumps(payload, separators=(",", ":")))
+    return 0 if result == "pass" else 1 if result == "needs-human" else 2
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("pull_request", type=int)
+    parser.add_argument("--repo", default="wilhel1812/LinkSim")
+    parser.add_argument("--host", default=os.environ.get("LINKSIM_SENTRY_HOST", ""))
+    parser.add_argument("--head-sha")
+    parser.add_argument("--interval", type=int, default=15)
+    parser.add_argument("--timeout", type=int, default=900)
+    args = parser.parse_args(argv)
+
+    if not args.host:
+        parser.error("--host or LINKSIM_SENTRY_HOST is required")
+    if args.interval < 1 or args.timeout < 1:
+        parser.error("interval and timeout must be positive")
+
+    started = time.monotonic()
+    try:
+        current_head = read_pr_head(args.pull_request, args.repo)
+        head_sha = args.head_sha or current_head
+        if current_head != head_sha:
+            return emit(
+                "head-changed",
+                args.pull_request,
+                args.repo,
+                head_sha,
+                started,
+                current_head_sha=current_head,
+            )
+
+        while True:
+            status = read_review_status(args.host, args.pull_request, head_sha)
+            state = str(status.get("state", ""))
+            if state == "completed":
+                current_head = read_pr_head(args.pull_request, args.repo)
+                if current_head != head_sha:
+                    return emit(
+                        "head-changed",
+                        args.pull_request,
+                        args.repo,
+                        head_sha,
+                        started,
+                        current_head_sha=current_head,
+                    )
+                return emit(
+                    "pass",
+                    args.pull_request,
+                    args.repo,
+                    head_sha,
+                    started,
+                    terminal_reason=str(status.get("terminal_reason", "")),
+                )
+            if state in TERMINAL_FAILURE_STATES:
+                return emit(
+                    "needs-human",
+                    args.pull_request,
+                    args.repo,
+                    head_sha,
+                    started,
+                    state=state,
+                    terminal_reason=str(status.get("terminal_reason", "")),
+                )
+            if state not in PENDING_STATES:
+                raise ValueError(f"unknown Sentry review state: {state or '<empty>'}")
+            if time.monotonic() - started >= args.timeout:
+                return emit(
+                    "timeout",
+                    args.pull_request,
+                    args.repo,
+                    head_sha,
+                    started,
+                    state=state,
+                )
+            time.sleep(args.interval)
+    except (RuntimeError, ValueError, json.JSONDecodeError) as error:
+        return emit(
+            "error",
+            args.pull_request,
+            args.repo,
+            args.head_sha or "",
+            started,
+            error=str(error)[:500],
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/linksim-ci-shepherd/tests/test_watch_sentry.py
+++ b/.agents/skills/linksim-ci-shepherd/tests/test_watch_sentry.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import importlib.util
+from importlib.machinery import SourceFileLoader
+import io
+import json
+import sys
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "watch-sentry"
+SPEC = importlib.util.spec_from_loader(
+    "watch_sentry", SourceFileLoader("watch_sentry", str(SCRIPT))
+)
+assert SPEC and SPEC.loader
+watch_sentry = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = watch_sentry
+SPEC.loader.exec_module(watch_sentry)
+
+
+class WatchSentryTest(unittest.TestCase):
+    def run_main(self, *arguments: str):
+        output = io.StringIO()
+        with redirect_stdout(output):
+            code = watch_sentry.main(list(arguments))
+        return code, json.loads(output.getvalue())
+
+    def test_passes_only_for_completed_exact_head(self):
+        head = "a" * 40
+        with (
+            patch.object(watch_sentry, "read_pr_head", side_effect=[head, head]),
+            patch.object(
+                watch_sentry,
+                "read_review_status",
+                return_value={
+                    "target": "pr:42",
+                    "revision": head,
+                    "state": "completed",
+                    "terminal_reason": "shadow-review-stored",
+                },
+            ) as status,
+        ):
+            code, result = self.run_main(
+                "42", "--repo", "wilhel1812/LinkSim", "--host", "operator@example"
+            )
+
+        self.assertEqual(code, 0)
+        self.assertEqual(result["result"], "pass")
+        self.assertEqual(result["head_sha"], head)
+        status.assert_called_once_with("operator@example", 42, head)
+
+    def test_fails_closed_for_terminal_review_failure(self):
+        head = "b" * 40
+        with (
+            patch.object(watch_sentry, "read_pr_head", return_value=head),
+            patch.object(
+                watch_sentry,
+                "read_review_status",
+                return_value={
+                    "target": "pr:42",
+                    "revision": head,
+                    "state": "needs-human",
+                    "terminal_reason": "provider-retry-exhausted",
+                },
+            ),
+        ):
+            code, result = self.run_main("42", "--host", "operator@example")
+
+        self.assertEqual(code, 1)
+        self.assertEqual(result["result"], "needs-human")
+        self.assertEqual(result["terminal_reason"], "provider-retry-exhausted")
+
+    def test_fails_when_pr_head_changes_after_review(self):
+        reviewed = "c" * 40
+        current = "d" * 40
+        with (
+            patch.object(watch_sentry, "read_pr_head", side_effect=[reviewed, current]),
+            patch.object(
+                watch_sentry,
+                "read_review_status",
+                return_value={"target": "pr:42", "revision": reviewed, "state": "completed"},
+            ),
+        ):
+            code, result = self.run_main("42", "--host", "operator@example")
+
+        self.assertEqual(code, 2)
+        self.assertEqual(result["result"], "head-changed")
+        self.assertEqual(result["head_sha"], reviewed)
+        self.assertEqual(result["current_head_sha"], current)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/skills/linksim-ci-shepherd/tests/test_watch_sentry.py
+++ b/.agents/skills/linksim-ci-shepherd/tests/test_watch_sentry.py
@@ -200,6 +200,27 @@ class WatchSentryTest(unittest.TestCase):
         self.assertEqual(result["result"], "timeout")
         self.assertEqual(clock.sleeps, [1.0])
 
+    def test_rejects_non_hexadecimal_head_sha_before_status_query(self):
+        valid_head = "a" * 40
+        invalid_head = "g" * 40
+        with (
+            patch.object(watch_sentry, "read_pr_head", return_value=valid_head),
+            patch.object(watch_sentry, "read_review_status") as read_status,
+        ):
+            code, result = self.run_main(
+                "42", "--host", "operator@example", "--head-sha", invalid_head
+            )
+
+        self.assertEqual(code, 2)
+        self.assertEqual(result["result"], "error")
+        read_status.assert_not_called()
+
+    def test_rejects_non_hexadecimal_github_head(self):
+        completed = subprocess.CompletedProcess([], 0, stdout="g" * 40, stderr="")
+        with patch.object(watch_sentry.subprocess, "run", return_value=completed):
+            with self.assertRaisesRegex(ValueError, "invalid PR head SHA"):
+                watch_sentry.read_pr_head(42, "wilhel1812/LinkSim")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.agents/skills/linksim-ci-shepherd/tests/test_watch_sentry.py
+++ b/.agents/skills/linksim-ci-shepherd/tests/test_watch_sentry.py
@@ -4,6 +4,7 @@ import importlib.util
 from importlib.machinery import SourceFileLoader
 import io
 import json
+import subprocess
 import sys
 import unittest
 from contextlib import redirect_stdout
@@ -90,6 +91,59 @@ class WatchSentryTest(unittest.TestCase):
         self.assertEqual(result["result"], "head-changed")
         self.assertEqual(result["head_sha"], reviewed)
         self.assertEqual(result["current_head_sha"], current)
+
+    def test_rejects_completed_status_for_wrong_or_missing_exact_identity(self):
+        head = "e" * 40
+        invalid_statuses = [
+            {"target": "pr:41", "revision": head, "state": "completed"},
+            {"target": "pr:42", "revision": "f" * 40, "state": "completed"},
+            {"target": "pr:42", "state": "completed"},
+        ]
+        for status in invalid_statuses:
+            with self.subTest(status=status):
+                with (
+                    patch.object(watch_sentry, "read_pr_head", return_value=head),
+                    patch.object(watch_sentry, "read_review_status", return_value=status),
+                ):
+                    code, result = self.run_main("42", "--host", "operator@example")
+
+                self.assertEqual(code, 2)
+                self.assertEqual(result["result"], "error")
+
+    def test_converts_process_start_and_timeout_failures_to_final_error(self):
+        head = "a" * 40
+        errors = [
+            FileNotFoundError("ssh not found"),
+            subprocess.TimeoutExpired(["ssh"], 30),
+        ]
+        for error in errors:
+            with self.subTest(error=type(error).__name__):
+                with (
+                    patch.object(watch_sentry, "read_pr_head", return_value=head),
+                    patch.object(watch_sentry, "read_review_status", side_effect=error),
+                ):
+                    code, result = self.run_main("42", "--host", "operator@example")
+
+                self.assertEqual(code, 2)
+                self.assertEqual(result["result"], "error")
+
+    def test_external_processes_have_bounded_timeouts(self):
+        completed = subprocess.CompletedProcess([], 0, stdout="a" * 40, stderr="")
+        with patch.object(watch_sentry.subprocess, "run", return_value=completed) as run:
+            watch_sentry.read_pr_head(42, "wilhel1812/LinkSim")
+        self.assertEqual(run.call_args.kwargs["timeout"], 30)
+
+        completed = subprocess.CompletedProcess(
+            [],
+            0,
+            stdout=json.dumps(
+                {"target": "pr:42", "revision": "a" * 40, "state": "completed"}
+            ),
+            stderr="",
+        )
+        with patch.object(watch_sentry.subprocess, "run", return_value=completed) as run:
+            watch_sentry.read_review_status("operator@example", 42, "a" * 40)
+        self.assertEqual(run.call_args.kwargs["timeout"], 30)
 
 
 if __name__ == "__main__":

--- a/.agents/skills/linksim-ci-shepherd/tests/test_watch_sentry.py
+++ b/.agents/skills/linksim-ci-shepherd/tests/test_watch_sentry.py
@@ -25,7 +25,10 @@ SPEC.loader.exec_module(watch_sentry)
 class WatchSentryTest(unittest.TestCase):
     def run_main(self, *arguments: str):
         output = io.StringIO()
-        with redirect_stdout(output):
+        with (
+            patch.dict(watch_sentry.os.environ, {"LINKSIM_SENTRY_HOST": "operator@example"}),
+            redirect_stdout(output),
+        ):
             code = watch_sentry.main(list(arguments))
         return code, json.loads(output.getvalue())
 
@@ -51,7 +54,9 @@ class WatchSentryTest(unittest.TestCase):
         self.assertEqual(code, 0)
         self.assertEqual(result["result"], "pass")
         self.assertEqual(result["head_sha"], head)
-        status.assert_called_once_with("operator@example", 42, head)
+        status.assert_called_once_with(
+            "operator@example", 42, head, timeout_seconds=30
+        )
 
     def test_fails_closed_for_terminal_review_failure(self):
         head = "b" * 40
@@ -144,6 +149,56 @@ class WatchSentryTest(unittest.TestCase):
         with patch.object(watch_sentry.subprocess, "run", return_value=completed) as run:
             watch_sentry.read_review_status("operator@example", 42, "a" * 40)
         self.assertEqual(run.call_args.kwargs["timeout"], 30)
+        self.assertEqual(run.call_args.args[0][0:3], ["ssh", "--", "operator@example"])
+
+    def test_rejects_host_outside_the_configured_allowlist(self):
+        with (
+            patch.dict(
+                watch_sentry.os.environ,
+                {"LINKSIM_SENTRY_HOST": "operator@example"},
+            ),
+            patch.object(watch_sentry, "read_pr_head") as read_head,
+        ):
+            output = io.StringIO()
+            with redirect_stdout(output):
+                code = watch_sentry.main(["42", "--host=-oProxyCommand=unsafe"])
+
+        self.assertEqual(code, 2)
+        self.assertEqual(json.loads(output.getvalue())["result"], "error")
+        read_head.assert_not_called()
+
+    def test_overall_timeout_caps_the_poll_sleep(self):
+        head = "a" * 40
+
+        class Clock:
+            now = 0.0
+            sleeps = []
+
+            def monotonic(self):
+                return self.now
+
+            def sleep(self, seconds):
+                self.sleeps.append(seconds)
+                self.now += seconds
+
+        clock = Clock()
+        with (
+            patch.object(watch_sentry, "read_pr_head", return_value=head),
+            patch.object(
+                watch_sentry,
+                "read_review_status",
+                return_value={"target": "pr:42", "revision": head, "state": "missing"},
+            ),
+            patch.object(watch_sentry.time, "monotonic", side_effect=clock.monotonic),
+            patch.object(watch_sentry.time, "sleep", side_effect=clock.sleep),
+        ):
+            code, result = self.run_main(
+                "42", "--host", "operator@example", "--timeout", "1", "--interval", "15"
+            )
+
+        self.assertEqual(code, 2)
+        self.assertEqual(result["result"], "timeout")
+        self.assertEqual(clock.sleeps, [1.0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Scope

- add a bounded, read-only watcher for one exact private Sentry review SHA;
- fail closed on a superseded head, terminal review failure, timeout, missing access, or malformed state;
- bound every GitHub and SSH subprocess and validate the returned target and revision before accepting completion;
- allow only the configured SSH destination, terminate SSH option parsing, and cap every subprocess and sleep by the overall deadline;
- require and normalize a 40-character hexadecimal Git object ID before any remote status query;
- require the watcher during the temporary private shadow-evaluation gate;
- correct the existing CI watcher path in the Forge skill.

The watcher cannot enqueue Sentry, trigger a model call, publish a review, rerun CI, modify Vidda, merge, or approve. Public Sentry remains disabled.

## Dependency

Blocked on [vidda-ops #32](https://github.com/wilhel1812/vidda-ops/pull/32), which supplies the read-only exact-SHA status endpoint and durable state synchronization.

## Verification

- watcher unit tests: 10 passed
- `npm test`: 844 passed
- `npm run build`: passed
- `npm run dev:check`: no LinkSim dev/watch servers found
- Python compilation with isolated bytecode cache: passed
- `git diff --check`: passed

## Documentation and versioning

- updates the existing repository-scoped Forge CI skill only;
- no LinkSim application SemVer bump because this is automation-only behavior.

Refs #1013

— Forge · AI coding agent

<!-- linksim-ai:v1 agent=Forge bot=true run=57f9ea56-cb37-4238-8c4a-a59ac3bc87f3 source=issue-1013 commit=f81235b1de860d7331adfd06933495406ebbbd8e -->
