### PR TITLE
feat: add reviewed AI role knowledge

### DIFF
--- a/.agents/skills/linksim-create-pr/SKILL.md
+++ b/.agents/skills/linksim-create-pr/SKILL.md
@@ -37,6 +37,9 @@ production.
 6. Update documentation only where behavior or operator guidance changed.
    Automation-only repository assets do not independently bump the application
    version unless current policy or the user requires it.
+7. Edit `config/ai-agent-knowledge.json` only when the approved Forge task
+   explicitly names the knowledge registry. Preserve human approval and
+   evidence; never promote a Steward suggestion automatically.
 
 ## Verify
 

--- a/.agents/skills/linksim-create-pr/SKILL.md
+++ b/.agents/skills/linksim-create-pr/SKILL.md
@@ -76,8 +76,8 @@ production.
    `HEAD`, a clean worktree, no unresolved blocking finding, and no missing
    required review.
 5. Push the issue branch and open a PR to `staging`.
-6. Add the `ai-assisted` label. Sign the PR body visibly as Forge and include a
-   valid hidden provenance marker generated through
+6. Sign the PR body visibly as Forge and include a valid hidden provenance
+   marker generated through
    `node scripts/ai-provenance.mjs`. Validate the complete PR body with that
    same script before publication; never hand-build the marker.
 7. Describe scope, authority boundary, tests, pre-PR review result and reviewed

--- a/.agents/skills/linksim-policy-audit/SKILL.md
+++ b/.agents/skills/linksim-policy-audit/SKILL.md
@@ -22,6 +22,9 @@ merged.
    anything new. Recommend consolidation where it reduces conflicting sources.
 5. Include quota impact, security, least privilege, provenance, maintenance,
    and failure modes where relevant.
+6. When evidence supports a durable lesson, suggest a compact knowledge
+   registry entry with affected agents, evidence, and proposed wording. Never
+   edit the knowledge registry; an explicitly approved Forge task is required.
 
 If evidence does not support a change, report `No policy suggestion` with the
 searched evidence. Do not create work merely because the audit ran.
@@ -40,7 +43,8 @@ For each supported improvement, provide:
 - files or systems that an approved Forge task would change.
 
 Keep facts, inferences, and recommendations visibly distinct. Never edit
-`AGENTS.md`, skills, prompts, permissions, workflows, infrastructure, or memory.
+`AGENTS.md`, skills, prompts, permissions, workflows, infrastructure, the
+knowledge registry, or memory.
 Never implement the recommendation. Human acceptance followed by an explicit
 Forge task is required.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,11 @@
 
 ## Implementation Rules
 
+- Before named-agent work, load only that role's approved, size-capped lessons
+  with `node scripts/ai-knowledge.mjs for-agent --agent <name>`. Do not load the
+  whole registry into agent context, and do not store raw chat transcripts or
+  personal/private memory there. Registry edits require an explicitly approved
+  Forge task and reviewed pull request; Steward may only suggest changes.
 - Prefer stabilization (consistency, hardening, tests, and UX cleanup) over net-new features unless explicitly requested.
 - Reuse or adapt existing code and UI. Never add a new UI element without approval; flag opportunities to remove or consolidate overlapping code or UI.
 - Keep terminology consistent: `Simulation`, `Site`, `Library`, `Path`, and `Channel`.

