### PR TITLE
Harden credentialed CORS and Access request boundaries

### DIFF
--- a/docs/cloudflare-auth-setup.md
+++ b/docs/cloudflare-auth-setup.md
@@ -103,6 +103,23 @@ restoration, so reauthentication cannot undo a durable demotion.
 
 Do not enable local dev fallback vars in production or shared preview deployments.
 
+### Browser origin policy
+
+LinkSim's Functions API permits credentialed browser requests only from the
+request's own origin. This covers `https://linksim.link`,
+`https://staging.linksim.link`, and each authenticated
+`https://<preview>.linksim-staging.pages.dev` deployment without allowing one
+environment to call another. Local development has one explicit cross-origin
+exception: the Vite app at `http://localhost:5174` may call the edge API at
+`http://127.0.0.1:8788`.
+
+Requests with another browser `Origin` (including `null`) are rejected before
+API handlers run, even when they carry a `CF_Authorization` cookie. Requests
+without `Origin`, such as curl and server-to-server API clients, remain allowed
+but receive no CORS authorization headers. This application boundary complements
+Access; it does not replace the configured issuer, audience, and signature
+verification or authorize changes to Access applications.
+
 ## 6) D1 Binding in Pages
 
 Pages project → Settings → Functions → D1 bindings:

--- a/docs/repository-guide.md
+++ b/docs/repository-guide.md
@@ -48,7 +48,7 @@ Start the Vite development server for normal frontend work:
 npm run dev
 ```
 
-Vite reports the local URL, normally `http://localhost:5173`.
+Vite serves the local app at the fixed URL `http://localhost:5174`.
 
 Use the local edge stack when Pages Functions, D1, or R2 behavior is part of the change:
 

--- a/docs/staging-environment.md
+++ b/docs/staging-environment.md
@@ -90,3 +90,9 @@ Run the refresh scripts only when explicitly needed, then merge a staging PR and
 | Staging (test) | https://staging.linksim.link | Public shell; Access on `/api/*` |
 | Pull request preview | Signed PR comment URL | Access-protected after rollout gate |
 | Production | https://linksim.link | ✅ Works with Access |
+
+Credentialed browser API requests are same-origin only. Each pull-request
+preview uses its own `https://<preview>.linksim-staging.pages.dev` API; it does
+not call the shared-staging API cross-origin. Originless API clients remain
+supported, while production, staging, and preview browser origins cannot call
+one another.

--- a/functions/_lib/http.test.ts
+++ b/functions/_lib/http.test.ts
@@ -1,5 +1,91 @@
 import { describe, expect, it } from "vitest";
