### PR TITLE
chore(agents): harden crew provenance contract

### DIFF
--- a/.agents/skills/linksim-create-pr/SKILL.md
+++ b/.agents/skills/linksim-create-pr/SKILL.md
@@ -58,7 +58,9 @@ production.
 
 3. Push the issue branch and open a PR to `staging`.
 4. Add the `ai-assisted` label. Sign the PR body visibly as Forge and include a
-   valid hidden provenance marker from `config/ai-agents.json`.
+   valid hidden provenance marker generated through
+   `node scripts/ai-provenance.mjs`. Validate the complete PR body with that
+   same script before publication; never hand-build the marker.
 5. Describe scope, authority boundary, tests, documentation impact, versioning
    decision, and linked issue. Do not claim unperformed verification.
 6. Hand the PR to `$linksim-ci-shepherd`. Do not merge it.

--- a/.agents/skills/linksim-epic/SKILL.md
+++ b/.agents/skills/linksim-epic/SKILL.md
@@ -57,4 +57,6 @@ Return a compact issue-ready specification containing:
 
 End with `Suggestion only — no implementation authorized.` and
 `— Steward · AI policy advisor`. Include valid provenance when publishing to
-GitHub. Fail closed if attribution or provenance cannot be generated.
+GitHub. Generate and validate the complete artifact through
+`node scripts/ai-provenance.mjs`; never hand-build the marker. Fail closed if
+attribution or provenance cannot be generated.

--- a/.agents/skills/linksim-policy-audit/SKILL.md
+++ b/.agents/skills/linksim-policy-audit/SKILL.md
@@ -47,11 +47,18 @@ Forge task is required.
 ## Publication gate
 
 For a scheduled audit, first confirm the shared quota guard permits a model
-call. Comment only when at least one evidence-backed improvement exists. Append
-through the deterministic publisher to the single configured `documentation` +
-`pending-discussion` issue; do not rewrite its body or create repeated issues.
-Publication must be idempotent, signed, and provenance-validated.
+call using the thresholds and durable issue in
+`config/steward-policy-audit.json`. If that configuration is disabled, its
+executor is unconfigured, telemetry is stale, or the guard is not `normal`, do
+not start a model call. Comment only when at least one evidence-backed
+improvement exists. Append through the deterministic publisher to the single
+configured `documentation` + `pending-discussion` issue; do not rewrite its
+body or create repeated issues. Publication must be idempotent, signed, and
+provenance-validated.
 
 End every output with `Suggestion only — no policy change applied.` and
 `— Steward · AI policy advisor`. Fail closed if attribution or provenance
-cannot be generated.
+cannot be generated. Generate the footer with
+`node scripts/ai-provenance.mjs footer`, render the complete comment to a file,
+then require `node scripts/ai-provenance.mjs validate-artifact --agent Steward`
+to pass before publication. Never hand-build the marker.

--- a/.agents/skills/linksim-release/SKILL.md
+++ b/.agents/skills/linksim-release/SKILL.md
@@ -76,4 +76,6 @@ After explicit approval in the current task:
   issue sign-off and milestone rules in `docs/release-flow.md`.
 
 Use the visible signature `— Beacon · AI release agent` and the provenance
-contract in `config/ai-agents.json`. Fail closed if provenance validation fails.
+contract in `config/ai-agents.json`. Generate and validate the complete artifact
+through `node scripts/ai-provenance.mjs`; never hand-build the marker. Fail
+closed if provenance validation fails.

--- a/.github/workflows/ci-quality-gates.yml
+++ b/.github/workflows/ci-quality-gates.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Validate named-agent identity and provenance contract
+        run: npm run agents:validate
+
       - name: Secret pattern scan
         run: npm run security:scan
 

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -72,16 +72,18 @@ jobs:
           PREVIEW_URL: ${{ steps.deploy.outputs.preview_url }}
         with:
           script: |
-            const registry = require('./config/ai-agents.json');
-            const beacon = registry.agents.find((agent) => agent.name === 'Beacon');
-            if (!beacon?.signature || !registry.markerPrefix) {
-              core.setFailed('Beacon identity or provenance marker is missing from the agent registry.');
-              return;
-            }
+            const { execFileSync } = require('node:child_process');
             const marker = '<!-- linksim-preview:v1 -->';
             const sha = context.payload.pull_request.head.sha;
             const runId = require('node:crypto').randomUUID();
