### PR TITLE
Harden required checks with target-specific native gates

### DIFF
--- a/.github/workflows/ci-quality-gates.yml
+++ b/.github/workflows/ci-quality-gates.yml
@@ -2,6 +2,7 @@ name: CI Quality Gates
 
 on:
   pull_request:
+    types: [opened, reopened, synchronize, edited]
     branches:
       - main
       - staging
@@ -15,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      statuses: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -44,16 +44,33 @@ jobs:
       - name: Report status
         run: |
           echo "::notice ::CI Quality Gates passed"
-      - name: Set commit status
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const statusSha = context.payload.pull_request?.head?.sha ?? context.sha;
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: statusSha,
-              state: 'success',
-              context: 'CI Quality Gates / verify',
-              description: 'All quality gates passed',
-            });
+
+  verify-staging:
+    name: verify-staging
+    if: always() && github.base_ref == 'staging'
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions: {}
+    env:
+      BASE_REF: ${{ github.base_ref }}
+      VERIFY_RESULT: ${{ needs.verify.result }}
+    steps:
+      - name: Confirm staging verification result
+        run: |
+          test "$BASE_REF" = "staging"
+          test "$VERIFY_RESULT" = "success"
+
+  verify-main:
+    name: verify-main
+    if: always() && github.base_ref == 'main'
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions: {}
+    env:
+      BASE_REF: ${{ github.base_ref }}
+      VERIFY_RESULT: ${{ needs.verify.result }}
+    steps:
+      - name: Confirm main verification result
+        run: |
+          test "$BASE_REF" = "main"
+          test "$VERIFY_RESULT" = "success"

--- a/.github/workflows/ci-quality-gates.yml
+++ b/.github/workflows/ci-quality-gates.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   verify:
+    name: CI Quality Gates / verify
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -46,7 +47,7 @@ jobs:
           echo "::notice ::CI Quality Gates passed"
 
   verify-staging:
-    name: verify-staging
+    name: CI Quality Gates / verify-staging
     if: always() && github.base_ref == 'staging'
     needs: verify
     runs-on: ubuntu-latest
@@ -61,7 +62,7 @@ jobs:
           test "$VERIFY_RESULT" = "success"
 
   verify-main:
-    name: verify-main
+    name: CI Quality Gates / verify-main
     if: always() && github.base_ref == 'main'
     needs: verify
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-branch-policy.yml
+++ b/.github/workflows/pr-branch-policy.yml
@@ -2,6 +2,7 @@ name: PR Branch Policy
 
 on:
   pull_request:
+    types: [opened, reopened, synchronize, edited]
     branches:
       - main
       - staging
@@ -11,7 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      statuses: write
     steps:
       - name: Validate head branch naming policy
         env:
@@ -33,29 +33,33 @@ jobs:
             echo "PR to main must come from staging, release/vX.Y.Z, or hotfix/<slug>."
             exit 1
           fi
-      - name: Set commit status on success
-        if: success()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: context.payload.pull_request.head.sha,
-              state: 'success',
-              context: 'PR Branch Policy / enforce',
-              description: 'Branch naming policy satisfied',
-            });
-      - name: Set commit status on failure
-        if: failure()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: context.payload.pull_request.head.sha,
-              state: 'failure',
-              context: 'PR Branch Policy / enforce',
-              description: 'Branch naming policy violation — PR to main must come from staging, release/vX.Y.Z, or hotfix/<slug>',
-            });
+
+  enforce-staging:
+    name: enforce-staging
+    if: always() && github.base_ref == 'staging'
+    needs: enforce
+    runs-on: ubuntu-latest
+    permissions: {}
+    env:
+      BASE_REF: ${{ github.base_ref }}
+      ENFORCE_RESULT: ${{ needs.enforce.result }}
+    steps:
+      - name: Confirm staging branch-policy result
+        run: |
+          test "$BASE_REF" = "staging"
+          test "$ENFORCE_RESULT" = "success"
+
+  enforce-main:
+    name: enforce-main
+    if: always() && github.base_ref == 'main'
+    needs: enforce
+    runs-on: ubuntu-latest
+    permissions: {}
+    env:
+      BASE_REF: ${{ github.base_ref }}
+      ENFORCE_RESULT: ${{ needs.enforce.result }}
+    steps:
+      - name: Confirm main branch-policy result
+        run: |
+          test "$BASE_REF" = "main"
+          test "$ENFORCE_RESULT" = "success"

