### PR TITLE
Scan tracked hidden files for secret patterns

### DIFF
--- a/functions/_lib/securityScan.test.ts
+++ b/functions/_lib/securityScan.test.ts
@@ -34,6 +34,7 @@ const runScanner = (root: string) =>
   });
 
 const fakeToken = () => `ghp_${"A".repeat(30)}`;
+const fakeCloudflareToken = () => ["CF_API", "_TOKEN=", "n123456789012345"].join("");
 
 afterEach(() => {
   for (const root of temporaryRepos.splice(0)) {
@@ -72,6 +73,16 @@ describe("security scan", () => {
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("notes with spaces.txt");
+  });
+
+  it("finds Cloudflare tokens containing a lowercase n", () => {
+    const root = createRepo();
+    writeTracked(root, "cloudflare.env", `${fakeCloudflareToken()}\n`);
+
+    const result = runScanner(root);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("cloudflare.env");
   });
 
   it("excludes only the scanner source and ignores tracked binary content", () => {

--- a/functions/_lib/securityScan.test.ts
+++ b/functions/_lib/securityScan.test.ts
@@ -1,0 +1,96 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const scannerPath = resolve(process.cwd(), "scripts/security-scan.mjs");
+const temporaryRepos: string[] = [];
+
+const createRepo = () => {
+  const root = mkdtempSync(join(tmpdir(), "linksim-security-scan-"));
+  temporaryRepos.push(root);
+  execFileSync("git", ["init", "--quiet"], { cwd: root });
+  return root;
+};
+
+const writeTracked = (root: string, relativePath: string, content: string | Buffer) => {
+  const path = join(root, relativePath);
+  mkdirSync(resolve(path, ".."), { recursive: true });
+  writeFileSync(path, content);
+  execFileSync("git", ["add", "--", relativePath], { cwd: root });
+};
+
+const runScanner = (root: string) =>
+  spawnSync(process.execPath, [scannerPath], {
+    cwd: root,
+    encoding: "utf8",
+  });
+
+const fakeToken = () => `ghp_${"A".repeat(30)}`;
+
+afterEach(() => {
+  for (const root of temporaryRepos.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("security scan", () => {
+  it("passes a clean tracked repository", () => {
+    const root = createRepo();
+    writeTracked(root, "src/clean.txt", "ordinary configuration\n");
+
+    const result = runScanner(root);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("No high-risk secret patterns found");
+  });
+
+  it("finds secret patterns in tracked hidden files without printing the secret", () => {
+    const root = createRepo();
+    const token = fakeToken();
+    writeTracked(root, ".config/.credentials", `${token}\n`);
+
+    const result = runScanner(root);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(".config/.credentials");
+    expect(result.stderr).not.toContain(token);
+  });
+
+  it("does not suppress another file whose matching line mentions the scanner", () => {
+    const root = createRepo();
+    writeTracked(root, "notes with spaces.txt", `scripts/security-scan.mjs: ${fakeToken()}\n`);
+
+    const result = runScanner(root);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("notes with spaces.txt");
+  });
+
+  it("excludes only the scanner source and ignores tracked binary content", () => {
+    const root = createRepo();
+    writeTracked(root, "scripts/security-scan.mjs", `${fakeToken()}\n`);
+    writeTracked(root, "fixtures/blob.bin", Buffer.from(`\0${fakeToken()}\0`, "utf8"));
+
+    const result = runScanner(root);
+
+    expect(result.status).toBe(0);
+  });
+
+  it("fails closed when tracked-file discovery cannot run", () => {
+    const root = mkdtempSync(join(tmpdir(), "linksim-security-scan-no-git-"));
+    temporaryRepos.push(root);
+
+    const result = runScanner(root);
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("Scan failed");
+  });
+});

--- a/scripts/security-scan.mjs
+++ b/scripts/security-scan.mjs
@@ -34,78 +34,43 @@ const run = (cmd, args) =>
     child.on("exit", (code) => resolve({ code, stdout, stderr }));
   });
 
-const rgArgs = [
+const gitGrepArgs = [
+  "grep",
   "-n",
-  "-S",
-  "-g",
-  "!.git",
-  "-g",
-  "!node_modules",
-  "-g",
-  "!.wrangler",
-  "-g",
-  "!dist",
-  "-g",
-  "!.tmp",
-  "-g",
-  "!scripts/security-scan.mjs",
-  patterns.join("|"),
-  ".",
-];
-
-const grepArgs = [
-  "-R",
-  "-n",
+  "-I",
+  "-l",
   "-E",
-  "--binary-files=without-match",
-  "--exclude-dir=.git",
-  "--exclude-dir=node_modules",
-  "--exclude-dir=.wrangler",
-  "--exclude-dir=dist",
-  "--exclude-dir=.tmp",
-  "--exclude=scripts/security-scan.mjs",
+  "-e",
   patterns.join("|"),
+  "--",
   ".",
+  ":(exclude)scripts/security-scan.mjs",
 ];
 
-const sanitizeMatches = (stdout) =>
-  stdout
-    .split("\n")
-    .filter((line) => line.trim().length > 0)
-    .filter((line) => !line.includes("scripts/security-scan.mjs:"))
-    .join("\n");
-
-const interpretResult = (result, label) => {
-  const filtered = sanitizeMatches(result.stdout || "");
-  // ripgrep/grep return 1 when no matches are found.
-  if (result.code === 1 || (result.code === 0 && !filtered)) {
-    console.log(`[security-scan] No high-risk secret patterns found (${label}).`);
+const interpretResult = (result) => {
+  // git grep returns 1 when no tracked file contains a match.
+  if (result.code === 1) {
+    console.log("[security-scan] No high-risk secret patterns found (tracked files).");
     process.exit(0);
   }
   if (result.code === 0) {
-    console.error("[security-scan] Potential secret material found:");
-    process.stderr.write(filtered);
+    console.error("[security-scan] Potential secret material found in tracked files:");
+    process.stderr.write(result.stdout);
     process.stderr.write("\n");
     process.exit(1);
   }
-  console.error(`[security-scan] Scan failed (${label}, ${result.code ?? "unknown"}): ${result.stderr || result.stdout}`);
+  console.error(
+    `[security-scan] Scan failed (git grep, ${result.code ?? "unknown"}): ${result.stderr || result.stdout}`,
+  );
   process.exit(2);
 };
 
 try {
-  const rgResult = await run("rg", rgArgs);
-  interpretResult(rgResult, "rg");
+  const result = await run("git", gitGrepArgs);
+  interpretResult(result);
 } catch (error) {
-  const code = error && typeof error === "object" && "code" in error ? String(error.code) : "unknown";
-  if (code !== "ENOENT") {
-    console.error(`[security-scan] Scan failed (rg spawn): ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(2);
-  }
-  const grepResult = await run("grep", grepArgs).catch((grepError) => {
-    console.error(
-      `[security-scan] Scan failed: neither rg nor grep is available (${grepError instanceof Error ? grepError.message : String(grepError)}).`,
-    );
-    process.exit(2);
-  });
-  interpretResult(grepResult, "grep");
+  console.error(
+    `[security-scan] Scan failed (git spawn): ${error instanceof Error ? error.message : String(error)}`,
+  );
+  process.exit(2);
 }

--- a/scripts/security-scan.mjs
+++ b/scripts/security-scan.mjs
@@ -12,7 +12,7 @@ const patterns = [
   "xox[baprs]-[A-Za-z0-9-]{10,}",
   "AKIA[0-9A-Z]{16}",
   "AIza[0-9A-Za-z_-]{20,}",
-  "CF_API_TOKEN[=:][^\\n]{12,}",
+  "CF_API_TOKEN[=:].{12,}",
 ];
 
 const run = (cmd, args) =>


### PR DESCRIPTION
## Summary

- scan Git-tracked working-tree files so tracked hidden paths and unusual filenames are included
- exclude only the scanner source and remove line-content suppression
- keep binary files ignored and report matching filenames without echoing secret material
- fail closed when tracked-file discovery fails

## Tests

- `npm run test -- --run functions/_lib/securityScan.test.ts` (6/6)
- `npm run security:scan`
- `npm test` (162 files, 1,042 tests)
- `npm run build`
- `npm run agents:validate`
- `npm run dev:check` (no LinkSim dev/watch servers)
- `git diff --check`
- independent exact-head pre-PR review: PASS, no findings, reviewed `04de8bb383564eff9b7523c3d58fd6653494bc82`

## Boundaries

No dependency, UI, application API, database, deployment, branch-protection, or version change is included. The public command remains `npm run security:scan`.

Refs #1052

— Forge · AI coding agent
<!-- linksim-ai:v1 agent=Forge bot=true run=ea7dd173-f8f2-447b-864d-92449529f7f5 source=issue:1052-secret-scan commit=04de8bb383564eff9b7523c3d58fd6653494bc82 -->
