### PR TITLE
Require native Sentry review contract

### DIFF
--- a/.agents/skills/linksim-ci-shepherd/SKILL.md
+++ b/.agents/skills/linksim-ci-shepherd/SKILL.md
@@ -30,6 +30,13 @@ The watcher reads deterministic SQLite state through the isolated
 `sentry-reviewer` container. It cannot enqueue a review, trigger a model call,
 publish a result, or rerun CI.
 
+The accepted private contract is review engine `codex-native-v2`: the official
+native Codex repository-review workflow checks the complete diff and related
+repository context, then stores a schema-validated verdict and finding count.
+Legacy compact reviews never satisfy this gate. A `clean` verdict with zero
+findings passes; any blocking or non-blocking finding returns `needs-human` so
+the finding can be inspected and addressed before handoff.
+
 Do not hand off a PR as merge-ready until the watcher returns `pass` for the
 exact current head SHA. A review of a superseded SHA does not satisfy the gate.
 `needs-human`, timeout, missing access, or malformed state fails closed. Re-run

--- a/.agents/skills/linksim-ci-shepherd/scripts/watch-sentry
+++ b/.agents/skills/linksim-ci-shepherd/scripts/watch-sentry
@@ -16,6 +16,7 @@ TERMINAL_FAILURE_STATES = {"cancelled", "failed", "needs-human"}
 PENDING_STATES = {"missing", "queued", "running"}
 PROCESS_TIMEOUT_SECONDS = 30
 HEAD_SHA_PATTERN = re.compile(r"[0-9a-fA-F]{40}")
+EXPECTED_REVIEW_ENGINE = "codex-native-v2"
 
 
 def validate_head_sha(value: str) -> str:
@@ -144,6 +145,28 @@ def main(argv: list[str] | None = None) -> int:
                 raise ValueError("Sentry status did not match the requested PR head SHA")
             state = str(status.get("state", ""))
             if state == "completed":
+                engine_version = str(status.get("engine_version", ""))
+                verdict = str(status.get("verdict", ""))
+                finding_count = status.get("finding_count")
+                if engine_version != EXPECTED_REVIEW_ENGINE:
+                    return emit(
+                        "needs-human",
+                        args.pull_request,
+                        args.repo,
+                        head_sha,
+                        started,
+                        state=state,
+                        terminal_reason="unexpected-review-engine",
+                        engine_version=engine_version,
+                    )
+                if (
+                    verdict not in {"clean", "blocking-findings", "non-blocking-findings"}
+                    or not isinstance(finding_count, int)
+                    or finding_count < 0
+                    or (verdict == "clean" and finding_count != 0)
+                    or (verdict != "clean" and finding_count == 0)
+                ):
+                    raise ValueError("Sentry completed with an invalid native review contract")
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     return emit("timeout", args.pull_request, args.repo, head_sha, started)
@@ -161,6 +184,19 @@ def main(argv: list[str] | None = None) -> int:
                         started,
                         current_head_sha=current_head,
                     )
+                if verdict != "clean" or finding_count:
+                    return emit(
+                        "needs-human",
+                        args.pull_request,
+                        args.repo,
+                        head_sha,
+                        started,
+                        state=state,
+                        terminal_reason=str(status.get("terminal_reason", "")),
+                        engine_version=engine_version,
+                        review_verdict=verdict,
+                        finding_count=finding_count,
+                    )
                 return emit(
                     "pass",
                     args.pull_request,
@@ -168,6 +204,9 @@ def main(argv: list[str] | None = None) -> int:
                     head_sha,
                     started,
                     terminal_reason=str(status.get("terminal_reason", "")),
+                    engine_version=engine_version,
+                    review_verdict=verdict,
+                    finding_count=finding_count,
                 )
             if state in TERMINAL_FAILURE_STATES:
                 return emit(

--- a/.agents/skills/linksim-ci-shepherd/tests/test_watch_sentry.py
+++ b/.agents/skills/linksim-ci-shepherd/tests/test_watch_sentry.py
@@ -43,7 +43,10 @@ class WatchSentryTest(unittest.TestCase):
                     "target": "pr:42",
                     "revision": head,
                     "state": "completed",
-                    "terminal_reason": "shadow-review-stored",
+                    "terminal_reason": "native-shadow-review-stored",
+                    "engine_version": "codex-native-v2",
+                    "verdict": "clean",
+                    "finding_count": 0,
                 },
             ) as status,
         ):