-            const provenance = `<!-- ${registry.markerPrefix} agent=${beacon.name} bot=true run=${runId} source=pull-request-${context.issue.number} commit=${sha} -->`;
+            const footer = JSON.parse(execFileSync(process.execPath, [
+              'scripts/ai-provenance.mjs',
+              'footer',
+              '--agent', 'Beacon',
+              '--run', runId,
+              '--source', `pull-request-${context.issue.number}`,
+              '--commit', sha,
+            ], { encoding: 'utf8' }));
             const body = [
               marker,
               'Authenticated staging preview:',
@@ -90,9 +92,9 @@ jobs:
               '',
               `Commit: \`${sha}\``,
               '',
-              beacon.signature,
+              footer.signature,
               '',
-              provenance,
+              footer.marker,
             ].join('\n');
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,3 +84,13 @@
 
 - A new agent must be able to continue using this file and its required linked documents only.
 - Keep durable repo policy here or in the linked source of truth; do not rely on chat-only knowledge.
+
+## AI Artifact Provenance
+
+- Treat `config/ai-agents.json` as the single source of truth for named-agent
+  identity, authority, and visible signatures.
+- Generate and validate bot-authored GitHub artifact footers through
+  `node scripts/ai-provenance.mjs`; do not hand-build provenance markers in
+  skills or workflows.
+- Validate the complete rendered artifact before publication and fail closed
+  when its identity, signature, run ID, source event, or commit SHA is invalid.

--- a/config/steward-policy-audit.json
+++ b/config/steward-policy-audit.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": 1,
+  "enabled": false,
+  "cadence": "weekly",
+  "executor": "unconfigured",
+  "discussionIssue": 1027,
+  "preModelGuard": {
+    "requiredState": "normal",
+    "minimumRemainingPercentExclusive": 25,
+    "maximumTelemetryAgeSeconds": 600
+  },
+  "publication": {
+    "appendOnly": true,
+    "evidenceRequired": true,
+    "idempotentByAuditWindow": true,
+    "publishWhenNoSuggestion": false,
+    "signedAgent": "Steward"
+  },
+  "blockedReason": "No approved executor can currently evaluate the shared usage guard before starting a model call. Native Codex scheduled tasks have no pre-run percentage threshold, and API-key-backed execution is excluded."
+}

