### PR TITLE
Authorize resource change history and reverts

### DIFF
--- a/functions/_lib/db.sharedSimulation.test.ts
+++ b/functions/_lib/db.sharedSimulation.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { fetchLibraryForUser, fetchPublicSimulationBundle, setSimulationLifecycleStatus, upsertLibrarySnapshot } from "./db";
+import {
+  fetchLibraryForUser,
+  fetchPublicSimulationBundle,
+  fetchResourceChanges,
+  revertResourceFromChangeCopy,
+  setSimulationLifecycleStatus,
+  upsertLibrarySnapshot,
+} from "./db";
 
 type AnyRow = Record<string, unknown>;
 
@@ -130,6 +137,7 @@ class FakeStatement {
 class FakeDb {
   readonly sites = new Map<string, AnyRow>();
   readonly simulations = new Map<string, AnyRow>();
+  readonly siteRoles = new Map<string, string>();
   readonly simulationRoles = new Map<string, string>();
   readonly resourceChanges: AnyRow[] = [];
   readonly adminUserIds = new Set<string>();
@@ -181,11 +189,15 @@ class FakeDb {
     }
     if (sql.includes("FROM simulations t") && sql.includes("LEFT JOIN simulation_roles")) {
       const id = String(bound[1] ?? "");
-      return this.simulations.get(id) ?? null;
+      const row = this.simulations.get(id);
+      if (!row) return null;
+      return { ...row, actor_role: this.simulationRoles.get(`${id}:${String(bound[0] ?? "")}`) ?? null };
     }
     if (sql.includes("FROM sites t") && sql.includes("LEFT JOIN site_roles")) {
       const id = String(bound[1] ?? "");
-      return this.sites.get(id) ?? null;
+      const row = this.sites.get(id);
+      if (!row) return null;
+      return { ...row, actor_role: this.siteRoles.get(`${id}:${String(bound[0] ?? "")}`) ?? null };
     }
     if (sql.includes("SELECT id FROM simulations WHERE lower(name) = lower(?)")) {
       const name = String(bound[0] ?? "").trim().toLowerCase();
@@ -214,6 +226,12 @@ class FakeDb {
       const role = this.simulationRoles.get(`${simulationId}:${userId}`);
       return role ? { role } : null;
     }
+    if (sql.includes("SELECT snapshot_json") && sql.includes("FROM resource_changes")) {
+      const [changeId, kind, resourceId] = bound;
+      return this.resourceChanges.find(
+        (change) => change.id === changeId && change.resource_kind === kind && change.resource_id === resourceId,
+      ) ?? null;
+    }
     return null;
   }
 
@@ -225,6 +243,16 @@ class FakeDb {
     }
     if (sql.includes("SELECT id, payload_json, visibility FROM sites WHERE id IN")) {
       return bound.map((id) => this.sites.get(String(id))).filter((row): row is AnyRow => Boolean(row));
+    }
+    if (sql.includes("FROM resource_changes c")) {
+      const [kind, resourceId] = bound;
+      return this.resourceChanges
+        .filter((change) => change.resource_kind === kind && change.resource_id === resourceId)
+        .map((change) => ({
+          ...change,
+          actor_name: String(change.actor_user_id),
+          actor_avatar_url: "",
+        }));
     }
     if (sql.includes("SELECT s.id") && sql.includes("s.status = 'deleted'")) {
       const userId = String(bound[1] ?? "");
@@ -297,6 +325,7 @@ class FakeDb {
     if (sql.includes("INSERT INTO resource_changes")) {
       const [resourceKind, resourceId, action, actorUserId, changedAt, note, detailsJson, snapshotJson] = bound;
       this.resourceChanges.push({
+        id: this.resourceChanges.length + 1,
         resource_kind: resourceKind,
         resource_id: resourceId,
         action,
@@ -306,6 +335,14 @@ class FakeDb {
         details_json: detailsJson,
         snapshot_json: snapshotJson,
       });
+      return;
+    }
+    if (sql.includes("INSERT INTO site_roles")) {
+      this.siteRoles.set(`${String(bound[0] ?? "")}:${String(bound[1] ?? "")}`, String(bound[2] ?? ""));
+      return;
+    }
+    if (sql.includes("INSERT INTO simulation_roles")) {
+      this.simulationRoles.set(`${String(bound[0] ?? "")}:${String(bound[1] ?? "")}`, String(bound[2] ?? ""));
       return;
     }
     if (sql.includes("UPDATE simulations") && sql.includes("SET status = ?")) {
@@ -323,7 +360,18 @@ class FakeDb {
       }
       return;
     }
-    if (sql.includes("DELETE FROM site_roles") || sql.includes("DELETE FROM simulation_roles")) {
+    if (sql.includes("DELETE FROM site_roles")) {
+      const resourceId = String(bound[0] ?? "");
+      for (const key of this.siteRoles.keys()) {
+        if (key.startsWith(`${resourceId}:`)) this.siteRoles.delete(key);
+      }
+      return;
+    }
+    if (sql.includes("DELETE FROM simulation_roles")) {
+      const resourceId = String(bound[0] ?? "");
+      for (const key of this.simulationRoles.keys()) {
+        if (key.startsWith(`${resourceId}:`)) this.simulationRoles.delete(key);
+      }
       return;
     }
   }
@@ -566,5 +614,203 @@ describe("upsertLibrarySnapshot shared simulations", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+  });
+});
+
+describe("resource change authorization", () => {
+  const actor = (id: string, overrides: Partial<{ isAdmin: boolean; isModerator: boolean }> = {}) => ({
+    id,
+    isAdmin: false,
+    isModerator: false,
+    ...overrides,
+  });
+
+  const createResourceHistoryDb = () => {
+    const db = new FakeDb();
+    db.sites.set("site-1", {
+      id: "site-1",
+      owner_user_id: "owner-1",
+      created_at: "2026-01-01T00:00:00.000Z",
+      name: "Private Site",
+      visibility: "private",
+      payload_json: JSON.stringify({
+        id: "site-1",
+        name: "Private Site",
+        visibility: "private",
+        sharedWith: [
+          { userId: "viewer-1", role: "viewer" },
+          { userId: "editor-1", role: "editor" },
+        ],
+      }),
+    });
+    db.siteRoles.set("site-1:viewer-1", "viewer");
+    db.siteRoles.set("site-1:editor-1", "editor");
+    db.simulations.set("sim-1", {
+      id: "sim-1",
+      owner_user_id: "owner-1",
+      created_at: "2026-01-01T00:00:00.000Z",
+      name: "Private Simulation",
+      visibility: "private",
+      status: "active",
+      payload_json: JSON.stringify({
+        id: "sim-1",
+        name: "Private Simulation",
+        visibility: "private",
+        sharedWith: [{ userId: "viewer-1", role: "viewer" }],
+      }),
+    });
+    db.simulationRoles.set("sim-1:viewer-1", "viewer");
+    db.resourceChanges.push(
+      {
+        id: 1,
+        resource_kind: "site",
+        resource_id: "site-1",
+        action: "updated",
+        actor_user_id: "owner-1",
+        changed_at: "2026-01-02T00:00:00.000Z",
+        note: "Moved Site",
+        details_json: JSON.stringify({
+          changedFields: ["name", "updatedAt"],
+          diff: {
+            name: { before: "Old Site", after: "Private Site" },
+            updatedAt: { before: "old", after: "new" },
+          },
+          internal: "do-not-return",
+        }),
+        snapshot_json: JSON.stringify({
+          id: "site-1",
+          name: "Private Site",
+          visibility: "private",
+          sharedWith: [
+            { userId: "viewer-1", role: "viewer" },
+            { userId: "editor-1", role: "editor" },
+          ],
+          position: { lat: 60, lon: 10 },
+        }),
+      },
+      {
+        id: 2,
+        resource_kind: "simulation",
+        resource_id: "sim-1",
+        action: "updated",
+        actor_user_id: "owner-1",
+        changed_at: "2026-01-02T00:00:00.000Z",
+        note: "Updated Simulation",
+        details_json: JSON.stringify({ diff: { name: { before: "Old", after: "Private Simulation" } } }),
+        snapshot_json: JSON.stringify({
+          id: "sim-1",
+          name: "Private Simulation",
+          visibility: "private",
+          sharedWith: [{ userId: "viewer-1", role: "viewer" }],
+        }),
+      },
+    );
+    return db;
+  };
+
+  it("returns minimized Site history to current owners, collaborators, and administrators", async () => {
+    const db = createResourceHistoryDb();
+    const env = { DB: db } as unknown as Parameters<typeof fetchResourceChanges>[0];
+
+    for (const currentActor of [
+      actor("owner-1"),
+      actor("viewer-1"),
+      actor("editor-1"),
+      actor("admin-1", { isAdmin: true }),
+    ]) {
+      const result = await fetchResourceChanges(env, "site", "site-1", currentActor);
+      expect(result).toEqual({
+        ok: true,
+        changes: [
+          {
+            id: 1,
+            action: "updated",
+            changedAt: "2026-01-02T00:00:00.000Z",
+            note: "Moved Site",
+            actorUserId: "owner-1",
+            actorName: "owner-1",
+            actorAvatarUrl: "",
+            details: { diff: { name: { before: "Old Site", after: "Private Site" } } },
+          },
+        ],
+      });
+    }
+  });
+
+  it("uses current visibility and grants, including transitions and revocation", async () => {
+    const db = createResourceHistoryDb();
+    const env = { DB: db } as unknown as Parameters<typeof fetchResourceChanges>[0];
+
+    await expect(fetchResourceChanges(env, "site", "site-1", actor("other-1")))
+      .resolves.toEqual({ ok: false, reason: "forbidden" });
+    await expect(fetchResourceChanges(env, "site", "site-1", actor("moderator-1", { isModerator: true })))
+      .resolves.toEqual({ ok: false, reason: "forbidden" });
+
+    db.sites.set("site-1", { ...db.sites.get("site-1"), visibility: "public_write" });
+    await expect(fetchResourceChanges(env, "site", "site-1", actor("other-1")))
+      .resolves.toMatchObject({ ok: true });
+    await expect(fetchResourceChanges(env, "site", "site-1", actor("moderator-1", { isModerator: true })))
+      .resolves.toMatchObject({ ok: true });
+
+    db.sites.set("site-1", { ...db.sites.get("site-1"), visibility: "private" });
+    await expect(fetchResourceChanges(env, "site", "site-1", actor("viewer-1")))
+      .resolves.toMatchObject({ ok: true });
+    db.siteRoles.delete("site-1:viewer-1");
+    await expect(fetchResourceChanges(env, "site", "site-1", actor("viewer-1")))
+      .resolves.toEqual({ ok: false, reason: "forbidden" });
+  });
+
+  it("authorizes active Simulation history and keeps deleted history administrator-only", async () => {
+    const db = createResourceHistoryDb();
+    const env = { DB: db } as unknown as Parameters<typeof fetchResourceChanges>[0];
+
+    for (const currentActor of [actor("owner-1"), actor("viewer-1"), actor("admin-1", { isAdmin: true })]) {
+      await expect(fetchResourceChanges(env, "simulation", "sim-1", currentActor))
+        .resolves.toMatchObject({ ok: true });
+    }
+    await expect(fetchResourceChanges(env, "simulation", "sim-1", actor("moderator-1", { isModerator: true })))
+      .resolves.toEqual({ ok: false, reason: "forbidden" });
+
+    db.simulations.set("sim-1", { ...db.simulations.get("sim-1"), status: "deleted" });
+    await expect(fetchResourceChanges(env, "simulation", "sim-1", actor("owner-1")))
+      .resolves.toEqual({ ok: false, reason: "forbidden" });
+    await expect(fetchResourceChanges(env, "simulation", "sim-1", actor("admin-1", { isAdmin: true })))
+      .resolves.toMatchObject({ ok: true });
+    await expect(revertResourceFromChangeCopy(env, "simulation", "sim-1", 2, actor("admin-1", { isAdmin: true })))
+      .resolves.toEqual({ ok: false, reason: "forbidden" });
+  });
+
+  it("requires current edit authority before loading and applying a revert snapshot", async () => {
+    const db = createResourceHistoryDb();
+    const env = { DB: db } as unknown as Parameters<typeof revertResourceFromChangeCopy>[0];
+
+    await expect(revertResourceFromChangeCopy(env, "site", "site-1", 1, actor("viewer-1")))
+      .resolves.toEqual({ ok: false, reason: "forbidden" });
+    await expect(revertResourceFromChangeCopy(env, "site", "site-1", 1, actor("moderator-1", { isModerator: true })))
+      .resolves.toEqual({ ok: false, reason: "forbidden" });
+    await expect(revertResourceFromChangeCopy(env, "site", "site-1", 1, actor("editor-1")))
+      .resolves.toEqual({ ok: true });
+    expect(db.resourceChanges.at(-1)?.note).toBe("Revert copy from change #1");
+  });
+
+  it("does not disclose whether a missing resource has historical rows", async () => {
+    const db = createResourceHistoryDb();
+    db.resourceChanges.push({
+      id: 3,
+      resource_kind: "site",
+      resource_id: "missing-site",
+      action: "updated",
+      actor_user_id: "owner-1",
+      changed_at: "2026-01-02T00:00:00.000Z",
+      note: "Orphaned history",
+      details_json: null,
+      snapshot_json: JSON.stringify({ id: "missing-site" }),
+    });
+    const env = { DB: db } as unknown as Parameters<typeof fetchResourceChanges>[0];
+
+    await expect(fetchResourceChanges(env, "site", "missing-site", actor("admin-1", { isAdmin: true })))
+      .resolves.toEqual({ ok: false, reason: "missing" });
+    await expect(revertResourceFromChangeCopy(env, "site", "missing-site", 3, actor("admin-1", { isAdmin: true })))
+      .resolves.toEqual({ ok: false, reason: "missing" });
   });
 });

--- a/functions/_lib/db.sharedSimulation.test.ts
+++ b/functions/_lib/db.sharedSimulation.test.ts
@@ -672,8 +672,29 @@ describe("resource change authorization", () => {
         details_json: JSON.stringify({
           changedFields: ["name", "updatedAt"],
           diff: {
-            name: { before: "Old Site", after: "Private Site" },
+            name: {
+              before: "Old Site",
+              after: "Private Site",
+              payload: { sites: [{ position: { lat: 60, lon: 10 } }] },
+            },
+            visibility: { before: "private", after: "shared" },
+            status: {
+              before: { value: "active", snapshot: { sites: [{ position: { lat: 60, lon: 10 } }] } },
+              after: { value: "deleted" },
+            },
+            " name ": {
+              before: { sites: [{ position: { lat: 60, lon: 10 } }] },
+              after: { sites: [{ position: { lat: 61, lon: 11 } }] },
+            },
             updatedAt: { before: "old", after: "new" },
+            snapshot: {
+              before: { sites: [{ id: "old", position: { lat: 60, lon: 10 } }] },
+              after: { sites: [{ id: "new", position: { lat: 61, lon: 11 } }] },
+            },
+            sharedWith: {
+              before: [{ userId: "former-1", role: "viewer" }],
+              after: [{ userId: "viewer-1", role: "viewer" }],
+            },
           },
           internal: "do-not-return",
         }),
@@ -730,7 +751,12 @@ describe("resource change authorization", () => {
             actorUserId: "owner-1",
             actorName: "owner-1",
             actorAvatarUrl: "",
-            details: { diff: { name: { before: "Old Site", after: "Private Site" } } },
+            details: {
+              diff: {
+                name: { before: "Old Site", after: "Private Site" },
+                visibility: { before: "private", after: "shared" },
+              },
+            },
           },
         ],
       });

--- a/functions/_lib/db.ts
+++ b/functions/_lib/db.ts
@@ -124,6 +124,13 @@ const isMeaningfulChangeField = (field: string): boolean => {
 
 type ResourceChangeDiffValue = { before: unknown; after: unknown };
 
+const isDisplayableResourceChangeValue = (field: string, value: unknown): boolean => {
+  if (field === "name") return typeof value === "string";
+  if (field === "visibility") return typeof value === "string" && VISIBILITIES.includes(value as Visibility);
+  if (field === "status") return value === "active" || value === "deleted";
+  return false;
+};
+
 const readDisplayableChangeDetails = (
   detailsJson: string | null,
 ): { diff: Record<string, ResourceChangeDiffValue> } | null => {
@@ -131,13 +138,13 @@ const readDisplayableChangeDetails = (
   try {
     const details = JSON.parse(detailsJson) as { diff?: unknown };
     if (!details.diff || typeof details.diff !== "object" || Array.isArray(details.diff)) return null;
-    const diff = Object.fromEntries(
-      Object.entries(details.diff as Record<string, unknown>)
-        .filter((entry): entry is [string, ResourceChangeDiffValue] => {
-          const [field, value] = entry;
-          return isMeaningfulChangeField(field) && Boolean(value) && typeof value === "object" && !Array.isArray(value);
-        }),
-    );
+    const diff: Record<string, ResourceChangeDiffValue> = {};
+    for (const [field, value] of Object.entries(details.diff as Record<string, unknown>)) {
+      if (!value || typeof value !== "object" || Array.isArray(value)) continue;
+      const { before, after } = value as { before?: unknown; after?: unknown };
+      if (!isDisplayableResourceChangeValue(field, before) || !isDisplayableResourceChangeValue(field, after)) continue;
+      diff[field] = { before, after };
+    }
     return Object.keys(diff).length ? { diff } : null;
   } catch {
     return null;

--- a/functions/_lib/db.ts
+++ b/functions/_lib/db.ts
@@ -122,6 +122,28 @@ const isMeaningfulChangeField = (field: string): boolean => {
   return !ignored.has(normalized);
 };
 
+type ResourceChangeDiffValue = { before: unknown; after: unknown };
+
+const readDisplayableChangeDetails = (
+  detailsJson: string | null,
+): { diff: Record<string, ResourceChangeDiffValue> } | null => {
+  if (!detailsJson) return null;
+  try {
+    const details = JSON.parse(detailsJson) as { diff?: unknown };
+    if (!details.diff || typeof details.diff !== "object" || Array.isArray(details.diff)) return null;
+    const diff = Object.fromEntries(
+      Object.entries(details.diff as Record<string, unknown>)
+        .filter((entry): entry is [string, ResourceChangeDiffValue] => {
+          const [field, value] = entry;
+          return isMeaningfulChangeField(field) && Boolean(value) && typeof value === "object" && !Array.isArray(value);
+        }),
+    );
+    return Object.keys(diff).length ? { diff } : null;
+  } catch {
+    return null;
+  }
+};
+
 const sanitizeEmail = (value: unknown): string | null => {
   if (typeof value !== "string") return null;
   const email = value.trim().toLowerCase();
@@ -1313,6 +1335,48 @@ const canEditResource = (
   return false;
 };
 
+type ResourceChangeAccessReason = "missing" | "forbidden";
+
+const resolveResourceChangeAccess = async (
+  env: Env,
+  kind: "site" | "simulation",
+  resourceId: string,
+  actor: ActorPolicy,
+  operation: "read" | "revert",
+): Promise<{ ok: true } | { ok: false; reason: ResourceChangeAccessReason }> => {
+  const table = kind === "site" ? "sites" : "simulations";
+  const rolesTable = kind === "site" ? "site_roles" : "simulation_roles";
+  const row = await env.DB
+    .prepare(
+      `SELECT t.owner_user_id, t.visibility${kind === "simulation" ? ", t.status" : ""}, r.role AS actor_role
+       FROM ${table} t
+       LEFT JOIN ${rolesTable} r ON r.${kind}_id = t.id AND r.user_id = ?
+       WHERE t.id = ?
+       LIMIT 1`,
+    )
+    .bind(actor.id, resourceId)
+    .first<{
+      owner_user_id: string;
+      visibility: DbVisibility;
+      status?: "active" | "deleted";
+      actor_role?: string | null;
+    }>();
+
+  if (!row) return { ok: false, reason: "missing" };
+  if (kind === "simulation" && row.status === "deleted") {
+    return operation === "read" && actor.isAdmin
+      ? { ok: true }
+      : { ok: false, reason: "forbidden" };
+  }
+
+  const explicitRole = typeof row.actor_role === "string" ? row.actor_role : null;
+  const visibility = visibilityFromDbVisibility(row.visibility);
+  const allowed = operation === "read"
+    ? canReadResource(actor, row.owner_user_id, visibility, explicitRole)
+    : canEditResource(actor, row.owner_user_id, visibility, explicitRole);
+  return allowed ? { ok: true } : { ok: false, reason: "forbidden" };
+};
+
 export const setSimulationLifecycleStatus = async (
   env: Env,
   actor: ActorPolicy,
@@ -1970,31 +2034,30 @@ export const fetchResourceChanges = async (
   env: Env,
   kind: "site" | "simulation",
   resourceId: string,
-  actor?: { isAdmin: boolean },
+  actor: ActorPolicy,
 ): Promise<
-  Array<{
-    id: number;
-    action: string;
-    changedAt: string;
-    note: string | null;
-    actorUserId: string;
-    actorName: string | null;
-    actorAvatarUrl: string | null;
-    details: Record<string, unknown> | null;
-    snapshot: Record<string, unknown> | null;
-  }>
+  | {
+      ok: true;
+      changes: Array<{
+        id: number;
+        action: string;
+        changedAt: string;
+        note: string | null;
+        actorUserId: string;
+        actorName: string | null;
+        actorAvatarUrl: string | null;
+        details: { diff: Record<string, ResourceChangeDiffValue> } | null;
+      }>;
+    }
+  | { ok: false; reason: ResourceChangeAccessReason }
 > => {
   await ensureSchema(env);
-  if (kind === "simulation" && !actor?.isAdmin) {
-    const simulation = await env.DB
-      .prepare("SELECT status FROM simulations WHERE id = ? LIMIT 1")
-      .bind(resourceId)
-      .first<{ status: "active" | "deleted" }>();
-    if (simulation?.status === "deleted") return [];
-  }
+  const access = await resolveResourceChangeAccess(env, kind, resourceId, actor, "read");
+  if (!access.ok) return access;
+
   const rows = await env.DB
     .prepare(
-      `SELECT c.id, c.action, c.changed_at, c.note, c.actor_user_id, c.details_json, c.snapshot_json,
+      `SELECT c.id, c.action, c.changed_at, c.note, c.actor_user_id, c.details_json,
               u.username AS actor_name,
               u.avatar_url AS actor_avatar_url
        FROM resource_changes c
@@ -2011,22 +2074,23 @@ export const fetchResourceChanges = async (
       note: string | null;
       actor_user_id: string;
       details_json: string | null;
-      snapshot_json: string | null;
       actor_name: string | null;
       actor_avatar_url: string | null;
     }>();
 
-  return rows.results.map((row) => ({
-    id: row.id,
-    action: row.action,
-    changedAt: row.changed_at,
-    note: row.note,
-    actorUserId: row.actor_user_id,
-    actorName: row.actor_name,
-    actorAvatarUrl: row.actor_avatar_url,
-    details: row.details_json ? (JSON.parse(row.details_json) as Record<string, unknown>) : null,
-    snapshot: row.snapshot_json ? (JSON.parse(row.snapshot_json) as Record<string, unknown>) : null,
-  }));
+  return {
+    ok: true,
+    changes: rows.results.map((row) => ({
+      id: row.id,
+      action: row.action,
+      changedAt: row.changed_at,
+      note: row.note,
+      actorUserId: row.actor_user_id,
+      actorName: row.actor_name,
+      actorAvatarUrl: row.actor_avatar_url,
+      details: readDisplayableChangeDetails(row.details_json),
+    })),
+  };
 };
 
 export const revertResourceFromChangeCopy = async (
@@ -2034,9 +2098,12 @@ export const revertResourceFromChangeCopy = async (
   kind: "site" | "simulation",
   resourceId: string,
   changeId: number,
-  actor: { id: string; isAdmin: boolean; isModerator?: boolean },
+  actor: ActorPolicy,
 ): Promise<{ ok: boolean; reason?: string }> => {
   await ensureSchema(env);
+  const access = await resolveResourceChangeAccess(env, kind, resourceId, actor, "revert");
+  if (!access.ok) return access;
+
   const snapshotRow = await env.DB
     .prepare(
       `SELECT snapshot_json
@@ -2056,11 +2123,7 @@ export const revertResourceFromChangeCopy = async (
   }
   snapshot.id = resourceId;
 
-  const result = await upsertOwnedResource(env, kind, {
-    id: actor.id,
-    isAdmin: actor.isAdmin,
-    isModerator: Boolean(actor.isModerator),
-  }, snapshot);
+  const result = await upsertOwnedResource(env, kind, actor, snapshot);
   if (!result.ok) return result;
 
   await createResourceChange(

--- a/functions/api/changes.test.ts
+++ b/functions/api/changes.test.ts
@@ -1,10 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { verifyAuthMock, ensureUserMock, assertUserAccessMock, fetchResourceChangesMock } = vi.hoisted(() => ({
+const {
+  verifyAuthMock,
+  ensureUserMock,
+  assertUserAccessMock,
+  fetchResourceChangesMock,
+  revertResourceFromChangeCopyMock,
+} = vi.hoisted(() => ({
   verifyAuthMock: vi.fn(),
   ensureUserMock: vi.fn(),
   assertUserAccessMock: vi.fn(),
   fetchResourceChangesMock: vi.fn(),
+  revertResourceFromChangeCopyMock: vi.fn(),
 }));
 
 vi.mock("../_lib/auth", () => ({ verifyAuth: verifyAuthMock }));
@@ -12,37 +19,109 @@ vi.mock("../_lib/db", () => ({
   ensureUser: ensureUserMock,
   assertUserAccess: assertUserAccessMock,
   fetchResourceChanges: fetchResourceChangesMock,
+  revertResourceFromChangeCopy: revertResourceFromChangeCopyMock,
 }));
 
-import { onRequestGet } from "./changes";
+import { onRequestGet, onRequestPost } from "./changes";
 
 const env = { DB: {} } as unknown as { DB: D1Database };
-const mkCtx = (request: Request) => ({ request, env } as unknown as Parameters<typeof onRequestGet>[0]);
+const mkGetCtx = (request: Request) => ({ request, env } as unknown as Parameters<typeof onRequestGet>[0]);
+const mkPostCtx = (request: Request) => ({ request, env } as unknown as Parameters<typeof onRequestPost>[0]);
 
 beforeEach(() => {
   vi.clearAllMocks();
   verifyAuthMock.mockResolvedValue({ userId: "u1", tokenPayload: {}, source: "headers" });
   ensureUserMock.mockResolvedValue(undefined);
-  assertUserAccessMock.mockResolvedValue({ id: "u1", isAdmin: false });
-  fetchResourceChangesMock.mockResolvedValue([{ id: 1, action: "updated" }]);
+  assertUserAccessMock.mockResolvedValue({ id: "u1", isAdmin: false, isModerator: true });
+  fetchResourceChangesMock.mockResolvedValue({ ok: true, changes: [{ id: 1, action: "updated" }] });
+  revertResourceFromChangeCopyMock.mockResolvedValue({ ok: true });
 });
 
 describe("api/changes", () => {
   it("returns 401 when not authenticated", async () => {
     verifyAuthMock.mockResolvedValueOnce(null);
-    const res = await onRequestGet(mkCtx(new Request("https://example.test/api/changes?kind=site&id=s1")));
+    const res = await onRequestGet(mkGetCtx(new Request("https://example.test/api/changes?kind=site&id=s1")));
     expect(res.status).toBe(401);
   });
 
+  it("returns 401 for an unauthenticated revert", async () => {
+    verifyAuthMock.mockResolvedValueOnce(null);
+    const res = await onRequestPost(mkPostCtx(new Request("https://example.test/api/changes", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ kind: "site", id: "s1", changeId: 7 }),
+    })));
+
+    expect(res.status).toBe(401);
+    expect(revertResourceFromChangeCopyMock).not.toHaveBeenCalled();
+  });
+
   it("returns 400 when kind or id are missing/invalid", async () => {
-    const res = await onRequestGet(mkCtx(new Request("https://example.test/api/changes?kind=bad&id=")));
+    const res = await onRequestGet(mkGetCtx(new Request("https://example.test/api/changes?kind=bad&id=")));
     expect(res.status).toBe(400);
   });
 
+  it("returns 400 when revert input is missing or invalid", async () => {
+    const res = await onRequestPost(mkPostCtx(new Request("https://example.test/api/changes", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ kind: "bad", id: "", changeId: "invalid" }),
+    })));
+
+    expect(res.status).toBe(400);
+    expect(revertResourceFromChangeCopyMock).not.toHaveBeenCalled();
+  });
+
   it("returns changes for valid kind and id", async () => {
-    const res = await onRequestGet(mkCtx(new Request("https://example.test/api/changes?kind=simulation&id=sim-1")));
+    const res = await onRequestGet(mkGetCtx(new Request("https://example.test/api/changes?kind=simulation&id=sim-1")));
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toEqual({ changes: [{ id: 1, action: "updated" }] });
-    expect(fetchResourceChangesMock).toHaveBeenCalledWith(env, "simulation", "sim-1", { isAdmin: false });
+    expect(fetchResourceChangesMock).toHaveBeenCalledWith(env, "simulation", "sim-1", {
+      id: "u1",
+      isAdmin: false,
+      isModerator: true,
+    });
+  });
+
+  it.each([
+    ["missing", 404],
+    ["forbidden", 403],
+  ] as const)("maps a %s resource result without returning history", async (reason, status) => {
+    fetchResourceChangesMock.mockResolvedValueOnce({ ok: false, reason });
+
+    const res = await onRequestGet(mkGetCtx(new Request("https://example.test/api/changes?kind=site&id=s1")));
+
+    expect(res.status).toBe(status);
+    await expect(res.json()).resolves.toEqual({ error: reason === "missing" ? "Resource not found" : "Forbidden" });
+  });
+
+  it("authorizes reverts with the complete current actor policy", async () => {
+    const res = await onRequestPost(mkPostCtx(new Request("https://example.test/api/changes", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ kind: "site", id: "s1", changeId: 7 }),
+    })));
+
+    expect(res.status).toBe(200);
+    expect(revertResourceFromChangeCopyMock).toHaveBeenCalledWith(env, "site", "s1", 7, {
+      id: "u1",
+      isAdmin: false,
+      isModerator: true,
+    });
+  });
+
+  it.each([
+    ["missing", 404],
+    ["forbidden", 403],
+  ] as const)("maps a %s revert result", async (reason, status) => {
+    revertResourceFromChangeCopyMock.mockResolvedValueOnce({ ok: false, reason });
+
+    const res = await onRequestPost(mkPostCtx(new Request("https://example.test/api/changes", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ kind: "simulation", id: "sim-1", changeId: 7 }),
+    })));
+
+    expect(res.status).toBe(status);
   });
 });

--- a/functions/api/changes.ts
+++ b/functions/api/changes.ts
@@ -22,8 +22,19 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
       return withCors(request, json({ error: "Missing kind or id" }, { status: 400 }));
     }
 
-    const changes = await fetchResourceChanges(env, kind, resourceId, { isAdmin: me.isAdmin });
-    return withCors(request, json({ changes }));
+    const result = await fetchResourceChanges(env, kind, resourceId, {
+      id: me.id,
+      isAdmin: me.isAdmin,
+      isModerator: Boolean((me as { isModerator?: boolean }).isModerator),
+    });
+    if (!result.ok) {
+      const missing = result.reason === "missing";
+      return withCors(request, json(
+        { error: missing ? "Resource not found" : "Forbidden" },
+        { status: missing ? 404 : 403 },
+      ));
+    }
+    return withCors(request, json({ changes: result.changes }));
   } catch (error) {
     return errorResponse(request, error, 500);
   }
@@ -51,7 +62,11 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
       isModerator: Boolean((me as { isModerator?: boolean }).isModerator),
     });
     if (!result.ok) {
-      return withCors(request, json({ error: result.reason ?? "Revert failed" }, { status: 403 }));
+      const missing = result.reason === "missing";
+      return withCors(request, json(
+        { error: missing ? "Resource not found" : result.reason ?? "Revert failed" },
+        { status: missing ? 404 : 403 },
+      ));
     }
     return withCors(request, json({ ok: true }));
   } catch (error) {

--- a/src/lib/cloudUser.ts
+++ b/src/lib/cloudUser.ts
@@ -32,8 +32,7 @@ export type ResourceChange = {
   actorUserId: string;
   actorName: string | null;
   actorAvatarUrl: string | null;
-  details?: Record<string, unknown> | null;
-  snapshot?: Record<string, unknown> | null;
+  details?: { diff?: Record<string, { before: unknown; after: unknown }> } | null;
 };
 
 export type DeletedCloudUser = {


### PR DESCRIPTION
## What changed

- authorize Site and Simulation change-history reads against the current owner, visibility, collaborator role, and administrator policy
- require current edit authority before a revert can load its historical snapshot
- keep deleted Simulation history administrator-readable but non-revertible until restore
- remove snapshots, changed-field indexes, and revert-internal metadata from the GET response
- return only validated scalar `name`, `visibility`, and lifecycle `status` summaries from historical diffs
- add regression coverage for owners, collaborators, moderators, administrators, visibility transitions, grant revocation, deleted Simulations, and missing resources

## Why this change

`GET /api/changes` previously authenticated the caller without authorizing the requested active resource, allowing unrelated approved users to retrieve historical actors, diffs, and snapshots by resource ID. Reverts also loaded the historical snapshot before applying the existing indirect edit check.

Relates to #1049.

## TDD Checklist

- [x] I started with failing automated tests that captured the intended authorization behavior.
- [x] I implemented only the minimum code needed to make the tests pass.
- [x] I refactored with tests still green.
- [x] I ran `npm test` and `npm run build` locally.

## Issue + branch hygiene

- [x] Branch `issue/1049-authorize-resource-history` was created from current `origin/staging`.
- [x] This PR references a single primary issue.
- [x] Issue #1049 moved from `pending-discussion` to `in-progress`; `in-staging` remains merge/deploy-gated.

## Verification

- [x] Targeted history/API tests: 2 files, 22 tests passed
- [x] `npm test`: 149 files, 932 tests passed
- [x] `npm run build`
- [x] `npm run test -- --run src/lib/deepLink.test.ts`: 35 tests passed
- [x] `npm run test -- --run functions/api/v1/calculate.test.ts`: 9 tests passed
- [x] `npm run test -- --run src/store/appStore.test.ts`: 32 tests passed
- [x] `npm run dev:check`: no LinkSim dev/watch servers found
- [x] `git diff --check`

## Independent pre-PR review

- Reviewed base: `83fa78d0a06a89f2aff43c4db2d0a4702c126b8d`
- Reviewed head: `9c3f2ba750d985c1641f28853ed08d8d3a08bda6`
- Verdict: `pass-with-notes`, with no blocking or important findings
- Review fix: excludes complete snapshots, collaborator grants, malformed safe-field values, whitespace-altered keys, and extra nested properties
- Residual risk: no live D1 or staging verification; database policy is covered by fake-D1 tests and remote CI remains pending

## Delivery boundaries

- No UI or documentation changes
- No D1 migration
- No SemVer change: `staging` already carries the intentional `0.27.0` development line
- No merge, staging deployment, live browser test, or production promotion included

— Forge · AI coding agent
<!-- linksim-ai:v1 agent=Forge bot=true run=4c310180-e07f-4f9d-b5c1-a0378d5c39cf source=issue-1049-pull-request commit=9c3f2ba750d985c1641f28853ed08d8d3a08bda6 -->