--- a/config/ai-agent-knowledge.json
+++ b/config/ai-agent-knowledge.json
@@ -1,0 +1,54 @@
+{
+  "schemaVersion": 1,
+  "maxLoadedCharacters": 2400,
+  "entries": [
+    {
+      "id": "preserve-reporter-intent",
+      "lesson": "Preserve the reporter's stated intent; do not broaden or reinterpret the request.",
+      "affectedAgents": ["Linky", "Scout"],
+      "evidence": ["issue-1035"],
+      "humanApproval": { "by": "wilhel1812", "source": "issue-1035", "approvedAt": "2026-08-10" },
+      "status": "approved"
+    },
+    {
+      "id": "ask-instead-of-inventing",
+      "lesson": "Ask one focused question when required details are missing; never invent them.",
+      "affectedAgents": ["Linky", "Scout"],
+      "evidence": ["issue-1035"],
+      "humanApproval": { "by": "wilhel1812", "source": "issue-1035", "approvedAt": "2026-08-10" },
+      "status": "approved"
+    },
+    {
+      "id": "resolve-conversations-independently",
+      "lesson": "Resolve each conversation independently; one pending draft must not replace or approve another.",
+      "affectedAgents": ["Linky"],
+      "evidence": ["issue-1035"],
+      "humanApproval": { "by": "wilhel1812", "source": "issue-1035", "approvedAt": "2026-08-10" },
+      "status": "approved"
+    },
+    {
+      "id": "keep-community-replies-concise",
+      "lesson": "Keep community replies concise, direct, active, and free of repeated user text or stock praise.",
+      "affectedAgents": ["Linky"],
+      "evidence": ["issue-1035"],
+      "humanApproval": { "by": "wilhel1812", "source": "issue-1035", "approvedAt": "2026-08-10" },
+      "status": "approved"
+    },
+    {
+      "id": "hide-internal-scout-reports",
+      "lesson": "Keep Scout's internal report private to the crew; Linky should return only the relevant distilled answer.",
+      "affectedAgents": ["Linky", "Scout"],
+      "evidence": ["issue-1035"],
+      "humanApproval": { "by": "wilhel1812", "source": "issue-1035", "approvedAt": "2026-08-10" },
+      "status": "approved"
+    },
+    {
+      "id": "ground-product-claims",
+      "lesson": "Ground current product and repository claims in evidence; state uncertainty instead of speculating.",
+      "affectedAgents": ["Linky", "Scout", "Sentry", "Forge", "Beacon", "Steward"],
+      "evidence": ["issue-1035"],
+      "humanApproval": { "by": "wilhel1812", "source": "issue-1035", "approvedAt": "2026-08-10" },
+      "status": "approved"
+    }
+  ]
+}