--- a/functions/_lib/aiProvenance.test.ts
+++ b/functions/_lib/aiProvenance.test.ts
@@ -1,0 +1,144 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  formatArtifactFooter,
+  formatProvenanceMarker,
+  loadAgentRegistry,
+  validateAgentRegistry,
+  validateSignedArtifact,
+} from "../../scripts/ai-provenance.mjs";
+
+const registryPath = resolve(process.cwd(), "config/ai-agents.json");
+const validRun = "19196eb1-92e6-49d1-944f-da1564941235";
+const validCommit = "810a698227512a06c7e6e22392f93c7623174030";
+
+describe("AI provenance contract", () => {
+  it("loads and validates the checked-in registry as the single source of truth", () => {
+    const registry = loadAgentRegistry(registryPath);
+
+    expect(registry.agents.map((agent) => agent.name)).toEqual([
+      "Linky",
+      "Scout",
+      "Sentry",
+      "Forge",
+      "Beacon",
+      "Steward",
+    ]);
+    expect(validateAgentRegistry(registry)).toBe(registry);
+  });
+
+  it("formats and validates a complete visible and machine-readable footer", () => {
+    const registry = loadAgentRegistry(registryPath);
+    const footer = formatArtifactFooter(registry, {
+      agent: "Steward",
+      run: validRun,
+      source: "LinkSim-1015-weekly",
+      commit: validCommit,
+    });
+
+    expect(footer.signature).toBe("— Steward · AI policy advisor");
+    expect(footer.marker).toBe(
+      `<!-- linksim-ai:v1 agent=Steward bot=true run=${validRun} source=LinkSim-1015-weekly commit=${validCommit} -->`,
+    );
+    expect(
+      validateSignedArtifact(registry, `${footer.signature}\n${footer.marker}`, {
+        expectedAgent: "Steward",
+      }),
+    ).toEqual({
+      agent: "Steward",
+      run: validRun,
+      source: "LinkSim-1015-weekly",
+      commit: validCommit,
+    });
+  });
+
+  it("fails closed for unsigned, falsely attributed, malformed, or unknown artifacts", () => {
+    const registry = loadAgentRegistry(registryPath);
+    const marker = formatProvenanceMarker(registry, {
+      agent: "Forge",
+      run: validRun,
+      source: "pull-request-42",
+      commit: validCommit,
+    });
+
+    expect(() => validateSignedArtifact(registry, marker)).toThrow("visible signature");
+    expect(() =>
+      validateSignedArtifact(registry, `— Beacon · AI release agent\n${marker}`),
+    ).toThrow("visible signature");
+    expect(() =>
+      formatProvenanceMarker(registry, {
+        agent: "Unknown",
+        run: validRun,
+        source: "test",
+        commit: validCommit,
+      }),
+    ).toThrow("unknown agent");
+    expect(() =>
+      formatProvenanceMarker(registry, {
+        agent: "Forge",
+        run: "not-a-run-id",
+        source: "test",
+        commit: validCommit,
+      }),
+    ).toThrow("run ID");
+    expect(() =>
+      formatProvenanceMarker(registry, {
+        agent: "Forge",
+        run: validRun,
+        source: "unsafe source",
+        commit: validCommit,
+      }),
+    ).toThrow("source");
+    expect(() =>
+      formatProvenanceMarker(registry, {
+        agent: "Forge",
+        run: validRun,
+        source: "test",
+        commit: "short",
+      }),
+    ).toThrow("commit SHA");
+    expect(() =>
+      validateSignedArtifact(
+        registry,
+        `— Forge · AI coding agent\n${marker}\n<!-- linksim-ai:v1 malformed -->`,
+      ),
+    ).toThrow("exactly one provenance marker");
+  });
+
+  it("rejects registry drift, duplicate authority, and broken relay identities", () => {
+    const registry = JSON.parse(readFileSync(registryPath, "utf8"));
+    registry.agents[0].allowedActions.push(registry.agents[0].prohibitedActions[0]);
+    expect(() => validateAgentRegistry(registry)).toThrow("both allowed and prohibited");
+
+    const brokenRelay = JSON.parse(readFileSync(registryPath, "utf8"));
+    brokenRelay.agents.find((agent: { name: string }) => agent.name === "Scout").githubIdentity.agent =
+      "Nobody";
+    expect(() => validateAgentRegistry(brokenRelay)).toThrow("unknown relay agent");
+  });
+
+  it("offers a deterministic CLI for workflows and Codex skills", () => {
+    const output = execFileSync(
+      process.execPath,
+      [
+        "scripts/ai-provenance.mjs",
+        "footer",
+        "--agent",
+        "Beacon",
+        "--run",
+        validRun,
+        "--source",
+        "pull-request-42",
+        "--commit",
+        validCommit,
+      ],
+      { cwd: process.cwd(), encoding: "utf8" },
+    );
+    const footer = JSON.parse(output);
+
+    expect(footer.signature).toBe("— Beacon · AI release agent");
+    expect(footer.marker).toContain("agent=Beacon bot=true");
+  });
+});

