### PR TITLE
Harden identity reconciliation and administrator lifecycle

### DIFF
--- a/docs/cloudflare-auth-setup.md
+++ b/docs/cloudflare-auth-setup.md
@@ -61,8 +61,30 @@ In Pages project env vars (Production + Preview):
 - `ACCESS_TEAM_DOMAIN` = your team domain (without `https://`)
 - `ACCESS_AUD` = comma-separated Access app AUD tags for every hostname served
   by that Pages environment
-- `ADMIN_USER_IDS` = bootstrap admin user IDs
+- `ADMIN_USER_IDS` = one-time bootstrap admin user IDs
 - `REGISTRATION_MODE` = `open`
+
+`ADMIN_USER_IDS` is consulted only when a listed identity is first inserted.
+After that, the role and revocation state stored in D1 is authoritative, so an
+administrator can durably demote or revoke a bootstrap identity. Diagnostics
+endpoints follow that current D1 state and do not provide a configuration-only
+break-glass bypass.
+
+## Account lifecycle policy
+
+- Profile email is editable display/contact data. It never transfers approval,
+  roles, ownership, grants, or audit identity.
+- Identity reconciliation requires an email claim from a successfully verified
+  Cloudflare Access JWT. Header-only and local-development identities do not
+  supply reconciliation evidence.
+- One matching verified identity is migrated atomically and recorded in the
+  identity audit log. Multiple verified matches fail closed without a transfer.
+- Deleting an account creates a durable tombstone. Old and newly issued IdP
+  sessions remain blocked until an administrator explicitly restores the ID.
+  Verified IdP identity evidence is retained in the identity audit log so a
+  changed IdP subject cannot bypass the tombstone; the next valid login after
+  restore creates a fresh account.
+- Avatar object keys are opaque and do not include the LinkSim user ID or email.
 
 Do not enable local dev fallback vars in production or shared preview deployments.
 

