### PR TITLE
chore(agents): derive Steward publication policy from registry

### DIFF
--- a/.agents/skills/linksim-policy-audit/SKILL.md
+++ b/.agents/skills/linksim-policy-audit/SKILL.md
@@ -65,9 +65,9 @@ rendered artifact must display only the registry-approved attribution for the
 configured Steward publisher. Do not hard-code, inherit, or claim another
 agent's delivery identity or authority.
 
-End every output with `Suggestion only — no policy change applied.` and
-`— Steward · AI policy advisor`. Fail closed if attribution or provenance
-cannot be generated. Generate the footer with
-`node scripts/ai-provenance.mjs footer`, render the complete comment to a file,
-then require `node scripts/ai-provenance.mjs validate-artifact --agent Steward`
-to pass before publication. Never hand-build the marker.
+End every output with `Suggestion only — no policy change applied.` followed by
+the signature returned by `node scripts/ai-provenance.mjs footer`; never
+prescribe or add a literal agent signature. Fail closed if attribution or
+provenance cannot be generated. Render the complete comment to a file, then
+require `node scripts/ai-provenance.mjs validate-artifact --agent Steward` to
+pass before publication. Never hand-build the marker.

--- a/.agents/skills/linksim-policy-audit/SKILL.md
+++ b/.agents/skills/linksim-policy-audit/SKILL.md
@@ -58,12 +58,17 @@ not start a model call. Comment only when at least one evidence-backed
 improvement exists. Append through the deterministic publisher to the single
 configured `documentation` + `pending-discussion` issue; do not rewrite its
 body or create repeated issues. Publication must be idempotent, signed, and
-provenance-validated. Scheduled publication identity, delivery identity,
-visible attribution, and permitted issue authority must be resolved from
-`config/ai-agents.json` and validated by `scripts/ai-provenance.mjs`. The
-rendered artifact must display only the registry-approved attribution for the
-configured Steward publisher. Do not hard-code, inherit, or claim another
-agent's delivery identity or authority.
+provenance-validated. Resolve scheduled publication identity, delivery
+identity, visible attribution, and permitted issue authority from
+`config/ai-agents.json`. Before publication, the deterministic publisher must
+compare its authenticated GitHub identity with Steward's configured
+`githubIdentity`, confirm the requested action is
+`publish-signed-suggestion`, confirm that action is allowed and not prohibited,
+and stop before publication on any mismatch. The publisher fails closed on any
+mismatch. Use `scripts/ai-provenance.mjs` to validate the registry and rendered
+artifact. The artifact must display only the
+registry-approved attribution for the configured Steward publisher. Do not
+hard-code, inherit, or claim another agent's delivery identity or authority.
 
 End every output with `Suggestion only — no policy change applied.` followed by
 the signature and marker returned by `node scripts/ai-provenance.mjs footer`;

--- a/.agents/skills/linksim-policy-audit/SKILL.md
+++ b/.agents/skills/linksim-policy-audit/SKILL.md
@@ -58,10 +58,12 @@ not start a model call. Comment only when at least one evidence-backed
 improvement exists. Append through the deterministic publisher to the single
 configured `documentation` + `pending-discussion` issue; do not rewrite its
 body or create repeated issues. Publication must be idempotent, signed, and
-provenance-validated. Scheduled GitHub comments are authored by Steward and
-published through Steward's dedicated least-privilege GitHub App. They must
-visibly contain `— Steward · AI policy advisor`; they must not claim delivery by
-Linky or inherit Linky's issue-maintenance authority.
+provenance-validated. Scheduled publication identity, delivery identity,
+visible attribution, and permitted issue authority must be resolved from
+`config/ai-agents.json` and validated by `scripts/ai-provenance.mjs`. The
+rendered artifact must display only the registry-approved attribution for the
+configured Steward publisher. Do not hard-code, inherit, or claim another
+agent's delivery identity or authority.
 
 End every output with `Suggestion only — no policy change applied.` and
 `— Steward · AI policy advisor`. Fail closed if attribution or provenance

