### PR TITLE
Fail closed on production deployment verification

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -267,6 +267,12 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: node scripts/access-boundary.mjs check production
 
+      - name: Validate production workflow commit
+        working-directory: ${{ runner.temp }}/linksim-release
+        env:
+          DEPLOY_VERIFY_COMMIT: ${{ github.sha }}
+        run: node "$GITHUB_WORKSPACE/scripts/deploy-pages-safe.mjs" --target prod-main --verify-commit-only
+
       - name: Apply production Simulation lifecycle migration
         working-directory: ${{ runner.temp }}/linksim-release
         env:

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -45,8 +45,14 @@ jobs:
 
       - name: Detect identity lifecycle schema change
         id: identity_schema
+        env:
+          PREVIEW_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          if git diff --quiet "${{ github.event.pull_request.base.sha }}"...HEAD -- db/migrations/2026-08-12_identity_lifecycle.sql; then
+          if [[ ! "$PREVIEW_BASE_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "Invalid preview base SHA." >&2
+            exit 1
+          fi
+          if git diff --quiet "$PREVIEW_BASE_SHA"...HEAD -- db/migrations/2026-08-12_identity_lifecycle.sql; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
@@ -236,7 +242,14 @@ jobs:
         run: node scripts/validate-prod-promotion.mjs
 
       - name: Prepare release worktree
-        run: git worktree add --detach "$RUNNER_TEMP/linksim-release" "${{ steps.release_tag.outputs.tag }}"
+        env:
+          RELEASE_TAG: ${{ steps.release_tag.outputs.tag }}
+        run: |
+          if [[ ! "$RELEASE_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "Invalid resolved release tag." >&2
+            exit 1
+          fi
+          git worktree add --detach "$RUNNER_TEMP/linksim-release" "$RELEASE_TAG"
 
       - name: Install dependencies
         working-directory: ${{ runner.temp }}/linksim-release

--- a/functions/_lib/deployPagesWorkflow.test.ts
+++ b/functions/_lib/deployPagesWorkflow.test.ts
@@ -7,6 +7,10 @@ const workflow = readFileSync(
   resolve(process.cwd(), ".github/workflows/deploy-pages.yml"),
   "utf8",
 );
+const deployScript = readFileSync(
+  resolve(process.cwd(), "scripts/deploy-pages-safe.mjs"),
+  "utf8",
+);
 
 const productionJob = workflow.split("  deploy-prod-main:")[1] ?? "";
 const stagingJob =
@@ -44,6 +48,28 @@ describe("Deploy LinkSim Pages workflow", () => {
     expect(previewJob).toContain("Detect identity lifecycle schema change");
     expect(previewJob).toContain("db/migrations/2026-08-12_identity_lifecycle.sql");
     expect(previewJob).toContain("steps.identity_schema.outputs.changed != 'true'");
+  });
+
+  it("validates workflow-derived preview and release values before quoted shell use", () => {
+    expect(previewJob).toContain(
+      "PREVIEW_BASE_SHA: ${{ github.event.pull_request.base.sha }}",
+    );
+    expect(previewJob).toContain('[[ ! "$PREVIEW_BASE_SHA" =~ ^[0-9a-fA-F]{40}$ ]]');
+    expect(previewJob).toContain('git diff --quiet "$PREVIEW_BASE_SHA"...HEAD');
+    expect(previewJob).not.toContain(
+      'git diff --quiet "${{ github.event.pull_request.base.sha }}"...HEAD',
+    );
+
+    expect(productionJob).toContain("RELEASE_TAG: ${{ steps.release_tag.outputs.tag }}");
+    expect(productionJob).toContain(
+      '[[ ! "$RELEASE_TAG" =~ ^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$ ]]',
+    );
+    expect(productionJob).toContain(
+      'git worktree add --detach "$RUNNER_TEMP/linksim-release" "$RELEASE_TAG"',
+    );
+    expect(productionJob).not.toContain(
+      'git worktree add --detach "$RUNNER_TEMP/linksim-release" "${{ steps.release_tag.outputs.tag }}"',
+    );
   });
 
   it("checks the production Access boundary without requiring an Access API token", () => {
@@ -106,6 +132,17 @@ describe("Deploy LinkSim Pages workflow", () => {
     );
     expect(productionJob.slice(0, productionJob.indexOf(releaseGateStep))).not.toContain(
       "npx wrangler d1 execute linksim --remote",
+    );
+  });
+
+  it("uses the validated workflow SHA and fails closed on production deployment lookup", () => {
+    expect(productionJob).toContain("DEPLOY_VERIFY_COMMIT: ${{ github.sha }}");
+    expect(deployScript).toContain("process.env.DEPLOY_VERIFY_COMMIT");
+    expect(deployScript).toContain("resolveDeploymentCommit");
+    expect(deployScript).toContain("await verifyMatchingPagesDeployment");
+    expect(deployScript).not.toContain("Proceeding because the Pages deploy itself completed successfully");
+    expect(deployScript.indexOf("await verifyMatchingPagesDeployment")).toBeLessThan(
+      deployScript.indexOf("[deploy-pages-safe] Success:"),
     );
   });
 

--- a/functions/_lib/deployPagesWorkflow.test.ts
+++ b/functions/_lib/deployPagesWorkflow.test.ts
@@ -159,6 +159,8 @@ describe("Deploy LinkSim Pages workflow", () => {
     expect(productionJob).toContain("DEPLOY_VERIFY_COMMIT: ${{ github.sha }}");
     expect(deployScript).toContain("process.env.DEPLOY_VERIFY_COMMIT");
     expect(deployScript).toContain("resolveDeploymentCommit");
+    expect(deployScript).toContain("deploymentUrl = parsePagesDeploymentUrl");
+    expect(deployScript).toContain("deploymentUrl,");
     expect(deployScript).toContain("await verifyMatchingPagesDeployment");
     expect(deployScript).not.toContain("Proceeding because the Pages deploy itself completed successfully");
     expect(deployScript.indexOf("await verifyMatchingPagesDeployment")).toBeLessThan(

--- a/functions/_lib/deployPagesWorkflow.test.ts
+++ b/functions/_lib/deployPagesWorkflow.test.ts
@@ -135,6 +135,26 @@ describe("Deploy LinkSim Pages workflow", () => {
     );
   });
 
+  it("validates the production workflow commit tree before any D1 migration", () => {
+    const commitGateStep = "- name: Validate production workflow commit";
+    const simulationMigrationStep =
+      "- name: Apply production Simulation lifecycle migration";
+    const identityMigrationStep =
+      "- name: Verify identity lifecycle migration prerequisites and apply migration";
+
+    expect(productionJob).toContain(commitGateStep);
+    expect(productionJob).toContain("DEPLOY_VERIFY_COMMIT: ${{ github.sha }}");
+    expect(productionJob).toContain(
+      'node "$GITHUB_WORKSPACE/scripts/deploy-pages-safe.mjs" --target prod-main --verify-commit-only',
+    );
+    expect(productionJob.indexOf(commitGateStep)).toBeLessThan(
+      productionJob.indexOf(simulationMigrationStep),
+    );
+    expect(productionJob.indexOf(commitGateStep)).toBeLessThan(
+      productionJob.indexOf(identityMigrationStep),
+    );
+  });
+
   it("uses the validated workflow SHA and fails closed on production deployment lookup", () => {
     expect(productionJob).toContain("DEPLOY_VERIFY_COMMIT: ${{ github.sha }}");
     expect(deployScript).toContain("process.env.DEPLOY_VERIFY_COMMIT");

--- a/functions/_lib/pagesPreviewDeployment.test.ts
+++ b/functions/_lib/pagesPreviewDeployment.test.ts
@@ -1,8 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   hasMatchingPagesDeployment,
   parsePagesDeploymentUrl,
+  resolveDeploymentCommit,
   validatePreviewBranch,
+  verifyMatchingPagesDeployment,
 } from "../../scripts/pages-preview.mjs";
 
 describe("Pages preview deployment helpers", () => {
@@ -67,5 +69,95 @@ describe("Pages preview deployment helpers", () => {
         deploymentUrl: "https://6b1cae65.linksim-staging.pages.dev",
       }),
     ).toBe(false);
+  });
+
+  it("uses the full workflow commit for production after its tree matches the release", async () => {
+    const workflowCommit = "a".repeat(40);
+    const resolveTree = vi.fn(async () => "release-tree");
+
+    await expect(
+      resolveDeploymentCommit({
+        targetName: "prod-main",
+        currentCommit: "12345678",
+        workflowCommit,
+        resolveTree,
+      }),
+    ).resolves.toBe(workflowCommit);
+    expect(resolveTree).toHaveBeenNthCalledWith(1, workflowCommit);
+    expect(resolveTree).toHaveBeenNthCalledWith(2, "HEAD");
+  });
+
+  it.each(["", "abc1234", "g".repeat(40), "a".repeat(39), "a".repeat(41)])(
+    "rejects malformed production workflow commit %j",
+    async (workflowCommit) => {
+      const resolveTree = vi.fn();
+      await expect(
+        resolveDeploymentCommit({
+          targetName: "prod-main",
+          currentCommit: "12345678",
+          workflowCommit,
+          resolveTree,
+        }),
+      ).rejects.toThrow("DEPLOY_VERIFY_COMMIT must be a full 40-character hexadecimal SHA");
+      expect(resolveTree).not.toHaveBeenCalled();
+    },
+  );
+
+  it("rejects a production workflow commit whose tree differs from the release", async () => {
+    const workflowCommit = "b".repeat(40);
+    const resolveTree = vi.fn(async (ref: string) =>
+      ref === "HEAD" ? "release-tree" : "workflow-tree",
+    );
+
+    await expect(
+      resolveDeploymentCommit({
+        targetName: "prod-main",
+        currentCommit: "12345678",
+        workflowCommit,
+        resolveTree,
+      }),
+    ).rejects.toThrow("workflow commit tree does not match the tagged release worktree");
+  });
+
+  it("accepts only the exact deployment commit and branch returned by Wrangler", async () => {
+    const commit = "c".repeat(40);
+    const listDeployments = vi.fn(async () =>
+      `│ deployment-id │ Production │ main │ ${commit} │ https://linksim.pages.dev │`,
+    );
+    const wait = vi.fn();
+
+    await expect(
+      verifyMatchingPagesDeployment({
+        projectName: "linksim",
+        commit,
+        branch: "main",
+        listDeployments,
+        wait,
+      }),
+    ).resolves.toBeUndefined();
+    expect(listDeployments).toHaveBeenCalledTimes(1);
+    expect(wait).not.toHaveBeenCalled();
+  });
+
+  it("fails closed after retries return only the wrong deployment record", async () => {
+    const listDeployments = vi.fn(async () =>
+      `│ deployment-id │ Production │ staging │ ${"d".repeat(40)} │ https://linksim.pages.dev │`,
+    );
+    const wait = vi.fn();
+
+    await expect(
+      verifyMatchingPagesDeployment({
+        projectName: "linksim",
+        commit: "e".repeat(40),
+        branch: "main",
+        attempts: 3,
+        listDeployments,
+        wait,
+      }),
+    ).rejects.toThrow(
+      `Post-deploy verification failed: no linksim deployment matched branch main and commit ${"e".repeat(40)}.`,
+    );
+    expect(listDeployments).toHaveBeenCalledTimes(3);
+    expect(wait).toHaveBeenCalledTimes(2);
   });
 });

--- a/functions/_lib/pagesPreviewDeployment.test.ts
+++ b/functions/_lib/pagesPreviewDeployment.test.ts
@@ -83,6 +83,21 @@ describe("Pages preview deployment helpers", () => {
     },
   );
 
+  it("does not accept an older successful deployment for the same branch and commit", () => {
+    const rows = [
+      "│ newest-id │ Production │ main │ 39d6b82 │ https://newest.linksim.pages.dev │ Failure │ https://dash.cloudflare.com/newest │",
+      "│ older-id │ Production │ main │ 39d6b82 │ https://older.linksim.pages.dev │ 2 minutes ago │ https://dash.cloudflare.com/older │",
+    ].join("\n");
+
+    expect(
+      hasMatchingPagesDeployment(rows, {
+        commit: "39d6b825",
+        branch: "main",
+        deploymentUrl: "https://newest.linksim.pages.dev",
+      }),
+    ).toBe(false);
+  });
+
   it("rejects a matching commit on the wrong branch or deployment URL", () => {
     const row =
       "│ id │ Preview │ another-branch │ 39d6b82 │ https://other.linksim-staging.pages.dev │";

--- a/functions/_lib/pagesPreviewDeployment.test.ts
+++ b/functions/_lib/pagesPreviewDeployment.test.ts
@@ -47,7 +47,9 @@ describe("Pages preview deployment helpers", () => {
       "Preview",
       "issue/1010-authenticated-pr-previews",
       "39d6b82",
-      "https://6b1cae65.linksim-staging.pages.dev │",
+      "https://6b1cae65.linksim-staging.pages.dev",
+      "just now",
+      "https://dash.cloudflare.com/example │",
     ].join(" │ ");
 
     expect(
@@ -58,6 +60,28 @@ describe("Pages preview deployment helpers", () => {
       }),
     ).toBe(true);
   });
+
+  it.each(["Queued", "Failure"])(
+    "rejects a matching deployment whose status is %s",
+    (status) => {
+      const row = [
+        "│ deployment-id",
+        "Production",
+        "main",
+        "39d6b82",
+        "https://linksim.pages.dev",
+        status,
+        "https://dash.cloudflare.com/example │",
+      ].join(" │ ");
+
+      expect(
+        hasMatchingPagesDeployment(row, {
+          commit: "39d6b825",
+          branch: "main",
+        }),
+      ).toBe(false);
+    },
+  );
 
   it("rejects a matching commit on the wrong branch or deployment URL", () => {
     const row =
@@ -122,7 +146,7 @@ describe("Pages preview deployment helpers", () => {
   it("accepts only the exact deployment commit and branch returned by Wrangler", async () => {
     const commit = "c".repeat(40);
     const listDeployments = vi.fn(async () =>
-      `│ deployment-id │ Production │ main │ ${commit} │ https://linksim.pages.dev │`,
+      `│ deployment-id │ Production │ main │ ${commit} │ https://linksim.pages.dev │ 2 minutes ago │ https://dash.cloudflare.com/example │`,
     );
     const wait = vi.fn();
 

--- a/scripts/deploy-pages-safe.mjs
+++ b/scripts/deploy-pages-safe.mjs
@@ -413,7 +413,7 @@ async function main() {
       : target.branch;
 
   await writeReleaseManifest(targetName, target.projectName, deployBranch, commit);
-  let deployedPreviewUrl = "";
+  let deploymentUrl = "";
 
   const rawCommitMsg = await getGitRef(["log", "-1", "--format=%s"]);
   // Cloudflare Pages API requires a pure ASCII commit message string.
@@ -441,15 +441,15 @@ async function main() {
       process.stdout.write(result.stdout);
       process.stderr.write(result.stderr);
 
+      deploymentUrl = parsePagesDeploymentUrl(
+        `${result.stdout}\n${result.stderr}`,
+        target.projectName,
+      );
+
       if (targetName === "staging-preview") {
-        const previewUrl = parsePagesDeploymentUrl(
-          `${result.stdout}\n${result.stderr}`,
-          target.projectName,
-        );
-        deployedPreviewUrl = previewUrl;
         const githubOutput = (process.env.GITHUB_OUTPUT ?? "").trim();
-        if (githubOutput) await appendFile(githubOutput, `preview_url=${previewUrl}\n`, "utf8");
-        console.log(`[deploy-pages-safe] Preview URL: ${previewUrl}`);
+        if (githubOutput) await appendFile(githubOutput, `preview_url=${deploymentUrl}\n`, "utf8");
+        console.log(`[deploy-pages-safe] Preview URL: ${deploymentUrl}`);
       }
     });
 
@@ -457,7 +457,7 @@ async function main() {
       projectName: target.projectName,
       commit,
       branch: deployBranch,
-      deploymentUrl: deployedPreviewUrl,
+      deploymentUrl,
       listDeployments: async () => {
         const { stdout } = await run(
           wrangler,

--- a/scripts/deploy-pages-safe.mjs
+++ b/scripts/deploy-pages-safe.mjs
@@ -2,9 +2,10 @@ import { appendFile, copyFile, readFile, rename, writeFile } from "node:fs/promi
 import path from "node:path";
 import { spawn } from "node:child_process";
 import {
-  hasMatchingPagesDeployment,
   parsePagesDeploymentUrl,
+  resolveDeploymentCommit,
   validatePreviewBranch,
+  verifyMatchingPagesDeployment,
 } from "./pages-preview.mjs";
 import { validateCurrentStagingVersionState } from "./version-state.mjs";
 
@@ -369,26 +370,6 @@ async function withWranglerConfig(configPath, fn) {
   }
 }
 
-async function verifyDeployment(targetName, projectName, commit, branch, deploymentUrl = "") {
-  for (let attempt = 1; attempt <= 6; attempt += 1) {
-    const { stdout } = await run(
-      wrangler,
-      ["pages", "deployment", "list", "--project-name", projectName],
-      { capture: true },
-    );
-    if (hasMatchingPagesDeployment(stdout, { commit, branch, deploymentUrl })) {
-      return;
-    }
-    await sleep(5000);
-  }
-  const message = `Post-deploy verification failed: no ${projectName} deployment matched branch ${branch} and commit ${commit}.`;
-  if (targetName === "prod-main") {
-    console.warn(`[deploy-pages-safe] ${message} Proceeding because the Pages deploy itself completed successfully.`);
-    return;
-  }
-  throw new Error(message);
-}
-
 async function main() {
   const targetName = parseArg("target");
   const target = TARGETS[targetName];
@@ -400,7 +381,13 @@ async function main() {
     );
   }
 
-  const { branch: currentBranch, commit } = await preflight(targetName, target);
+  const { branch: currentBranch, commit: currentCommit } = await preflight(targetName, target);
+  const commit = await resolveDeploymentCommit({
+    targetName,
+    currentCommit,
+    workflowCommit: process.env.DEPLOY_VERIFY_COMMIT,
+    resolveTree: async (ref) => getGitRef(["rev-parse", `${ref}^{tree}`]),
+  });
   const requestedPreviewBranch = parseArg("branch");
   if (requestedPreviewBranch && targetName !== "staging-preview") {
     throw new Error("--branch is only valid for the staging-preview target.");
@@ -451,13 +438,21 @@ async function main() {
       }
     });
 
-    await verifyDeployment(
-      targetName,
-      target.projectName,
+    await verifyMatchingPagesDeployment({
+      projectName: target.projectName,
       commit,
-      deployBranch,
-      deployedPreviewUrl,
-    );
+      branch: deployBranch,
+      deploymentUrl: deployedPreviewUrl,
+      listDeployments: async () => {
+        const { stdout } = await run(
+          wrangler,
+          ["pages", "deployment", "list", "--project-name", target.projectName],
+          { capture: true },
+        );
+        return stdout;
+      },
+      wait: sleep,
+    });
     console.log(
       `[deploy-pages-safe] Success: target=${targetName} project=${target.projectName} branch=${deployBranch} commit=${commit}`,
     );

--- a/scripts/deploy-pages-safe.mjs
+++ b/scripts/deploy-pages-safe.mjs
@@ -286,6 +286,15 @@ async function getGitRef(args = ["rev-parse", "--abbrev-ref", "HEAD"]) {
   return stdout.trim();
 }
 
+async function resolveVerifiedDeploymentCommit(targetName, currentCommit) {
+  return resolveDeploymentCommit({
+    targetName,
+    currentCommit,
+    workflowCommit: process.env.DEPLOY_VERIFY_COMMIT,
+    resolveTree: async (ref) => getGitRef(["rev-parse", `${ref}^{tree}`]),
+  });
+}
+
 async function preflight(targetName, target) {
   const branch = await getGitRef();
   const commit = await getGitRef(["rev-parse", "--short", "HEAD"]);
@@ -381,13 +390,19 @@ async function main() {
     );
   }
 
+  if (process.argv.includes("--verify-commit-only")) {
+    assert(
+      targetName === "prod-main",
+      "--verify-commit-only is only valid for the prod-main target.",
+    );
+    const currentCommit = await getGitRef(["rev-parse", "--short", "HEAD"]);
+    const commit = await resolveVerifiedDeploymentCommit(targetName, currentCommit);
+    console.log(`[deploy-pages-safe] Production workflow commit validated: ${commit}`);
+    return;
+  }
+
   const { branch: currentBranch, commit: currentCommit } = await preflight(targetName, target);
-  const commit = await resolveDeploymentCommit({
-    targetName,
-    currentCommit,
-    workflowCommit: process.env.DEPLOY_VERIFY_COMMIT,
-    resolveTree: async (ref) => getGitRef(["rev-parse", `${ref}^{tree}`]),
-  });
+  const commit = await resolveVerifiedDeploymentCommit(targetName, currentCommit);
   const requestedPreviewBranch = parseArg("branch");
   if (requestedPreviewBranch && targetName !== "staging-preview") {
     throw new Error("--branch is only valid for the staging-preview target.");

--- a/scripts/pages-preview.mjs
+++ b/scripts/pages-preview.mjs
@@ -52,3 +52,49 @@ export function hasMatchingPagesDeployment(output, { commit, branch, deploymentU
     );
   });
 }
+
+export async function resolveDeploymentCommit({
+  targetName,
+  currentCommit,
+  workflowCommit,
+  resolveTree,
+}) {
+  if (targetName !== "prod-main") return currentCommit;
+
+  const commit = String(workflowCommit ?? "").trim().toLowerCase();
+  if (!/^[0-9a-f]{40}$/.test(commit)) {
+    throw new Error(
+      "DEPLOY_VERIFY_COMMIT must be a full 40-character hexadecimal SHA for production.",
+    );
+  }
+
+  const [workflowTree, releaseTree] = await Promise.all([
+    resolveTree(commit),
+    resolveTree("HEAD"),
+  ]);
+  if (String(workflowTree).trim().toLowerCase() !== String(releaseTree).trim().toLowerCase()) {
+    throw new Error(
+      "DEPLOY_VERIFY_COMMIT workflow commit tree does not match the tagged release worktree.",
+    );
+  }
+  return commit;
+}
+
+export async function verifyMatchingPagesDeployment({
+  projectName,
+  commit,
+  branch,
+  deploymentUrl = "",
+  attempts = 6,
+  listDeployments,
+  wait,
+}) {
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const output = await listDeployments();
+    if (hasMatchingPagesDeployment(output, { commit, branch, deploymentUrl })) return;
+    if (attempt < attempts) await wait(5000);
+  }
+  throw new Error(
+    `Post-deploy verification failed: no ${projectName} deployment matched branch ${branch} and commit ${commit}.`,
+  );
+}

--- a/scripts/pages-preview.mjs
+++ b/scripts/pages-preview.mjs
@@ -29,6 +29,18 @@ export function parsePagesDeploymentUrl(output, projectName) {
   return match[0].replace(/[),.;]+$/, "");
 }
 
+const SUCCESSFUL_PAGES_STATUS = /^(?:just now|right now|(?:\d+ (?:seconds?|minutes?|hours?|days?|weeks?|months?|years?) ago)|(?:in \d+ (?:seconds?|minutes?|hours?|days?|weeks?|months?|years?)))$/;
+
+function hasSuccessfulPagesStatus(columns, expectedUrl) {
+  const deploymentIndex = columns.findIndex((column) =>
+    expectedUrl
+      ? column === expectedUrl
+      : /^https:\/\/[^\s]+\.pages\.dev(?:\/[^\s]*)?$/i.test(column),
+  );
+  if (deploymentIndex < 0) return false;
+  return SUCCESSFUL_PAGES_STATUS.test(columns[deploymentIndex + 1] ?? "");
+}
+
 export function hasMatchingPagesDeployment(output, { commit, branch, deploymentUrl = "" }) {
   const expectedCommit = String(commit ?? "").trim().toLowerCase();
   const expectedBranch = String(branch ?? "").trim();
@@ -48,7 +60,8 @@ export function hasMatchingPagesDeployment(output, { commit, branch, deploymentU
     return (
       Boolean(source) &&
       columns.includes(expectedBranch) &&
-      (!expectedUrl || columns.includes(expectedUrl))
+      (!expectedUrl || columns.includes(expectedUrl)) &&
+      hasSuccessfulPagesStatus(columns, expectedUrl)
     );
   });
 }


### PR DESCRIPTION
## Summary

- validate the workflow SHA and require its tree to match the tagged release worktree before any production D1 migration or deployment metadata is created
- require the exact immutable Pages deployment returned by the current command to match and succeed, and fail when lookup retries are exhausted without printing a false success marker
- validate workflow-derived preview and release values before using quoted shell variables
- add deployment-helper and workflow regressions for malformed, mismatched, missing, and successful verification paths

## Authority boundary

This PR changes release verification code and tests only. It does not run a preview, mutate Cloudflare or D1, deploy to production, promote staging, or change branch protection.

## Verification

- focused regression: 2 files, 37 tests passed
- `npm test`: 163 files, 1069 tests passed
- `npm run build`
- `npm run agents:validate`
- `npm run security:scan`
- `git diff --check`
- `npm run dev:check` (no server running)
- independent exact-head review: PASS for base `f3430b10b01bafd60823cc00f31fe243fca5e236` and head `d01de658d1b492ccc5ebf45841068a42ee3dd7fa`

## Release notes

- documentation impact: none
- version remains `0.27.0`

Refs #1052

— Forge · AI coding agent
<!-- linksim-ai:v1 agent=Forge bot=true run=ab80ab2a-fd50-4a45-b23c-08c82e06dc6d source=issue:1052-production-verification-pr commit=d01de658d1b492ccc5ebf45841068a42ee3dd7fa -->