-import { normalizeApiErrorMessage, statusFromErrorMessage } from "./http";
+import {
+  corsHeaders,
+  corsRejectionResponse,
+  getCorsOriginDecision,
+  handleOptions,
+  normalizeApiErrorMessage,
+  statusFromErrorMessage,
+  withCors,
+} from "./http";
+
+describe("credentialed CORS policy", () => {
+  it.each([
+    ["https://linksim.link/api/me", "https://linksim.link"],
+    ["https://staging.linksim.link/api/me", "https://staging.linksim.link"],
+    ["https://6ed2da50.linksim-staging.pages.dev/api/me", "https://6ed2da50.linksim-staging.pages.dev"],
+    ["http://localhost:8788/api/me", "http://localhost:8788"],
+    ["http://127.0.0.1:8788/api/me", "http://127.0.0.1:8788"],
+    ["http://127.0.0.1:8788/api/me", "http://localhost:5174"],
+  ])("allows %s from %s", (url, origin) => {
+    expect(getCorsOriginDecision(new Request(url, { headers: { origin } }))).toBe("allowed");
+  });
+
+  it.each([
+    ["https://linksim.link/api/me", "https://staging.linksim.link"],
+    ["https://staging.linksim.link/api/me", "https://linksim.link"],
+    ["https://staging.linksim.link/api/me", "https://6ed2da50.linksim-staging.pages.dev"],
+    ["https://6ed2da50.linksim-staging.pages.dev/api/me", "https://staging.linksim.link"],
+    ["https://linksim.link/api/me", "https://linksim.pages.dev"],
+    ["http://127.0.0.1:8788/api/me", "http://localhost:5173"],
+    ["http://127.0.0.1:8788/api/me", "http://localhost:5175"],
+    ["http://localhost:8788/api/me", "http://localhost:5174"],
+    ["https://linksim.link/api/me", "null"],
+    ["https://linksim.link/api/me", "not a URL"],
+    ["https://linksim.link/api/me", "https://linksim.link/path"],
+  ])("rejects %s from %s", (url, origin) => {
+    expect(getCorsOriginDecision(new Request(url, { headers: { origin } }))).toBe("denied");
+  });
+
+  it("allows an originless request without adding credentialed CORS headers", () => {
+    const request = new Request("https://linksim.link/api/v1/calculate");
+    expect(getCorsOriginDecision(request)).toBe("originless");
+    const headers = corsHeaders(request);
+    expect(headers.get("access-control-allow-origin")).toBeNull();
+    expect(headers.get("access-control-allow-credentials")).toBeNull();
+    expect(headers.get("vary")).toBe("Origin");
+  });
+
+  it("adds the exact approved origin and credentialed CORS contract", () => {
+    const request = new Request("https://staging.linksim.link/api/me", {
+      headers: { origin: "https://staging.linksim.link" },
+    });
+    const response = withCors(request, new Response("ok", { headers: { "cache-control": "no-store" } }));
+    expect(response.headers.get("access-control-allow-origin")).toBe("https://staging.linksim.link");
+    expect(response.headers.get("access-control-allow-credentials")).toBe("true");
+    expect(response.headers.get("access-control-allow-headers")).toBe("Authorization, Content-Type");
+    expect(response.headers.get("access-control-allow-methods")).toBe("GET, POST, PUT, PATCH, DELETE, OPTIONS");
+    expect(response.headers.get("vary")).toBe("Origin");
+    expect(response.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it.each(["GET", "POST", "PUT", "PATCH", "DELETE"])(
+    "accepts an approved %s preflight",
+    (method) => {
+      const response = handleOptions(new Request("https://linksim.link/api/me", {
+        method: "OPTIONS",
+        headers: {
+          origin: "https://linksim.link",
+          "access-control-request-method": method,
+        },
+      }));
+      expect(response.status).toBe(204);
+      expect(response.headers.get("access-control-allow-origin")).toBe("https://linksim.link");
+    },
+  );
+
+  it("rejects a disallowed preflight without credentialed CORS headers", () => {
+    const request = new Request("https://linksim.link/api/me", {
+      method: "OPTIONS",
+      headers: { origin: "https://attacker.example", "access-control-request-method": "DELETE" },
+    });
+    const response = handleOptions(request);
+    expect(response.status).toBe(403);
+    expect(response.headers.get("access-control-allow-origin")).toBeNull();
+    expect(response.headers.get("access-control-allow-credentials")).toBeNull();
+    expect(corsRejectionResponse(request)?.status).toBe(403);
+  });
+});
 
 describe("http error normalization", () => {
   it("maps known auth/access errors to stable statuses", () => {

--- a/functions/_lib/http.ts
+++ b/functions/_lib/http.ts
@@ -9,15 +9,54 @@ export const json = (body: unknown, init?: ResponseInit): Response => {
   });
 };
 
+export type CorsOriginDecision = "allowed" | "originless" | "denied";
+
+const LOCAL_VITE_ORIGIN = "http://localhost:5174";
+const LOCAL_EDGE_ORIGIN = "http://127.0.0.1:8788";
+
+const normalizeBrowserOrigin = (raw: string): string | null => {
+  if (!raw || raw === "null") return null;
+  try {
+    const parsed = new URL(raw);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+    if (parsed.username || parsed.password || parsed.pathname !== "/" || parsed.search || parsed.hash) return null;
+    return parsed.origin;
+  } catch {
+    return null;
+  }
+};
+
+export const getCorsOriginDecision = (request: Request): CorsOriginDecision => {
+  const rawOrigin = request.headers.get("origin");
+  if (rawOrigin === null) return "originless";
+
+  const origin = normalizeBrowserOrigin(rawOrigin);
+  if (!origin) return "denied";
+
+  const requestOrigin = new URL(request.url).origin;
+  if (origin === requestOrigin) return "allowed";
+  if (origin === LOCAL_VITE_ORIGIN && requestOrigin === LOCAL_EDGE_ORIGIN) return "allowed";
+  return "denied";
+};
+
 export const corsHeaders = (request: Request): Headers => {
-  const origin = request.headers.get("origin") ?? "*";
   const headers = new Headers();
-  headers.set("Access-Control-Allow-Origin", origin);
   headers.set("Vary", "Origin");
-  headers.set("Access-Control-Allow-Credentials", "true");
-  headers.set("Access-Control-Allow-Headers", "Authorization, Content-Type");
-  headers.set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS");
+  if (getCorsOriginDecision(request) === "allowed") {
+    headers.set("Access-Control-Allow-Origin", normalizeBrowserOrigin(request.headers.get("origin")!)!);
+    headers.set("Access-Control-Allow-Credentials", "true");
+    headers.set("Access-Control-Allow-Headers", "Authorization, Content-Type");
+    headers.set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS");
+  }
   return headers;
+};
+
+export const corsRejectionResponse = (request: Request): Response | null => {
+  if (getCorsOriginDecision(request) !== "denied") return null;
+  return json(
+    { error: "Forbidden." },
+    { status: 403, headers: corsHeaders(request) },
+  );
 };
 
 export const withCors = (request: Request, response: Response): Response => {
@@ -31,11 +70,14 @@ export const withCors = (request: Request, response: Response): Response => {
   });
 };
 
-export const handleOptions = (request: Request): Response =>
-  new Response(null, {
+export const handleOptions = (request: Request): Response => {
+  const rejected = corsRejectionResponse(request);
+  if (rejected) return rejected;
+  return new Response(null, {
     status: 204,
     headers: corsHeaders(request),
   });
+};
 
 const isRevokedAuthMessage = (message: string): boolean => {
   const lower = message.toLowerCase();

--- a/functions/_middleware.test.ts
+++ b/functions/_middleware.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import { onRequest } from "./_middleware";
 
-const invoke = async (url: string) => {
+const invoke = async (url: string, init?: RequestInit) => {
   const next = vi.fn(async () => new Response("app", { status: 200 }));
-  const response = await onRequest({ request: new Request(url), next });
+  const response = await onRequest({ request: new Request(url, init), next });
   return { response, next };
 };
 
@@ -24,6 +24,57 @@ describe("canonical Pages host middleware", () => {
     "https://6ed2da50.linksim-staging.pages.dev/",
   ])("passes canonical and immutable preview hosts through: %s", async (url) => {
     const { response, next } = await invoke(url);
+    expect(response.status).toBe(200);
+    expect(next).toHaveBeenCalledOnce();
+  });
+});
+
+describe("API origin boundary", () => {
+  it.each([
+    ["PATCH", "administrator role mutation", "https://linksim.link/api/users/user-1"],
+    ["DELETE", "user deletion", "https://linksim.link/api/users/user-1"],
+    ["POST", "ownership reassignment", "https://linksim.link/api/admin-ownership-tools"],
+    ["PUT", "Library write", "https://linksim.link/api/library"],
+    ["DELETE", "Library deletion", "https://linksim.link/api/library/simulations/sim-1"],
+    ["POST", "change revert", "https://linksim.link/api/changes"],
+  ])("rejects cross-origin %s before the %s handler", async (method, _behavior, url) => {
+    const { response, next } = await invoke(url, {
+      method,
+      headers: {
+        origin: "https://attacker.example",
+        cookie: "CF_Authorization=stolen-browser-cookie",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ action: "mutation" }),
+    });
+
+    expect(response.status).toBe(403);
+    expect(response.headers.get("access-control-allow-origin")).toBeNull();
+    expect(response.headers.get("access-control-allow-credentials")).toBeNull();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("allows a same-origin guest public Simulation read", async () => {
+    const { response, next } = await invoke(
+      "https://staging.linksim.link/api/public-simulation?sim=sim-1",
+      { headers: { origin: "https://staging.linksim.link" } },
+    );
+    expect(response.status).toBe(200);
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it("allows an originless guest deep-link read", async () => {
+    const { response, next } = await invoke(
+      "https://linksim.link/api/deep-link-status?sim=sim-1",
+    );
+    expect(response.status).toBe(200);
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it("does not apply the API boundary to app routes", async () => {
+    const { response, next } = await invoke("https://linksim.link/Owner/Simulation", {
+      headers: { origin: "https://attacker.example" },
+    });
     expect(response.status).toBe(200);
     expect(next).toHaveBeenCalledOnce();
   });

--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -1,3 +1,5 @@
+import { corsRejectionResponse } from "./_lib/http";
+
 const CANONICAL_HOSTS: Readonly<Record<string, string>> = {
   "linksim-staging.pages.dev": "staging.linksim.link",
   "linksim.pages.dev": "linksim.link",
@@ -5,6 +7,11 @@ const CANONICAL_HOSTS: Readonly<Record<string, string>> = {
 
 export const onRequest: PagesFunction = async ({ request, next }) => {
   const url = new URL(request.url);
+  if (url.pathname === "/api" || url.pathname.startsWith("/api/")) {
+    const corsRejection = corsRejectionResponse(request);
+    if (corsRejection) return corsRejection;
+  }
+
   const canonicalHost = CANONICAL_HOSTS[url.hostname.toLowerCase()];
   if (!canonicalHost) return next();
 

--- a/functions/api/deep-link-status.test.ts
+++ b/functions/api/deep-link-status.test.ts
@@ -41,6 +41,8 @@ describe("api/deep-link-status", () => {
     verifyAuthMock.mockResolvedValueOnce(null);
     const res = await onRequestGet(mkCtx(new Request("https://example.test/api/deep-link-status?sim=sim-1")));
     expect(res.status).toBe(200);
+    expect(res.headers.get("access-control-allow-origin")).toBeNull();
+    expect(res.headers.get("access-control-allow-credentials")).toBeNull();
     await expect(res.json()).resolves.toEqual({
       status: "ok",
       simulationId: "sim-1",

--- a/functions/api/public-simulation.test.ts
+++ b/functions/api/public-simulation.test.ts
@@ -111,7 +111,12 @@ describe("api/public-simulation", () => {
 
   it("passes an anonymous actor when request is unauthenticated", async () => {
     verifyAuthMock.mockResolvedValue(null);
-    await onRequestGet(mkCtx(new Request("https://example.test/api/public-simulation?sim=sim-1")));
+    const response = await onRequestGet(mkCtx(new Request(
+      "https://example.test/api/public-simulation?sim=sim-1",
+      { headers: { origin: "https://example.test" } },
+    )));
+    expect(response.headers.get("access-control-allow-origin")).toBe("https://example.test");
+    expect(response.headers.get("access-control-allow-credentials")).toBe("true");
     expect(fetchPublicSimulationBundleMock).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ actor: null }),

--- a/functions/api/v1/calculate.jobs.jobId.test.ts
+++ b/functions/api/v1/calculate.jobs.jobId.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+import { onRequestGet, onRequestOptions } from "./calculate.jobs.jobId";
+
+const makeEnv = (row: unknown = null) => {
+  const first = vi.fn(async () => row);
+  const bind = vi.fn(() => ({ first }));
+  const run = vi.fn(async () => ({ success: true }));
+  const prepare = vi.fn((sql: string) => sql.startsWith("CREATE TABLE") ? { run } : { bind });
+  return { env: { DB: { prepare } } as unknown as Parameters<typeof onRequestGet>[0]["env"], first };
+};
+
+describe("api/v1/calculate job status CORS", () => {
+  it("keeps an originless API client free of CORS authorization headers", async () => {
+    const { env } = makeEnv();
+    const response = await onRequestGet({
+      request: new Request("https://linksim.link/api/v1/calculate/jobs/job-1"),
+      env,
+    });
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("access-control-allow-origin")).toBeNull();
+    expect(response.headers.get("access-control-allow-credentials")).toBeNull();
+  });
+
+  it("uses the shared credentialed contract for a same-origin response", async () => {
+    const { env } = makeEnv({
+      id: "job-1",
+      status: "completed",
+      input_json: "{}",
+      result_json: "{\"ok\":true}",
+      error_message: null,
+      created_at: "2026-08-13T00:00:00Z",
+      updated_at: "2026-08-13T00:00:01Z",
+    });
+    const response = await onRequestGet({
+      request: new Request("https://staging.linksim.link/api/v1/calculate/jobs/job-1", {
+        headers: { origin: "https://staging.linksim.link" },
+      }),
+      env,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("access-control-allow-origin")).toBe("https://staging.linksim.link");
+    expect(response.headers.get("access-control-allow-credentials")).toBe("true");
+  });
+
+  it("uses the shared preflight policy for the local Vite exception", async () => {
+    const { env } = makeEnv();
+    const response = await onRequestOptions({
+      request: new Request("http://127.0.0.1:8788/api/v1/calculate/jobs/job-1", {
+        method: "OPTIONS",
+        headers: {
+          origin: "http://localhost:5174",
+          "access-control-request-method": "GET",
+        },
+      }),
+      env,
+    });
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("access-control-allow-origin")).toBe("http://localhost:5174");
+    expect(response.headers.get("access-control-allow-credentials")).toBe("true");
+  });
+});

--- a/functions/api/v1/calculate.jobs.jobId.ts
+++ b/functions/api/v1/calculate.jobs.jobId.ts
@@ -1,4 +1,4 @@
-import { handleOptions } from "../../_lib/http";
+import { handleOptions, withCors } from "../../_lib/http";
 import type { Env } from "../../_lib/types";
 
 type Context = {
@@ -36,44 +36,31 @@ const getJob = async (env: Env, jobId: string) => {
   return row;
 };
 
-export const onRequestOptions = async ({ request }: Context) => {
-  const origin = request.headers.get("origin") ?? "*";
-  const headers = new Headers();
-  headers.set("Access-Control-Allow-Origin", origin);
-  headers.set("Vary", "Origin");
-  headers.set("Access-Control-Allow-Methods", "GET, OPTIONS");
-  return new Response(null, { status: 204, headers });
-};
+export const onRequestOptions = async ({ request }: Context) => handleOptions(request);
 
 export const onRequestGet = async ({ request, env }: Context) => {
   const url = new URL(request.url);
   const jobId = url.pathname.split("/").pop();
 
   if (!jobId) {
-    return new Response(JSON.stringify({ error: "Job ID is required." }), {
+    return withCors(request, new Response(JSON.stringify({ error: "Job ID is required." }), {
       status: 400,
       headers: { "content-type": "application/json" },
-    });
+    }));
   }
-
-  const origin = request.headers.get("origin") ?? "*";
 
   try {
     await ensureCalculationJobsTable(env);
     const job = await getJob(env, jobId);
 
     if (!job) {
-      return new Response(
+      return withCors(request, new Response(
         JSON.stringify({ error: "Job not found." }),
         {
           status: 404,
-          headers: {
-            "content-type": "application/json",
-            "Access-Control-Allow-Origin": origin,
-            "Vary": "Origin",
-          },
+          headers: { "content-type": "application/json" },
         },
-      );
+      ));
     }
 
     const response: Record<string, unknown> = {
@@ -99,26 +86,18 @@ export const onRequestGet = async ({ request, env }: Context) => {
       response.error = "Job timed out before completion.";
     }
 
-    return new Response(JSON.stringify(response), {
+    return withCors(request, new Response(JSON.stringify(response), {
       status: 200,
-      headers: {
-        "content-type": "application/json",
-        "Access-Control-Allow-Origin": origin,
-        "Vary": "Origin",
-      },
-    });
+      headers: { "content-type": "application/json" },
+    }));
   } catch (error) {
     const message = error instanceof Error ? error.message : "Internal error";
-    return new Response(
+    return withCors(request, new Response(
       JSON.stringify({ error: message }),
       {
         status: 500,
-        headers: {
-          "content-type": "application/json",
-          "Access-Control-Allow-Origin": origin,
-          "Vary": "Origin",
-        },
+        headers: { "content-type": "application/json" },
       },
-    );
+    ));
   }
 };


### PR DESCRIPTION
## Summary

- replace credentialed arbitrary-Origin reflection with a centralized same-origin policy
- allow only the exact local Vite-to-edge exception and reject other browser origins before API dispatch
- preserve originless API clients and same-origin public Simulation/deep-link reads without exposing credentialed CORS headers
- consolidate the calculation job-status endpoint onto the shared CORS helpers
- document the local, preview, staging, production, and Cloudflare Access assumptions

## Authority boundary

Implementation was explicitly authorized for #1048. This PR does not change Cloudflare Access configuration, authentication verification, UI, database schema, deployment configuration, or production state. It targets `staging` and must remain manually merged.

## Validation

- [x] Focused auth/API/deep-link/store regression suite: 14 files / 178 tests
- [x] Replacement endpoint/shared-policy suite: 3 files / 44 tests
- [x] `npm test`: 160 files / 1030 tests
- [x] `npm run build`
- [x] ESLint on all changed TypeScript files
- [x] `git diff --check`
- [x] `npm run dev:check`: no LinkSim dev/watch servers running

Repository-wide lint remains red on 55 pre-existing errors outside the changed files; this PR introduces no changed-file lint errors.

## Independent pre-PR review

The first candidate was blocked because one calculation job-status endpoint retained legacy Origin reflection. That implementation was consolidated into the shared helpers and regression-tested. Independent review of replacement head `b3d99363723eed73ad3270d109860f3dd68742e6` returned `pass` with no findings.

## Documentation and versioning

The existing authentication, staging, and repository guides now state the approved origin policy and fixed local Vite port. LinkSim remains on the already-selected `0.27.0` development line; no version bump is introduced.

Closes #1048 after shared-staging verification and maintainer sign-off.

— Forge · AI coding agent
<!-- linksim-ai:v1 agent=Forge bot=true run=019ffa59-23a0-7172-a578-5cc24e9382cd source=issue:1048-pr commit=b3d99363723eed73ad3270d109860f3dd68742e6 -->
