### PR TITLE
chore(agents): give Steward a dedicated GitHub identity

### DIFF
--- a/.agents/skills/linksim-policy-audit/SKILL.md
+++ b/.agents/skills/linksim-policy-audit/SKILL.md
@@ -55,10 +55,9 @@ improvement exists. Append through the deterministic publisher to the single
 configured `documentation` + `pending-discussion` issue; do not rewrite its
 body or create repeated issues. Publication must be idempotent, signed, and
 provenance-validated. Scheduled GitHub comments are authored by Steward and
-delivered through Linky's least-privilege App, so they must visibly contain both
-`— Steward · AI policy advisor` and
-`Delivered by Linky · AI community bot`. This delivery mechanism does not give
-Steward Linky's issue-maintenance authority.
+published through Steward's dedicated least-privilege GitHub App. They must
+visibly contain `— Steward · AI policy advisor`; they must not claim delivery by
+Linky or inherit Linky's issue-maintenance authority.
 
 End every output with `Suggestion only — no policy change applied.` and
 `— Steward · AI policy advisor`. Fail closed if attribution or provenance

--- a/config/ai-agents.json
+++ b/config/ai-agents.json
@@ -46,10 +46,7 @@
       "name": "Steward",
       "role": "Policy, skills, memory, and workflow-improvement advice",
       "signature": "— Steward · AI policy advisor",
-      "githubIdentity": {
-        "kind": "approved-codex-session",
-        "scheduledPublisher": { "kind": "relayed-by", "agent": "Linky" }
-      },
+      "githubIdentity": { "kind": "github-app", "slug": "steward-for-linksim" },
       "allowedActions": ["propose-epic", "audit-policy", "suggest-policy-wording", "identify-workflow-improvement", "publish-signed-suggestion"],
       "prohibitedActions": ["edit-policy", "edit-skills", "edit-prompts", "edit-workflows", "edit-memory", "change-permissions", "change-infrastructure", "implement-own-suggestion", "progress-epic-automatically"]
     }

--- a/config/steward-policy-audit.json
+++ b/config/steward-policy-audit.json
@@ -14,8 +14,7 @@
     "evidenceRequired": true,
     "idempotentByAuditWindow": true,
     "publishWhenNoSuggestion": false,
-    "signedAgent": "Steward",
-    "deliveredBy": "Linky"
+    "signedAgent": "Steward"
   },
   "activation": {
     "state": "pending-live-acceptance",

--- a/functions/_lib/aiProvenance.test.ts
+++ b/functions/_lib/aiProvenance.test.ts
@@ -28,9 +28,8 @@ describe("AI provenance contract", () => {
       "Steward",
     ]);
     expect(
-      registry.agents.find((agent) => agent.name === "Steward")?.githubIdentity
-        .scheduledPublisher,
-    ).toEqual({ kind: "relayed-by", agent: "Linky" });
+      registry.agents.find((agent) => agent.name === "Steward")?.githubIdentity,
+    ).toEqual({ kind: "github-app", slug: "steward-for-linksim" });
     expect(validateAgentRegistry(registry)).toBe(registry);
   });
 
@@ -122,13 +121,11 @@ describe("AI provenance contract", () => {
       "Nobody";
     expect(() => validateAgentRegistry(brokenRelay)).toThrow("unknown relay agent");
 
-    const brokenScheduledPublisher = JSON.parse(readFileSync(registryPath, "utf8"));
-    brokenScheduledPublisher.agents.find(
+    const brokenStewardApp = JSON.parse(readFileSync(registryPath, "utf8"));
+    brokenStewardApp.agents.find(
       (agent: { name: string }) => agent.name === "Steward",
-    ).githubIdentity.scheduledPublisher = { kind: "relayed-by", agent: "Nobody" };
-    expect(() => validateAgentRegistry(brokenScheduledPublisher)).toThrow(
-      "unknown scheduled publisher agent",
-    );
+    ).githubIdentity = { kind: "github-app", slug: "Linky for LinkSim" };
+    expect(() => validateAgentRegistry(brokenStewardApp)).toThrow("GitHub App slug");
   });
 
   it("offers a deterministic CLI for workflows and Codex skills", () => {

--- a/functions/_lib/stewardPolicyAuditConfig.test.ts
+++ b/functions/_lib/stewardPolicyAuditConfig.test.ts
@@ -32,7 +32,6 @@ describe("Steward policy audit rollout", () => {
       idempotentByAuditWindow: true,
       publishWhenNoSuggestion: false,
       signedAgent: "Steward",
-      deliveredBy: "Linky",
     });
     expect(config.activation).toEqual({
       state: "pending-live-acceptance",
@@ -44,7 +43,8 @@ describe("Steward policy audit rollout", () => {
   it("routes every publication through the shared deterministic validator", () => {
     expect(policySkill).toContain("scripts/ai-provenance.mjs");
     expect(policySkill).toContain("config/steward-policy-audit.json");
-    expect(policySkill).toContain("Delivered by Linky · AI community bot");
+    expect(policySkill).toContain("Steward's dedicated least-privilege GitHub App");
+    expect(policySkill).not.toContain("Delivered by Linky · AI community bot");
     expect(repositoryPolicy).toContain("scripts/ai-provenance.mjs");
     expect(repositoryPolicy).toContain("fail closed");
     expect(packageJson.scripts["agents:validate"]).toBe(

--- a/scripts/ai-provenance.mjs
+++ b/scripts/ai-provenance.mjs
@@ -62,7 +62,19 @@ export function validateAgentRegistry(registry) {
     if (typeof agent.githubIdentity !== "object" || !agent.githubIdentity) {
       throw new Error(`${name} GitHub identity is missing`);
     }
-    requireNonEmptyString(agent.githubIdentity.kind, `${name} GitHub identity kind`);
+    const identityKind = requireNonEmptyString(
+      agent.githubIdentity.kind,
+      `${name} GitHub identity kind`,
+    );
+    if (identityKind === "github-app") {
+      const slug = requireNonEmptyString(
+        agent.githubIdentity.slug,
+        `${name} GitHub App slug`,
+      );
+      if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug)) {
+        throw new Error(`${name} GitHub App slug is invalid`);
+      }
+    }
     const allowed = requireUniqueStrings(agent.allowedActions, `${name} allowed actions`);
     const prohibited = requireUniqueStrings(
       agent.prohibitedActions,


### PR DESCRIPTION
## Summary

- register Steward's dedicated `steward-for-linksim` GitHub App as its public identity
- remove Linky relay attribution from Steward's publication contract
- validate GitHub App slugs deterministically and fail closed on invalid identities

## Validation

- `npm test` — 144 files, 851 tests passed
- `npm run build` — passed
- `npm run dev:check` — no LinkSim dev/watch servers found
- `git diff --check` — passed

Part of #1015

— Forge · AI coding agent
<!-- linksim-ai:v1 agent=Forge bot=true run=7c97195c-d018-45dc-8cb5-e0e8efb8f674 source=issue-1015 commit=bcaaf893d94c75298677cb75723a82b76ef95e22 -->