--- a/functions/_lib/aiAgentKnowledge.test.ts
+++ b/functions/_lib/aiAgentKnowledge.test.ts
@@ -75,7 +75,7 @@ describe("reviewed AI role knowledge", () => {
         entries: [
           {
             id: "link-only",
-            lesson: "A".repeat(150),
+            lesson: "A".repeat(80),
             affectedAgents: ["Linky"],
             evidence: ["issue-1"],
             humanApproval: { by: "owner", source: "issue-1", approvedAt: "2026-08-10" },
@@ -112,6 +112,8 @@ describe("reviewed AI role knowledge", () => {
 
     const selected = selectKnowledgeForAgent(registry, "Linky");
     expect(selected.entries.map((entry: { id: string }) => entry.id)).toEqual(["link-only"]);
+    expect(JSON.stringify(selected).length).toBeLessThanOrEqual(256);
+    expect(selected.characters).toBe(JSON.stringify(selected).length);
     expect(selected.characters).toBeLessThanOrEqual(256);
     expect(selected.truncated).toBe(true);
   });
@@ -153,6 +155,7 @@ describe("reviewed AI role knowledge", () => {
     expect(steward).toMatch(/suggest[\s\S]{0,80}knowledge\s+registry/i);
     expect(steward).toMatch(/never[\s\S]{0,80}edit[\s\S]{0,80}knowledge registry/i);
     expect(createPr).toMatch(/approved Forge[\s\S]{0,100}knowledge registry/i);
+    expect(createPr).not.toContain("ai-assisted");
     expect(policy).toContain("node scripts/ai-knowledge.mjs for-agent --agent <name>");
     expect(policy).toMatch(/do not store.*raw chat transcripts/i);
   });

--- a/functions/_lib/aiAgentKnowledge.test.ts
+++ b/functions/_lib/aiAgentKnowledge.test.ts
@@ -116,6 +116,29 @@ describe("reviewed AI role knowledge", () => {
     expect(selected.truncated).toBe(true);
   });
 
+  it("uses the caller-selected agent registry during selection", () => {
+    const customAgents = { agents: [{ name: "Custom" }] };
+    const registry = validateKnowledgeRegistry(
+      {
+        schemaVersion: 1,
+        maxLoadedCharacters: 512,
+        entries: [
+          {
+            id: "custom-only",
+            lesson: "Load only for the custom registry role.",
+            affectedAgents: ["Custom"],
+            evidence: ["issue-custom"],
+            humanApproval: { by: "owner", source: "issue-custom", approvedAt: "2026-08-10" },
+            status: "approved",
+          },
+        ],
+      },
+      customAgents,
+    );
+
+    expect(selectKnowledgeForAgent(registry, "Custom", customAgents).entries).toHaveLength(1);
+  });
+
   it("keeps Steward suggestion-only and requires an approved Forge edit", () => {
     const steward = readFileSync(
       resolve(process.cwd(), ".agents/skills/linksim-policy-audit/SKILL.md"),

--- a/functions/_lib/aiAgentKnowledge.test.ts
+++ b/functions/_lib/aiAgentKnowledge.test.ts
@@ -1,0 +1,136 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  loadKnowledgeRegistry,
+  selectKnowledgeForAgent,
+  validateKnowledgeRegistry,
+} from "../../scripts/ai-knowledge.mjs";
+
+const agentRegistry = JSON.parse(
+  readFileSync(resolve(process.cwd(), "config/ai-agents.json"), "utf8"),
+);
+
+describe("reviewed AI role knowledge", () => {
+  it("ships the six human-approved lessons from the crew follow-up", () => {
+    const registry = loadKnowledgeRegistry();
+
+    expect(registry.entries.map((entry: { id: string }) => entry.id)).toEqual([
+      "preserve-reporter-intent",
+      "ask-instead-of-inventing",
+      "resolve-conversations-independently",
+      "keep-community-replies-concise",
+      "hide-internal-scout-reports",
+      "ground-product-claims",
+    ]);
+    expect(registry.entries.every((entry: { status: string }) => entry.status === "approved")).toBe(true);
+    expect(registry.entries.every((entry: { humanApproval: { by: string } }) => entry.humanApproval.by === "wilhel1812")).toBe(true);
+  });
+
+  it("rejects unknown agents, missing approval, and transcript-shaped fields", () => {
+    const base = {
+      schemaVersion: 1,
+      maxLoadedCharacters: 512,
+      entries: [
+        {
+          id: "one-lesson",
+          lesson: "Keep the answer grounded.",
+          affectedAgents: ["Linky"],
+          evidence: ["issue-1035"],
+          humanApproval: {
+            by: "wilhel1812",
+            source: "issue-1035",
+            approvedAt: "2026-08-10",
+          },
+          status: "approved",
+        },
+      ],
+    };
+
+    expect(() =>
+      validateKnowledgeRegistry(
+        { ...base, entries: [{ ...base.entries[0], affectedAgents: ["Unknown"] }] },
+        agentRegistry,
+      ),
+    ).toThrow(/unknown agent/i);
+    expect(() =>
+      validateKnowledgeRegistry(
+        { ...base, entries: [{ ...base.entries[0], humanApproval: undefined }] },
+        agentRegistry,
+      ),
+    ).toThrow(/human approval/i);
+    expect(() =>
+      validateKnowledgeRegistry(
+        { ...base, entries: [{ ...base.entries[0], transcript: "raw chat" }] },
+        agentRegistry,
+      ),
+    ).toThrow(/unsupported field/i);
+  });
+
+  it("loads only approved entries for one agent under the strict character cap", () => {
+    const registry = validateKnowledgeRegistry(
+      {
+        schemaVersion: 1,
+        maxLoadedCharacters: 256,
+        entries: [
+          {
+            id: "link-only",
+            lesson: "A".repeat(150),
+            affectedAgents: ["Linky"],
+            evidence: ["issue-1"],
+            humanApproval: { by: "owner", source: "issue-1", approvedAt: "2026-08-10" },
+            status: "approved",
+          },
+          {
+            id: "retired-link",
+            lesson: "Do not load retired advice.",
+            affectedAgents: ["Linky"],
+            evidence: ["issue-2"],
+            humanApproval: { by: "owner", source: "issue-2", approvedAt: "2026-08-10" },
+            status: "retired",
+          },
+          {
+            id: "forge-only",
+            lesson: "Do not load another role's advice.",
+            affectedAgents: ["Forge"],
+            evidence: ["issue-3"],
+            humanApproval: { by: "owner", source: "issue-3", approvedAt: "2026-08-10" },
+            status: "approved",
+          },
+          {
+            id: "link-over-cap",
+            lesson: "B".repeat(150),
+            affectedAgents: ["Linky"],
+            evidence: ["issue-4"],
+            humanApproval: { by: "owner", source: "issue-4", approvedAt: "2026-08-10" },
+            status: "approved",
+          },
+        ],
+      },
+      agentRegistry,
+    );
+
+    const selected = selectKnowledgeForAgent(registry, "Linky");
+    expect(selected.entries.map((entry: { id: string }) => entry.id)).toEqual(["link-only"]);
+    expect(selected.characters).toBeLessThanOrEqual(256);
+    expect(selected.truncated).toBe(true);
+  });
+
+  it("keeps Steward suggestion-only and requires an approved Forge edit", () => {
+    const steward = readFileSync(
+      resolve(process.cwd(), ".agents/skills/linksim-policy-audit/SKILL.md"),
+      "utf8",
+    );
+    const createPr = readFileSync(
+      resolve(process.cwd(), ".agents/skills/linksim-create-pr/SKILL.md"),
+      "utf8",
+    );
+    const policy = readFileSync(resolve(process.cwd(), "AGENTS.md"), "utf8");
+
+    expect(steward).toMatch(/suggest[\s\S]{0,80}knowledge\s+registry/i);
+    expect(steward).toMatch(/never[\s\S]{0,80}edit[\s\S]{0,80}knowledge registry/i);
+    expect(createPr).toMatch(/approved Forge[\s\S]{0,100}knowledge registry/i);
+    expect(policy).toContain("node scripts/ai-knowledge.mjs for-agent --agent <name>");
+    expect(policy).toMatch(/do not store.*raw chat transcripts/i);
+  });
+});

--- a/functions/_lib/stewardPolicyAuditConfig.test.ts
+++ b/functions/_lib/stewardPolicyAuditConfig.test.ts
@@ -49,7 +49,7 @@ describe("Steward policy audit rollout", () => {
     expect(repositoryPolicy).toContain("scripts/ai-provenance.mjs");
     expect(repositoryPolicy).toContain("fail closed");
     expect(packageJson.scripts["agents:validate"]).toBe(
-      "node scripts/ai-provenance.mjs validate-registry",
+      "node scripts/ai-provenance.mjs validate-registry && node scripts/ai-knowledge.mjs validate",
     );
     expect(qualityWorkflow).toContain("npm run agents:validate");
   });

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "GPL-3.0-only",
   "type": "module",
   "scripts": {
-    "agents:validate": "node scripts/ai-provenance.mjs validate-registry",
+    "agents:validate": "node scripts/ai-provenance.mjs validate-registry && node scripts/ai-knowledge.mjs validate",
     "build:meta": "node scripts/generate-build-info.mjs",
     "peaks:build": "node scripts/build-open-peak-index.mjs",
     "peaks:tiles:bootstrap": "node scripts/build-peak-tiles-bootstrap.mjs",

--- a/scripts/ai-knowledge.mjs
+++ b/scripts/ai-knowledge.mjs
@@ -102,8 +102,11 @@ export function loadKnowledgeRegistry(knowledgePath = DEFAULT_KNOWLEDGE_PATH, ag
   return validateKnowledgeRegistry(JSON.parse(readFileSync(knowledgePath, "utf8")), loadAgentRegistry(agentPath));
 }
 
-export function selectKnowledgeForAgent(registry, agentName) {
-  const agentRegistry = loadAgentRegistry(DEFAULT_AGENT_PATH);
+export function selectKnowledgeForAgent(
+  registry,
+  agentName,
+  agentRegistry = loadAgentRegistry(DEFAULT_AGENT_PATH),
+) {
   const validated = validateKnowledgeRegistry(registry, agentRegistry);
   if (!agentRegistry.agents.some((agent) => agent.name === agentName)) {
     throw new Error(`unknown agent: ${agentName}`);
@@ -147,14 +150,18 @@ function parseOptions(args) {
 function runCli(args) {
   const [command, ...rest] = args;
   const options = parseOptions(rest);
-  const registry = loadKnowledgeRegistry(options.registry ?? DEFAULT_KNOWLEDGE_PATH, options.agents ?? DEFAULT_AGENT_PATH);
+  const agentRegistry = loadAgentRegistry(options.agents ?? DEFAULT_AGENT_PATH);
+  const registry = validateKnowledgeRegistry(
+    JSON.parse(readFileSync(options.registry ?? DEFAULT_KNOWLEDGE_PATH, "utf8")),
+    agentRegistry,
+  );
   if (command === "validate") {
     process.stdout.write("AI role knowledge registry valid.\n");
     return;
   }
   if (command === "for-agent") {
     const agent = requireShortString(options.agent, "agent", 40);
-    process.stdout.write(`${JSON.stringify(selectKnowledgeForAgent(registry, agent))}\n`);
+    process.stdout.write(`${JSON.stringify(selectKnowledgeForAgent(registry, agent, agentRegistry))}\n`);
     return;
   }
   throw new Error(`unknown command: ${command ?? ""}`);

--- a/scripts/ai-knowledge.mjs
+++ b/scripts/ai-knowledge.mjs
@@ -102,6 +102,20 @@ export function loadKnowledgeRegistry(knowledgePath = DEFAULT_KNOWLEDGE_PATH, ag
   return validateKnowledgeRegistry(JSON.parse(readFileSync(knowledgePath, "utf8")), loadAgentRegistry(agentPath));
 }
 
+function buildSelectedKnowledgePayload(agentName, maxCharacters, truncated, entries) {
+  const payload = {
+    agent: agentName,
+    maxCharacters,
+    characters: 0,
+    truncated,
+    entries,
+  };
+  while (payload.characters !== JSON.stringify(payload).length) {
+    payload.characters = JSON.stringify(payload).length;
+  }
+  return payload;
+}
+
 export function selectKnowledgeForAgent(
   registry,
   agentName,
@@ -119,19 +133,24 @@ export function selectKnowledgeForAgent(
     }
     const publicEntry = { id: entry.id, lesson: entry.lesson, evidence: entry.evidence };
     const candidate = [...entries, publicEntry];
-    if (JSON.stringify(candidate).length > validated.maxLoadedCharacters) {
+    const candidatePayload = buildSelectedKnowledgePayload(
+      agentName,
+      validated.maxLoadedCharacters,
+      false,
+      candidate,
+    );
+    if (candidatePayload.characters > validated.maxLoadedCharacters) {
       truncated = true;
       break;
     }
     entries.push(publicEntry);
   }
-  return {
-    agent: agentName,
-    maxCharacters: validated.maxLoadedCharacters,
-    characters: JSON.stringify(entries).length,
+  return buildSelectedKnowledgePayload(
+    agentName,
+    validated.maxLoadedCharacters,
     truncated,
     entries,
-  };
+  );
 }
 
 function parseOptions(args) {

--- a/scripts/ai-knowledge.mjs
+++ b/scripts/ai-knowledge.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadAgentRegistry } from "./ai-provenance.mjs";
+
+const DEFAULT_KNOWLEDGE_PATH = resolve(process.cwd(), "config/ai-agent-knowledge.json");
+const DEFAULT_AGENT_PATH = resolve(process.cwd(), "config/ai-agents.json");
+const ENTRY_FIELDS = ["affectedAgents", "evidence", "humanApproval", "id", "lesson", "status"];
+
+function requireObject(value, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value;
+}
+
+function requireExactFields(value, fields, label) {
+  const actual = Object.keys(requireObject(value, label)).sort();
+  const expected = [...fields].sort();
+  const unsupported = actual.filter((field) => !expected.includes(field));
+  const missing = expected.filter((field) => !actual.includes(field));
+  if (unsupported.length > 0) {
+    throw new Error(`${label} contains unsupported field: ${unsupported[0]}`);
+  }
+  if (missing.length > 0) {
+    throw new Error(`${label} is missing field: ${missing[0]}`);
+  }
+}
+
+function requireShortString(value, label, maximum = 280) {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  if (value.length > maximum || /[\r\n]/.test(value)) {
+    throw new Error(`${label} must be one short line`);
+  }
+  return value;
+}
+
+function requireUniqueStrings(value, label, maximum = 280) {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error(`${label} must be a non-empty array`);
+  }
+  const strings = value.map((item) => requireShortString(item, label, maximum));
+  if (new Set(strings).size !== strings.length) {
+    throw new Error(`${label} contains duplicate values`);
+  }
+  return strings;
+}
+
+export function validateKnowledgeRegistry(registry, agentRegistry = loadAgentRegistry(DEFAULT_AGENT_PATH)) {
+  requireExactFields(registry, ["schemaVersion", "maxLoadedCharacters", "entries"], "knowledge registry");
+  if (registry.schemaVersion !== 1) {
+    throw new Error("unsupported knowledge registry schema version");
+  }
+  if (!Number.isInteger(registry.maxLoadedCharacters) || registry.maxLoadedCharacters < 256 || registry.maxLoadedCharacters > 4000) {
+    throw new Error("knowledge load cap must be an integer from 256 to 4000 characters");
+  }
+  if (!Array.isArray(registry.entries) || registry.entries.length === 0) {
+    throw new Error("knowledge registry must define entries");
+  }
+
+  const knownAgents = new Set(agentRegistry.agents.map((agent) => agent.name));
+  const ids = new Set();
+  for (const entry of registry.entries) {
+    requireExactFields(entry, ENTRY_FIELDS, "knowledge entry");
+    const id = requireShortString(entry.id, "knowledge entry id", 80);
+    if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(id)) {
+      throw new Error(`invalid knowledge entry id: ${id}`);
+    }
+    if (ids.has(id)) {
+      throw new Error(`duplicate knowledge entry id: ${id}`);
+    }
+    ids.add(id);
+    requireShortString(entry.lesson, `${id} lesson`);
+    const affectedAgents = requireUniqueStrings(entry.affectedAgents, `${id} affected agents`, 40);
+    for (const agent of affectedAgents) {
+      if (!knownAgents.has(agent)) {
+        throw new Error(`${id} references unknown agent: ${agent}`);
+      }
+    }
+    if (entry.evidence.length > 5) {
+      throw new Error(`${id} evidence exceeds five items`);
+    }
+    requireUniqueStrings(entry.evidence, `${id} evidence`, 240);
+    requireExactFields(entry.humanApproval, ["approvedAt", "by", "source"], `${id} human approval`);
+    requireShortString(entry.humanApproval.by, `${id} human approval by`, 80);
+    requireShortString(entry.humanApproval.source, `${id} human approval source`, 160);
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(String(entry.humanApproval.approvedAt))) {
+      throw new Error(`${id} human approval date must use YYYY-MM-DD`);
+    }
+    if (!new Set(["approved", "retired"]).has(entry.status)) {
+      throw new Error(`${id} status must be approved or retired`);
+    }
+  }
+  return registry;
+}
+
+export function loadKnowledgeRegistry(knowledgePath = DEFAULT_KNOWLEDGE_PATH, agentPath = DEFAULT_AGENT_PATH) {
+  return validateKnowledgeRegistry(JSON.parse(readFileSync(knowledgePath, "utf8")), loadAgentRegistry(agentPath));
+}
+
+export function selectKnowledgeForAgent(registry, agentName) {
+  const agentRegistry = loadAgentRegistry(DEFAULT_AGENT_PATH);
+  const validated = validateKnowledgeRegistry(registry, agentRegistry);
+  if (!agentRegistry.agents.some((agent) => agent.name === agentName)) {
+    throw new Error(`unknown agent: ${agentName}`);
+  }
+  const entries = [];
+  let truncated = false;
+  for (const entry of validated.entries) {
+    if (entry.status !== "approved" || !entry.affectedAgents.includes(agentName)) {
+      continue;
+    }
+    const publicEntry = { id: entry.id, lesson: entry.lesson, evidence: entry.evidence };
+    const candidate = [...entries, publicEntry];
+    if (JSON.stringify(candidate).length > validated.maxLoadedCharacters) {
+      truncated = true;
+      break;
+    }
+    entries.push(publicEntry);
+  }
+  return {
+    agent: agentName,
+    maxCharacters: validated.maxLoadedCharacters,
+    characters: JSON.stringify(entries).length,
+    truncated,
+    entries,
+  };
+}
+
+function parseOptions(args) {
+  const options = {};
+  for (let index = 0; index < args.length; index += 2) {
+    const key = args[index];
+    const value = args[index + 1];
+    if (!key?.startsWith("--") || value === undefined) {
+      throw new Error(`invalid CLI option: ${key ?? ""}`);
+    }
+    options[key.slice(2)] = value;
+  }
+  return options;
+}
+
+function runCli(args) {
+  const [command, ...rest] = args;
+  const options = parseOptions(rest);
+  const registry = loadKnowledgeRegistry(options.registry ?? DEFAULT_KNOWLEDGE_PATH, options.agents ?? DEFAULT_AGENT_PATH);
+  if (command === "validate") {
+    process.stdout.write("AI role knowledge registry valid.\n");
+    return;
+  }
+  if (command === "for-agent") {
+    const agent = requireShortString(options.agent, "agent", 40);
+    process.stdout.write(`${JSON.stringify(selectKnowledgeForAgent(registry, agent))}\n`);
+    return;
+  }
+  throw new Error(`unknown command: ${command ?? ""}`);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  try {
+    runCli(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
Part of #1039.

## Scope

- add one checked-in, schema-validated AI role knowledge registry
- load only approved lessons relevant to the selected agent, with a strict 2,400-character cap over the complete emitted payload
- seed the six human-approved lessons from the conversation-intelligence epic
- require Steward suggestions to be implemented only through an explicitly approved Forge task
- integrate knowledge validation into the existing agent validation command
- remove the `ai-assisted` PR-label requirement while retaining visible and hidden provenance

## Authority and privacy boundaries

The registry stores short reviewed lessons and evidence references, not raw chat logs, transcripts, personal memory, or private group context. Steward remains suggestion-only and cannot edit the registry. This PR does not add a Vidda runtime consumer, so issue #1039 remains open for that later integration.

## Verification

- `npm run agents:validate` — passed at `a71539bbc43add865eedb994812de05e1382c532`
- `npm test` — 148 test files / 882 tests passed at the same SHA
- `npm run build` — passed at the same SHA
- `npm run dev:check` — no LinkSim dev/watch servers found
- `git diff --check` — passed
- independent pre-PR review — `pass`; no findings, reviewed exact head `a71539bbc43add865eedb994812de05e1382c532`

## Documentation and versioning

Repository-scoped automation only. No user-facing application behavior changed, so the LinkSim application version is unchanged.

— Forge · AI coding agent
<!-- linksim-ai:v1 agent=Forge bot=true run=5aaf94da-f542-4cea-9d76-eaef8eaa4671 source=issue-1039 commit=a71539bbc43add865eedb994812de05e1382c532 -->
