### PR TITLE
Validate production release before D1 migrations

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -229,6 +229,12 @@ jobs:
         working-directory: ${{ runner.temp }}/linksim-release
         run: npm ci
 
+      - name: Validate release gate
+        working-directory: ${{ runner.temp }}/linksim-release
+        env:
+          PRODUCTION_PREVIOUS_REF: ${{ github.event.before }}
+        run: node scripts/validate-prod-release.mjs
+
       - name: Apply production Simulation lifecycle migration
         working-directory: ${{ runner.temp }}/linksim-release
         env:
@@ -251,12 +257,6 @@ jobs:
             npx wrangler d1 execute linksim --remote --file db/migrations/2026-08-12_identity_lifecycle.sql --yes
           fi
           node scripts/verify-identity-lifecycle-d1.mjs linksim post
-
-      - name: Validate release gate
-        working-directory: ${{ runner.temp }}/linksim-release
-        env:
-          PRODUCTION_PREVIOUS_REF: ${{ github.event.before }}
-        run: node scripts/validate-prod-release.mjs
 
       - name: Deploy prod/main with guardrails
         working-directory: ${{ runner.temp }}/linksim-release

--- a/functions/_lib/deployPagesWorkflow.test.ts
+++ b/functions/_lib/deployPagesWorkflow.test.ts
@@ -65,6 +65,25 @@ describe("Deploy LinkSim Pages workflow", () => {
     );
   });
 
+  it("validates the release before any production D1 migration", () => {
+    const releaseGateStep = "- name: Validate release gate";
+    const simulationMigrationStep =
+      "- name: Apply production Simulation lifecycle migration";
+    const identityMigrationStep =
+      "- name: Verify identity lifecycle migration prerequisites and apply migration";
+
+    expect(productionJob).toContain(releaseGateStep);
+    expect(productionJob.indexOf(releaseGateStep)).toBeLessThan(
+      productionJob.indexOf(simulationMigrationStep),
+    );
+    expect(productionJob.indexOf(releaseGateStep)).toBeLessThan(
+      productionJob.indexOf(identityMigrationStep),
+    );
+    expect(productionJob.slice(0, productionJob.indexOf(releaseGateStep))).not.toContain(
+      "npx wrangler d1 execute linksim --remote",
+    );
+  });
+
   it("probes, applies, and verifies identity lifecycle schema before staging and production deploys", () => {
     for (const [job, database] of [[stagingJob, "linksim_staging"], [productionJob, "linksim"]] as const) {
       expect(job).toContain("Verify identity lifecycle migration prerequisites");


### PR DESCRIPTION
## Summary

- move the production SemVer release gate ahead of both remote D1 migration steps
- preserve the existing tagged-release worktree and migration/deploy ordering
- add a regression requiring no production D1 command before release validation

## Review finding

Addresses the post-merge P1 on #1060: a release rejected by `validate-prod-release.mjs` must not mutate production D1 first.

## Validation

- `npm run test -- --run functions/_lib/deployPagesWorkflow.test.ts` (7/7)
- `npm test` (157 files, 976 tests)
- `npm run build`
- `git diff --check`
- `npm run dev:check` (no LinkSim dev/watch servers)
- independent exact-head pre-PR review: PASS, no findings

Refs #1050

No production promotion or deployment is included.

— Forge · AI coding agent
<!-- linksim-ai:v1 agent=Forge bot=true run=9cf69de0-e640-4870-80ed-5d3fe8f56c12 source=pull-request:1061 commit=b9e3e2f08e606440e5ce997e120580a8bd013b84 -->