--- a/functions/_lib/auth.test.ts
+++ b/functions/_lib/auth.test.ts
@@ -111,6 +111,18 @@ describe("verifyAuth", () => {
     );
 
     expect(auth?.userId).toBe("stable-user-uuid");
+    expect(auth?.verifiedIdpEmail).toBe("user@example.com");
+  });
+
+  it("does not treat header-only email as verified IdP identity evidence", async () => {
+    const request = new Request("https://example.test/api/me", {
+      headers: { "Cf-Access-Authenticated-User-Email": "user@example.com" },
+    });
+
+    const auth = await verifyAuth(request, makeEnv());
+
+    expect(auth?.userId).toBe("user@example.com");
+    expect(auth?.verifiedIdpEmail).toBeUndefined();
   });
 
   it("rejects a JWT whose audience is not configured", async () => {

--- a/functions/_lib/auth.ts
+++ b/functions/_lib/auth.ts
@@ -16,6 +16,7 @@ export class AuthVerificationTimeoutError extends Error {
 type AccessTokenVerifier = (token: string, env: Env) => Promise<JWTPayload>;
 
 const accessKeySets = new Map<string, ReturnType<typeof createRemoteJWKSet>>();
+const VERIFIED_IDP_EMAIL_CLAIM = "__linksim_verified_idp_email";
 
 const normalizeTeamDomain = (raw: string): string => {
   const trimmed = raw.trim();
@@ -174,6 +175,10 @@ const decodeCfAccessJwt = async (
     const userId = fallback || fromHeader;
     if (!userId) return null;
 
+    const verifiedIdpEmail =
+      typeof payload.email === "string" && payload.email.trim()
+        ? payload.email.trim().toLowerCase()
+        : undefined;
     return {
       userId,
       tokenPayload: {
@@ -186,7 +191,9 @@ const decodeCfAccessJwt = async (
           typeof payload.name === "string" && payload.name.trim()
             ? payload.name
             : readHeaderUserName(request),
+        [VERIFIED_IDP_EMAIL_CLAIM]: verifiedIdpEmail,
       },
+      verifiedIdpEmail,
       source: "jwt",
     };
   } catch {

--- a/functions/_lib/db.identity.test.ts
+++ b/functions/_lib/db.identity.test.ts
@@ -41,6 +41,7 @@ class SqliteStatement {
 
 class SqliteD1 {
   readonly db = new DatabaseSync(":memory:");
+  beforeBatch: (() => void) | null = null;
 
   constructor() {
     this.db.exec(`
@@ -96,6 +97,8 @@ class SqliteD1 {
   }
 
   async batch(statements: SqliteStatement[]) {
+    this.beforeBatch?.();
+    this.beforeBatch = null;
     this.db.exec("BEGIN");
     try {
       for (const statement of statements) statement.runSync();
@@ -177,6 +180,15 @@ describe("identity reconciliation", () => {
     `);
 
     const env = { DB: db as unknown as D1Database };
+    db.beforeBatch = () => {
+      const site = JSON.parse(
+        (db.db.prepare("SELECT payload_json FROM sites WHERE id = 'shared-site'").get() as { payload_json: string })
+          .payload_json,
+      );
+      db.db
+        .prepare("UPDATE sites SET payload_json = ? WHERE id = 'shared-site'")
+        .run(JSON.stringify({ ...site, concurrentEdit: "preserved" }));
+    };
     await reconcileUserIdentityByIdpEmail(env, "stable-id", "user@example.com");
 
     const site = JSON.parse(
@@ -186,6 +198,7 @@ describe("identity reconciliation", () => {
       (db.db.prepare("SELECT payload_json FROM simulations WHERE id = 'shared-simulation'").get() as { payload_json: string }).payload_json,
     );
     expect(site.sharedWith).toEqual([{ userId: "stable-id", role: "editor" }]);
+    expect(site.concurrentEdit).toBe("preserved");
     expect(simulation.sharedWith).toEqual([{ userId: "stable-id", role: "editor" }]);
 
     await expect(

--- a/functions/_lib/db.identity.test.ts
+++ b/functions/_lib/db.identity.test.ts
@@ -5,6 +5,7 @@ import {
   findDeletionBlock,
   reconcileUserIdentityByIdpEmail,
   shouldBootstrapAdmin,
+  upsertLibrarySnapshot,
 } from "./db";
 
 class SqliteStatement {
@@ -45,16 +46,43 @@ class SqliteD1 {
     this.db.exec(`
       PRAGMA foreign_keys = ON;
       CREATE TABLE users (
-        id TEXT PRIMARY KEY, email TEXT, idp_email TEXT, idp_email_verified INTEGER NOT NULL DEFAULT 0,
+        id TEXT PRIMARY KEY, username TEXT, email TEXT, username_set_at TEXT, bio TEXT, access_request_note TEXT,
+        idp_email TEXT, idp_email_verified INTEGER NOT NULL DEFAULT 0, avatar_url TEXT, email_public INTEGER,
+        default_frequency_preset_id TEXT, simulation_defaults_preference_json TEXT, avatar_object_key TEXT,
+        avatar_thumb_key TEXT, avatar_hash TEXT, avatar_bytes INTEGER, avatar_content_type TEXT,
         is_admin INTEGER NOT NULL DEFAULT 0, is_moderator INTEGER NOT NULL DEFAULT 0,
-        is_approved INTEGER NOT NULL DEFAULT 0, approved_at TEXT, approved_by_user_id TEXT, updated_at TEXT
+        is_approved INTEGER NOT NULL DEFAULT 0, approved_at TEXT, approved_by_user_id TEXT, created_at TEXT, updated_at TEXT
       );
-      CREATE TABLE sites (id TEXT PRIMARY KEY, owner_user_id TEXT NOT NULL, created_by_user_id TEXT, last_edited_by_user_id TEXT);
-      CREATE TABLE simulations (id TEXT PRIMARY KEY, owner_user_id TEXT NOT NULL, created_by_user_id TEXT, last_edited_by_user_id TEXT);
-      CREATE TABLE site_roles (site_id TEXT NOT NULL, user_id TEXT NOT NULL, role TEXT NOT NULL, created_at TEXT NOT NULL, PRIMARY KEY (site_id, user_id));
-      CREATE TABLE simulation_roles (simulation_id TEXT NOT NULL, user_id TEXT NOT NULL, role TEXT NOT NULL, created_at TEXT NOT NULL, PRIMARY KEY (simulation_id, user_id));
-      CREATE TABLE resource_changes (id INTEGER PRIMARY KEY, actor_user_id TEXT NOT NULL);
-      CREATE TABLE simulation_path_leaderboard_entries (simulation_id TEXT, canonical_path_key TEXT, owner_user_id TEXT NOT NULL, PRIMARY KEY (simulation_id, canonical_path_key));
+      CREATE TABLE sites (
+        id TEXT PRIMARY KEY, owner_user_id TEXT NOT NULL, created_by_user_id TEXT, last_edited_by_user_id TEXT,
+        created_at TEXT, last_edited_at TEXT, name TEXT, visibility TEXT, payload_json TEXT, updated_at TEXT,
+        FOREIGN KEY (owner_user_id) REFERENCES users(id) ON DELETE CASCADE
+      );
+      CREATE TABLE simulations (
+        id TEXT PRIMARY KEY, owner_user_id TEXT NOT NULL, created_by_user_id TEXT, last_edited_by_user_id TEXT,
+        created_at TEXT, last_edited_at TEXT, name TEXT, visibility TEXT, status TEXT DEFAULT 'active', payload_json TEXT,
+        updated_at TEXT, FOREIGN KEY (owner_user_id) REFERENCES users(id) ON DELETE CASCADE
+      );
+      CREATE TABLE site_roles (
+        site_id TEXT NOT NULL, user_id TEXT NOT NULL, role TEXT NOT NULL, created_at TEXT NOT NULL,
+        PRIMARY KEY (site_id, user_id), FOREIGN KEY (site_id) REFERENCES sites(id) ON DELETE CASCADE,
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+      );
+      CREATE TABLE simulation_roles (
+        simulation_id TEXT NOT NULL, user_id TEXT NOT NULL, role TEXT NOT NULL, created_at TEXT NOT NULL,
+        PRIMARY KEY (simulation_id, user_id), FOREIGN KEY (simulation_id) REFERENCES simulations(id) ON DELETE CASCADE,
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+      );
+      CREATE TABLE resource_changes (
+        id INTEGER PRIMARY KEY, resource_kind TEXT, resource_id TEXT, action TEXT, actor_user_id TEXT NOT NULL,
+        changed_at TEXT, note TEXT, details_json TEXT, snapshot_json TEXT
+      );
+      CREATE TABLE simulation_path_leaderboard_entries (
+        simulation_id TEXT, canonical_path_key TEXT, owner_user_id TEXT NOT NULL, from_site_id TEXT, to_site_id TEXT,
+        link_id TEXT, path_label TEXT, simulation_name TEXT, distance_km REAL, rx_after_env_loss_dbm REAL,
+        rx_margin_db REAL, terrain_obstructed INTEGER, terrain_dataset TEXT, terrain_tile_signature TEXT,
+        simulation_updated_at TEXT, created_at TEXT, updated_at TEXT, PRIMARY KEY (simulation_id, canonical_path_key)
+      );
       CREATE TABLE user_identity_audit (
         id INTEGER PRIMARY KEY AUTOINCREMENT, event_type TEXT NOT NULL, target_user_id TEXT NOT NULL,
         source_user_id TEXT, actor_user_id TEXT, idp_email TEXT, details_json TEXT, created_at TEXT NOT NULL
@@ -86,14 +114,17 @@ const seedMigration = (db: SqliteD1) => {
       VALUES ('stable-id', 'new@example.com', 'user@example.com', 1, 0, 1, '2026-01-02', 'stable-id');
     INSERT INTO users (id, email, idp_email, idp_email_verified, is_admin, is_approved, approved_at, approved_by_user_id)
       VALUES ('legacy-id', 'editable@example.com', 'user@example.com', 1, 1, 1, '2026-01-01', 'legacy-id');
-    INSERT INTO sites VALUES ('site-1', 'legacy-id', 'legacy-id', 'legacy-id');
-    INSERT INTO simulations VALUES ('sim-1', 'legacy-id', 'legacy-id', 'legacy-id');
+    INSERT INTO sites (id, owner_user_id, created_by_user_id, last_edited_by_user_id)
+      VALUES ('site-1', 'legacy-id', 'legacy-id', 'legacy-id');
+    INSERT INTO simulations (id, owner_user_id, created_by_user_id, last_edited_by_user_id)
+      VALUES ('sim-1', 'legacy-id', 'legacy-id', 'legacy-id');
     INSERT INTO site_roles VALUES ('site-1', 'stable-id', 'viewer', '2026-01-02');
     INSERT INTO site_roles VALUES ('site-1', 'legacy-id', 'editor', '2026-01-01');
     INSERT INTO simulation_roles VALUES ('sim-1', 'stable-id', 'editor', '2026-01-02');
     INSERT INTO simulation_roles VALUES ('sim-1', 'legacy-id', 'viewer', '2026-01-01');
-    INSERT INTO resource_changes VALUES (1, 'legacy-id');
-    INSERT INTO simulation_path_leaderboard_entries VALUES ('sim-1', 'path-1', 'legacy-id');
+    INSERT INTO resource_changes (id, actor_user_id) VALUES (1, 'legacy-id');
+    INSERT INTO simulation_path_leaderboard_entries (simulation_id, canonical_path_key, owner_user_id)
+      VALUES ('sim-1', 'path-1', 'legacy-id');
   `);
 };
 
@@ -114,6 +145,65 @@ describe("identity reconciliation", () => {
       event_type: "reconciled_by_verified_idp_email",
       source_user_id: "legacy-id",
     });
+  });
+
+  it("keeps serialized grants valid when a resource is saved after reconciliation", async () => {
+    const db = new SqliteD1();
+    db.db.exec(`
+      INSERT INTO users (id, idp_email, idp_email_verified, is_approved)
+        VALUES ('stable-id', 'user@example.com', 1, 1);
+      INSERT INTO users (id, idp_email, idp_email_verified, is_approved)
+        VALUES ('legacy-id', 'user@example.com', 1, 1);
+      INSERT INTO users (id, idp_email, idp_email_verified, is_approved)
+        VALUES ('owner-id', 'owner@example.com', 1, 1);
+      INSERT INTO sites
+        (id, owner_user_id, created_by_user_id, last_edited_by_user_id, created_at, name, visibility, payload_json, updated_at)
+        VALUES (
+          'shared-site', 'owner-id', 'owner-id', 'owner-id', '2026-01-01', 'Shared Site', 'public_write',
+          '{"id":"shared-site","name":"Shared Site","visibility":"shared","sharedWith":[{"userId":"stable-id","role":"viewer"},{"userId":"legacy-id","role":"editor"}]}',
+          '2026-01-01'
+        );
+      INSERT INTO simulations
+        (id, owner_user_id, created_by_user_id, last_edited_by_user_id, created_at, name, visibility, status, payload_json, updated_at)
+        VALUES (
+          'shared-simulation', 'owner-id', 'owner-id', 'owner-id', '2026-01-01', 'Shared Simulation', 'public_write', 'active',
+          '{"id":"shared-simulation","name":"Shared Simulation","visibility":"shared","sharedWith":[{"userId":"stable-id","role":"editor"},{"userId":"legacy-id","role":"viewer"}]}',
+          '2026-01-01'
+        );
+      INSERT INTO site_roles VALUES ('shared-site', 'legacy-id', 'editor', '2026-01-01');
+      INSERT INTO site_roles VALUES ('shared-site', 'stable-id', 'viewer', '2026-01-02');
+      INSERT INTO simulation_roles VALUES ('shared-simulation', 'legacy-id', 'viewer', '2026-01-01');
+      INSERT INTO simulation_roles VALUES ('shared-simulation', 'stable-id', 'editor', '2026-01-02');
+    `);
+
+    const env = { DB: db as unknown as D1Database };
+    await reconcileUserIdentityByIdpEmail(env, "stable-id", "user@example.com");
+
+    const site = JSON.parse(
+      (db.db.prepare("SELECT payload_json FROM sites WHERE id = 'shared-site'").get() as { payload_json: string }).payload_json,
+    );
+    const simulation = JSON.parse(
+      (db.db.prepare("SELECT payload_json FROM simulations WHERE id = 'shared-simulation'").get() as { payload_json: string }).payload_json,
+    );
+    expect(site.sharedWith).toEqual([{ userId: "stable-id", role: "editor" }]);
+    expect(simulation.sharedWith).toEqual([{ userId: "stable-id", role: "editor" }]);
+
+    await expect(
+      upsertLibrarySnapshot(
+        env,
+        { id: "owner-id", isAdmin: false, isModerator: false },
+        {
+          siteLibrary: [{ ...site, name: "Shared Site Updated" }],
+          simulationPresets: [{ ...simulation, name: "Shared Simulation Updated" }],
+        },
+      ),
+    ).resolves.toEqual({ upsertedSites: 1, upsertedSimulations: 1, conflicts: [] });
+    expect(db.db.prepare("SELECT user_id, role FROM site_roles WHERE site_id = 'shared-site'").all()).toEqual([
+      { user_id: "stable-id", role: "editor" },
+    ]);
+    expect(
+      db.db.prepare("SELECT user_id, role FROM simulation_roles WHERE simulation_id = 'shared-simulation'").all(),
+    ).toEqual([{ user_id: "stable-id", role: "editor" }]);
   });
 
   it("rolls back every transfer when the audit insert fails", async () => {

--- a/functions/_lib/db.identity.test.ts
+++ b/functions/_lib/db.identity.test.ts
@@ -2,6 +2,7 @@ import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
 import {
   assertDeletedUserMayRegister,
+  ensureUser,
   findDeletionBlock,
   reconcileUserIdentityByIdpEmail,
   revertResourceFromChangeCopy,
@@ -403,6 +404,86 @@ describe("identity reconciliation", () => {
     expect(db.db.prepare("SELECT id, deleted_by_user_id FROM deleted_users").all()).toEqual([
       { id: "stable-id", deleted_by_user_id: "admin-id" },
     ]);
+  });
+
+  it("rolls back target creation so a pending-source reconciliation retry stays pending", async () => {
+    const db = new SqliteD1();
+    db.db.exec(`
+      INSERT INTO users (id, email, idp_email, idp_email_verified, is_approved, approved_at, approved_by_user_id)
+        VALUES ('pending-id', 'old@example.com', 'user@example.com', 1, 0, NULL, NULL);
+      CREATE TRIGGER reject_reconciliation_audit
+        BEFORE INSERT ON user_identity_audit
+        WHEN NEW.event_type = 'reconciled_by_verified_idp_email'
+        BEGIN SELECT RAISE(ABORT, 'audit unavailable'); END;
+    `);
+    const env = { DB: db as unknown as D1Database };
+    const tokenPayload = {
+      email: "user@example.com",
+      __linksim_verified_idp_email: "user@example.com",
+    };
+
+    await expect(ensureUser(env, "stable-id", tokenPayload)).rejects.toThrow("audit unavailable");
+    expect(db.db.prepare("SELECT id FROM users WHERE id = 'stable-id'").get()).toBeUndefined();
+
+    db.db.exec("DROP TRIGGER reject_reconciliation_audit");
+    await ensureUser(env, "stable-id", tokenPayload);
+
+    expect(
+      db.db
+        .prepare("SELECT is_approved, approved_at, approved_by_user_id FROM users WHERE id = 'stable-id'")
+        .get(),
+    ).toEqual({ is_approved: 0, approved_at: null, approved_by_user_id: null });
+    expect(db.db.prepare("SELECT id FROM users WHERE id = 'pending-id'").get()).toBeUndefined();
+  });
+
+  it("does not recreate a user deleted immediately before the atomic ensure batch", async () => {
+    const db = new SqliteD1();
+    db.db.exec(`
+      INSERT INTO users (id, email, idp_email, idp_email_verified, is_approved, approved_at, approved_by_user_id)
+        VALUES ('stable-id', 'user@example.com', 'user@example.com', 1, 1, '2026-01-01', 'system:open-registration');
+    `);
+    db.beforeBatch = () => {
+      db.db.exec(`
+        INSERT INTO deleted_users VALUES ('stable-id', '2026-03-01', 'admin-id');
+        DELETE FROM users WHERE id = 'stable-id';
+      `);
+    };
+
+    await expect(
+      ensureUser(
+        { DB: db as unknown as D1Database },
+        "stable-id",
+        { email: "user@example.com", __linksim_verified_idp_email: "user@example.com" },
+      ),
+    ).rejects.toThrow("UNIQUE constraint failed");
+    expect(db.db.prepare("SELECT id FROM users WHERE id = 'stable-id'").get()).toBeUndefined();
+    expect(db.db.prepare("SELECT id, deleted_by_user_id FROM deleted_users WHERE id = 'stable-id'").get()).toEqual({
+      id: "stable-id",
+      deleted_by_user_id: "admin-id",
+    });
+  });
+
+  it("aborts when a revoked matching source appears before a zero-candidate ensure batch", async () => {
+    const db = new SqliteD1();
+    db.beforeBatch = () => {
+      db.db.exec(`
+        INSERT INTO users
+          (id, email, idp_email, idp_email_verified, is_approved, approved_at, approved_by_user_id)
+          VALUES ('revoked-id', 'old@example.com', 'user@example.com', 1, 0, '2026-01-01', 'revoked:admin-id');
+      `);
+    };
+
+    await expect(
+      ensureUser(
+        { DB: db as unknown as D1Database },
+        "stable-id",
+        { email: "user@example.com", __linksim_verified_idp_email: "user@example.com" },
+      ),
+    ).rejects.toThrow("UNIQUE constraint failed");
+    expect(db.db.prepare("SELECT id FROM users WHERE id = 'stable-id'").get()).toBeUndefined();
+    expect(
+      db.db.prepare("SELECT id, is_approved, approved_by_user_id FROM users WHERE id = 'revoked-id'").get(),
+    ).toEqual({ id: "revoked-id", is_approved: 0, approved_by_user_id: "revoked:admin-id" });
   });
 
   it("preserves pending state when a verified identity first moves to a new subject", async () => {

--- a/functions/_lib/db.identity.test.ts
+++ b/functions/_lib/db.identity.test.ts
@@ -1,53 +1,231 @@
+import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
-import { chooseIdentityReconcileCandidate } from "./db";
+import {
+  assertDeletedUserMayRegister,
+  findDeletionBlock,
+  reconcileUserIdentityByIdpEmail,
+  shouldBootstrapAdmin,
+} from "./db";
 
-type Candidate = Parameters<typeof chooseIdentityReconcileCandidate>[0][number];
+class SqliteStatement {
+  private values: unknown[] = [];
 
-const makeCandidate = (patch: Partial<Candidate>): Candidate => ({
-  id: patch.id ?? "u",
-  username: patch.username ?? null,
-  email: patch.email ?? null,
-  bio: patch.bio ?? null,
-  access_request_note: patch.access_request_note ?? null,
-  idp_email: patch.idp_email ?? null,
-  idp_email_verified: patch.idp_email_verified ?? 0,
-  avatar_url: patch.avatar_url ?? null,
-  email_public: patch.email_public ?? 1,
-  default_frequency_preset_id: patch.default_frequency_preset_id ?? null,
-  avatar_object_key: patch.avatar_object_key ?? null,
-  avatar_thumb_key: patch.avatar_thumb_key ?? null,
-  avatar_hash: patch.avatar_hash ?? null,
-  avatar_bytes: patch.avatar_bytes ?? null,
-  avatar_content_type: patch.avatar_content_type ?? null,
-  is_admin: patch.is_admin ?? 0,
-  is_moderator: patch.is_moderator ?? 0,
-  is_approved: patch.is_approved ?? 0,
-  approved_at: patch.approved_at ?? null,
-  approved_by_user_id: patch.approved_by_user_id ?? null,
-  created_at: patch.created_at ?? "2026-01-01T00:00:00.000Z",
-  updated_at: patch.updated_at ?? null,
-  match_kind: patch.match_kind ?? "legacy_email",
-});
+  constructor(
+    private readonly db: DatabaseSync,
+    private readonly sql: string,
+  ) {}
 
-describe("chooseIdentityReconcileCandidate", () => {
-  it("prefers verified idp-email matches over legacy email matches", () => {
-    const selected = chooseIdentityReconcileCandidate([
-      makeCandidate({ id: "legacy", match_kind: "legacy_email", is_admin: 1, is_approved: 1 }),
-      makeCandidate({ id: "verified", match_kind: "verified_idp_email", is_admin: 0, is_approved: 0 }),
-    ]);
-    expect(selected?.id).toBe("verified");
+  bind(...values: unknown[]) {
+    this.values = values;
+    return this;
+  }
+
+  async all<T>() {
+    return { results: this.db.prepare(this.sql).all(...this.values as never[]) as T[] };
+  }
+
+  async first<T>() {
+    return (this.db.prepare(this.sql).get(...this.values as never[]) as T | undefined) ?? null;
+  }
+
+  async run() {
+    this.runSync();
+    return { success: true };
+  }
+
+  runSync() {
+    this.db.prepare(this.sql).run(...this.values as never[]);
+  }
+}
+
+class SqliteD1 {
+  readonly db = new DatabaseSync(":memory:");
+
+  constructor() {
+    this.db.exec(`
+      PRAGMA foreign_keys = ON;
+      CREATE TABLE users (
+        id TEXT PRIMARY KEY, email TEXT, idp_email TEXT, idp_email_verified INTEGER NOT NULL DEFAULT 0,
+        is_admin INTEGER NOT NULL DEFAULT 0, is_moderator INTEGER NOT NULL DEFAULT 0,
+        is_approved INTEGER NOT NULL DEFAULT 0, approved_at TEXT, approved_by_user_id TEXT, updated_at TEXT
+      );
+      CREATE TABLE sites (id TEXT PRIMARY KEY, owner_user_id TEXT NOT NULL, created_by_user_id TEXT, last_edited_by_user_id TEXT);
+      CREATE TABLE simulations (id TEXT PRIMARY KEY, owner_user_id TEXT NOT NULL, created_by_user_id TEXT, last_edited_by_user_id TEXT);
+      CREATE TABLE site_roles (site_id TEXT NOT NULL, user_id TEXT NOT NULL, role TEXT NOT NULL, created_at TEXT NOT NULL, PRIMARY KEY (site_id, user_id));
+      CREATE TABLE simulation_roles (simulation_id TEXT NOT NULL, user_id TEXT NOT NULL, role TEXT NOT NULL, created_at TEXT NOT NULL, PRIMARY KEY (simulation_id, user_id));
+      CREATE TABLE resource_changes (id INTEGER PRIMARY KEY, actor_user_id TEXT NOT NULL);
+      CREATE TABLE simulation_path_leaderboard_entries (simulation_id TEXT, canonical_path_key TEXT, owner_user_id TEXT NOT NULL, PRIMARY KEY (simulation_id, canonical_path_key));
+      CREATE TABLE user_identity_audit (
+        id INTEGER PRIMARY KEY AUTOINCREMENT, event_type TEXT NOT NULL, target_user_id TEXT NOT NULL,
+        source_user_id TEXT, actor_user_id TEXT, idp_email TEXT, details_json TEXT, created_at TEXT NOT NULL
+      );
+      CREATE TABLE deleted_users (id TEXT PRIMARY KEY, deleted_at TEXT NOT NULL, deleted_by_user_id TEXT);
+    `);
+  }
+
+  prepare(sql: string) {
+    return new SqliteStatement(this.db, sql);
+  }
+
+  async batch(statements: SqliteStatement[]) {
+    this.db.exec("BEGIN");
+    try {
+      for (const statement of statements) statement.runSync();
+      this.db.exec("COMMIT");
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      throw error;
+    }
+    return statements.map(() => ({ success: true }));
+  }
+}
+
+const seedMigration = (db: SqliteD1) => {
+  db.db.exec(`
+    INSERT INTO users (id, email, idp_email, idp_email_verified, is_admin, is_approved, approved_at, approved_by_user_id)
+      VALUES ('stable-id', 'new@example.com', 'user@example.com', 1, 0, 1, '2026-01-02', 'stable-id');
+    INSERT INTO users (id, email, idp_email, idp_email_verified, is_admin, is_approved, approved_at, approved_by_user_id)
+      VALUES ('legacy-id', 'editable@example.com', 'user@example.com', 1, 1, 1, '2026-01-01', 'legacy-id');
+    INSERT INTO sites VALUES ('site-1', 'legacy-id', 'legacy-id', 'legacy-id');
+    INSERT INTO simulations VALUES ('sim-1', 'legacy-id', 'legacy-id', 'legacy-id');
+    INSERT INTO site_roles VALUES ('site-1', 'stable-id', 'viewer', '2026-01-02');
+    INSERT INTO site_roles VALUES ('site-1', 'legacy-id', 'editor', '2026-01-01');
+    INSERT INTO simulation_roles VALUES ('sim-1', 'stable-id', 'editor', '2026-01-02');
+    INSERT INTO simulation_roles VALUES ('sim-1', 'legacy-id', 'viewer', '2026-01-01');
+    INSERT INTO resource_changes VALUES (1, 'legacy-id');
+    INSERT INTO simulation_path_leaderboard_entries VALUES ('sim-1', 'path-1', 'legacy-id');
+  `);
+};
+
+describe("identity reconciliation", () => {
+  it("transfers verified identity, strongest grants, ownership, and audit identity atomically", async () => {
+    const db = new SqliteD1();
+    seedMigration(db);
+
+    await reconcileUserIdentityByIdpEmail({ DB: db as unknown as D1Database }, "stable-id", "user@example.com");
+
+    expect(db.db.prepare("SELECT is_admin FROM users WHERE id = 'stable-id'").get()).toEqual({ is_admin: 1 });
+    expect(db.db.prepare("SELECT id FROM users WHERE id = 'legacy-id'").get()).toBeUndefined();
+    expect(db.db.prepare("SELECT owner_user_id FROM sites WHERE id = 'site-1'").get()).toEqual({ owner_user_id: "stable-id" });
+    expect(db.db.prepare("SELECT role FROM site_roles WHERE site_id = 'site-1'").get()).toEqual({ role: "editor" });
+    expect(db.db.prepare("SELECT role FROM simulation_roles WHERE simulation_id = 'sim-1'").get()).toEqual({ role: "editor" });
+    expect(db.db.prepare("SELECT actor_user_id FROM resource_changes WHERE id = 1").get()).toEqual({ actor_user_id: "stable-id" });
+    expect(db.db.prepare("SELECT event_type, source_user_id FROM user_identity_audit").get()).toEqual({
+      event_type: "reconciled_by_verified_idp_email",
+      source_user_id: "legacy-id",
+    });
   });
 
-  it("within same match kind prefers admin then approved then oldest", () => {
-    const selected = chooseIdentityReconcileCandidate([
-      makeCandidate({ id: "newer", match_kind: "verified_idp_email", is_admin: 0, is_approved: 1, created_at: "2026-01-03T00:00:00.000Z" }),
-      makeCandidate({ id: "older", match_kind: "verified_idp_email", is_admin: 0, is_approved: 1, created_at: "2026-01-02T00:00:00.000Z" }),
-      makeCandidate({ id: "admin", match_kind: "verified_idp_email", is_admin: 1, is_approved: 0, created_at: "2026-01-10T00:00:00.000Z" }),
-    ]);
-    expect(selected?.id).toBe("admin");
+  it("rolls back every transfer when the audit insert fails", async () => {
+    const db = new SqliteD1();
+    seedMigration(db);
+    db.db.exec("CREATE TRIGGER reject_identity_audit BEFORE INSERT ON user_identity_audit BEGIN SELECT RAISE(ABORT, 'audit unavailable'); END");
+
+    await expect(
+      reconcileUserIdentityByIdpEmail({ DB: db as unknown as D1Database }, "stable-id", "user@example.com"),
+    ).rejects.toThrow("audit unavailable");
+
+    expect(db.db.prepare("SELECT is_admin FROM users WHERE id = 'stable-id'").get()).toEqual({ is_admin: 0 });
+    expect(db.db.prepare("SELECT owner_user_id FROM sites WHERE id = 'site-1'").get()).toEqual({ owner_user_id: "legacy-id" });
+    expect(db.db.prepare("SELECT id FROM users WHERE id = 'legacy-id'").get()).toEqual({ id: "legacy-id" });
   });
 
-  it("returns null for empty candidate list", () => {
-    expect(chooseIdentityReconcileCandidate([])).toBeNull();
+  it("preserves a durable revocation when the verified identity moves to a new subject", async () => {
+    const db = new SqliteD1();
+    db.db.exec(`
+      INSERT INTO users (id, email, idp_email, idp_email_verified, is_approved, approved_at, approved_by_user_id)
+        VALUES ('stable-id', 'new@example.com', 'user@example.com', 1, 1, '2026-02-01', 'system:open-registration');
+      INSERT INTO users (id, email, idp_email, idp_email_verified, is_approved, approved_at, approved_by_user_id)
+        VALUES ('revoked-id', 'old@example.com', 'user@example.com', 1, 0, '2026-01-01', 'revoked:admin-id');
+    `);
+
+    await reconcileUserIdentityByIdpEmail({ DB: db as unknown as D1Database }, "stable-id", "user@example.com");
+
+    expect(db.db.prepare("SELECT is_approved, approved_by_user_id FROM users WHERE id = 'stable-id'").get()).toEqual({
+      is_approved: 0,
+      approved_by_user_id: "revoked:admin-id",
+    });
+  });
+
+  it("preserves pending state when a verified identity first moves to a new subject", async () => {
+    const db = new SqliteD1();
+    db.db.exec(`
+      INSERT INTO users (id, email, idp_email, idp_email_verified, is_approved, approved_at, approved_by_user_id)
+        VALUES ('stable-id', 'new@example.com', 'user@example.com', 1, 1, '2026-02-01', 'system:open-registration');
+      INSERT INTO users (id, email, idp_email, idp_email_verified, is_approved, approved_at, approved_by_user_id)
+        VALUES ('pending-id', 'old@example.com', 'user@example.com', 1, 0, NULL, NULL);
+    `);
+
+    await reconcileUserIdentityByIdpEmail({ DB: db as unknown as D1Database }, "stable-id", "user@example.com");
+
+    expect(db.db.prepare("SELECT is_approved, approved_at, approved_by_user_id FROM users WHERE id = 'stable-id'").get()).toEqual({
+      is_approved: 0,
+      approved_at: null,
+      approved_by_user_id: null,
+    });
+  });
+
+  it("does not reconcile from mutable profile email", async () => {
+    const db = new SqliteD1();
+    db.db.exec(`
+      INSERT INTO users (id, email, idp_email, idp_email_verified) VALUES ('stable-id', 'new@example.com', 'user@example.com', 1);
+      INSERT INTO users (id, email, idp_email, idp_email_verified, is_admin) VALUES ('editable-id', 'user@example.com', 'other@example.com', 1, 1);
+    `);
+
+    await reconcileUserIdentityByIdpEmail({ DB: db as unknown as D1Database }, "stable-id", "user@example.com");
+
+    expect(db.db.prepare("SELECT is_admin FROM users WHERE id = 'stable-id'").get()).toEqual({ is_admin: 0 });
+    expect(db.db.prepare("SELECT id FROM users WHERE id = 'editable-id'").get()).toEqual({ id: "editable-id" });
+  });
+
+  it("audits a verified identity collision and transfers nothing", async () => {
+    const db = new SqliteD1();
+    db.db.exec(`
+      INSERT INTO users (id, idp_email, idp_email_verified) VALUES ('stable-id', 'user@example.com', 1);
+      INSERT INTO users (id, idp_email, idp_email_verified) VALUES ('one', 'user@example.com', 1);
+      INSERT INTO users (id, idp_email, idp_email_verified) VALUES ('two', 'user@example.com', 1);
+    `);
+
+    await expect(
+      reconcileUserIdentityByIdpEmail({ DB: db as unknown as D1Database }, "stable-id", "user@example.com"),
+    ).rejects.toThrow("Verified identity collision");
+    expect(db.db.prepare("SELECT COUNT(*) AS count FROM users").get()).toEqual({ count: 3 });
+    expect(db.db.prepare("SELECT event_type FROM user_identity_audit").get()).toEqual({
+      event_type: "verified_idp_email_collision",
+    });
+  });
+
+  it("keeps deletion blocks durable until explicit restore", () => {
+    expect(() => assertDeletedUserMayRegister({ deleted_at: "2026-01-01T00:00:00Z" })).toThrow("Session revoked by admin");
+    expect(() => assertDeletedUserMayRegister(null)).not.toThrow();
+  });
+
+  it("blocks a new subject that presents the deleted account's verified identity", async () => {
+    const db = new SqliteD1();
+    db.db.exec(`
+      INSERT INTO deleted_users VALUES ('old-subject', '2026-01-01', 'admin-id');
+      INSERT INTO user_identity_audit
+        (event_type, target_user_id, actor_user_id, idp_email, details_json, created_at)
+        VALUES ('user_deleted', 'old-subject', 'admin-id', 'user@example.com', '{}', '2026-01-01');
+    `);
+
+    const deletion = await findDeletionBlock(
+      { DB: db as unknown as D1Database },
+      "new-subject",
+      "user@example.com",
+    );
+
+    expect(deletion).toEqual({ deleted_at: "2026-01-01" });
+    db.db.exec("DELETE FROM deleted_users WHERE id = 'old-subject'");
+    await expect(findDeletionBlock(
+      { DB: db as unknown as D1Database },
+      "new-subject",
+      "user@example.com",
+    )).resolves.toBeNull();
+  });
+
+  it("applies bootstrap admin only when creating the user", () => {
+    expect(shouldBootstrapAdmin(false, true)).toBe(true);
+    expect(shouldBootstrapAdmin(true, true)).toBe(false);
   });
 });

--- a/functions/_lib/db.identity.test.ts
+++ b/functions/_lib/db.identity.test.ts
@@ -4,6 +4,7 @@ import {
   assertDeletedUserMayRegister,
   findDeletionBlock,
   reconcileUserIdentityByIdpEmail,
+  revertResourceFromChangeCopy,
   shouldBootstrapAdmin,
   upsertLibrarySnapshot,
 } from "./db";
@@ -177,6 +178,12 @@ describe("identity reconciliation", () => {
       INSERT INTO site_roles VALUES ('shared-site', 'stable-id', 'viewer', '2026-01-02');
       INSERT INTO simulation_roles VALUES ('shared-simulation', 'legacy-id', 'viewer', '2026-01-01');
       INSERT INTO simulation_roles VALUES ('shared-simulation', 'stable-id', 'editor', '2026-01-02');
+      INSERT INTO resource_changes
+        (id, resource_kind, resource_id, action, actor_user_id, changed_at, snapshot_json)
+        VALUES (
+          1, 'site', 'shared-site', 'updated', 'owner-id', '2026-01-01',
+          '{"id":"shared-site","name":"Historical Site","visibility":"shared","sharedWith":[{"userId":"legacy-id","role":"editor"}]}'
+        );
     `);
 
     const env = { DB: db as unknown as D1Database };
@@ -217,6 +224,17 @@ describe("identity reconciliation", () => {
     expect(
       db.db.prepare("SELECT user_id, role FROM simulation_roles WHERE simulation_id = 'shared-simulation'").all(),
     ).toEqual([{ user_id: "stable-id", role: "editor" }]);
+
+    await expect(
+      revertResourceFromChangeCopy(env, "site", "shared-site", 1, {
+        id: "owner-id",
+        isAdmin: false,
+        isModerator: false,
+      }),
+    ).resolves.toEqual({ ok: true });
+    expect(db.db.prepare("SELECT user_id, role FROM site_roles WHERE site_id = 'shared-site'").all()).toEqual([
+      { user_id: "stable-id", role: "editor" },
+    ]);
   });
 
   it("rolls back every transfer when the audit insert fails", async () => {
@@ -248,6 +266,143 @@ describe("identity reconciliation", () => {
       is_approved: 0,
       approved_by_user_id: "revoked:admin-id",
     });
+  });
+
+  it("uses lifecycle state changed immediately before the reconciliation batch", async () => {
+    const db = new SqliteD1();
+    db.db.exec(`
+      INSERT INTO users (id, email, idp_email, idp_email_verified, is_approved, approved_at, approved_by_user_id)
+        VALUES ('stable-id', 'new@example.com', 'user@example.com', 1, 1, '2026-02-01', 'system:open-registration');
+      INSERT INTO users (id, email, idp_email, idp_email_verified, is_admin, is_approved, approved_at, approved_by_user_id)
+        VALUES ('legacy-id', 'old@example.com', 'user@example.com', 1, 1, 1, '2026-01-01', 'legacy-id');
+    `);
+    db.beforeBatch = () => {
+      db.db
+        .prepare(
+          `UPDATE users
+           SET is_admin = 0, is_moderator = 0, is_approved = 0, approved_by_user_id = 'revoked:admin-id'
+           WHERE id = 'legacy-id'`,
+        )
+        .run();
+    };
+
+    await reconcileUserIdentityByIdpEmail({ DB: db as unknown as D1Database }, "stable-id", "user@example.com");
+
+    expect(
+      db.db
+        .prepare("SELECT is_admin, is_moderator, is_approved, approved_by_user_id FROM users WHERE id = 'stable-id'")
+        .get(),
+    ).toEqual({ is_admin: 0, is_moderator: 0, is_approved: 0, approved_by_user_id: "revoked:admin-id" });
+    const audit = db.db
+      .prepare("SELECT details_json FROM user_identity_audit WHERE event_type = 'reconciled_by_verified_idp_email'")
+      .get() as { details_json: string };
+    expect(JSON.parse(audit.details_json)).toMatchObject({
+      mergedFromIsAdmin: false,
+      mergedFromIsApproved: false,
+      mergedFromAccountState: "revoked",
+    });
+  });
+
+  it("fails closed when the source is deleted immediately before the reconciliation batch", async () => {
+    const db = new SqliteD1();
+    db.db.exec(`
+      INSERT INTO users (id, email, idp_email, idp_email_verified, is_approved, approved_at, approved_by_user_id)
+        VALUES ('stable-id', 'new@example.com', 'user@example.com', 1, 1, '2026-02-01', 'system:open-registration');
+      INSERT INTO users (id, email, idp_email, idp_email_verified, is_admin, is_approved, approved_at, approved_by_user_id)
+        VALUES ('legacy-id', 'old@example.com', 'user@example.com', 1, 1, 1, '2026-01-01', 'legacy-id');
+    `);
+    db.beforeBatch = () => {
+      db.db.exec(`
+        INSERT INTO deleted_users VALUES ('legacy-id', '2026-03-01', 'admin-id');
+        DELETE FROM users WHERE id = 'legacy-id';
+      `);
+    };
+
+    await reconcileUserIdentityByIdpEmail({ DB: db as unknown as D1Database }, "stable-id", "user@example.com");
+
+    expect(
+      db.db
+        .prepare("SELECT is_admin, is_moderator, is_approved, approved_by_user_id FROM users WHERE id = 'stable-id'")
+        .get(),
+    ).toEqual({ is_admin: 0, is_moderator: 0, is_approved: 0, approved_by_user_id: "revoked:admin-id" });
+    const audit = db.db
+      .prepare("SELECT details_json FROM user_identity_audit WHERE event_type = 'reconciled_by_verified_idp_email'")
+      .get() as { details_json: string };
+    expect(JSON.parse(audit.details_json)).toMatchObject({
+      mergedFromIsAdmin: false,
+      mergedFromIsApproved: false,
+      mergedFromAccountState: "revoked",
+    });
+  });
+
+  it("aborts when the source loses its verified identity match before the reconciliation batch", async () => {
+    const db = new SqliteD1();
+    db.db.exec(`
+      INSERT INTO users (id, email, idp_email, idp_email_verified, is_admin, is_approved)
+        VALUES ('stable-id', 'new@example.com', 'user@example.com', 1, 0, 1);
+      INSERT INTO users (id, email, idp_email, idp_email_verified, is_admin, is_approved)
+        VALUES ('legacy-id', 'old@example.com', 'user@example.com', 1, 1, 1);
+    `);
+    db.beforeBatch = () => {
+      db.db.prepare("UPDATE users SET idp_email = 'other@example.com' WHERE id = 'legacy-id'").run();
+    };
+
+    await expect(
+      reconcileUserIdentityByIdpEmail({ DB: db as unknown as D1Database }, "stable-id", "user@example.com"),
+    ).rejects.toThrow("UNIQUE constraint failed");
+    expect(db.db.prepare("SELECT id, is_admin FROM users ORDER BY id").all()).toEqual([
+      { id: "legacy-id", is_admin: 1 },
+      { id: "stable-id", is_admin: 0 },
+    ]);
+  });
+
+  it("aborts when a verified identity collision appears before the reconciliation batch", async () => {
+    const db = new SqliteD1();
+    db.db.exec(`
+      INSERT INTO users (id, email, idp_email, idp_email_verified, is_admin, is_approved)
+        VALUES ('stable-id', 'new@example.com', 'user@example.com', 1, 0, 1);
+      INSERT INTO users (id, email, idp_email, idp_email_verified, is_admin, is_approved)
+        VALUES ('legacy-id', 'old@example.com', 'user@example.com', 1, 1, 1);
+    `);
+    db.beforeBatch = () => {
+      db.db.exec(`
+        INSERT INTO users (id, email, idp_email, idp_email_verified, is_admin, is_approved)
+          VALUES ('collision-id', 'collision@example.com', 'user@example.com', 1, 0, 1);
+      `);
+    };
+
+    await expect(
+      reconcileUserIdentityByIdpEmail({ DB: db as unknown as D1Database }, "stable-id", "user@example.com"),
+    ).rejects.toThrow("UNIQUE constraint failed");
+    expect(db.db.prepare("SELECT id FROM users ORDER BY id").all()).toEqual([
+      { id: "collision-id" },
+      { id: "legacy-id" },
+      { id: "stable-id" },
+    ]);
+  });
+
+  it("aborts when the target is deleted immediately before the reconciliation batch", async () => {
+    const db = new SqliteD1();
+    db.db.exec(`
+      INSERT INTO users (id, email, idp_email, idp_email_verified, is_admin, is_approved)
+        VALUES ('stable-id', 'new@example.com', 'user@example.com', 1, 0, 1);
+      INSERT INTO users (id, email, idp_email, idp_email_verified, is_admin, is_approved)
+        VALUES ('legacy-id', 'old@example.com', 'user@example.com', 1, 1, 1);
+    `);
+    db.beforeBatch = () => {
+      db.db.exec(`
+        INSERT INTO deleted_users VALUES ('stable-id', '2026-03-01', 'admin-id');
+        DELETE FROM users WHERE id = 'stable-id';
+      `);
+    };
+
+    await expect(
+      reconcileUserIdentityByIdpEmail({ DB: db as unknown as D1Database }, "stable-id", "user@example.com"),
+    ).rejects.toThrow("UNIQUE constraint failed");
+    expect(db.db.prepare("SELECT id, is_admin FROM users").all()).toEqual([{ id: "legacy-id", is_admin: 1 }]);
+    expect(db.db.prepare("SELECT id, deleted_by_user_id FROM deleted_users").all()).toEqual([
+      { id: "stable-id", deleted_by_user_id: "admin-id" },
+    ]);
   });
 
   it("preserves pending state when a verified identity first moves to a new subject", async () => {

--- a/functions/_lib/db.ts
+++ b/functions/_lib/db.ts
@@ -582,22 +582,54 @@ type UserRow = {
   updated_at: string | null;
 };
 
-type IdentityReconcileCandidate = Pick<
-  UserRow,
-  "id" | "is_admin" | "is_moderator" | "is_approved" | "approved_at" | "approved_by_user_id"
->;
+type IdentityReconcileCandidate = Pick<UserRow, "id">;
+
+const IDENTITY_RECONCILE_SOURCE_STATE_SQL = `
+  SELECT
+    ?4 AS id,
+    COALESCE(source.is_admin, 0) AS is_admin,
+    COALESCE(source.is_moderator, 0) AS is_moderator,
+    COALESCE(source.is_approved, 0) AS is_approved,
+    CASE
+      WHEN tombstone.id IS NOT NULL OR source.id IS NULL
+      THEN COALESCE(tombstone.deleted_at, source.approved_at, ?2)
+      ELSE source.approved_at
+    END AS approved_at,
+    CASE
+      WHEN tombstone.id IS NOT NULL OR source.id IS NULL
+      THEN 'revoked:' || COALESCE(tombstone.deleted_by_user_id, 'system')
+      ELSE source.approved_by_user_id
+    END AS approved_by_user_id,
+    CASE
+      WHEN tombstone.id IS NOT NULL OR source.id IS NULL THEN 1
+      WHEN source.is_admin = 0 AND source.is_moderator = 0 AND source.is_approved = 0
+        AND (source.approved_at IS NOT NULL OR source.approved_by_user_id IS NOT NULL)
+      THEN 1 ELSE 0
+    END AS is_revoked,
+    CASE
+      WHEN tombstone.id IS NULL AND source.id IS NOT NULL
+        AND source.is_admin = 0 AND source.is_moderator = 0 AND source.is_approved = 0
+        AND source.approved_at IS NULL AND source.approved_by_user_id IS NULL
+      THEN 1 ELSE 0
+    END AS is_pending
+  FROM (SELECT 1) seed
+  LEFT JOIN users source ON source.id = ?4
+  LEFT JOIN deleted_users tombstone ON tombstone.id = ?4
+`;
 
 const prepareSerializedGrantMigration = (
   env: Env,
-  table: "sites" | "simulations",
+  location:
+    | { table: "sites" | "simulations"; column: "payload_json" }
+    | { table: "resource_changes"; column: "snapshot_json" },
   sourceUserId: string,
   targetUserId: string,
 ): D1PreparedStatement =>
   env.DB
     .prepare(
-      `UPDATE ${table}
-       SET payload_json = json_set(
-         payload_json,
+      `UPDATE ${location.table}
+       SET ${location.column} = json_set(
+         ${location.column},
          '$.sharedWith',
          json((
            SELECT json_group_array(
@@ -621,17 +653,17 @@ const prepareSerializedGrantMigration = (
                      ELSE -1
                    END
                  ELSE -1 END AS role_strength
-               FROM json_each(payload_json, '$.sharedWith') grant
+               FROM json_each(${location.column}, '$.sharedWith') grant
              ) serialized_grants
              WHERE user_id <> '' AND role_strength >= 0
              GROUP BY CASE WHEN user_id = ?1 THEN ?2 ELSE user_id END
            ) migrated_grants
          ))
        )
-       WHERE json_valid(payload_json)
+       WHERE json_valid(${location.column})
          AND EXISTS (
            SELECT 1
-           FROM json_each(payload_json, '$.sharedWith') grant
+           FROM json_each(${location.column}, '$.sharedWith') grant
            WHERE grant.type = 'object'
              AND trim(json_extract(grant.value, '$.userId')) = ?1
          )`,
@@ -705,7 +737,7 @@ export const reconcileUserIdentityByIdpEmail = async (
 
   const rows = await env.DB
     .prepare(
-      `SELECT id, is_admin, is_moderator, is_approved, approved_at, approved_by_user_id
+      `SELECT id
        FROM users
        WHERE id <> ?
          AND lower(idp_email) = lower(?)
@@ -738,44 +770,76 @@ export const reconcileUserIdentityByIdpEmail = async (
   if (!existing) return;
 
   const now = new Date().toISOString();
-  const sourceIsRevoked =
-    existing.is_admin !== 1 &&
-    existing.is_moderator !== 1 &&
-    existing.is_approved !== 1 &&
-    Boolean(existing.approved_at || existing.approved_by_user_id);
-  const sourceIsPending =
-    existing.is_admin !== 1 &&
-    existing.is_moderator !== 1 &&
-    existing.is_approved !== 1 &&
-    !sourceIsRevoked;
-  const preserveSourceLifecycle = sourceIsRevoked || (!targetWasExisting && sourceIsPending);
   await env.DB.batch([
+    env.DB
+      .prepare(
+        `INSERT INTO users (id, created_at)
+         SELECT ?2, ?4
+         WHERE EXISTS (SELECT 1 FROM users WHERE id = ?2)
+           AND NOT EXISTS (SELECT 1 FROM deleted_users WHERE id = ?2)
+           AND NOT EXISTS (SELECT 1 FROM deleted_users WHERE id = ?1)
+           AND NOT (
+             (
+               SELECT COUNT(*)
+               FROM users
+               WHERE id <> ?2
+                 AND lower(idp_email) = lower(?3)
+                 AND idp_email_verified = 1
+             ) = 1
+             AND EXISTS (
+               SELECT 1
+               FROM users
+               WHERE id = ?1
+                 AND lower(idp_email) = lower(?3)
+                 AND idp_email_verified = 1
+             )
+           )`,
+      )
+      .bind(existing.id, userId, normalized, now),
+    env.DB
+      .prepare(
+        `INSERT INTO deleted_users (id, deleted_at, deleted_by_user_id)
+         SELECT ?1, ?2, 'reconcile-guard'
+         FROM (SELECT 1 UNION ALL SELECT 2)
+         WHERE NOT EXISTS (SELECT 1 FROM users WHERE id = ?1)
+            OR EXISTS (SELECT 1 FROM deleted_users WHERE id = ?1)`,
+      )
+      .bind(userId, now),
     env.DB.prepare(
-      `UPDATE users
-       SET is_admin = CASE WHEN ? = 1 THEN 0 WHEN ? = 1 THEN 1 ELSE is_admin END,
-           is_moderator = CASE WHEN ? = 1 THEN 0 WHEN ? = 1 THEN 1 ELSE is_moderator END,
-           is_approved = CASE WHEN ? = 1 THEN 0 WHEN ? = 1 THEN 1 ELSE is_approved END,
-           approved_at = CASE WHEN ? = 1 THEN ? WHEN ? = 1 THEN COALESCE(approved_at, ?) ELSE approved_at END,
-           approved_by_user_id = CASE WHEN ? = 1 THEN ? WHEN ? = 1 THEN COALESCE(approved_by_user_id, ?) ELSE approved_by_user_id END,
-           updated_at = ?
-       WHERE id = ?`,
+      `UPDATE users AS target
+       SET is_admin = CASE
+             WHEN source.is_revoked = 1 OR (?1 = 0 AND source.is_pending = 1) THEN 0
+             WHEN source.is_admin = 1 THEN 1
+             ELSE target.is_admin
+           END,
+           is_moderator = CASE
+             WHEN source.is_revoked = 1 OR (?1 = 0 AND source.is_pending = 1) THEN 0
+             WHEN source.is_moderator = 1 THEN 1
+             ELSE target.is_moderator
+           END,
+           is_approved = CASE
+             WHEN source.is_revoked = 1 OR (?1 = 0 AND source.is_pending = 1) THEN 0
+             WHEN source.is_approved = 1 THEN 1
+             ELSE target.is_approved
+           END,
+           approved_at = CASE
+             WHEN source.is_revoked = 1 OR (?1 = 0 AND source.is_pending = 1) THEN source.approved_at
+             WHEN source.is_approved = 1 THEN COALESCE(target.approved_at, source.approved_at, ?2)
+             ELSE target.approved_at
+           END,
+           approved_by_user_id = CASE
+             WHEN source.is_revoked = 1 OR (?1 = 0 AND source.is_pending = 1) THEN source.approved_by_user_id
+             WHEN source.is_approved = 1 THEN COALESCE(target.approved_by_user_id, source.approved_by_user_id, source.id)
+             ELSE target.approved_by_user_id
+           END,
+           updated_at = ?2
+       FROM (${IDENTITY_RECONCILE_SOURCE_STATE_SQL}) AS source
+       WHERE target.id = ?3`,
     ).bind(
-      preserveSourceLifecycle ? 1 : 0,
-      existing.is_admin === 1 ? 1 : 0,
-      preserveSourceLifecycle ? 1 : 0,
-      existing.is_moderator === 1 ? 1 : 0,
-      preserveSourceLifecycle ? 1 : 0,
-      existing.is_approved === 1 ? 1 : 0,
-      preserveSourceLifecycle ? 1 : 0,
-      existing.approved_at,
-      existing.is_approved === 1 ? 1 : 0,
-      existing.approved_at ?? now,
-      preserveSourceLifecycle ? 1 : 0,
-      existing.approved_by_user_id,
-      existing.is_approved === 1 ? 1 : 0,
-      existing.approved_by_user_id ?? existing.id,
+      targetWasExisting ? 1 : 0,
       now,
       userId,
+      existing.id,
     ),
     env.DB.prepare("UPDATE sites SET owner_user_id = ? WHERE owner_user_id = ?").bind(userId, existing.id),
     env.DB
@@ -817,33 +881,41 @@ export const reconcileUserIdentityByIdpEmail = async (
       )
       .bind(userId, existing.id),
     env.DB.prepare("DELETE FROM simulation_roles WHERE user_id = ?").bind(existing.id),
-    prepareSerializedGrantMigration(env, "sites", existing.id, userId),
-    prepareSerializedGrantMigration(env, "simulations", existing.id, userId),
+    prepareSerializedGrantMigration(env, { table: "sites", column: "payload_json" }, existing.id, userId),
+    prepareSerializedGrantMigration(env, { table: "simulations", column: "payload_json" }, existing.id, userId),
+    prepareSerializedGrantMigration(
+      env,
+      { table: "resource_changes", column: "snapshot_json" },
+      existing.id,
+      userId,
+    ),
     env.DB.prepare("UPDATE resource_changes SET actor_user_id = ? WHERE actor_user_id = ?").bind(userId, existing.id),
     env.DB
       .prepare("UPDATE simulation_path_leaderboard_entries SET owner_user_id = ? WHERE owner_user_id = ?")
       .bind(userId, existing.id),
-    env.DB.prepare("UPDATE users SET approved_by_user_id = ? WHERE approved_by_user_id = ?").bind(userId, existing.id),
     env.DB.prepare(
       `INSERT INTO user_identity_audit
        (event_type, target_user_id, source_user_id, actor_user_id, idp_email, details_json, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`,
-    ).bind(
-      "reconciled_by_verified_idp_email",
-      userId,
-      existing.id,
-      userId,
-      normalized,
-      JSON.stringify({
-        mergedFromUserId: existing.id,
-        matchKind: "verified_idp_email",
-        mergedFromIsAdmin: existing.is_admin === 1,
-        mergedFromIsModerator: existing.is_moderator === 1,
-        mergedFromIsApproved: existing.is_approved === 1,
-        mergedFromAccountState: sourceIsRevoked ? "revoked" : sourceIsPending ? "pending" : "approved",
-      }),
-      now,
-    ),
+       SELECT 'reconciled_by_verified_idp_email', ?3, source.id, ?3, ?5,
+              json_object(
+                'mergedFromUserId', source.id,
+                'matchKind', 'verified_idp_email',
+                'mergedFromIsAdmin', json(CASE WHEN source.is_admin = 1 THEN 'true' ELSE 'false' END),
+                'mergedFromIsModerator', json(CASE WHEN source.is_moderator = 1 THEN 'true' ELSE 'false' END),
+                'mergedFromIsApproved', json(CASE WHEN source.is_approved = 1 THEN 'true' ELSE 'false' END),
+                'mergedFromAccountState', CASE
+                  WHEN source.is_admin = 0 AND source.is_moderator = 0 AND source.is_approved = 0
+                    AND (source.approved_at IS NOT NULL OR source.approved_by_user_id IS NOT NULL)
+                  THEN 'revoked'
+                  WHEN source.is_admin = 0 AND source.is_moderator = 0 AND source.is_approved = 0
+                  THEN 'pending'
+                  ELSE 'approved'
+                END
+              ),
+              ?2
+       FROM (${IDENTITY_RECONCILE_SOURCE_STATE_SQL}) source`,
+    ).bind(targetWasExisting ? 1 : 0, now, userId, existing.id, normalized),
+    env.DB.prepare("UPDATE users SET approved_by_user_id = ? WHERE approved_by_user_id = ?").bind(userId, existing.id),
     env.DB.prepare("DELETE FROM users WHERE id = ?").bind(existing.id),
   ]);
 };

--- a/functions/_lib/db.ts
+++ b/functions/_lib/db.ts
@@ -587,64 +587,56 @@ type IdentityReconcileCandidate = Pick<
   "id" | "is_admin" | "is_moderator" | "is_approved" | "approved_at" | "approved_by_user_id"
 >;
 
-type SerializedGrantRow = {
-  id: string;
-  payload_json: string;
-};
-
-const rewriteSerializedGrantUserId = (
-  payloadJson: string,
-  sourceUserId: string,
-  targetUserId: string,
-): string | null => {
-  try {
-    const payload = JSON.parse(payloadJson) as CloudResourceRecord;
-    const grants = sanitizeGrants(payload.sharedWith);
-    if (!grants.some((grant) => grant.userId === sourceUserId)) return null;
-
-    const migrated = new Map<string, Grant>();
-    for (const grant of grants) {
-      const userId = grant.userId === sourceUserId ? targetUserId : grant.userId;
-      const current = migrated.get(userId);
-      if (!current || ROLES.indexOf(grant.role) > ROLES.indexOf(current.role)) {
-        migrated.set(userId, { userId, role: grant.role });
-      }
-    }
-    return JSON.stringify({ ...payload, sharedWith: Array.from(migrated.values()) });
-  } catch {
-    return null;
-  }
-};
-
-const prepareSerializedGrantMigrations = async (
+const prepareSerializedGrantMigration = (
   env: Env,
+  table: "sites" | "simulations",
   sourceUserId: string,
   targetUserId: string,
-): Promise<D1PreparedStatement[]> => {
-  const statements: D1PreparedStatement[] = [];
-  for (const table of ["sites", "simulations"] as const) {
-    const rows = await env.DB
-      .prepare(
-        `SELECT id, payload_json
-         FROM ${table}
-         WHERE json_valid(payload_json)
-           AND EXISTS (
-             SELECT 1
-             FROM json_each(payload_json, '$.sharedWith') grant
-             WHERE json_extract(grant.value, '$.userId') = ?
-           )`,
-      )
-      .bind(sourceUserId)
-      .all<SerializedGrantRow>();
-    for (const row of rows.results) {
-      const payloadJson = rewriteSerializedGrantUserId(row.payload_json, sourceUserId, targetUserId);
-      if (payloadJson) {
-        statements.push(env.DB.prepare(`UPDATE ${table} SET payload_json = ? WHERE id = ?`).bind(payloadJson, row.id));
-      }
-    }
-  }
-  return statements;
-};
+): D1PreparedStatement =>
+  env.DB
+    .prepare(
+      `UPDATE ${table}
+       SET payload_json = json_set(
+         payload_json,
+         '$.sharedWith',
+         json((
+           SELECT json_group_array(
+             json_object(
+               'userId', migrated_user_id,
+               'role', CASE strongest_role WHEN 2 THEN 'admin' WHEN 1 THEN 'editor' ELSE 'viewer' END
+             )
+           )
+           FROM (
+             SELECT
+               CASE WHEN user_id = ?1 THEN ?2 ELSE user_id END AS migrated_user_id,
+               MAX(role_strength) AS strongest_role
+             FROM (
+               SELECT
+                 CASE WHEN grant.type = 'object' THEN trim(json_extract(grant.value, '$.userId')) ELSE '' END AS user_id,
+                 CASE WHEN grant.type = 'object' THEN
+                   CASE json_extract(grant.value, '$.role')
+                     WHEN 'admin' THEN 2
+                     WHEN 'editor' THEN 1
+                     WHEN 'viewer' THEN 0
+                     ELSE -1
+                   END
+                 ELSE -1 END AS role_strength
+               FROM json_each(payload_json, '$.sharedWith') grant
+             ) serialized_grants
+             WHERE user_id <> '' AND role_strength >= 0
+             GROUP BY CASE WHEN user_id = ?1 THEN ?2 ELSE user_id END
+           ) migrated_grants
+         ))
+       )
+       WHERE json_valid(payload_json)
+         AND EXISTS (
+           SELECT 1
+           FROM json_each(payload_json, '$.sharedWith') grant
+           WHERE grant.type = 'object'
+             AND trim(json_extract(grant.value, '$.userId')) = ?1
+         )`,
+    )
+    .bind(sourceUserId, targetUserId);
 
 const toUserProfile = (row: UserRow) => ({
   id: row.id,
@@ -757,7 +749,6 @@ export const reconcileUserIdentityByIdpEmail = async (
     existing.is_approved !== 1 &&
     !sourceIsRevoked;
   const preserveSourceLifecycle = sourceIsRevoked || (!targetWasExisting && sourceIsPending);
-  const serializedGrantMigrations = await prepareSerializedGrantMigrations(env, existing.id, userId);
   await env.DB.batch([
     env.DB.prepare(
       `UPDATE users
@@ -826,7 +817,8 @@ export const reconcileUserIdentityByIdpEmail = async (
       )
       .bind(userId, existing.id),
     env.DB.prepare("DELETE FROM simulation_roles WHERE user_id = ?").bind(existing.id),
-    ...serializedGrantMigrations,
+    prepareSerializedGrantMigration(env, "sites", existing.id, userId),
+    prepareSerializedGrantMigration(env, "simulations", existing.id, userId),
     env.DB.prepare("UPDATE resource_changes SET actor_user_id = ? WHERE actor_user_id = ?").bind(userId, existing.id),
     env.DB
       .prepare("UPDATE simulation_path_leaderboard_entries SET owner_user_id = ? WHERE owner_user_id = ?")

--- a/functions/_lib/db.ts
+++ b/functions/_lib/db.ts
@@ -223,19 +223,8 @@ const deriveDefaultEmail = (userId: string, tokenPayload?: Record<string, unknow
 };
 
 const deriveVerifiedIdpEmail = (tokenPayload?: Record<string, unknown>): string => {
-  const fromPayload = sanitizeEmail(tokenPayload?.email);
+  const fromPayload = sanitizeEmail(tokenPayload?.__linksim_verified_idp_email);
   return fromPayload ?? "";
-};
-
-const parseTokenIssuedAtMs = (tokenPayload?: Record<string, unknown>): number | null => {
-  if (!tokenPayload) return null;
-  const raw = tokenPayload.iat;
-  if (typeof raw === "number" && Number.isFinite(raw)) return raw * 1000;
-  if (typeof raw === "string") {
-    const parsed = Number(raw);
-    if (Number.isFinite(parsed)) return parsed * 1000;
-  }
-  return null;
 };
 
 const parseAdminUserIds = (env: Env): Set<string> => {
@@ -593,33 +582,10 @@ type UserRow = {
   updated_at: string | null;
 };
 
-type IdentityMatchKind = "verified_idp_email" | "legacy_email";
-type IdentityReconcileCandidate = UserRow & { match_kind: IdentityMatchKind };
-
-const matchRank = (kind: IdentityMatchKind): number => (kind === "verified_idp_email" ? 2 : 1);
-
-const normalizeDateSafe = (value: string | null): number => {
-  if (!value) return Number.MAX_SAFE_INTEGER;
-  const parsed = Date.parse(value);
-  return Number.isFinite(parsed) ? parsed : Number.MAX_SAFE_INTEGER;
-};
-
-export const chooseIdentityReconcileCandidate = (
-  candidates: IdentityReconcileCandidate[],
-): IdentityReconcileCandidate | null => {
-  if (!candidates.length) return null;
-  const sorted = [...candidates].sort((a, b) => {
-    const rankDiff = matchRank(b.match_kind) - matchRank(a.match_kind);
-    if (rankDiff !== 0) return rankDiff;
-    if (a.is_admin !== b.is_admin) return b.is_admin - a.is_admin;
-    if (a.is_moderator !== b.is_moderator) return b.is_moderator - a.is_moderator;
-    if (a.is_approved !== b.is_approved) return b.is_approved - a.is_approved;
-    const createdDiff = normalizeDateSafe(a.created_at) - normalizeDateSafe(b.created_at);
-    if (createdDiff !== 0) return createdDiff;
-    return a.id.localeCompare(b.id);
-  });
-  return sorted[0] ?? null;
-};
+type IdentityReconcileCandidate = Pick<
+  UserRow,
+  "id" | "is_admin" | "is_moderator" | "is_approved" | "approved_at" | "approved_by_user_id"
+>;
 
 const toUserProfile = (row: UserRow) => ({
   id: row.id,
@@ -628,8 +594,6 @@ const toUserProfile = (row: UserRow) => ({
   email: sanitizeEmail(row.email) ?? "unknown@users.linksim.local",
   bio: row.bio ?? "",
   accessRequestNote: row.access_request_note ?? "",
-  idpEmail: row.idp_email ?? "",
-  idpEmailVerified: row.idp_email_verified === 1,
   avatarUrl: row.avatar_url ?? "",
   emailPublic: row.email_public === 1,
   defaultFrequencyPresetId: row.default_frequency_preset_id,
@@ -679,66 +643,89 @@ const readUserRow = async (env: Env, userId: string): Promise<UserRow | null> =>
     .first<UserRow>();
 };
 
-const reconcileUserIdentityByIdpEmail = async (
+export const reconcileUserIdentityByIdpEmail = async (
   env: Env,
   userId: string,
   idpEmail: string,
+  targetWasExisting = false,
 ): Promise<void> => {
   const normalized = sanitizeEmail(idpEmail);
   if (!normalized) return;
 
   const rows = await env.DB
     .prepare(
-      `SELECT id, username, email, username_set_at, bio, access_request_note, idp_email, idp_email_verified, avatar_url, email_public, default_frequency_preset_id, simulation_defaults_preference_json, avatar_object_key, avatar_thumb_key, avatar_hash, avatar_bytes, avatar_content_type, is_admin, is_moderator, is_approved, approved_at, approved_by_user_id, created_at, updated_at,
-              CASE
-                WHEN lower(idp_email) = lower(?) AND idp_email_verified = 1 THEN 'verified_idp_email'
-                WHEN lower(email) = lower(?) THEN 'legacy_email'
-                ELSE NULL
-              END AS match_kind
+      `SELECT id, is_admin, is_moderator, is_approved, approved_at, approved_by_user_id
        FROM users
        WHERE id <> ?
-         AND (
-           (lower(idp_email) = lower(?) AND idp_email_verified = 1)
-           OR lower(email) = lower(?)
-         )
-       LIMIT 25`,
+         AND lower(idp_email) = lower(?)
+         AND idp_email_verified = 1
+       ORDER BY id ASC
+       LIMIT 3`,
     )
-    .bind(normalized, normalized, userId, normalized, normalized)
+    .bind(userId, normalized)
     .all<IdentityReconcileCandidate>();
-  const existing = chooseIdentityReconcileCandidate(
-    rows.results.filter(
-      (row): row is IdentityReconcileCandidate =>
-        row.match_kind === "verified_idp_email" || row.match_kind === "legacy_email",
-    ),
-  );
+  if (rows.results.length > 1) {
+    const now = new Date().toISOString();
+    await env.DB.prepare(
+      `INSERT INTO user_identity_audit
+       (event_type, target_user_id, source_user_id, actor_user_id, idp_email, details_json, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    )
+      .bind(
+        "verified_idp_email_collision",
+        userId,
+        null,
+        userId,
+        normalized,
+        JSON.stringify({ candidateUserIds: rows.results.map((row) => row.id) }),
+        now,
+      )
+      .run();
+    throw new Error("Verified identity collision. Contact an administrator.");
+  }
+  const existing = rows.results[0] ?? null;
   if (!existing) return;
 
   const now = new Date().toISOString();
-  await env.DB
-    .prepare(
+  const sourceIsRevoked =
+    existing.is_admin !== 1 &&
+    existing.is_moderator !== 1 &&
+    existing.is_approved !== 1 &&
+    Boolean(existing.approved_at || existing.approved_by_user_id);
+  const sourceIsPending =
+    existing.is_admin !== 1 &&
+    existing.is_moderator !== 1 &&
+    existing.is_approved !== 1 &&
+    !sourceIsRevoked;
+  const preserveSourceLifecycle = sourceIsRevoked || (!targetWasExisting && sourceIsPending);
+  await env.DB.batch([
+    env.DB.prepare(
       `UPDATE users
-       SET is_admin = CASE WHEN ? = 1 THEN 1 ELSE is_admin END,
-           is_moderator = CASE WHEN ? = 1 THEN 1 ELSE is_moderator END,
-           is_approved = CASE WHEN ? = 1 THEN 1 ELSE is_approved END,
-           approved_at = CASE WHEN ? = 1 THEN COALESCE(approved_at, ?) ELSE approved_at END,
-           approved_by_user_id = CASE WHEN ? = 1 THEN COALESCE(approved_by_user_id, ?) ELSE approved_by_user_id END,
+       SET is_admin = CASE WHEN ? = 1 THEN 0 WHEN ? = 1 THEN 1 ELSE is_admin END,
+           is_moderator = CASE WHEN ? = 1 THEN 0 WHEN ? = 1 THEN 1 ELSE is_moderator END,
+           is_approved = CASE WHEN ? = 1 THEN 0 WHEN ? = 1 THEN 1 ELSE is_approved END,
+           approved_at = CASE WHEN ? = 1 THEN ? WHEN ? = 1 THEN COALESCE(approved_at, ?) ELSE approved_at END,
+           approved_by_user_id = CASE WHEN ? = 1 THEN ? WHEN ? = 1 THEN COALESCE(approved_by_user_id, ?) ELSE approved_by_user_id END,
            updated_at = ?
        WHERE id = ?`,
-    )
-    .bind(
+    ).bind(
+      preserveSourceLifecycle ? 1 : 0,
       existing.is_admin === 1 ? 1 : 0,
+      preserveSourceLifecycle ? 1 : 0,
       existing.is_moderator === 1 ? 1 : 0,
+      preserveSourceLifecycle ? 1 : 0,
       existing.is_approved === 1 ? 1 : 0,
+      preserveSourceLifecycle ? 1 : 0,
+      existing.approved_at,
       existing.is_approved === 1 ? 1 : 0,
       existing.approved_at ?? now,
+      preserveSourceLifecycle ? 1 : 0,
+      existing.approved_by_user_id,
       existing.is_approved === 1 ? 1 : 0,
       existing.approved_by_user_id ?? existing.id,
       now,
       userId,
-    )
-    .run();
-
-  await env.DB.batch([
+    ),
     env.DB.prepare("UPDATE sites SET owner_user_id = ? WHERE owner_user_id = ?").bind(userId, existing.id),
     env.DB
       .prepare(
@@ -755,18 +742,40 @@ const reconcileUserIdentityByIdpEmail = async (
              last_edited_by_user_id = CASE WHEN last_edited_by_user_id = ? THEN ? ELSE last_edited_by_user_id END`,
       )
       .bind(existing.id, userId, existing.id, userId),
-    env.DB.prepare("UPDATE site_roles SET user_id = ? WHERE user_id = ?").bind(userId, existing.id),
-    env.DB.prepare("UPDATE simulation_roles SET user_id = ? WHERE user_id = ?").bind(userId, existing.id),
+    env.DB
+      .prepare(
+        `INSERT INTO site_roles (site_id, user_id, role, created_at)
+         SELECT site_id, ?, role, created_at FROM site_roles WHERE user_id = ?
+         ON CONFLICT(site_id, user_id) DO UPDATE SET role = CASE
+           WHEN excluded.role = 'admin' OR site_roles.role = 'admin' THEN 'admin'
+           WHEN excluded.role = 'editor' OR site_roles.role = 'editor' THEN 'editor'
+           ELSE 'viewer'
+         END`,
+      )
+      .bind(userId, existing.id),
+    env.DB.prepare("DELETE FROM site_roles WHERE user_id = ?").bind(existing.id),
+    env.DB
+      .prepare(
+        `INSERT INTO simulation_roles (simulation_id, user_id, role, created_at)
+         SELECT simulation_id, ?, role, created_at FROM simulation_roles WHERE user_id = ?
+         ON CONFLICT(simulation_id, user_id) DO UPDATE SET role = CASE
+           WHEN excluded.role = 'admin' OR simulation_roles.role = 'admin' THEN 'admin'
+           WHEN excluded.role = 'editor' OR simulation_roles.role = 'editor' THEN 'editor'
+           ELSE 'viewer'
+         END`,
+      )
+      .bind(userId, existing.id),
+    env.DB.prepare("DELETE FROM simulation_roles WHERE user_id = ?").bind(existing.id),
     env.DB.prepare("UPDATE resource_changes SET actor_user_id = ? WHERE actor_user_id = ?").bind(userId, existing.id),
-  ]);
-
-  await env.DB
-    .prepare(
+    env.DB
+      .prepare("UPDATE simulation_path_leaderboard_entries SET owner_user_id = ? WHERE owner_user_id = ?")
+      .bind(userId, existing.id),
+    env.DB.prepare("UPDATE users SET approved_by_user_id = ? WHERE approved_by_user_id = ?").bind(userId, existing.id),
+    env.DB.prepare(
       `INSERT INTO user_identity_audit
        (event_type, target_user_id, source_user_id, actor_user_id, idp_email, details_json, created_at)
        VALUES (?, ?, ?, ?, ?, ?, ?)`,
-    )
-    .bind(
+    ).bind(
       "reconciled_by_verified_idp_email",
       userId,
       existing.id,
@@ -774,15 +783,46 @@ const reconcileUserIdentityByIdpEmail = async (
       normalized,
       JSON.stringify({
         mergedFromUserId: existing.id,
-        matchKind: existing.match_kind,
+        matchKind: "verified_idp_email",
         mergedFromIsAdmin: existing.is_admin === 1,
         mergedFromIsModerator: existing.is_moderator === 1,
         mergedFromIsApproved: existing.is_approved === 1,
+        mergedFromAccountState: sourceIsRevoked ? "revoked" : sourceIsPending ? "pending" : "approved",
       }),
       now,
-    )
-    .run();
+    ),
+    env.DB.prepare("DELETE FROM users WHERE id = ?").bind(existing.id),
+  ]);
 };
+
+export const assertDeletedUserMayRegister = (deletion: { deleted_at: string } | null): void => {
+  if (deletion?.deleted_at) throw new Error("Session revoked by admin");
+};
+
+export const findDeletionBlock = async (
+  env: Pick<Env, "DB">,
+  userId: string,
+  verifiedIdpEmail: string,
+): Promise<{ deleted_at: string } | null> =>
+  env.DB
+    .prepare(
+      `SELECT d.deleted_at
+       FROM deleted_users d
+       WHERE d.id = ?
+          OR (? <> '' AND EXISTS (
+            SELECT 1 FROM user_identity_audit a
+            WHERE a.event_type = 'user_deleted'
+              AND a.target_user_id = d.id
+              AND lower(a.idp_email) = lower(?)
+          ))
+       ORDER BY d.deleted_at DESC
+       LIMIT 1`,
+    )
+    .bind(userId, verifiedIdpEmail, verifiedIdpEmail)
+    .first<{ deleted_at: string }>();
+
+export const shouldBootstrapAdmin = (userExists: boolean, listedAsAdmin: boolean): boolean =>
+  !userExists && listedAsAdmin;
 
 export const ensureUser = async (
   env: Env,
@@ -790,23 +830,20 @@ export const ensureUser = async (
   tokenPayload?: Record<string, unknown>,
 ): Promise<void> => {
   await ensureSchema(env);
-  const deletion = await env.DB
-    .prepare("SELECT deleted_at FROM deleted_users WHERE id = ? LIMIT 1")
-    .bind(userId)
-    .first<{ deleted_at: string }>();
-  if (deletion?.deleted_at) {
-    const tokenIssuedAtMs = parseTokenIssuedAtMs(tokenPayload);
-    const deletedAtMs = Date.parse(deletion.deleted_at);
-    if (!Number.isFinite(deletedAtMs) || tokenIssuedAtMs === null || tokenIssuedAtMs <= deletedAtMs) {
-      throw new Error("Session revoked by admin");
-    }
-    await env.DB.prepare("DELETE FROM deleted_users WHERE id = ?").bind(userId).run();
-  }
-  const now = new Date().toISOString();
   const email = deriveDefaultEmail(userId, tokenPayload);
   const idpEmail = deriveVerifiedIdpEmail(tokenPayload);
+  const deletion = await findDeletionBlock(env, userId, idpEmail);
+  assertDeletedUserMayRegister(deletion ?? null);
+  const existingUser = await env.DB
+    .prepare("SELECT id FROM users WHERE id = ? LIMIT 1")
+    .bind(userId)
+    .first<{ id: string }>();
+  const now = new Date().toISOString();
   const idpEmailVerified = idpEmail ? 1 : 0;
-  const isBootstrapAdmin = parseAdminUserIds(env).has(userId.toLowerCase()) ? 1 : 0;
+  const isBootstrapAdmin = shouldBootstrapAdmin(
+    Boolean(existingUser?.id),
+    parseAdminUserIds(env).has(userId.toLowerCase()),
+  ) ? 1 : 0;
   const autoApprove = 1;
 
   await env.DB.prepare(
@@ -832,10 +869,8 @@ export const ensureUser = async (
   await env.DB.prepare(
     `UPDATE users
      SET email = COALESCE(NULLIF(TRIM(email), ''), ?),
-         idp_email = CASE WHEN ? = 1 THEN COALESCE(NULLIF(TRIM(idp_email), ''), ?) ELSE idp_email END,
+         idp_email = CASE WHEN ? = 1 THEN ? ELSE idp_email END,
          idp_email_verified = CASE WHEN ? = 1 THEN 1 ELSE idp_email_verified END,
-         is_admin = CASE WHEN ? = 1 THEN 1 ELSE is_admin END,
-         is_moderator = CASE WHEN ? = 1 THEN 1 ELSE is_moderator END,
          is_approved = CASE WHEN ? = 1 AND (approved_by_user_id IS NULL OR approved_by_user_id NOT LIKE 'revoked:%') THEN 1 ELSE is_approved END,
          approved_at = CASE WHEN ? = 1 AND approved_at IS NULL THEN ? ELSE approved_at END,
          approved_by_user_id = CASE WHEN ? = 1 AND approved_by_user_id IS NULL THEN ? ELSE approved_by_user_id END,
@@ -847,8 +882,6 @@ export const ensureUser = async (
       idpEmailVerified,
       idpEmail || null,
       idpEmailVerified,
-      isBootstrapAdmin,
-      0,
       autoApprove,
       autoApprove,
       now,
@@ -860,13 +893,39 @@ export const ensureUser = async (
     .run();
 
   if (idpEmailVerified) {
-    await reconcileUserIdentityByIdpEmail(env, userId, idpEmail);
+    await reconcileUserIdentityByIdpEmail(env, userId, idpEmail, Boolean(existingUser?.id));
   }
 };
 
 export const fetchUserProfile = async (env: Env, userId: string) => {
   const row = await readUserRow(env, userId);
   return row ? toUserProfile(row) : null;
+};
+
+export const fetchUserDiagnosticAccessState = async (env: Pick<Env, "DB">, userId: string) => {
+  const row = await env.DB
+    .prepare(
+      `SELECT is_admin, is_moderator, is_approved, approved_at, approved_by_user_id
+       FROM users WHERE id = ? LIMIT 1`,
+    )
+    .bind(userId)
+    .first<{
+      is_admin: number;
+      is_moderator: number;
+      is_approved: number;
+      approved_at: string | null;
+      approved_by_user_id: string | null;
+    }>();
+  if (!row) return null;
+  const approved = row.is_admin === 1 || row.is_moderator === 1 || row.is_approved === 1;
+  return {
+    isAdmin: row.is_admin === 1,
+    accountState: approved
+      ? ("approved" as const)
+      : row.approved_at || row.approved_by_user_id
+        ? ("revoked" as const)
+        : ("pending" as const),
+  };
 };
 
 export const assertUserAccess = async (env: Env, userId: string) => {
@@ -1031,14 +1090,20 @@ export const getUserAvatarKeys = async (
   };
 };
 
-export const listUsers = async (env: Env) => {
+export const listUsers = async (env: Env, includePrivateEmail = false) => {
   await ensureSchema(env);
   const rows = await env.DB
     .prepare(
       "SELECT id, username, email, username_set_at, bio, access_request_note, idp_email, idp_email_verified, avatar_url, email_public, default_frequency_preset_id, simulation_defaults_preference_json, avatar_object_key, avatar_thumb_key, avatar_hash, avatar_bytes, avatar_content_type, is_admin, is_moderator, is_approved, approved_at, approved_by_user_id, created_at, updated_at FROM users ORDER BY created_at DESC LIMIT 2000",
     )
     .all<UserRow>();
-  return rows.results.map(toUserProfile);
+  return rows.results.map((row) => {
+    const profile = toUserProfile(row);
+    if (includePrivateEmail || profile.emailPublic) return profile;
+    const redacted: Partial<typeof profile> = { ...profile };
+    delete redacted.email;
+    return redacted;
+  });
 };
 
 export const listCollaboratorDirectory = async (env: Env) => {
@@ -1155,6 +1220,11 @@ export const setUserApproval = async (
 export const deleteUser = async (env: Env, userId: string, actorUserId?: string): Promise<void> => {
   await ensureSchema(env);
   const now = new Date().toISOString();
+  const identity = await env.DB
+    .prepare("SELECT idp_email, idp_email_verified FROM users WHERE id = ? LIMIT 1")
+    .bind(userId)
+    .first<{ idp_email: string | null; idp_email_verified: number }>();
+  const verifiedIdpEmail = identity?.idp_email_verified === 1 ? sanitizeEmail(identity.idp_email) : null;
   await env.DB.batch([
     env.DB
       .prepare(
@@ -1163,6 +1233,21 @@ export const deleteUser = async (env: Env, userId: string, actorUserId?: string)
          ON CONFLICT(id) DO UPDATE SET deleted_at = excluded.deleted_at, deleted_by_user_id = excluded.deleted_by_user_id`,
       )
       .bind(userId, now, actorUserId ?? null),
+    env.DB
+      .prepare(
+        `INSERT INTO user_identity_audit
+         (event_type, target_user_id, source_user_id, actor_user_id, idp_email, details_json, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        "user_deleted",
+        userId,
+        null,
+        actorUserId ?? null,
+        verifiedIdpEmail,
+        JSON.stringify({ durableBlock: true, hasVerifiedIdpEmail: Boolean(verifiedIdpEmail) }),
+        now,
+      ),
     env.DB.prepare("DELETE FROM users WHERE id = ?").bind(userId),
   ]);
 };

--- a/functions/_lib/db.ts
+++ b/functions/_lib/db.ts
@@ -587,6 +587,65 @@ type IdentityReconcileCandidate = Pick<
   "id" | "is_admin" | "is_moderator" | "is_approved" | "approved_at" | "approved_by_user_id"
 >;
 
+type SerializedGrantRow = {
+  id: string;
+  payload_json: string;
+};
+
+const rewriteSerializedGrantUserId = (
+  payloadJson: string,
+  sourceUserId: string,
+  targetUserId: string,
+): string | null => {
+  try {
+    const payload = JSON.parse(payloadJson) as CloudResourceRecord;
+    const grants = sanitizeGrants(payload.sharedWith);
+    if (!grants.some((grant) => grant.userId === sourceUserId)) return null;
+
+    const migrated = new Map<string, Grant>();
+    for (const grant of grants) {
+      const userId = grant.userId === sourceUserId ? targetUserId : grant.userId;
+      const current = migrated.get(userId);
+      if (!current || ROLES.indexOf(grant.role) > ROLES.indexOf(current.role)) {
+        migrated.set(userId, { userId, role: grant.role });
+      }
+    }
+    return JSON.stringify({ ...payload, sharedWith: Array.from(migrated.values()) });
+  } catch {
+    return null;
+  }
+};
+
+const prepareSerializedGrantMigrations = async (
+  env: Env,
+  sourceUserId: string,
+  targetUserId: string,
+): Promise<D1PreparedStatement[]> => {
+  const statements: D1PreparedStatement[] = [];
+  for (const table of ["sites", "simulations"] as const) {
+    const rows = await env.DB
+      .prepare(
+        `SELECT id, payload_json
+         FROM ${table}
+         WHERE json_valid(payload_json)
+           AND EXISTS (
+             SELECT 1
+             FROM json_each(payload_json, '$.sharedWith') grant
+             WHERE json_extract(grant.value, '$.userId') = ?
+           )`,
+      )
+      .bind(sourceUserId)
+      .all<SerializedGrantRow>();
+    for (const row of rows.results) {
+      const payloadJson = rewriteSerializedGrantUserId(row.payload_json, sourceUserId, targetUserId);
+      if (payloadJson) {
+        statements.push(env.DB.prepare(`UPDATE ${table} SET payload_json = ? WHERE id = ?`).bind(payloadJson, row.id));
+      }
+    }
+  }
+  return statements;
+};
+
 const toUserProfile = (row: UserRow) => ({
   id: row.id,
   username: sanitizeName(row.username) ?? "",
@@ -698,6 +757,7 @@ export const reconcileUserIdentityByIdpEmail = async (
     existing.is_approved !== 1 &&
     !sourceIsRevoked;
   const preserveSourceLifecycle = sourceIsRevoked || (!targetWasExisting && sourceIsPending);
+  const serializedGrantMigrations = await prepareSerializedGrantMigrations(env, existing.id, userId);
   await env.DB.batch([
     env.DB.prepare(
       `UPDATE users
@@ -766,6 +826,7 @@ export const reconcileUserIdentityByIdpEmail = async (
       )
       .bind(userId, existing.id),
     env.DB.prepare("DELETE FROM simulation_roles WHERE user_id = ?").bind(existing.id),
+    ...serializedGrantMigrations,
     env.DB.prepare("UPDATE resource_changes SET actor_user_id = ? WHERE actor_user_id = ?").bind(userId, existing.id),
     env.DB
       .prepare("UPDATE simulation_path_leaderboard_entries SET owner_user_id = ? WHERE owner_user_id = ?")

--- a/functions/_lib/db.ts
+++ b/functions/_lib/db.ts
@@ -731,9 +731,13 @@ export const reconcileUserIdentityByIdpEmail = async (
   userId: string,
   idpEmail: string,
   targetWasExisting = false,
+  leadingStatements: D1PreparedStatement[] = [],
 ): Promise<void> => {
   const normalized = sanitizeEmail(idpEmail);
-  if (!normalized) return;
+  if (!normalized) {
+    if (leadingStatements.length) await env.DB.batch(leadingStatements);
+    return;
+  }
 
   const rows = await env.DB
     .prepare(
@@ -767,10 +771,33 @@ export const reconcileUserIdentityByIdpEmail = async (
     throw new Error("Verified identity collision. Contact an administrator.");
   }
   const existing = rows.results[0] ?? null;
-  if (!existing) return;
+  if (!existing) {
+    if (leadingStatements.length) {
+      const now = new Date().toISOString();
+      await env.DB.batch([
+        env.DB
+          .prepare(
+            `INSERT INTO deleted_users (id, deleted_at, deleted_by_user_id)
+             SELECT ?1, ?3, 'reconcile-zero-candidate-guard'
+             FROM (SELECT 1 UNION ALL SELECT 2)
+             WHERE EXISTS (
+               SELECT 1
+               FROM users
+               WHERE id <> ?1
+                 AND lower(idp_email) = lower(?2)
+                 AND idp_email_verified = 1
+             )`,
+          )
+          .bind(userId, normalized, now),
+        ...leadingStatements,
+      ]);
+    }
+    return;
+  }
 
   const now = new Date().toISOString();
   await env.DB.batch([
+    ...leadingStatements,
     env.DB
       .prepare(
         `INSERT INTO users (id, created_at)
@@ -971,55 +998,78 @@ export const ensureUser = async (
   ) ? 1 : 0;
   const autoApprove = 1;
 
-  await env.DB.prepare(
-    `INSERT OR IGNORE INTO users
-      (id, username, email, username_set_at, bio, access_request_note, idp_email, idp_email_verified, avatar_url, email_public, avatar_object_key, avatar_thumb_key, avatar_hash, avatar_bytes, avatar_content_type, is_admin, is_moderator, is_approved, approved_at, approved_by_user_id, created_at, updated_at)
-     VALUES (?, '', ?, NULL, '', '', ?, ?, '', 1, NULL, NULL, NULL, NULL, NULL, ?, ?, ?, ?, ?, ?, ?)`,
-  )
-    .bind(
-      userId,
-      email,
-      idpEmail || null,
-      idpEmailVerified,
-      isBootstrapAdmin,
-      0,
-      autoApprove,
-      now,
-      "system:open-registration",
-      now,
-      now,
-    )
-    .run();
+  const ensureStatements = [
+    env.DB
+      .prepare(
+        `INSERT INTO deleted_users (id, deleted_at, deleted_by_user_id)
+         SELECT ?1, ?3, 'ensure-user-guard'
+         FROM (SELECT 1 UNION ALL SELECT 2)
+         WHERE EXISTS (
+           SELECT 1
+           FROM deleted_users d
+           WHERE d.id = ?1
+              OR (?2 <> '' AND EXISTS (
+                SELECT 1 FROM user_identity_audit a
+                WHERE a.event_type = 'user_deleted'
+                  AND a.target_user_id = d.id
+                  AND lower(a.idp_email) = lower(?2)
+              ))
+         )`,
+      )
+      .bind(userId, idpEmail, now),
+    env.DB
+      .prepare(
+        `INSERT OR IGNORE INTO users
+          (id, username, email, username_set_at, bio, access_request_note, idp_email, idp_email_verified, avatar_url, email_public, avatar_object_key, avatar_thumb_key, avatar_hash, avatar_bytes, avatar_content_type, is_admin, is_moderator, is_approved, approved_at, approved_by_user_id, created_at, updated_at)
+         VALUES (?, '', ?, NULL, '', '', ?, ?, '', 1, NULL, NULL, NULL, NULL, NULL, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        userId,
+        email,
+        idpEmail || null,
+        idpEmailVerified,
+        isBootstrapAdmin,
+        0,
+        autoApprove,
+        now,
+        "system:open-registration",
+        now,
+        now,
+      ),
+    env.DB
+      .prepare(
+        `UPDATE users
+         SET email = COALESCE(NULLIF(TRIM(email), ''), ?),
+             idp_email = CASE WHEN ? = 1 THEN ? ELSE idp_email END,
+             idp_email_verified = CASE WHEN ? = 1 THEN 1 ELSE idp_email_verified END,
+             is_approved = CASE WHEN ? = 1 AND (approved_by_user_id IS NULL OR approved_by_user_id NOT LIKE 'revoked:%') THEN 1 ELSE is_approved END,
+             approved_at = CASE WHEN ? = 1 AND approved_at IS NULL THEN ? ELSE approved_at END,
+             approved_by_user_id = CASE WHEN ? = 1 AND approved_by_user_id IS NULL THEN ? ELSE approved_by_user_id END,
+             updated_at = ?
+         WHERE id = ?`,
+      )
+      .bind(
+        email,
+        idpEmailVerified,
+        idpEmail || null,
+        idpEmailVerified,
+        autoApprove,
+        autoApprove,
+        now,
+        autoApprove,
+        "system:open-registration",
+        now,
+        userId,
+      ),
+  ];
 
-  await env.DB.prepare(
-    `UPDATE users
-     SET email = COALESCE(NULLIF(TRIM(email), ''), ?),
-         idp_email = CASE WHEN ? = 1 THEN ? ELSE idp_email END,
-         idp_email_verified = CASE WHEN ? = 1 THEN 1 ELSE idp_email_verified END,
-         is_approved = CASE WHEN ? = 1 AND (approved_by_user_id IS NULL OR approved_by_user_id NOT LIKE 'revoked:%') THEN 1 ELSE is_approved END,
-         approved_at = CASE WHEN ? = 1 AND approved_at IS NULL THEN ? ELSE approved_at END,
-         approved_by_user_id = CASE WHEN ? = 1 AND approved_by_user_id IS NULL THEN ? ELSE approved_by_user_id END,
-         updated_at = ?
-     WHERE id = ?`,
-  )
-    .bind(
-      email,
-      idpEmailVerified,
-      idpEmail || null,
-      idpEmailVerified,
-      autoApprove,
-      autoApprove,
-      now,
-      autoApprove,
-      "system:open-registration",
-      now,
-      userId,
-    )
-    .run();
-
-  if (idpEmailVerified) {
-    await reconcileUserIdentityByIdpEmail(env, userId, idpEmail, Boolean(existingUser?.id));
-  }
+  await reconcileUserIdentityByIdpEmail(
+    env,
+    userId,
+    idpEmail,
+    Boolean(existingUser?.id),
+    ensureStatements,
+  );
 };
 
 export const fetchUserProfile = async (env: Env, userId: string) => {

--- a/functions/_lib/types.ts
+++ b/functions/_lib/types.ts
@@ -47,5 +47,6 @@ export type Env = {
 export type AuthContext = {
   userId: string;
   tokenPayload: Record<string, unknown>;
+  verifiedIdpEmail?: string;
   source?: "jwt" | "headers" | "dev";
 };

--- a/functions/api/auth-diagnostics.test.ts
+++ b/functions/api/auth-diagnostics.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { verifyAuthMock, fetchUserDiagnosticAccessStateMock } = vi.hoisted(() => ({
+  verifyAuthMock: vi.fn(),
+  fetchUserDiagnosticAccessStateMock: vi.fn(),
+}));
+
+vi.mock("../_lib/auth", () => ({ verifyAuth: verifyAuthMock, inspectAuthRequest: vi.fn(() => ({})) }));
+vi.mock("../_lib/db", () => ({ fetchUserDiagnosticAccessState: fetchUserDiagnosticAccessStateMock }));
+
+import { onRequestGet } from "./auth-diagnostics";
+
+const env = { DB: {}, ADMIN_USER_IDS: "configured-admin" } as unknown as Parameters<typeof onRequestGet>[0]["env"];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  verifyAuthMock.mockResolvedValue({ userId: "configured-admin", tokenPayload: {}, source: "jwt" });
+});
+
+describe("auth diagnostics authorization", () => {
+  it("uses current DB role instead of ADMIN_USER_IDS", async () => {
+    fetchUserDiagnosticAccessStateMock.mockResolvedValue({ isAdmin: false, accountState: "approved" });
+    const response = await onRequestGet({ request: new Request("https://example.test/api/auth-diagnostics"), env } as never);
+    expect(response.status).toBe(403);
+  });
+
+  it("denies a revoked configured bootstrap identity", async () => {
+    fetchUserDiagnosticAccessStateMock.mockResolvedValue({ isAdmin: false, accountState: "revoked" });
+    const response = await onRequestGet({ request: new Request("https://example.test/api/auth-diagnostics"), env } as never);
+    expect(response.status).toBe(403);
+  });
+
+  it("returns diagnostics for a current DB admin without strict schema initialization", async () => {
+    fetchUserDiagnosticAccessStateMock.mockResolvedValue({ isAdmin: true, accountState: "approved" });
+    const response = await onRequestGet({ request: new Request("https://example.test/api/auth-diagnostics"), env } as never);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      auth: { userId: "configured-admin", source: "jwt" },
+    });
+  });
+});

--- a/functions/api/auth-diagnostics.ts
+++ b/functions/api/auth-diagnostics.ts
@@ -1,30 +1,18 @@
 import { verifyAuth, inspectAuthRequest } from "../_lib/auth";
-import { ensureUser, fetchUserProfile } from "../_lib/db";
+import { fetchUserDiagnosticAccessState } from "../_lib/db";
 import { errorResponse, handleOptions, json, withCors } from "../_lib/http";
 import type { Env } from "../_lib/types";
 
 export const onRequestOptions: PagesFunction<Env> = async ({ request }) => handleOptions(request);
 
-const isBootstrapAdmin = (env: Env, userId: string): boolean =>
-  (env.ADMIN_USER_IDS ?? "")
-    .split(",")
-    .map((value) => value.trim().toLowerCase())
-    .filter(Boolean)
-    .includes(userId.toLowerCase());
-
 export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
   try {
     const auth = await verifyAuth(request, env);
     if (!auth) return withCors(request, json({ error: "Unauthorized" }, { status: 401 }));
-    let allowed = isBootstrapAdmin(env, auth.userId);
-    try {
-      await ensureUser(env, auth.userId, auth.tokenPayload);
-      const me = await fetchUserProfile(env, auth.userId);
-      if (me?.isAdmin) allowed = true;
-    } catch {
-      // If schema is out of date, allow bootstrap admins to inspect diagnostics.
+    const me = await fetchUserDiagnosticAccessState(env, auth.userId);
+    if (!me?.isAdmin || me.accountState === "revoked") {
+      return withCors(request, json({ error: "Forbidden" }, { status: 403 }));
     }
-    if (!allowed) return withCors(request, json({ error: "Forbidden" }, { status: 403 }));
 
     const claims = auth.tokenPayload;
     return withCors(

--- a/functions/api/avatar-upload.test.ts
+++ b/functions/api/avatar-upload.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { verifyAuthMock, ensureUserMock, fetchUserProfileMock, getUserAvatarKeysMock, setUserAvatarAssetsMock } = vi.hoisted(() => ({
+  verifyAuthMock: vi.fn(), ensureUserMock: vi.fn(), fetchUserProfileMock: vi.fn(),
+  getUserAvatarKeysMock: vi.fn(), setUserAvatarAssetsMock: vi.fn(),
+}));
+vi.mock("../_lib/auth", () => ({ verifyAuth: verifyAuthMock }));
+vi.mock("../_lib/db", () => ({
+  ensureUser: ensureUserMock, fetchUserProfile: fetchUserProfileMock,
+  getUserAvatarKeys: getUserAvatarKeysMock, setUserAvatarAssets: setUserAvatarAssetsMock,
+}));
+
+import { onRequestPost } from "./avatar-upload";
+
+describe("avatar upload privacy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    verifyAuthMock.mockResolvedValue({ userId: "hidden@example.com", tokenPayload: {}, source: "headers" });
+    fetchUserProfileMock.mockResolvedValue({ id: "hidden@example.com" });
+    getUserAvatarKeysMock.mockResolvedValue({ avatarObjectKey: null, avatarThumbKey: null });
+    setUserAvatarAssetsMock.mockImplementation(async (_env, _id, avatar) => ({ id: "hidden@example.com", ...avatar }));
+  });
+
+  it("uses opaque keys and URLs that do not disclose an email-shaped user ID", async () => {
+    const puts: string[] = [];
+    const env = {
+      DB: {},
+      AVATAR_BUCKET: { put: vi.fn(async (key: string) => { puts.push(key); }), delete: vi.fn() },
+    } as unknown as Parameters<typeof onRequestPost>[0]["env"];
+    const image = `data:image/png;base64,${btoa("png")}`;
+    const response = await onRequestPost({
+      request: new Request("https://example.test/api/avatar-upload", {
+        method: "POST", headers: { "content-type": "application/json" },
+        body: JSON.stringify({ originalDataUrl: image, thumbDataUrl: image }),
+      }),
+      env,
+    } as never);
+
+    expect(response.status).toBe(200);
+    expect(puts).toHaveLength(2);
+    expect(puts.join(" ")).not.toContain("hidden@example.com");
+    expect(JSON.stringify(await response.json())).not.toContain("hidden%40example.com");
+  });
+});

--- a/functions/api/avatar-upload.ts
+++ b/functions/api/avatar-upload.ts
@@ -62,11 +62,11 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
 
     const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", original.bytes));
     const hash = toHex(digest);
-    const stamp = Date.now();
+    const opaqueKey = crypto.randomUUID();
     const ext = extForType(original.contentType);
     const thumbExt = extForType(thumb.contentType);
-    const objectKey = `users/${auth.userId}/avatar-${stamp}-${hash.slice(0, 16)}.${ext}`;
-    const thumbKey = `users/${auth.userId}/avatar-${stamp}-${hash.slice(0, 16)}-thumb.${thumbExt}`;
+    const objectKey = `users/${opaqueKey}/avatar-${hash.slice(0, 16)}.${ext}`;
+    const thumbKey = `users/${opaqueKey}/avatar-${hash.slice(0, 16)}-thumb.${thumbExt}`;
 
     await env.AVATAR_BUCKET.put(objectKey, original.bytes, {
       httpMetadata: { contentType: original.contentType, cacheControl: "public, max-age=31536000, immutable" },

--- a/functions/api/me.test.ts
+++ b/functions/api/me.test.ts
@@ -43,6 +43,17 @@ describe("api/me", () => {
     await expect(res.json()).resolves.toEqual({ user: { id: "u1", username: "", needsUsername: true } });
   });
 
+  it("omits internal IdP identity evidence from the ordinary profile response", async () => {
+    fetchUserProfileMock.mockResolvedValueOnce({
+      id: "u1", username: "User", email: "private@example.com",
+      idpEmail: "private@example.com", idpEmailVerified: true,
+    });
+    const res = await onRequestGet(mkCtx(new Request("https://example.test/api/me")));
+    const body = await res.json();
+    expect(body.user.idpEmail).toBeUndefined();
+    expect(body.user.idpEmailVerified).toBeUndefined();
+  });
+
   it("returns a controlled service unavailable response when auth verification times out", async () => {
     verifyAuthMock.mockRejectedValue(new Error("Auth verification timed out"));
     const res = await onRequestGet(mkCtx(new Request("https://example.test/api/me")));

--- a/functions/api/me.ts
+++ b/functions/api/me.ts
@@ -6,6 +6,12 @@ import type { Env } from "../_lib/types";
 export const onRequestOptions: PagesFunction<Env> = async ({ request }) => handleOptions(request);
 
 const NO_STORE_HEADERS = { "cache-control": "no-store" };
+const withoutInternalIdentity = <T extends Record<string, unknown>>(profile: T): Omit<T, "idpEmail" | "idpEmailVerified"> => {
+  const ordinaryProfile = { ...profile };
+  delete ordinaryProfile.idpEmail;
+  delete ordinaryProfile.idpEmailVerified;
+  return ordinaryProfile;
+};
 
 export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
   try {
@@ -22,7 +28,7 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
       request,
       json(
         {
-          user: profile,
+          user: withoutInternalIdentity(profile),
         },
         { headers: NO_STORE_HEADERS },
       ),
@@ -50,7 +56,7 @@ export const onRequestPatch: PagesFunction<Env> = async ({ request, env }) => {
       simulationDefaultsPreference?: unknown;
     };
     const user = await updateUserProfile(env, auth.userId, body);
-    return withCors(request, json({ user }, { headers: NO_STORE_HEADERS }));
+    return withCors(request, json({ user: withoutInternalIdentity(user) }, { headers: NO_STORE_HEADERS }));
   } catch (error) {
     return errorResponse(request, error, 500);
   }

--- a/functions/api/schema-diagnostics.test.ts
+++ b/functions/api/schema-diagnostics.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { verifyAuthMock, fetchUserDiagnosticAccessStateMock, getSchemaDiagnosticsMock } = vi.hoisted(() => ({
+  verifyAuthMock: vi.fn(), fetchUserDiagnosticAccessStateMock: vi.fn(), getSchemaDiagnosticsMock: vi.fn(),
+}));
+vi.mock("../_lib/auth", () => ({ verifyAuth: verifyAuthMock }));
+vi.mock("../_lib/db", () => ({
+  fetchUserDiagnosticAccessState: fetchUserDiagnosticAccessStateMock,
+  getSchemaDiagnostics: getSchemaDiagnosticsMock,
+}));
+
+import { onRequestGet } from "./schema-diagnostics";
+
+const env = { DB: {}, ADMIN_USER_IDS: "configured-admin" } as unknown as Parameters<typeof onRequestGet>[0]["env"];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  verifyAuthMock.mockResolvedValue({ userId: "configured-admin", tokenPayload: {}, source: "jwt" });
+  getSchemaDiagnosticsMock.mockResolvedValue({ ok: true, version: "test", missing: [] });
+});
+
+describe("schema diagnostics authorization", () => {
+  it("denies a configured identity that is no longer a DB admin", async () => {
+    fetchUserDiagnosticAccessStateMock.mockResolvedValue({ isAdmin: false, accountState: "approved" });
+    const response = await onRequestGet({ request: new Request("https://example.test/api/schema-diagnostics"), env } as never);
+    expect(response.status).toBe(403);
+    expect(getSchemaDiagnosticsMock).not.toHaveBeenCalled();
+  });
+
+  it("allows a current, non-revoked DB admin", async () => {
+    fetchUserDiagnosticAccessStateMock.mockResolvedValue({ isAdmin: true, accountState: "approved" });
+    const response = await onRequestGet({ request: new Request("https://example.test/api/schema-diagnostics"), env } as never);
+    expect(response.status).toBe(200);
+  });
+
+  it("returns structured missing-schema diagnostics without running ensureUser", async () => {
+    fetchUserDiagnosticAccessStateMock.mockResolvedValue({ isAdmin: true, accountState: "approved" });
+    getSchemaDiagnosticsMock.mockResolvedValue({
+      ok: false, version: "test", missing: [{ table: "users", columns: ["new_column"] }],
+    });
+    const response = await onRequestGet({ request: new Request("https://example.test/api/schema-diagnostics"), env } as never);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      schema: { ok: false, version: "test", missing: [{ table: "users", columns: ["new_column"] }] },
+    });
+  });
+});

--- a/functions/api/schema-diagnostics.ts
+++ b/functions/api/schema-diagnostics.ts
@@ -1,31 +1,19 @@
 import { verifyAuth } from "../_lib/auth";
-import { ensureUser, fetchUserProfile, getSchemaDiagnostics } from "../_lib/db";
+import { fetchUserDiagnosticAccessState, getSchemaDiagnostics } from "../_lib/db";
 import { errorResponse, handleOptions, json, withCors } from "../_lib/http";
 import type { Env } from "../_lib/types";
 
 export const onRequestOptions: PagesFunction<Env> = async ({ request }) => handleOptions(request);
-
-const isBootstrapAdmin = (env: Env, userId: string): boolean =>
-  (env.ADMIN_USER_IDS ?? "")
-    .split(",")
-    .map((value) => value.trim().toLowerCase())
-    .filter(Boolean)
-    .includes(userId.toLowerCase());
 
 export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
   try {
     const auth = await verifyAuth(request, env);
     if (!auth) return withCors(request, json({ error: "Unauthorized" }, { status: 401 }));
 
-    let allowed = isBootstrapAdmin(env, auth.userId);
-    try {
-      await ensureUser(env, auth.userId, auth.tokenPayload);
-      const me = await fetchUserProfile(env, auth.userId);
-      if (me?.isAdmin) allowed = true;
-    } catch {
-      // If schema is out of date, allow bootstrap admins to inspect diagnostics.
+    const me = await fetchUserDiagnosticAccessState(env, auth.userId);
+    if (!me?.isAdmin || me.accountState === "revoked") {
+      return withCors(request, json({ error: "Forbidden" }, { status: 403 }));
     }
-    if (!allowed) return withCors(request, json({ error: "Forbidden" }, { status: 403 }));
 
     const diagnostics = await getSchemaDiagnostics(env);
     return withCors(request, json({ schema: diagnostics }));

--- a/functions/api/users.test.ts
+++ b/functions/api/users.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { verifyAuthMock, ensureUserMock, assertUserAccessMock, fetchUserProfileMock, listUsersMock } = vi.hoisted(() => ({
+  verifyAuthMock: vi.fn(), ensureUserMock: vi.fn(), assertUserAccessMock: vi.fn(),
+  fetchUserProfileMock: vi.fn(), listUsersMock: vi.fn(),
+}));
+vi.mock("../_lib/auth", () => ({ verifyAuth: verifyAuthMock }));
+vi.mock("../_lib/db", () => ({
+  ensureUser: ensureUserMock, assertUserAccess: assertUserAccessMock,
+  fetchUserProfile: fetchUserProfileMock, listUsers: listUsersMock,
+}));
+
+import { onRequestGet } from "./users";
+
+const env = { DB: {} } as unknown as Parameters<typeof onRequestGet>[0]["env"];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  verifyAuthMock.mockResolvedValue({ userId: "moderator", tokenPayload: {}, source: "jwt" });
+  ensureUserMock.mockResolvedValue(undefined);
+  assertUserAccessMock.mockResolvedValue(undefined);
+  listUsersMock.mockResolvedValue([]);
+});
+
+describe("users directory email privacy", () => {
+  it("does not request hidden email for moderators", async () => {
+    fetchUserProfileMock.mockResolvedValue({ id: "moderator", isAdmin: false, isModerator: true });
+    const response = await onRequestGet({ request: new Request("https://example.test/api/users"), env } as never);
+    expect(response.status).toBe(200);
+    expect(listUsersMock).toHaveBeenCalledWith(env, false);
+  });
+
+  it("allows administrators to receive hidden email", async () => {
+    fetchUserProfileMock.mockResolvedValue({ id: "admin", isAdmin: true, isModerator: false });
+    const response = await onRequestGet({ request: new Request("https://example.test/api/users"), env } as never);
+    expect(response.status).toBe(200);
+    expect(listUsersMock).toHaveBeenCalledWith(env, true);
+  });
+});

--- a/functions/api/users.ts
+++ b/functions/api/users.ts
@@ -17,7 +17,7 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
     if (!me) return withCors(request, json({ error: "Unauthorized" }, { status: 401 }));
     if (!canListUsers(me)) return withCors(request, json({ error: "Forbidden" }, { status: 403 }));
 
-    const users = await listUsers(env);
+    const users = await listUsers(env, me.isAdmin);
     return withCors(request, json({ users }));
   } catch (error) {
     return errorResponse(request, error, 500);

--- a/functions/api/users/[id].ts
+++ b/functions/api/users/[id].ts
@@ -34,7 +34,7 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env, params })
     const user = await fetchUserProfile(env, targetId);
     if (!user) return withCors(request, json({ error: "User not found" }, { status: 404 }));
 
-    if (!me.isAdmin && !("isModerator" in me && Boolean((me as { isModerator?: boolean }).isModerator)) && me.id !== targetId) {
+    if (!me.isAdmin && me.id !== targetId) {
       const canSeeEmail = user.emailPublic;
       return withCors(
         request,

--- a/src/lib/cloudUser.ts
+++ b/src/lib/cloudUser.ts
@@ -7,8 +7,6 @@ export type CloudUser = {
   email?: string;
   bio: string;
   accessRequestNote?: string;
-  idpEmail?: string;
-  idpEmailVerified?: boolean;
   avatarUrl: string;
   emailPublic?: boolean;
   defaultFrequencyPresetId?: string | null;


### PR DESCRIPTION
## What changed

- require verified Cloudflare Access JWT email evidence for identity reconciliation; editable profile email, header-only auth, and dev auth cannot transfer identity
- make verified identity transfers atomic and auditable across lifecycle state, ownership, strongest collaborator grants, resource history, and leaderboard ownership
- fail closed on verified identity collisions and preserve revoked or first-migration pending state
- make deletion a durable subject-and-verified-identity block until explicit administrator restore
- treat `ADMIN_USER_IDS` as creation-time bootstrap only and authorize both diagnostics endpoints from current persisted role/revocation state
- generate opaque avatar keys and remove internal IdP evidence/private email from ordinary profile/directory responses
- document the account lifecycle policy

## Why this change

Profile email previously participated in reconciliation, request-time bootstrap configuration could undo durable demotion, newer sessions could clear deletion tombstones, diagnostics could bypass or depend on strict schema state, and generated avatar paths could expose an email-shaped user ID.

Closes #1050 after shared-staging verification and maintainer sign-off.

## TDD Checklist

- [x] I started with failing automated tests that captured the intended behavior.
- [x] I implemented only the minimum code needed to make the tests pass.
- [x] I refactored with tests still green.
- [x] I ran `npm test` and `npm run build` locally.

## Issue + branch hygiene

- [x] Branch `issue/1050-harden-identity-lifecycle` was created from current `origin/staging`.
- [x] This PR references a single primary issue.
- [x] Issue #1050 moved from `pending-discussion` to `in-progress`; `in-staging` remains merge/deploy-gated.

## Verification

- [x] SQLite-backed identity/lifecycle tests cover atomic transfer and rollback, collision, revocation/pending migration, mutable-email isolation, and cross-subject deletion/restore
- [x] Diagnostics, avatar, profile, and directory API regression tests
- [x] `npm test`: 153 files, 949 tests passed on `47904d45c50eb5dcd4999764f439b25e7cd66a93`
- [x] `npm run build`
- [x] `npm run test -- --run src/lib/deepLink.test.ts`: 35 tests passed
- [x] `npm run test -- --run functions/api/v1/calculate.test.ts`: 9 tests passed
- [x] `npm run test -- --run src/store/appStore.test.ts`: 32 tests passed
- [x] Scoped ESLint passed for every changed TypeScript file
- [x] `npm run dev:check`: no LinkSim dev/watch servers found
- [x] `git diff --check`

## Independent pre-PR review

- Reviewed base: `4b108ec4bd47ed804bbd66395137987ee9e943a6`
- Reviewed head: `47904d45c50eb5dcd4999764f439b25e7cd66a93`
- Verdict: `pass`, with no findings
- Earlier blocked candidates were corrected and fully revalidated before this exact-SHA review
- Residual risk: no live D1, Access-JWT, browser, shared-staging, or production verification; deletion coverage uses SQLite-backed audit lookup rather than a deployed end-to-end flow

## Delivery boundaries

- Documentation updated for the lifecycle policy
- No UI or D1 schema addition
- No SemVer change: `staging` already carries the intentional `0.27.0` development line
- No merge, staging deployment, live user migration, browser test, native Codex review request, or production promotion included

— Forge · AI coding agent
<!-- linksim-ai:v1 agent=Forge bot=true run=b290fa71-574f-449b-8dd1-b86c33ce53c5 source=issue-1050-pull-request commit=47904d45c50eb5dcd4999764f439b25e7cd66a93 -->
