### PR TITLE
Configure guarded Steward delivery

### DIFF
--- a/.agents/skills/linksim-policy-audit/SKILL.md
+++ b/.agents/skills/linksim-policy-audit/SKILL.md
@@ -54,7 +54,11 @@ not start a model call. Comment only when at least one evidence-backed
 improvement exists. Append through the deterministic publisher to the single
 configured `documentation` + `pending-discussion` issue; do not rewrite its
 body or create repeated issues. Publication must be idempotent, signed, and
-provenance-validated.
+provenance-validated. Scheduled GitHub comments are authored by Steward and
+delivered through Linky's least-privilege App, so they must visibly contain both
+`— Steward · AI policy advisor` and
+`Delivered by Linky · AI community bot`. This delivery mechanism does not give
+Steward Linky's issue-maintenance authority.
 
 End every output with `Suggestion only — no policy change applied.` and
 `— Steward · AI policy advisor`. Fail closed if attribution or provenance

--- a/config/ai-agents.json
+++ b/config/ai-agents.json
@@ -46,7 +46,10 @@
       "name": "Steward",
       "role": "Policy, skills, memory, and workflow-improvement advice",
       "signature": "— Steward · AI policy advisor",
-      "githubIdentity": { "kind": "approved-codex-session" },
+      "githubIdentity": {
+        "kind": "approved-codex-session",
+        "scheduledPublisher": { "kind": "relayed-by", "agent": "Linky" }
+      },
       "allowedActions": ["propose-epic", "audit-policy", "suggest-policy-wording", "identify-workflow-improvement", "publish-signed-suggestion"],
       "prohibitedActions": ["edit-policy", "edit-skills", "edit-prompts", "edit-workflows", "edit-memory", "change-permissions", "change-infrastructure", "implement-own-suggestion", "progress-epic-automatically"]
     }

--- a/config/steward-policy-audit.json
+++ b/config/steward-policy-audit.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "enabled": false,
   "cadence": "weekly",
-  "executor": "unconfigured",
+  "executor": "vidda-guarded-worker",
   "discussionIssue": 1027,
   "preModelGuard": {
     "requiredState": "normal",
@@ -14,7 +14,11 @@
     "evidenceRequired": true,
     "idempotentByAuditWindow": true,
     "publishWhenNoSuggestion": false,
-    "signedAgent": "Steward"
+    "signedAgent": "Steward",
+    "deliveredBy": "Linky"
   },
-  "blockedReason": "No approved executor can currently evaluate the shared usage guard before starting a model call. Native Codex scheduled tasks have no pre-run percentage threshold, and API-key-backed execution is excluded."
+  "activation": {
+    "state": "pending-live-acceptance",
+    "remainingGate": "Validate the isolated OAuth profile, quota states, and first manual audit before enabling the weekly switch."
+  }
 }

--- a/functions/_lib/aiProvenance.test.ts
+++ b/functions/_lib/aiProvenance.test.ts
@@ -27,6 +27,10 @@ describe("AI provenance contract", () => {
       "Beacon",
       "Steward",
     ]);
+    expect(
+      registry.agents.find((agent) => agent.name === "Steward")?.githubIdentity
+        .scheduledPublisher,
+    ).toEqual({ kind: "relayed-by", agent: "Linky" });
     expect(validateAgentRegistry(registry)).toBe(registry);
   });
 
