### PR TITLE
chore(agents): enable weekly Steward audits

### DIFF
--- a/config/steward-policy-audit.json
+++ b/config/steward-policy-audit.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "enabled": false,
+  "enabled": true,
   "cadence": "weekly",
   "executor": "vidda-guarded-worker",
   "discussionIssue": 1027,
@@ -17,7 +17,9 @@
     "signedAgent": "Steward"
   },
   "activation": {
-    "state": "pending-live-acceptance",
-    "remainingGate": "Validate the isolated OAuth profile, quota states, and first manual audit before enabling the weekly switch."
+    "state": "enabled-after-live-acceptance",
+    "acceptedAt": "2026-08-10",
+    "acceptedBy": "wilhel1812",
+    "acceptedRun": "043bd069-8ef0-4086-90c2-a0f01148cb67"
   }
 }

--- a/functions/_lib/stewardPolicyAuditConfig.test.ts
+++ b/functions/_lib/stewardPolicyAuditConfig.test.ts
@@ -17,11 +17,11 @@ const qualityWorkflow = readFileSync(
 );
 
 describe("Steward policy audit rollout", () => {
-  it("uses one durable discussion issue and remains disabled pending live acceptance", () => {
+  it("uses one durable discussion issue and is enabled after live acceptance", () => {
     expect(config.schemaVersion).toBe(1);
     expect(config.discussionIssue).toBe(1027);
     expect(config.cadence).toBe("weekly");
-    expect(config.enabled).toBe(false);
+    expect(config.enabled).toBe(true);
     expect(config.executor).toBe("vidda-guarded-worker");
     expect(config.preModelGuard.requiredState).toBe("normal");
     expect(config.preModelGuard.minimumRemainingPercentExclusive).toBe(25);
@@ -34,9 +34,10 @@ describe("Steward policy audit rollout", () => {
       signedAgent: "Steward",
     });
     expect(config.activation).toEqual({
-      state: "pending-live-acceptance",
-      remainingGate:
-        "Validate the isolated OAuth profile, quota states, and first manual audit before enabling the weekly switch.",
+      state: "enabled-after-live-acceptance",
+      acceptedAt: "2026-08-10",
+      acceptedBy: "wilhel1812",
+      acceptedRun: "043bd069-8ef0-4086-90c2-a0f01148cb67",
     });
   });
 


### PR DESCRIPTION
## Summary

- enable the quota-gated weekly Steward policy audit after successful live acceptance
- record the accepting maintainer and dedicated-Steward acceptance run
- retain the existing weekly idempotency, more-than-25% quota threshold, append-only discussion issue, and suggestion-only authority

## Existing audit history

Both current-week comments remain unchanged. The existing weekly event key prevents another scheduled audit in the current ISO week; the next automatic opportunity is the next ISO week.

## Validation

- `npm test` — 144 files, 851 tests passed
- `npm run build` — passed
- `npm run dev:check` — no LinkSim dev/watch servers found
- `git diff --check` — passed

No application version bump: this changes repository automation configuration only.

Part of #1015

— Forge · AI coding agent
<!-- linksim-ai:v1 agent=Forge bot=true run=01f12ebb-5df0-4273-b1b5-ad5533841e5f source=issue-1015 commit=8aa01f16614756accc0782c22496e33439f84989 -->