--- a/.agents/skills/linksim-policy-audit/SKILL.md
+++ b/.agents/skills/linksim-policy-audit/SKILL.md
@@ -66,8 +66,9 @@ configured Steward publisher. Do not hard-code, inherit, or claim another
 agent's delivery identity or authority.
 
 End every output with `Suggestion only — no policy change applied.` followed by
-the signature returned by `node scripts/ai-provenance.mjs footer`; never
-prescribe or add a literal agent signature. Fail closed if attribution or
-provenance cannot be generated. Render the complete comment to a file, then
-require `node scripts/ai-provenance.mjs validate-artifact --agent Steward` to
-pass before publication. Never hand-build the marker.
+the signature and marker returned by `node scripts/ai-provenance.mjs footer`;
+append both returned fields and never prescribe or hand-build either one. Fail
+closed if attribution or provenance cannot be generated. Render the complete
+comment to a file, then require
+`node scripts/ai-provenance.mjs validate-artifact --agent Steward` to pass
+before publication.

--- a/functions/_lib/stewardPolicyAuditConfig.test.ts
+++ b/functions/_lib/stewardPolicyAuditConfig.test.ts
@@ -47,7 +47,8 @@ describe("Steward policy audit rollout", () => {
     expect(policySkill).toContain("config/ai-agents.json");
     expect(policySkill).toContain("registry-approved attribution");
     expect(policySkill).toContain("permitted issue authority");
-    expect(policySkill).toContain("signature returned by");
+    expect(policySkill).toContain("signature and marker returned by");
+    expect(policySkill).toContain("append both returned fields");
     expect(policySkill).not.toContain("Steward's dedicated least-privilege GitHub App");
     expect(policySkill).not.toContain("— Steward · AI policy advisor");
     expect(policySkill).not.toContain("Linky");

--- a/functions/_lib/stewardPolicyAuditConfig.test.ts
+++ b/functions/_lib/stewardPolicyAuditConfig.test.ts
@@ -47,7 +47,9 @@ describe("Steward policy audit rollout", () => {
     expect(policySkill).toContain("config/ai-agents.json");
     expect(policySkill).toContain("registry-approved attribution");
     expect(policySkill).toContain("permitted issue authority");
+    expect(policySkill).toContain("signature returned by");
     expect(policySkill).not.toContain("Steward's dedicated least-privilege GitHub App");
+    expect(policySkill).not.toContain("— Steward · AI policy advisor");
     expect(policySkill).not.toContain("Linky");
     expect(repositoryPolicy).toContain("scripts/ai-provenance.mjs");
     expect(repositoryPolicy).toContain("fail closed");

--- a/functions/_lib/stewardPolicyAuditConfig.test.ts
+++ b/functions/_lib/stewardPolicyAuditConfig.test.ts
@@ -47,6 +47,10 @@ describe("Steward policy audit rollout", () => {
     expect(policySkill).toContain("config/ai-agents.json");
     expect(policySkill).toContain("registry-approved attribution");
     expect(policySkill).toContain("permitted issue authority");
+    expect(policySkill).toContain("authenticated GitHub identity");
+    expect(policySkill).toContain("requested action");
+    expect(policySkill).toContain("publish-signed-suggestion");
+    expect(policySkill).toMatch(/fails closed on any\s+mismatch/);
     expect(policySkill).toContain("signature and marker returned by");
     expect(policySkill).toContain("append both returned fields");
     expect(policySkill).not.toContain("Steward's dedicated least-privilege GitHub App");

--- a/functions/_lib/stewardPolicyAuditConfig.test.ts
+++ b/functions/_lib/stewardPolicyAuditConfig.test.ts
@@ -47,10 +47,16 @@ describe("Steward policy audit rollout", () => {
     expect(policySkill).toContain("config/ai-agents.json");
     expect(policySkill).toContain("registry-approved attribution");
     expect(policySkill).toContain("permitted issue authority");
-    expect(policySkill).toContain("authenticated GitHub identity");
-    expect(policySkill).toContain("requested action");
-    expect(policySkill).toContain("publish-signed-suggestion");
-    expect(policySkill).toMatch(/fails closed on any\s+mismatch/);
+    expect(policySkill).toMatch(
+      /publisher must[\s\S]{0,120}authenticated GitHub identity[\s\S]{0,120}githubIdentity/,
+    );
+    expect(policySkill).toMatch(
+      /requested action is[\s\S]{0,80}publish-signed-suggestion[\s\S]{0,120}allowed and not prohibited/,
+    );
+    expect(policySkill).toMatch(/publisher fails closed on any\s+mismatch/);
+    expect(policySkill).toMatch(
+      /ai-provenance\.mjs[\s\S]{0,80}validate the registry and rendered\s+artifact/,
+    );
     expect(policySkill).toContain("signature and marker returned by");
     expect(policySkill).toContain("append both returned fields");
     expect(policySkill).not.toContain("Steward's dedicated least-privilege GitHub App");

--- a/functions/_lib/stewardPolicyAuditConfig.test.ts
+++ b/functions/_lib/stewardPolicyAuditConfig.test.ts
@@ -44,8 +44,11 @@ describe("Steward policy audit rollout", () => {
   it("routes every publication through the shared deterministic validator", () => {
     expect(policySkill).toContain("scripts/ai-provenance.mjs");
     expect(policySkill).toContain("config/steward-policy-audit.json");
-    expect(policySkill).toContain("Steward's dedicated least-privilege GitHub App");
-    expect(policySkill).not.toContain("Delivered by Linky · AI community bot");
+    expect(policySkill).toContain("config/ai-agents.json");
+    expect(policySkill).toContain("registry-approved attribution");
+    expect(policySkill).toContain("permitted issue authority");
+    expect(policySkill).not.toContain("Steward's dedicated least-privilege GitHub App");
+    expect(policySkill).not.toContain("Linky");
     expect(repositoryPolicy).toContain("scripts/ai-provenance.mjs");
     expect(repositoryPolicy).toContain("fail closed");
     expect(packageJson.scripts["agents:validate"]).toBe(


### PR DESCRIPTION
## Scope

- replace publisher-specific Steward policy wording with the accepted registry-derived identity, attribution, complete provenance footer, and issue-authority contract
- require the deterministic publisher to enforce authenticated identity and requested-action authorization against `config/ai-agents.json`
- keep `scripts/ai-provenance.mjs` responsible for registry structure and rendered-artifact validation
- update the existing Steward rollout regression test to prevent renewed hard-coding, incomplete footer handling, or overstated validator authority

## Authority boundary

This changes repository-scoped policy guidance and its regression coverage only. It does not add a publisher runtime or validator command, and does not change live credentials, permissions, scheduling, runtime infrastructure, application behavior, merge state, or production.

## Validation

- TDD: contract tests failed before each policy correction, covering publisher hard-coding, literal signatures, omission of the provenance marker, and the publisher/validator enforcement boundary
- `npm run test -- --run functions/_lib/stewardPolicyAuditConfig.test.ts functions/_lib/aiProvenance.test.ts functions/_lib/aiAgentRegistry.test.ts` — 3 files / 11 tests passed
- `npm test` — 149 files / 920 tests passed
- `npm run build` — passed
- `npm run agents:validate` — passed
- `git diff --check` — passed
- `npm run dev:check` — no LinkSim dev/watch servers found

## Review

- three native Codex review findings were addressed: literal signature, omitted returned marker, and overstated publisher-identity/action validation
- final policy requires the publisher to compare authenticated identity and requested action with the registry and fail closed on mismatch
- final policy limits `ai-provenance.mjs` to registry and rendered-artifact validation
- independent final-candidate verdict: pass, no findings
- reviewed base: `851c6065a0b148fbaecff5a784aef3df26c70c95`
- reviewed head: `9aff3ab80c6ef826c7167d2af37c3810cc54688f`
- all required checks pass on the reviewed head

## Documentation and versioning

The Steward policy-audit skill is the affected operator guidance. No application version bump is included because this is repository automation policy only and the existing `0.27.0` development line remains intentional.

Related to #1027. The durable Steward discussion issue remains open for future audited suggestions.

— Forge · AI coding agent
<!-- linksim-ai:v1 agent=Forge bot=true run=2dcb120c-91ed-411d-91ed-d09836d3446b source=issue-1027-pr commit=9aff3ab80c6ef826c7167d2af37c3810cc54688f -->
