### PR TITLE
Start explicit 0.27.0 staging development line

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -134,6 +134,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: staging
+          fetch-depth: 0
+
+      - name: Fetch production version baseline
+        run: git fetch --no-tags origin main:refs/remotes/origin/main
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -212,6 +216,8 @@ jobs:
 
       - name: Validate release gate
         working-directory: ${{ runner.temp }}/linksim-release
+        env:
+          PRODUCTION_PREVIOUS_REF: ${{ github.event.before }}
         run: node scripts/validate-prod-release.mjs
 
       - name: Deploy prod/main with guardrails

--- a/docs/milestone-release-checklist.md
+++ b/docs/milestone-release-checklist.md
@@ -14,7 +14,9 @@ Use this checklist before opening a normal production promotion PR (`staging` ->
 - [ ] Verified production promotion will use the exact same release tree that was verified on staging.
 
 ## Version and notes
-- [ ] SemVer bump is present and intentional.
+- [ ] The development-line SemVer in `package.json` is intentional and newer than the previous production version.
+- [ ] `package-lock.json` declares the same base version.
+- [ ] The release does not change minor/patch lines implicitly during promotion.
 - [ ] `CHANGELOG.md` has a human-readable entry for this release.
 - [ ] Release tag `vX.Y.Z` points to the verified release tree that production will deploy.
 

--- a/docs/milestone-release-checklist.md
+++ b/docs/milestone-release-checklist.md
@@ -16,7 +16,7 @@ Use this checklist before opening a normal production promotion PR (`staging` ->
 ## Version and notes
 - [ ] The development-line SemVer in `package.json` is intentional and newer than the previous production version.
 - [ ] `package-lock.json` declares the same base version.
-- [ ] The release does not change minor/patch lines implicitly during promotion.
+- [ ] The release does not change patch, minor, or major lines implicitly during promotion.
 - [ ] `CHANGELOG.md` has a human-readable entry for this release.
 - [ ] Release tag `vX.Y.Z` points to the verified release tree that production will deploy.
 

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -30,7 +30,7 @@
 - Open PR `staging` -> `main` first (direct path — branch policy allows `staging` as head branch).
 - If GitHub reports conflicts because prior production releases were squash-merged, use the approved fallback: create `release/vX.Y.Z` from `main`, squash-merge `origin/staging`, resolve conflicts by keeping the verified staging release tree, tag `vX.Y.Z`, then PR `release/vX.Y.Z` -> `main`.
 - CI automatically deploys to production on every merge to `main`. Monitor the `Deploy LinkSim Pages / deploy-prod-main` GitHub Actions job and report the commit SHA when complete.
-- Note: the CI deploy job validates that the release tag exists, the `main` HEAD tree matches the tag tree, and the tagged release commit has the required SemVer bump.
+- Note: the CI deploy job validates that the release tag exists, the `main` HEAD tree matches the tag tree, and the release SemVer is newer than the previous production version.
 - After production deploy, continue all new work from updated `origin/staging`.
 - If a `hotfix/*` reconcile/snapshot PR to `main` is used, treat that as an incident exception path and immediately run main->staging sync before starting any new work.
 
@@ -62,19 +62,25 @@
 
 ## Versioning Policy
 - SemVer is mandatory (`MAJOR.MINOR.PATCH`).
-- The current version is defined by `package.json`; do not duplicate it in release documentation.
+- The current base version is defined by `package.json` on each branch; do not duplicate it in milestones, repository variables, or release documentation.
 - Bump level decision rules:
   - `PATCH` (`0.9.x`): bug fixes, polish, performance tuning, and non-breaking UX behavior fixes.
   - `MINOR` (`0.x.0`): new user-facing features or meaningful workflow additions that are backward-compatible.
   - `MAJOR` (`x.0.0`): breaking changes (data model incompatibility, removed/renamed API behavior, auth/permission model breaks), or first stable `1.0.0` declaration.
 - Environment bump rules:
   - Same commit must keep the same base SemVer (`X.Y.Z`) in all environments.
+  - Immediately after production promotion, `staging` may retain production's base version while both branch trees are identical.
+  - The first subsequent change that makes the staging tree diverge must deliberately update `package.json` and `package-lock.json` to one reviewed development line:
+    - Normal development: next minor `X.(Y+1).0`.
+    - Approved patch development: next patch `X.Y.(Z+1)`.
+  - CI validates the selected line before shared-staging deployment and never edits or commits versions.
   - Build label channel by environment:
     - Local: `vX.Y.Z-alpha+<commit>`
     - Staging: `vX.Y.Z-beta+<commit>`
     - Production: `vX.Y.Z`
-  - Live production: SemVer bump is required before release.
-- Version bump required for `prod:main` deploys (release candidates).
+  - Live production: the tagged base SemVer must be newer than the previous production version.
+- The development version is normally selected at the beginning of the cycle, not fabricated in the final release commit.
+- A maintainer must choose minor versus patch explicitly; automation cannot infer it from issue, commit, or feature contents.
 
 ## Iteration Rules
 - Default loop for every task:
@@ -100,6 +106,7 @@
   - `npm test` passes
   - `npm run build` passes
   - `CHANGELOG.md` includes a human-readable entry for the release
+  - the already-selected `package.json` version is still intentional and newer than production
   - `docs/milestone-release-checklist.md` is completed
 - PR body requirement for normal promotion (`staging` -> `main`):
   - include the checked line:

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -73,6 +73,7 @@
   - The first subsequent change that makes the staging tree diverge must deliberately update `package.json` and `package-lock.json` to one reviewed development line:
     - Normal development: next minor `X.(Y+1).0`.
     - Approved patch development: next patch `X.Y.(Z+1)`.
+    - Approved breaking or first-stable development: next major `(X+1).0.0`.
   - CI validates the selected line before shared-staging deployment and never edits or commits versions.
   - Build label channel by environment:
     - Local: `vX.Y.Z-alpha+<commit>`
@@ -80,7 +81,7 @@
     - Production: `vX.Y.Z`
   - Live production: the tagged base SemVer must be newer than the previous production version.
 - The development version is normally selected at the beginning of the cycle, not fabricated in the final release commit.
-- A maintainer must choose minor versus patch explicitly; automation cannot infer it from issue, commit, or feature contents.
+- A maintainer must choose minor, patch, or major explicitly; automation cannot infer it from issue, commit, or feature contents.
 
 ## Iteration Rules
 - Default loop for every task:

--- a/functions/_lib/deployPagesWorkflow.test.ts
+++ b/functions/_lib/deployPagesWorkflow.test.ts
@@ -9,6 +9,8 @@ const workflow = readFileSync(
 );
 
 const productionJob = workflow.split("  deploy-prod-main:")[1] ?? "";
+const stagingJob =
+  workflow.split("  deploy-staging:")[1]?.split("  deploy-prod-main:")[0] ?? "";
 const previewJob =
   workflow.split("  deploy-staging-preview:")[1]?.split("  deploy-staging:")[0] ?? "";
 
@@ -51,6 +53,19 @@ describe("Deploy LinkSim Pages workflow", () => {
     );
     expect(productionJob.indexOf(migrationStep)).toBeLessThan(
       productionJob.indexOf(deployStep),
+    );
+    expect(productionJob).toContain(
+      "PRODUCTION_PREVIOUS_REF: ${{ github.event.before }}",
+    );
+  });
+
+  it("fetches the production baseline before validating a staging deployment", () => {
+    expect(stagingJob).toContain("fetch-depth: 0");
+    expect(stagingJob).toContain(
+      "git fetch --no-tags origin main:refs/remotes/origin/main",
+    );
+    expect(stagingJob.indexOf("Fetch production version baseline")).toBeLessThan(
+      stagingJob.indexOf("Deploy staging with guardrails"),
     );
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linksim",
-  "version": "0.26.2",
+  "version": "0.27.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linksim",
-      "version": "0.26.2",
+      "version": "0.27.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "linksim",
   "private": true,
-  "version": "0.26.2",
+  "version": "0.27.0",
   "license": "GPL-3.0-only",
   "type": "module",
   "scripts": {

--- a/scripts/deploy-pages-safe.mjs
+++ b/scripts/deploy-pages-safe.mjs
@@ -6,6 +6,7 @@ import {
   parsePagesDeploymentUrl,
   validatePreviewBranch,
 } from "./pages-preview.mjs";
+import { validateCurrentStagingVersionState } from "./version-state.mjs";
 
 const root = process.cwd();
 const wrangler = path.join(root, "node_modules", ".bin", "wrangler");
@@ -278,6 +279,14 @@ async function preflight(targetName, target) {
   }
 
   await verifyRequiredDeployEnv(targetName);
+
+  if (targetName === "staging") {
+    const versionState = validateCurrentStagingVersionState();
+    console.log(
+      `[deploy-pages-safe] Version state: production=${versionState.productionVersion} ` +
+        `staging=${versionState.stagingVersion}`,
+    );
+  }
 
   const configText = await readFile(target.configPath, "utf8");
   assert(!configText.includes("REPLACE_WITH_"), "Preflight failed: unresolved placeholders in Wrangler config.");

--- a/scripts/release-prod.mjs
+++ b/scripts/release-prod.mjs
@@ -4,7 +4,7 @@ console.error(
   [
     "[release:prod] This local production release script is intentionally disabled.",
     "Production releases must use the protected PR + CI flow:",
-    "1. Prepare release notes/version on chore/release-X-Y-Z and merge to staging.",
+    "1. Confirm the already-selected development version, prepare release notes on chore/release-X-Y-Z, and merge to staging.",
     "2. Verify staging deployment.",
     "3. Promote with a PR from staging to main, or release/vX.Y.Z to main if direct promotion conflicts.",
     "4. Let CI deploy production after protected-branch checks and approvals pass.",

--- a/scripts/validate-prod-promotion.mjs
+++ b/scripts/validate-prod-promotion.mjs
@@ -2,6 +2,7 @@
 import { readFile } from "node:fs/promises";
 import { spawn } from "node:child_process";
 import path from "node:path";
+import { parseBaseVersion } from "./version-state.mjs";
 
 const root = process.cwd();
 
@@ -31,8 +32,10 @@ const run = (cmd, args) =>
 
 export const validatePromotionInputs = ({ version, tagCommit, treesMatch }) => {
   const normalizedVersion = String(version ?? "").trim();
-  if (!normalizedVersion) {
-    throw new Error("Prod promotion gate failed: package.json version is missing.");
+  try {
+    parseBaseVersion(normalizedVersion, "package.json version");
+  } catch (error) {
+    throw new Error(`Prod promotion gate failed: ${error instanceof Error ? error.message : String(error)}`);
   }
   if (!String(tagCommit ?? "").trim()) {
     throw new Error(`Prod promotion gate failed: release tag v${normalizedVersion} does not exist.`);

--- a/scripts/validate-prod-promotion.mjs
+++ b/scripts/validate-prod-promotion.mjs
@@ -2,7 +2,10 @@
 import { readFile } from "node:fs/promises";
 import { spawn } from "node:child_process";
 import path from "node:path";
-import { parseBaseVersion } from "./version-state.mjs";
+import {
+  parsePackageVersionInputs,
+  validatePackageVersionParity,
+} from "./version-state.mjs";
 
 const root = process.cwd();
 
@@ -30,10 +33,21 @@ const run = (cmd, args) =>
     });
   });
 
-export const validatePromotionInputs = ({ version, tagCommit, treesMatch }) => {
-  const normalizedVersion = String(version ?? "").trim();
+export const validatePromotionInputs = ({
+  version,
+  lockfileVersion,
+  lockfileRootVersion,
+  tagCommit,
+  treesMatch,
+}) => {
+  let normalizedVersion;
   try {
-    parseBaseVersion(normalizedVersion, "package.json version");
+    normalizedVersion = validatePackageVersionParity({
+      packageVersion: version,
+      lockfileVersion,
+      lockfileRootVersion,
+      label: "production",
+    });
   } catch (error) {
     throw new Error(`Prod promotion gate failed: ${error instanceof Error ? error.message : String(error)}`);
   }
@@ -50,8 +64,14 @@ export const validatePromotionInputs = ({ version, tagCommit, treesMatch }) => {
 };
 
 async function main() {
-  const pkg = JSON.parse(await readFile(path.join(root, "package.json"), "utf8"));
-  const version = String(pkg.version ?? "").trim();
+  const versionInputs = parsePackageVersionInputs(
+    await readFile(path.join(root, "package.json"), "utf8"),
+    await readFile(path.join(root, "package-lock.json"), "utf8"),
+  );
+  const version = validatePackageVersionParity({
+    ...versionInputs,
+    label: "production",
+  });
   const tag = `v${version}`;
   const tagCommit = (await run("git", ["rev-parse", "--verify", `${tag}^{commit}`])).stdout.trim();
   let treesMatch = true;
@@ -61,7 +81,13 @@ async function main() {
     treesMatch = false;
   }
 
-  validatePromotionInputs({ version, tagCommit, treesMatch });
+  validatePromotionInputs({
+    version,
+    lockfileVersion: versionInputs.lockfileVersion,
+    lockfileRootVersion: versionInputs.lockfileRootVersion,
+    tagCommit,
+    treesMatch,
+  });
   console.log(`[validate-prod-promotion] ok tag=${tag} tagCommit=${tagCommit.slice(0, 8)}`);
 }
 

--- a/scripts/validate-prod-release.mjs
+++ b/scripts/validate-prod-release.mjs
@@ -2,6 +2,8 @@
 import { readFile } from "node:fs/promises";
 import { spawn } from "node:child_process";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { compareBaseVersions, parseBaseVersion } from "./version-state.mjs";
 
 const root = process.cwd();
 const packageJsonPath = path.join(root, "package.json");
@@ -36,13 +38,34 @@ const readVersionAtRef = async (ref) => {
   return String(pkg.version ?? "").trim();
 };
 
+export const validateReleaseVersionInputs = ({
+  version,
+  previousProductionVersion,
+  hasMatchingHeadTag,
+}) => {
+  const current = parseBaseVersion(version, "release version");
+  const previous = parseBaseVersion(
+    previousProductionVersion,
+    "previous production version",
+  );
+  const expectedTag = `v${current.value}`;
+  if (!hasMatchingHeadTag) {
+    throw new Error(`Prod release gate failed: HEAD must be tagged '${expectedTag}'.`);
+  }
+  if (compareBaseVersions(current.value, previous.value) <= 0) {
+    throw new Error(
+      `Prod release gate failed: release version ${current.value} must be newer than ` +
+        `previous production ${previous.value}.`,
+    );
+  }
+  return expectedTag;
+};
+
 async function main() {
   const pkgText = await readFile(packageJsonPath, "utf8");
   const pkg = JSON.parse(pkgText);
   const version = String(pkg.version ?? "").trim();
-  if (!version) {
-    throw new Error("Prod release gate failed: package.json version is missing.");
-  }
+  parseBaseVersion(version, "release version");
 
   const expectedTag = `v${version}`;
   const { stdout: tagsAtHead } = await run("git", ["tag", "--points-at", "HEAD"]);
@@ -51,26 +74,23 @@ async function main() {
     .map((line) => line.trim())
     .filter(Boolean)
     .includes(expectedTag);
-  if (!hasMatchingHeadTag) {
-    throw new Error(`Prod release gate failed: HEAD must be tagged '${expectedTag}'.`);
-  }
+  const previousProductionRef =
+    String(process.env.PRODUCTION_PREVIOUS_REF ?? "").trim() || "origin/main^";
+  const previousProductionVersion = await readVersionAtRef(previousProductionRef);
+  validateReleaseVersionInputs({
+    version,
+    previousProductionVersion,
+    hasMatchingHeadTag,
+  });
 
-  const parentCheck = await run("git", ["rev-list", "--count", "HEAD"]);
-  const commitCount = Number.parseInt(parentCheck.stdout.trim(), 10);
-  if (!Number.isFinite(commitCount) || commitCount < 2) {
-    throw new Error("Prod release gate failed: cannot verify version bump on first commit.");
-  }
-
-  const versionAtHead = await readVersionAtRef("HEAD");
-  const versionAtParent = await readVersionAtRef("HEAD^");
-  if (versionAtHead === versionAtParent) {
-    throw new Error(`Prod release gate failed: package version was not bumped in HEAD (still ${versionAtHead}).`);
-  }
-
-  console.log(`[validate-prod-release] ok version=${version} tag=${expectedTag}`);
+  console.log(
+    `[validate-prod-release] ok version=${version} previous=${previousProductionVersion} tag=${expectedTag}`,
+  );
 }
 
-main().catch((error) => {
-  console.error(`[validate-prod-release] ${error instanceof Error ? error.message : String(error)}`);
-  process.exit(1);
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(`[validate-prod-release] ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  });
+}

--- a/scripts/validate-prod-release.mjs
+++ b/scripts/validate-prod-release.mjs
@@ -3,10 +3,15 @@ import { readFile } from "node:fs/promises";
 import { spawn } from "node:child_process";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { compareBaseVersions, parseBaseVersion } from "./version-state.mjs";
+import {
+  compareBaseVersions,
+  parsePackageVersionInputs,
+  validatePackageVersionParity,
+} from "./version-state.mjs";
 
 const root = process.cwd();
 const packageJsonPath = path.join(root, "package.json");
+const packageLockPath = path.join(root, "package-lock.json");
 
 const run = (cmd, args) =>
   new Promise((resolve, reject) => {
@@ -33,39 +38,51 @@ const run = (cmd, args) =>
   });
 
 const readVersionAtRef = async (ref) => {
-  const { stdout } = await run("git", ["show", `${ref}:package.json`]);
-  const pkg = JSON.parse(stdout);
-  return String(pkg.version ?? "").trim();
+  const [{ stdout: packageContent }, { stdout: lockfileContent }] = await Promise.all([
+    run("git", ["show", `${ref}:package.json`]),
+    run("git", ["show", `${ref}:package-lock.json`]),
+  ]);
+  return validatePackageVersionParity({
+    ...parsePackageVersionInputs(packageContent, lockfileContent),
+    label: `production ref ${ref}`,
+  });
 };
 
 export const validateReleaseVersionInputs = ({
   version,
+  lockfileVersion,
+  lockfileRootVersion,
   previousProductionVersion,
   hasMatchingHeadTag,
 }) => {
-  const current = parseBaseVersion(version, "release version");
-  const previous = parseBaseVersion(
-    previousProductionVersion,
-    "previous production version",
-  );
-  const expectedTag = `v${current.value}`;
+  const current = validatePackageVersionParity({
+    packageVersion: version,
+    lockfileVersion,
+    lockfileRootVersion,
+    label: "release",
+  });
+  const expectedTag = `v${current}`;
   if (!hasMatchingHeadTag) {
     throw new Error(`Prod release gate failed: HEAD must be tagged '${expectedTag}'.`);
   }
-  if (compareBaseVersions(current.value, previous.value) <= 0) {
+  if (compareBaseVersions(current, previousProductionVersion) <= 0) {
     throw new Error(
-      `Prod release gate failed: release version ${current.value} must be newer than ` +
-        `previous production ${previous.value}.`,
+      `Prod release gate failed: release version ${current} must be newer than ` +
+        `previous production ${previousProductionVersion}.`,
     );
   }
   return expectedTag;
 };
 
 async function main() {
-  const pkgText = await readFile(packageJsonPath, "utf8");
-  const pkg = JSON.parse(pkgText);
-  const version = String(pkg.version ?? "").trim();
-  parseBaseVersion(version, "release version");
+  const versionInputs = parsePackageVersionInputs(
+    await readFile(packageJsonPath, "utf8"),
+    await readFile(packageLockPath, "utf8"),
+  );
+  const version = validatePackageVersionParity({
+    ...versionInputs,
+    label: "release",
+  });
 
   const expectedTag = `v${version}`;
   const { stdout: tagsAtHead } = await run("git", ["tag", "--points-at", "HEAD"]);
@@ -79,6 +96,8 @@ async function main() {
   const previousProductionVersion = await readVersionAtRef(previousProductionRef);
   validateReleaseVersionInputs({
     version,
+    lockfileVersion: versionInputs.lockfileVersion,
+    lockfileRootVersion: versionInputs.lockfileRootVersion,
     previousProductionVersion,
     hasMatchingHeadTag,
   });

--- a/scripts/version-state.mjs
+++ b/scripts/version-state.mjs
@@ -91,18 +91,27 @@ export const validateStagingVersionState = ({
     staging.major === production.major &&
     staging.minor === production.minor + 1 &&
     staging.patch === 0;
+  const isNextMajor =
+    staging.major === production.major + 1 &&
+    staging.minor === 0 &&
+    staging.patch === 0;
 
-  if (!isNextPatch && !isNextMinor) {
+  if (!isNextPatch && !isNextMinor && !isNextMajor) {
     throw new Error(
       `Staging version ${staging.value} must explicitly select either next patch ` +
         `${production.major}.${production.minor}.${production.patch + 1} or next minor ` +
-        `${production.major}.${production.minor + 1}.0.`,
+        `${production.major}.${production.minor + 1}.0 or next major ` +
+        `${production.major + 1}.0.0.`,
     );
   }
 
   return {
     state: "development-line",
-    progression: isNextPatch ? "next-patch" : "next-minor",
+    progression: isNextPatch
+      ? "next-patch"
+      : isNextMinor
+        ? "next-minor"
+        : "next-major",
   };
 };
 

--- a/scripts/version-state.mjs
+++ b/scripts/version-state.mjs
@@ -26,6 +26,40 @@ export const compareBaseVersions = (left, right) => {
   return a.major - b.major || a.minor - b.minor || a.patch - b.patch;
 };
 
+export const parsePackageVersionInputs = (packageContent, lockfileContent) => {
+  const packageJson = JSON.parse(packageContent);
+  const packageLock = JSON.parse(lockfileContent);
+  return {
+    packageVersion: packageJson.version,
+    lockfileVersion: packageLock.version,
+    lockfileRootVersion: packageLock.packages?.[""]?.version,
+  };
+};
+
+export const validatePackageVersionParity = ({
+  packageVersion,
+  lockfileVersion,
+  lockfileRootVersion,
+  label = "package",
+}) => {
+  const declared = parseBaseVersion(packageVersion, `${label} package.json version`);
+  const lockfile = parseBaseVersion(
+    lockfileVersion,
+    `${label} package-lock.json version`,
+  );
+  const lockfileRoot = parseBaseVersion(
+    lockfileRootVersion,
+    `${label} package-lock.json root package version`,
+  );
+  if (lockfile.value !== declared.value || lockfileRoot.value !== declared.value) {
+    throw new Error(
+      `${label} package-lock.json versions must match package.json ` +
+        `(${declared.value}); found ${lockfile.value} and ${lockfileRoot.value}.`,
+    );
+  }
+  return declared.value;
+};
+
 export const validateStagingVersionState = ({
   productionVersion,
   stagingVersion,
@@ -72,11 +106,6 @@ export const validateStagingVersionState = ({
   };
 };
 
-const readPackageVersion = (content, label) => {
-  const parsed = JSON.parse(content);
-  return parseBaseVersion(parsed.version, label).value;
-};
-
 const runGit = (args, options = {}) =>
   execFileSync("git", args, {
     encoding: "utf8",
@@ -84,14 +113,20 @@ const runGit = (args, options = {}) =>
   });
 
 export const validateCurrentStagingVersionState = ({ productionRef = "origin/main" } = {}) => {
-  const stagingVersion = readPackageVersion(
-    readFileSync(new URL("../package.json", import.meta.url), "utf8"),
-    "staging version",
-  );
-  const productionVersion = readPackageVersion(
-    runGit(["show", `${productionRef}:package.json`]),
-    "production version",
-  );
+  const stagingVersion = validatePackageVersionParity({
+    ...parsePackageVersionInputs(
+      readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+      readFileSync(new URL("../package-lock.json", import.meta.url), "utf8"),
+    ),
+    label: "staging",
+  });
+  const productionVersion = validatePackageVersionParity({
+    ...parsePackageVersionInputs(
+      runGit(["show", `${productionRef}:package.json`]),
+      runGit(["show", `${productionRef}:package-lock.json`]),
+    ),
+    label: "production",
+  });
 
   let treesMatch = true;
   try {

--- a/scripts/version-state.mjs
+++ b/scripts/version-state.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const BASE_SEMVER_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+
+export const parseBaseVersion = (value, label = "version") => {
+  const normalized = String(value ?? "").trim();
+  const match = normalized.match(BASE_SEMVER_PATTERN);
+  if (!match) {
+    throw new Error(`${label} must be a valid base SemVer (MAJOR.MINOR.PATCH): ${normalized || "(missing)"}.`);
+  }
+  return {
+    value: normalized,
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+  };
+};
+
+export const compareBaseVersions = (left, right) => {
+  const a = parseBaseVersion(left, "version");
+  const b = parseBaseVersion(right, "comparison version");
+  return a.major - b.major || a.minor - b.minor || a.patch - b.patch;
+};
+
+export const validateStagingVersionState = ({
+  productionVersion,
+  stagingVersion,
+  treesMatch,
+}) => {
+  const production = parseBaseVersion(productionVersion, "production version");
+  const staging = parseBaseVersion(stagingVersion, "staging version");
+
+  if (treesMatch) {
+    if (staging.value !== production.value) {
+      throw new Error(
+        `Staging and production trees match but declare different versions (${staging.value} and ${production.value}).`,
+      );
+    }
+    return "same-release-tree";
+  }
+
+  if (staging.value === production.value) {
+    throw new Error(
+      `Staging diverged from production without selecting the next development version after ${production.value}.`,
+    );
+  }
+
+  const isNextPatch =
+    staging.major === production.major &&
+    staging.minor === production.minor &&
+    staging.patch === production.patch + 1;
+  const isNextMinor =
+    staging.major === production.major &&
+    staging.minor === production.minor + 1 &&
+    staging.patch === 0;
+
+  if (!isNextPatch && !isNextMinor) {
+    throw new Error(
+      `Staging version ${staging.value} must explicitly select either next patch ` +
+        `${production.major}.${production.minor}.${production.patch + 1} or next minor ` +
+        `${production.major}.${production.minor + 1}.0.`,
+    );
+  }
+
+  return {
+    state: "development-line",
+    progression: isNextPatch ? "next-patch" : "next-minor",
+  };
+};
+
+const readPackageVersion = (content, label) => {
+  const parsed = JSON.parse(content);
+  return parseBaseVersion(parsed.version, label).value;
+};
+
+const runGit = (args, options = {}) =>
+  execFileSync("git", args, {
+    encoding: "utf8",
+    stdio: options.allowDifference ? ["ignore", "ignore", "pipe"] : ["ignore", "pipe", "pipe"],
+  });
+
+export const validateCurrentStagingVersionState = ({ productionRef = "origin/main" } = {}) => {
+  const stagingVersion = readPackageVersion(
+    readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+    "staging version",
+  );
+  const productionVersion = readPackageVersion(
+    runGit(["show", `${productionRef}:package.json`]),
+    "production version",
+  );
+
+  let treesMatch = true;
+  try {
+    runGit(["diff", "--quiet", "HEAD", productionRef, "--"], {
+      allowDifference: true,
+    });
+  } catch (error) {
+    if (error?.status === 1) treesMatch = false;
+    else throw error;
+  }
+
+  return {
+    productionVersion,
+    stagingVersion,
+    result: validateStagingVersionState({
+      productionVersion,
+      stagingVersion,
+      treesMatch,
+    }),
+  };
+};
+
+const parseArg = (name) => {
+  const index = process.argv.indexOf(`--${name}`);
+  return index >= 0 ? process.argv[index + 1] : "";
+};
+
+const main = () => {
+  const command = process.argv[2];
+  if (command !== "staging") {
+    throw new Error("Usage: node scripts/version-state.mjs staging [--production-ref origin/main]");
+  }
+  const result = validateCurrentStagingVersionState({
+    productionRef: parseArg("production-ref") || "origin/main",
+  });
+  console.log(
+    `[version-state] ok production=${result.productionVersion} staging=${result.stagingVersion} ` +
+      `state=${typeof result.result === "string" ? result.result : result.result.progression}`,
+  );
+};
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`[version-state] ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+}

--- a/src/lib/prodPromotionPolicy.test.ts
+++ b/src/lib/prodPromotionPolicy.test.ts
@@ -29,6 +29,8 @@ describe("prod promotion policy", () => {
   it("accepts a release tag whose tree matches main HEAD", () => {
     const result = evaluatePolicy(`validatePromotionInputs({
         version: "0.19.0",
+        lockfileVersion: "0.19.0",
+        lockfileRootVersion: "0.19.0",
         tagCommit: "15269c7682a0671824a7dfe532f67e30b3b052da",
         treesMatch: true,
       })`);
@@ -39,6 +41,8 @@ describe("prod promotion policy", () => {
   it("rejects missing release tags", () => {
     const result = evaluatePolicy(`validatePromotionInputs({
         version: "0.19.0",
+        lockfileVersion: "0.19.0",
+        lockfileRootVersion: "0.19.0",
         tagCommit: "",
         treesMatch: true,
       })`);
@@ -49,6 +53,8 @@ describe("prod promotion policy", () => {
   it("rejects non-base SemVer package versions", () => {
     const result = evaluatePolicy(`validatePromotionInputs({
         version: "0.27.0-beta",
+        lockfileVersion: "0.27.0-beta",
+        lockfileRootVersion: "0.27.0-beta",
         tagCommit: "15269c7682a0671824a7dfe532f67e30b3b052da",
         treesMatch: true,
       })`);
@@ -60,6 +66,8 @@ describe("prod promotion policy", () => {
   it("rejects production-only tree changes", () => {
     const result = evaluatePolicy(`validatePromotionInputs({
         version: "0.19.0",
+        lockfileVersion: "0.19.0",
+        lockfileRootVersion: "0.19.0",
         tagCommit: "15269c7682a0671824a7dfe532f67e30b3b052da",
         treesMatch: false,
       })`);
@@ -67,4 +75,23 @@ describe("prod promotion policy", () => {
     expect(result.ok).toBe(false);
     expect(result.ok ? "" : result.message).toContain("main HEAD tree differs from release tag v0.19.0");
   });
+
+  it.each([
+    ["0.18.0", "0.19.0"],
+    ["0.19.0", "0.18.0"],
+  ])(
+    "rejects promotion lockfile drift %s / %s",
+    (lockfileVersion, lockfileRootVersion) => {
+      const result = evaluatePolicy(`validatePromotionInputs({
+        version: "0.19.0",
+        lockfileVersion: ${JSON.stringify(lockfileVersion)},
+        lockfileRootVersion: ${JSON.stringify(lockfileRootVersion)},
+        tagCommit: "15269c7682a0671824a7dfe532f67e30b3b052da",
+        treesMatch: true,
+      })`);
+
+      expect(result.ok).toBe(false);
+      expect(result.ok ? "" : result.message).toContain("package-lock.json");
+    },
+  );
 });

--- a/src/lib/prodPromotionPolicy.test.ts
+++ b/src/lib/prodPromotionPolicy.test.ts
@@ -46,6 +46,17 @@ describe("prod promotion policy", () => {
     expect(result).toEqual({ ok: false, message: "Prod promotion gate failed: release tag v0.19.0 does not exist." });
   });
 
+  it("rejects non-base SemVer package versions", () => {
+    const result = evaluatePolicy(`validatePromotionInputs({
+        version: "0.27.0-beta",
+        tagCommit: "15269c7682a0671824a7dfe532f67e30b3b052da",
+        treesMatch: true,
+      })`);
+
+    expect(result.ok).toBe(false);
+    expect(result.ok ? "" : result.message).toContain("valid base SemVer");
+  });
+
   it("rejects production-only tree changes", () => {
     const result = evaluatePolicy(`validatePromotionInputs({
         version: "0.19.0",

--- a/src/lib/prodReleasePolicy.test.ts
+++ b/src/lib/prodReleasePolicy.test.ts
@@ -32,6 +32,8 @@ describe("production release version policy", () => {
     expect(
       evaluatePolicy(`validateReleaseVersionInputs({
         version: "0.27.0",
+        lockfileVersion: "0.27.0",
+        lockfileRootVersion: "0.27.0",
         previousProductionVersion: "0.26.2",
         hasMatchingHeadTag: true,
       })`),
@@ -47,9 +49,30 @@ describe("production release version policy", () => {
     expect(
       evaluatePolicy(`validateReleaseVersionInputs({
         version: ${JSON.stringify(version)},
+        lockfileVersion: ${JSON.stringify(version)},
+        lockfileRootVersion: ${JSON.stringify(version)},
         previousProductionVersion: ${JSON.stringify(previousProductionVersion)},
         hasMatchingHeadTag: ${hasMatchingHeadTag},
       })`).ok,
     ).toBe(false);
   });
+
+  it.each([
+    ["0.26.2", "0.27.0"],
+    ["0.27.0", "0.26.2"],
+  ])(
+    "rejects release lockfile drift %s / %s",
+    (lockfileVersion, lockfileRootVersion) => {
+      const result = evaluatePolicy(`validateReleaseVersionInputs({
+        version: "0.27.0",
+        lockfileVersion: ${JSON.stringify(lockfileVersion)},
+        lockfileRootVersion: ${JSON.stringify(lockfileRootVersion)},
+        previousProductionVersion: "0.26.2",
+        hasMatchingHeadTag: true,
+      })`);
+
+      expect(result.ok).toBe(false);
+      expect(result.ok ? "" : result.message).toContain("package-lock.json");
+    },
+  );
 });

--- a/src/lib/prodReleasePolicy.test.ts
+++ b/src/lib/prodReleasePolicy.test.ts
@@ -1,0 +1,55 @@
+/// <reference types="node" />
+
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const scriptPath = resolve(process.cwd(), "scripts/validate-prod-release.mjs");
+
+const evaluatePolicy = (expression: string) => {
+  const output = execFileSync(
+    process.execPath,
+    [
+      "--input-type=module",
+      "--eval",
+      `import { validateReleaseVersionInputs } from ${JSON.stringify(scriptPath)};
+       try {
+         const result = ${expression};
+         console.log(JSON.stringify({ ok: true, value: result }));
+       } catch (error) {
+         console.log(JSON.stringify({ ok: false, message: error instanceof Error ? error.message : String(error) }));
+       }`,
+    ],
+    { encoding: "utf8" },
+  );
+  return JSON.parse(output) as
+    | { ok: true; value: unknown }
+    | { ok: false; message: string };
+};
+
+describe("production release version policy", () => {
+  it("accepts a version selected before the final release commit", () => {
+    expect(
+      evaluatePolicy(`validateReleaseVersionInputs({
+        version: "0.27.0",
+        previousProductionVersion: "0.26.2",
+        hasMatchingHeadTag: true,
+      })`),
+    ).toEqual({ ok: true, value: "v0.27.0" });
+  });
+
+  it.each([
+    ["0.26.2", "0.26.2", true],
+    ["0.26.1", "0.26.2", true],
+    ["0.27.0", "0.26.2", false],
+    ["0.27.0-beta", "0.26.2", true],
+  ])("rejects invalid release transition %s after %s", (version, previousProductionVersion, hasMatchingHeadTag) => {
+    expect(
+      evaluatePolicy(`validateReleaseVersionInputs({
+        version: ${JSON.stringify(version)},
+        previousProductionVersion: ${JSON.stringify(previousProductionVersion)},
+        hasMatchingHeadTag: ${hasMatchingHeadTag},
+      })`).ok,
+    ).toBe(false);
+  });
+});

--- a/src/lib/versionStatePolicy.test.ts
+++ b/src/lib/versionStatePolicy.test.ts
@@ -1,0 +1,82 @@
+/// <reference types="node" />
+
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const scriptPath = resolve(process.cwd(), "scripts/version-state.mjs");
+
+const evaluatePolicy = (expression: string) => {
+  const output = execFileSync(
+    process.execPath,
+    [
+      "--input-type=module",
+      "--eval",
+      `import { validateStagingVersionState } from ${JSON.stringify(scriptPath)};
+       try {
+         const result = ${expression};
+         console.log(JSON.stringify({ ok: true, value: result }));
+       } catch (error) {
+         console.log(JSON.stringify({ ok: false, message: error instanceof Error ? error.message : String(error) }));
+       }`,
+    ],
+    { encoding: "utf8" },
+  );
+  return JSON.parse(output) as
+    | { ok: true; value: unknown }
+    | { ok: false; message: string };
+};
+
+describe("staging version-state policy", () => {
+  it("permits the production version while the trees are identical", () => {
+    expect(
+      evaluatePolicy(`validateStagingVersionState({
+        productionVersion: "0.26.2",
+        stagingVersion: "0.26.2",
+        treesMatch: true,
+      })`),
+    ).toEqual({ ok: true, value: "same-release-tree" });
+  });
+
+  it("requires an explicit development version when staging diverges", () => {
+    const result = evaluatePolicy(`validateStagingVersionState({
+      productionVersion: "0.26.2",
+      stagingVersion: "0.26.2",
+      treesMatch: false,
+    })`);
+
+    expect(result.ok).toBe(false);
+    expect(result.ok ? "" : result.message).toContain(
+      "diverged from production without selecting",
+    );
+  });
+
+  it.each([
+    ["0.27.0", "next-minor"],
+    ["0.26.3", "next-patch"],
+  ])("accepts the explicit %s development line", (stagingVersion, progression) => {
+    expect(
+      evaluatePolicy(`validateStagingVersionState({
+        productionVersion: "0.26.2",
+        stagingVersion: ${JSON.stringify(stagingVersion)},
+        treesMatch: false,
+      })`),
+    ).toEqual({
+      ok: true,
+      value: { state: "development-line", progression },
+    });
+  });
+
+  it.each(["0.28.0", "0.26.4", "0.25.9", "1.0.0", "0.27.0-beta"])(
+    "rejects implicit, skipped, or malformed line %s",
+    (stagingVersion) => {
+      expect(
+        evaluatePolicy(`validateStagingVersionState({
+          productionVersion: "0.26.2",
+          stagingVersion: ${JSON.stringify(stagingVersion)},
+          treesMatch: false,
+        })`).ok,
+      ).toBe(false);
+    },
+  );
+});

--- a/src/lib/versionStatePolicy.test.ts
+++ b/src/lib/versionStatePolicy.test.ts
@@ -72,6 +72,7 @@ describe("staging version-state policy", () => {
   it.each([
     ["0.27.0", "next-minor"],
     ["0.26.3", "next-patch"],
+    ["1.0.0", "next-major"],
   ])("accepts the explicit %s development line", (stagingVersion, progression) => {
     expect(
       evaluatePolicy(`validateStagingVersionState({
@@ -85,7 +86,7 @@ describe("staging version-state policy", () => {
     });
   });
 
-  it.each(["0.28.0", "0.26.4", "0.25.9", "1.0.0", "0.27.0-beta"])(
+  it.each(["0.28.0", "0.26.4", "0.25.9", "2.0.0", "0.27.0-beta"])(
     "rejects implicit, skipped, or malformed line %s",
     (stagingVersion) => {
       expect(

--- a/src/lib/versionStatePolicy.test.ts
+++ b/src/lib/versionStatePolicy.test.ts
@@ -12,7 +12,7 @@ const evaluatePolicy = (expression: string) => {
     [
       "--input-type=module",
       "--eval",
-      `import { validateStagingVersionState } from ${JSON.stringify(scriptPath)};
+      `import { validatePackageVersionParity, validateStagingVersionState } from ${JSON.stringify(scriptPath)};
        try {
          const result = ${expression};
          console.log(JSON.stringify({ ok: true, value: result }));
@@ -28,6 +28,24 @@ const evaluatePolicy = (expression: string) => {
 };
 
 describe("staging version-state policy", () => {
+  it.each([
+    ["0.26.2", "0.27.0"],
+    ["0.27.0", "0.26.2"],
+  ])(
+    "rejects package-lock versions %s / %s that differ from package.json",
+    (lockfileVersion, lockfileRootVersion) => {
+      const result = evaluatePolicy(`validatePackageVersionParity({
+        packageVersion: "0.27.0",
+        lockfileVersion: ${JSON.stringify(lockfileVersion)},
+        lockfileRootVersion: ${JSON.stringify(lockfileRootVersion)},
+        label: "staging",
+      })`);
+
+      expect(result.ok).toBe(false);
+      expect(result.ok ? "" : result.message).toContain("package-lock.json");
+    },
+  );
+
   it("permits the production version while the trees are identical", () => {
     expect(
       evaluatePolicy(`validateStagingVersionState({


### PR DESCRIPTION
## Summary

- start the explicitly approved `0.27.0` development line in `package.json` and `package-lock.json`;
- validate staging's declared version against the production tree and base version before shared-staging deployment;
- enforce parity between `package.json` and both `package-lock.json` version fields across staging and protected-production gates;
- permit only the reviewed immediate next patch, minor, or major progression when staging first diverges;
- update production validation so an earlier-selected development version can be released while retaining exact tag/tree and newer-than-production guarantees;
- update the existing release flow, checklist, and disabled local release guidance.

Closes #1033 after staging verification and maintainer sign-off.

## Reuse and scope

This reuses the existing package version, build metadata, Sidebar channel label, guarded Pages workflow, and protected release scripts. It adds no second version source, milestone inference, repository-writing Action, deployment path, required check, or UI.

## Versioning decision

Production remains `v0.26.2`. This first divergent staging change explicitly selects the normal next minor line, so staging will display `v0.27.0-beta+<commit>` and local builds `v0.27.0-alpha+<commit>`. Patch development would instead require a separately reviewed `0.26.3` selection, while a breaking or first-stable cycle would require `1.0.0`; automation does not choose among them.

## Validation

- targeted version, release, workflow, build-label, migration, lockfile-mismatch, and next-major tests passed;
- full suite: 146 test files / 874 tests passed;
- `npm run build` passed;
- changed files pass ESLint;
- repository-wide `npm run lint` still reports its pre-existing 75-problem baseline; this PR adds no lint findings;
- security scan, registry validation, version-state CLI, process guard, and `git diff --check` passed.

## Authority boundary

PR targets `staging` only. Forge cannot merge it or promote production. Production remains an explicit Beacon/human approval flow.

— Forge · AI coding agent
<!-- linksim-ai:v1 agent=Forge bot=true run=d269d23e-1358-4829-969c-483fe89c5803 source=issue-1033 commit=b1c3b1906c57a3d522e2ea6805327dd2097fbbfd -->