@@ -117,6 +121,14 @@ describe("AI provenance contract", () => {
     brokenRelay.agents.find((agent: { name: string }) => agent.name === "Scout").githubIdentity.agent =
       "Nobody";
     expect(() => validateAgentRegistry(brokenRelay)).toThrow("unknown relay agent");
+
+    const brokenScheduledPublisher = JSON.parse(readFileSync(registryPath, "utf8"));
+    brokenScheduledPublisher.agents.find(
+      (agent: { name: string }) => agent.name === "Steward",
+    ).githubIdentity.scheduledPublisher = { kind: "relayed-by", agent: "Nobody" };
+    expect(() => validateAgentRegistry(brokenScheduledPublisher)).toThrow(
+      "unknown scheduled publisher agent",
+    );
   });
 
   it("offers a deterministic CLI for workflows and Codex skills", () => {

--- a/functions/_lib/stewardPolicyAuditConfig.test.ts
+++ b/functions/_lib/stewardPolicyAuditConfig.test.ts
@@ -17,12 +17,12 @@ const qualityWorkflow = readFileSync(
 );
 
 describe("Steward policy audit rollout", () => {
-  it("uses one durable discussion issue and remains fail-closed without a pre-model guard", () => {
+  it("uses one durable discussion issue and remains disabled pending live acceptance", () => {
     expect(config.schemaVersion).toBe(1);
     expect(config.discussionIssue).toBe(1027);
     expect(config.cadence).toBe("weekly");
     expect(config.enabled).toBe(false);
-    expect(config.executor).toBe("unconfigured");
+    expect(config.executor).toBe("vidda-guarded-worker");
     expect(config.preModelGuard.requiredState).toBe("normal");
     expect(config.preModelGuard.minimumRemainingPercentExclusive).toBe(25);
     expect(config.preModelGuard.maximumTelemetryAgeSeconds).toBe(600);
@@ -32,12 +32,19 @@ describe("Steward policy audit rollout", () => {
       idempotentByAuditWindow: true,
       publishWhenNoSuggestion: false,
       signedAgent: "Steward",
+      deliveredBy: "Linky",
+    });
+    expect(config.activation).toEqual({
+      state: "pending-live-acceptance",
+      remainingGate:
+        "Validate the isolated OAuth profile, quota states, and first manual audit before enabling the weekly switch.",
     });
   });
 
   it("routes every publication through the shared deterministic validator", () => {
     expect(policySkill).toContain("scripts/ai-provenance.mjs");
     expect(policySkill).toContain("config/steward-policy-audit.json");
+    expect(policySkill).toContain("Delivered by Linky · AI community bot");
     expect(repositoryPolicy).toContain("scripts/ai-provenance.mjs");
     expect(repositoryPolicy).toContain("fail closed");
     expect(packageJson.scripts["agents:validate"]).toBe(

--- a/scripts/ai-provenance.mjs
+++ b/scripts/ai-provenance.mjs
@@ -84,6 +84,25 @@ export function validateAgentRegistry(registry) {
     ) {
       throw new Error(`${agent.name} references unknown relay agent`);
     }
+    const scheduledPublisher = agent.githubIdentity.scheduledPublisher;
+    if (scheduledPublisher !== undefined) {
+      if (!scheduledPublisher || typeof scheduledPublisher !== "object") {
+        throw new Error(`${agent.name} scheduled publisher must be an identity object`);
+      }
+      if (scheduledPublisher.kind !== "relayed-by") {
+        throw new Error(`${agent.name} scheduled publisher must use relayed-by`);
+      }
+      const publisher = requireNonEmptyString(
+        scheduledPublisher.agent,
+        `${agent.name} scheduled publisher agent`,
+      );
+      if (!names.has(publisher)) {
+        throw new Error(`${agent.name} references unknown scheduled publisher agent`);
+      }
+      if (publisher === agent.name) {
+        throw new Error(`${agent.name} cannot be its own scheduled publisher`);
+      }
+    }
   }
   return registry;
 }


### PR DESCRIPTION
## Scope

- authorize scheduled Steward comments to be transparently delivered through Linky's existing least-privilege GitHub App
- validate nested scheduled-publisher identities in the shared provenance registry
- configure the checked-in weekly audit for the guarded Vidda executor
- keep activation disabled pending isolated OAuth, quota-state, and first-manual-audit acceptance

## Authority boundary

This does not give Steward Linky's issue-maintenance authority, enable the live worker, allow automatic policy edits, or add repository-write permissions. Scheduled comments must identify both Steward as author and Linky as delivery bot.

## Validation

- `npm test` — 144 files, 851 tests passed
- `npm run build`
- `npm run agents:validate`
- targeted provenance and Steward configuration tests
- `git diff --check`
- `npm run dev:check` — no LinkSim dev/watch server found

## Documentation and versioning

The existing policy-audit skill now documents the dual-attribution contract. This is repository automation policy only, so the application version remains `0.26.2`.

Closes #1015 after live acceptance and staging sign-off; this PR alone does not close the issue.

— Forge · AI coding agent

<!-- linksim-ai:v1 agent=Forge bot=true run=6cc2e404-7fea-440c-96b2-6ce81e308255 source=issue-1015 commit=968d29daa7008fd9f067c1f12c2f310153474219 -->