@@ -57,6 +60,57 @@ class WatchSentryTest(unittest.TestCase):
         status.assert_called_once_with(
             "operator@example", 42, head, timeout_seconds=30
         )
+
+    def test_fails_closed_when_native_review_has_findings(self):
+        head = "9" * 40
+        with (
+            patch.object(watch_sentry, "read_pr_head", return_value=head),
+            patch.object(
+                watch_sentry,
+                "read_review_status",
+                return_value={
+                    "target": "pr:42",
+                    "revision": head,
+                    "state": "completed",
+                    "terminal_reason": "native-shadow-review-stored",
+                    "engine_version": "codex-native-v2",
+                    "verdict": "non-blocking-findings",
+                    "finding_count": 1,
+                },
+            ),
+        ):
+            code, result = self.run_main("42", "--host", "operator@example")
+
+        self.assertEqual(code, 1)
+        self.assertEqual(result["result"], "needs-human")
+        self.assertEqual(result["finding_count"], 1)
+        self.assertEqual(result["review_verdict"], "non-blocking-findings")
+
+    def test_rejects_legacy_or_incomplete_completed_review_contract(self):
+        head = "8" * 40
+        invalid_statuses = [
+            {
+                "target": "pr:42", "revision": head, "state": "completed",
+                "engine_version": "legacy-one-shot-v1", "verdict": "clean", "finding_count": 0,
+            },
+            {
+                "target": "pr:42", "revision": head, "state": "completed",
+                "engine_version": "codex-native-v2", "finding_count": 0,
+            },
+            {
+                "target": "pr:42", "revision": head, "state": "completed",
+                "engine_version": "codex-native-v2", "verdict": "clean", "finding_count": 1,
+            },
+        ]
+        for status in invalid_statuses:
+            with self.subTest(status=status):
+                with (
+                    patch.object(watch_sentry, "read_pr_head", return_value=head),
+                    patch.object(watch_sentry, "read_review_status", return_value=status),
+                ):
+                    code, result = self.run_main("42", "--host", "operator@example")
+                self.assertNotEqual(code, 0)
+                self.assertNotEqual(result["result"], "pass")
 
     def test_fails_closed_for_terminal_review_failure(self):
         head = "b" * 40
@@ -87,7 +141,14 @@ class WatchSentryTest(unittest.TestCase):
             patch.object(
                 watch_sentry,
                 "read_review_status",
-                return_value={"target": "pr:42", "revision": reviewed, "state": "completed"},
+                return_value={
+                    "target": "pr:42",
+                    "revision": reviewed,
+                    "state": "completed",
+                    "engine_version": "codex-native-v2",
+                    "verdict": "clean",
+                    "finding_count": 0,
+                },
             ),
         ):
             code, result = self.run_main("42", "--host", "operator@example")


### PR DESCRIPTION
## Summary

- require Sentry review engine `codex-native-v2` for the private exact-SHA gate
- accept only schema-complete verdict and finding-count state
- fail closed for legacy results, malformed contracts, findings, or superseded heads
- document the native review contract in the CI shepherd skill

## Authority and scope

Implements the approved Sentry portion of #1013. This changes repository-scoped automation only; it does not alter LinkSim application behavior, enable public review posting, merge a PR, or promote production.

## Verification

- 12 `watch-sentry` unit tests
- full `npm test`: 844 tests passed
- `npm run build`
- `npm run dev:check`
- `git diff --check`

## Versioning and documentation

No LinkSim application version bump: this is automation-only. The CI shepherd skill documents the new contract.

— Forge · AI coding agent

<!-- linksim-ai:v1 agent=Forge bot=true run=ea9512e5-18ff-4e1d-a4a7-905485a8d5a5 source=github:issue:1013 commit=78796159 -->