--- a/functions/_lib/deployPagesWorkflow.test.ts
+++ b/functions/_lib/deployPagesWorkflow.test.ts
@@ -29,9 +29,11 @@ describe("Deploy LinkSim Pages workflow", () => {
 
   it("updates one signed preview comment instead of posting duplicates", () => {
     expect(previewJob).toContain("<!-- linksim-preview:v1 -->");
-    expect(previewJob).toContain("require('./config/ai-agents.json')");
-    expect(previewJob).toContain("beacon.signature");
-    expect(previewJob).toContain("registry.markerPrefix");
+    expect(previewJob).toContain("scripts/ai-provenance.mjs");
+    expect(previewJob).toContain("execFileSync");
+    expect(previewJob).toContain("footer.signature");
+    expect(previewJob).toContain("footer.marker");
+    expect(previewJob).not.toContain("`<!-- ${registry.markerPrefix}");
     expect(previewJob).toContain("github.rest.issues.updateComment");
     expect(previewJob).toContain("github.rest.issues.createComment");
   });

--- a/functions/_lib/stewardPolicyAuditConfig.test.ts
+++ b/functions/_lib/stewardPolicyAuditConfig.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const config = JSON.parse(
+  readFileSync(resolve(process.cwd(), "config/steward-policy-audit.json"), "utf8"),
+);
+const policySkill = readFileSync(
+  resolve(process.cwd(), ".agents/skills/linksim-policy-audit/SKILL.md"),
+  "utf8",
+);
+const repositoryPolicy = readFileSync(resolve(process.cwd(), "AGENTS.md"), "utf8");
+const packageJson = JSON.parse(readFileSync(resolve(process.cwd(), "package.json"), "utf8"));
+const qualityWorkflow = readFileSync(
+  resolve(process.cwd(), ".github/workflows/ci-quality-gates.yml"),
+  "utf8",
+);
+
+describe("Steward policy audit rollout", () => {
+  it("uses one durable discussion issue and remains fail-closed without a pre-model guard", () => {
+    expect(config.schemaVersion).toBe(1);
+    expect(config.discussionIssue).toBe(1027);
+    expect(config.cadence).toBe("weekly");
+    expect(config.enabled).toBe(false);
+    expect(config.executor).toBe("unconfigured");
+    expect(config.preModelGuard.requiredState).toBe("normal");
+    expect(config.preModelGuard.minimumRemainingPercentExclusive).toBe(25);
+    expect(config.preModelGuard.maximumTelemetryAgeSeconds).toBe(600);
+    expect(config.publication).toEqual({
+      appendOnly: true,
+      evidenceRequired: true,
+      idempotentByAuditWindow: true,
+      publishWhenNoSuggestion: false,
+      signedAgent: "Steward",
+    });
+  });
+
+  it("routes every publication through the shared deterministic validator", () => {
+    expect(policySkill).toContain("scripts/ai-provenance.mjs");
+    expect(policySkill).toContain("config/steward-policy-audit.json");
+    expect(repositoryPolicy).toContain("scripts/ai-provenance.mjs");
+    expect(repositoryPolicy).toContain("fail closed");
+    expect(packageJson.scripts["agents:validate"]).toBe(
+      "node scripts/ai-provenance.mjs validate-registry",
+    );
+    expect(qualityWorkflow).toContain("npm run agents:validate");
+  });
+});

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "GPL-3.0-only",
   "type": "module",
   "scripts": {
+    "agents:validate": "node scripts/ai-provenance.mjs validate-registry",
     "build:meta": "node scripts/generate-build-info.mjs",
     "peaks:build": "node scripts/build-open-peak-index.mjs",
     "peaks:tiles:bootstrap": "node scripts/build-peak-tiles-bootstrap.mjs",

--- a/scripts/ai-provenance.mjs
+++ b/scripts/ai-provenance.mjs
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_REGISTRY_PATH = resolve(process.cwd(), "config/ai-agents.json");
+const RUN_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SOURCE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,159}$/;
+const COMMIT_PATTERN = /^[0-9a-f]{40}$/i;
+
+function requireNonEmptyString(value, label) {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+function requireUniqueStrings(value, label) {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error(`${label} must be a non-empty array`);
+  }
+  const normalized = value.map((item) => requireNonEmptyString(item, label));
+  if (new Set(normalized).size !== normalized.length) {
+    throw new Error(`${label} contains duplicate values`);
+  }
+  return normalized;
+}
+
+export function validateAgentRegistry(registry) {
+  if (!registry || typeof registry !== "object" || Array.isArray(registry)) {
+    throw new Error("agent registry must be an object");
+  }
+  if (registry.schemaVersion !== 1) {
+    throw new Error("unsupported agent registry schema version");
+  }
+  if (registry.markerPrefix !== "linksim-ai:v1") {
+    throw new Error("unsupported provenance marker prefix");
+  }
+  if (!Array.isArray(registry.agents) || registry.agents.length === 0) {
+    throw new Error("agent registry must define agents");
+  }
+
+  const names = new Set();
+  const signatures = new Set();
+  for (const agent of registry.agents) {
+    const name = requireNonEmptyString(agent?.name, "agent name");
+    const role = requireNonEmptyString(agent?.role, `${name} role`);
+    const signature = requireNonEmptyString(agent?.signature, `${name} signature`);
+    if (!/^[A-Za-z][A-Za-z0-9_-]*$/.test(name)) {
+      throw new Error(`invalid agent name: ${name}`);
+    }
+    if (names.has(name)) {
+      throw new Error(`duplicate agent name: ${name}`);
+    }
+    if (signatures.has(signature)) {
+      throw new Error(`duplicate agent signature: ${signature}`);
+    }
+    if (!signature.includes(name) || !signature.includes("AI ")) {
+      throw new Error(`${name} signature is not visibly bot-attributed`);
+    }
+    if (typeof agent.githubIdentity !== "object" || !agent.githubIdentity) {
+      throw new Error(`${name} GitHub identity is missing`);
+    }
+    requireNonEmptyString(agent.githubIdentity.kind, `${name} GitHub identity kind`);
+    const allowed = requireUniqueStrings(agent.allowedActions, `${name} allowed actions`);
+    const prohibited = requireUniqueStrings(
+      agent.prohibitedActions,
+      `${name} prohibited actions`,
+    );
+    const overlap = allowed.find((action) => prohibited.includes(action));
+    if (overlap) {
+      throw new Error(`${name} action is both allowed and prohibited: ${overlap}`);
+    }
+    requireNonEmptyString(role, `${name} role`);
+    names.add(name);
+    signatures.add(signature);
+  }
+
+  for (const agent of registry.agents) {
+    if (
+      agent.githubIdentity.kind === "relayed-by" &&
+      !names.has(agent.githubIdentity.agent)
+    ) {
+      throw new Error(`${agent.name} references unknown relay agent`);
+    }
+  }
+  return registry;
+}
+
+export function loadAgentRegistry(path = DEFAULT_REGISTRY_PATH) {
+  return validateAgentRegistry(JSON.parse(readFileSync(path, "utf8")));
+}
+
+export function getAgent(registry, name) {
+  validateAgentRegistry(registry);
+  const agent = registry.agents.find((candidate) => candidate.name === name);
+  if (!agent) {
+    throw new Error(`unknown agent: ${name}`);
+  }
+  return agent;
+}
+
+function validateArtifactFields(registry, fields) {
+  const agent = getAgent(registry, fields.agent);
+  if (!RUN_ID_PATTERN.test(String(fields.run ?? ""))) {
+    throw new Error("invalid provenance run ID");
+  }
+  if (!SOURCE_PATTERN.test(String(fields.source ?? ""))) {
+    throw new Error("invalid provenance source");
+  }
+  if (!COMMIT_PATTERN.test(String(fields.commit ?? ""))) {
+    throw new Error("invalid provenance commit SHA");
+  }
+  return {
+    agent,
+    run: String(fields.run).toLowerCase(),
+    source: String(fields.source),
+    commit: String(fields.commit).toLowerCase(),
+  };
+}
+
+export function formatProvenanceMarker(registry, fields) {
+  const valid = validateArtifactFields(registry, fields);
+  return `<!-- ${registry.markerPrefix} agent=${valid.agent.name} bot=true run=${valid.run} source=${valid.source} commit=${valid.commit} -->`;
+}
+
+export function formatArtifactFooter(registry, fields) {
+  const agent = getAgent(registry, fields.agent);
+  return {
+    signature: agent.signature,
+    marker: formatProvenanceMarker(registry, fields),
+  };
+}
+
+function escapePattern(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function validateSignedArtifact(registry, artifact, options = {}) {
+  validateAgentRegistry(registry);
+  if (typeof artifact !== "string" || artifact.trim() === "") {
+    throw new Error("artifact must be non-empty text");
+  }
+  const markerStart = `<!-- ${registry.markerPrefix} `;
+  const markerCount = artifact.split(markerStart).length - 1;
+  if (markerCount !== 1) {
+    throw new Error("artifact must contain exactly one provenance marker");
+  }
+  const markerPattern = new RegExp(
+    `<!-- ${escapePattern(registry.markerPrefix)} agent=([A-Za-z][A-Za-z0-9_-]*) bot=true run=([^ ]+) source=([^ ]+) commit=([0-9a-fA-F]+) -->`,
+    "g",
+  );
+  const matches = [...artifact.matchAll(markerPattern)];
+  if (matches.length !== 1) {
+    throw new Error("artifact must contain exactly one valid provenance marker");
+  }
+  const [, agentName, run, source, commit] = matches[0];
+  const valid = validateArtifactFields(registry, {
+    agent: agentName,
+    run,
+    source,
+    commit,
+  });
+  if (options.expectedAgent && valid.agent.name !== options.expectedAgent) {
+    throw new Error(`artifact names ${valid.agent.name}, expected ${options.expectedAgent}`);
+  }
+  const signaturePattern = new RegExp(
+    `(?:^|\\n)${escapePattern(valid.agent.signature)}(?:$|\\n)`,
+  );
+  if (!signaturePattern.test(artifact)) {
+    throw new Error(`artifact is missing ${valid.agent.name}'s visible signature`);
+  }
+  return {
+    agent: valid.agent.name,
+    run: valid.run,
+    source: valid.source,
+    commit: valid.commit,
+  };
+}
+
+function parseOptions(args) {
+  const options = {};
+  for (let index = 0; index < args.length; index += 2) {
+    const key = args[index];
+    const value = args[index + 1];
+    if (!key?.startsWith("--") || value === undefined) {
+      throw new Error(`invalid CLI option: ${key ?? ""}`);
+    }
+    options[key.slice(2)] = value;
+  }
+  return options;
+}
+
+function runCli(args) {
+  const [command, ...rest] = args;
+  const options = parseOptions(rest);
+  const registry = loadAgentRegistry(options.registry ?? DEFAULT_REGISTRY_PATH);
+  if (command === "validate-registry") {
+    process.stdout.write("Agent registry valid.\n");
+    return;
+  }
+  if (command === "footer") {
+    process.stdout.write(
+      `${JSON.stringify(
+        formatArtifactFooter(registry, {
+          agent: options.agent,
+          run: options.run,
+          source: options.source,
+          commit: options.commit,
+        }),
+      )}\n`,
+    );
+    return;
+  }
+  if (command === "validate-artifact") {
+    const artifactPath = requireNonEmptyString(options.file, "artifact file");
+    validateSignedArtifact(registry, readFileSync(artifactPath, "utf8"), {
+      expectedAgent: options.agent,
+    });
+    process.stdout.write("AI artifact provenance valid.\n");
+    return;
+  }
+  throw new Error(`unknown command: ${command ?? ""}`);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  try {
+    runCli(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Summary

- add one registry-backed formatter and validator for every named AI artifact
- route authenticated preview comments and repository-scoped crew skills through the shared validator
- record the weekly Steward audit contract, durable discussion issue, and fail-closed usage gate

## Authority and rollout boundary

This implements the deterministic provenance and policy-learning foundations authorized in #1015. The weekly audit executor remains disabled: native Codex scheduled tasks cannot evaluate the shared remaining-usage percentage before starting a model call, while API-key-backed automation is deliberately excluded. Enabling it therefore requires a separately reviewed execution path that preserves the existing pre-model quota safeguard.

No application runtime behavior, UI, production deployment, or automatic policy modification is included. Steward remains suggestion-only.

## Validation

- `npm test` (144 files, 851 tests)
- `npm run build`
- `npm run agents:validate`
- `npm run dev:check`
- `git diff --check`

## Versioning and documentation

- no application version bump: repository automation/policy hardening only
- updates `AGENTS.md` and the existing Forge, Beacon, Steward, and epic skills to use the shared validator

Closes the provenance-validator portion of #1015.
Supports the dedicated Steward discussion issue #1027.

— Forge · AI coding agent

<!-- linksim-ai:v1 agent=Forge bot=true run=7d20e1b7-f1a5-4b26-92ee-cfd7a84a2f64 source=issue-1015 commit=1449ca1e593ccd754bc05128ca1a34e371fdc8f6 -->