--- a/.github/workflows/pr-branch-policy.yml
+++ b/.github/workflows/pr-branch-policy.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   enforce:
+    name: PR Branch Policy / enforce
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -35,7 +36,7 @@ jobs:
           fi
 
   enforce-staging:
-    name: enforce-staging
+    name: PR Branch Policy / enforce-staging
     if: always() && github.base_ref == 'staging'
     needs: enforce
     runs-on: ubuntu-latest
@@ -50,7 +51,7 @@ jobs:
           test "$ENFORCE_RESULT" = "success"
 
   enforce-main:
-    name: enforce-main
+    name: PR Branch Policy / enforce-main
     if: always() && github.base_ref == 'main'
     needs: enforce
     runs-on: ubuntu-latest

--- a/functions/_lib/requiredChecksWorkflow.test.ts
+++ b/functions/_lib/requiredChecksWorkflow.test.ts
@@ -26,8 +26,9 @@ describe("required check workflows", () => {
   });
 
   it("publishes target-specific CI checks after the generic verification job", () => {
-    expect(qualityWorkflow).toContain("name: verify-staging");
-    expect(qualityWorkflow).toContain("name: verify-main");
+    expect(qualityWorkflow).toContain("name: CI Quality Gates / verify");
+    expect(qualityWorkflow).toContain("name: CI Quality Gates / verify-staging");
+    expect(qualityWorkflow).toContain("name: CI Quality Gates / verify-main");
     expect(qualityWorkflow.match(/needs: verify/g)).toHaveLength(2);
     expect(qualityWorkflow).toContain("if: always() && github.base_ref == 'staging'");
     expect(qualityWorkflow).toContain("if: always() && github.base_ref == 'main'");
@@ -38,8 +39,9 @@ describe("required check workflows", () => {
   });
 
   it("publishes target-specific branch-policy checks after enforcement", () => {
-    expect(branchWorkflow).toContain("name: enforce-staging");
-    expect(branchWorkflow).toContain("name: enforce-main");
+    expect(branchWorkflow).toContain("name: PR Branch Policy / enforce");
+    expect(branchWorkflow).toContain("name: PR Branch Policy / enforce-staging");
+    expect(branchWorkflow).toContain("name: PR Branch Policy / enforce-main");
     expect(branchWorkflow.match(/needs: enforce/g)).toHaveLength(2);
     expect(branchWorkflow).toContain("if: always() && github.base_ref == 'staging'");
     expect(branchWorkflow).toContain("if: always() && github.base_ref == 'main'");

--- a/functions/_lib/requiredChecksWorkflow.test.ts
+++ b/functions/_lib/requiredChecksWorkflow.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const readWorkflow = (name: string) =>
+  readFileSync(resolve(process.cwd(), ".github/workflows", name), "utf8");
+
+const qualityWorkflow = readWorkflow("ci-quality-gates.yml");
+const branchWorkflow = readWorkflow("pr-branch-policy.yml");
+
+describe("required check workflows", () => {
+  it.each([
+    ["CI quality gates", qualityWorkflow],
+    ["PR branch policy", branchWorkflow],
+  ])("uses native checks without reusable status-write authority for %s", (_label, workflow) => {
+    expect(workflow).not.toContain("statuses: write");
+    expect(workflow).not.toContain("createCommitStatus");
+  });
+
+  it.each([
+    ["CI quality gates", qualityWorkflow],
+    ["PR branch policy", branchWorkflow],
+  ])("re-evaluates %s when a pull request is retargeted", (_label, workflow) => {
+    expect(workflow).toContain("types: [opened, reopened, synchronize, edited]");
+  });
+
+  it("publishes target-specific CI checks after the generic verification job", () => {
+    expect(qualityWorkflow).toContain("name: verify-staging");
+    expect(qualityWorkflow).toContain("name: verify-main");
+    expect(qualityWorkflow.match(/needs: verify/g)).toHaveLength(2);
+    expect(qualityWorkflow).toContain("if: always() && github.base_ref == 'staging'");
+    expect(qualityWorkflow).toContain("if: always() && github.base_ref == 'main'");
+    expect(qualityWorkflow.match(/VERIFY_RESULT: \$\{\{ needs\.verify\.result \}\}/g)).toHaveLength(2);
+    expect(qualityWorkflow.match(/test "\$VERIFY_RESULT" = "success"/g)).toHaveLength(2);
+    expect(qualityWorkflow).toContain('test "$BASE_REF" = "staging"');
+    expect(qualityWorkflow).toContain('test "$BASE_REF" = "main"');
+  });
+
+  it("publishes target-specific branch-policy checks after enforcement", () => {
+    expect(branchWorkflow).toContain("name: enforce-staging");
+    expect(branchWorkflow).toContain("name: enforce-main");
+    expect(branchWorkflow.match(/needs: enforce/g)).toHaveLength(2);
+    expect(branchWorkflow).toContain("if: always() && github.base_ref == 'staging'");
+    expect(branchWorkflow).toContain("if: always() && github.base_ref == 'main'");
+    expect(branchWorkflow.match(/ENFORCE_RESULT: \$\{\{ needs\.enforce\.result \}\}/g)).toHaveLength(2);
+    expect(branchWorkflow.match(/test "\$ENFORCE_RESULT" = "success"/g)).toHaveLength(2);
+    expect(branchWorkflow).toContain('test "$BASE_REF" = "staging"');
+    expect(branchWorkflow).toContain('test "$BASE_REF" = "main"');
+  });
+});

--- a/functions/_lib/requiredChecksWorkflow.test.ts
+++ b/functions/_lib/requiredChecksWorkflow.test.ts
@@ -26,9 +26,9 @@ describe("required check workflows", () => {
   });
 
   it("publishes target-specific CI checks after the generic verification job", () => {
-    expect(qualityWorkflow).toContain("name: CI Quality Gates / verify");
-    expect(qualityWorkflow).toContain("name: CI Quality Gates / verify-staging");
-    expect(qualityWorkflow).toContain("name: CI Quality Gates / verify-main");
+    expect(qualityWorkflow).toMatch(/^    name: CI Quality Gates \/ verify$/m);
+    expect(qualityWorkflow).toMatch(/^    name: CI Quality Gates \/ verify-staging$/m);
+    expect(qualityWorkflow).toMatch(/^    name: CI Quality Gates \/ verify-main$/m);
     expect(qualityWorkflow.match(/needs: verify/g)).toHaveLength(2);
     expect(qualityWorkflow).toContain("if: always() && github.base_ref == 'staging'");
     expect(qualityWorkflow).toContain("if: always() && github.base_ref == 'main'");
@@ -39,9 +39,9 @@ describe("required check workflows", () => {
   });
 
   it("publishes target-specific branch-policy checks after enforcement", () => {
-    expect(branchWorkflow).toContain("name: PR Branch Policy / enforce");
-    expect(branchWorkflow).toContain("name: PR Branch Policy / enforce-staging");
-    expect(branchWorkflow).toContain("name: PR Branch Policy / enforce-main");
+    expect(branchWorkflow).toMatch(/^    name: PR Branch Policy \/ enforce$/m);
+    expect(branchWorkflow).toMatch(/^    name: PR Branch Policy \/ enforce-staging$/m);
+    expect(branchWorkflow).toMatch(/^    name: PR Branch Policy \/ enforce-main$/m);
     expect(branchWorkflow.match(/needs: enforce/g)).toHaveLength(2);
     expect(branchWorkflow).toContain("if: always() && github.base_ref == 'staging'");
     expect(branchWorkflow).toContain("if: always() && github.base_ref == 'main'");


### PR DESCRIPTION
## Summary

- remove reusable `statuses: write` authority and manual commit-status publication from the two required-check workflows
- retain the existing generic native jobs for the two-phase rollback window
- publish target-specific native staging/main gates and re-evaluate them when a pull request is retargeted
- fail each target gate unless its underlying verification or branch-policy job succeeded

## Authority and rollout boundary

This is the approved producer phase for #1052. Existing branch protection remains unchanged and continues to require the generic native checks. Adding the new target-specific contexts to branch protection is a separate second phase after this workflow is merged and observed. No merge, preview, Cloudflare mutation, production action, or version change is included.

## Validation

- `npm run test -- --run functions/_lib/requiredChecksWorkflow.test.ts` (6/6)
- `npm test` (161 files, 1,036 tests)
- `npm run build`
- `npm run agents:validate`
- `npm run dev:check` (no LinkSim dev/watch servers)
- `git diff --check`
- independent exact-head pre-PR review: PASS, no findings, reviewed `dee00a5960f856ac212c3a8c9a32916bf434682f`

## Documentation and versioning

No operator documentation changes are needed until branch protection is activated. Automation-only hardening remains on the selected `0.27.0` development line.

Refs #1052

— Forge · AI coding agent
<!-- linksim-ai:v1 agent=Forge bot=true run=02f8777b-1def-4713-9b23-844a1a3bf904 source=issue:1052-batch-1 commit=dee00a5960f856ac212c3a8c9a32916bf434682f -->
