### PR TITLE
fix(security): constrain proxy trust boundaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN npm run build
 
 FROM nginx:1.27-alpine AS production
 COPY nginx/default.conf /etc/nginx/conf.d/default.conf
+RUN nginx -t
 COPY --from=build /app/dist /usr/share/nginx/html
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/calculation_api/main.py
+++ b/calculation_api/main.py
@@ -19,8 +19,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         if request.url.path == "/health":
             return await call_next(request)
 
-        client_ip = request.headers.get("x-forwarded-for", request.client.host if request.client else "unknown")
-        client_key = client_ip.split(",", 1)[0].strip() or "unknown"
+        client_key = request.client.host if request.client else "unknown"
         allowed, retry_after = self._limiter.allow(client_key)
         if not allowed:
             return JSONResponse(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       target: development
     command: npm run dev -- --host 0.0.0.0 --port 5173
     ports:
-      - "5173:5173"
+      - "${LINKSIM_DOCKER_BIND_ADDRESS:-127.0.0.1}:5173:5173"
     volumes:
       - .:/app
       - /app/node_modules
@@ -24,7 +24,7 @@ services:
       target: development
     command: sh -lc "npm run build:client && npx wrangler pages dev dist --ip 0.0.0.0 --port 8788 --d1 DB=d669aac0-37ea-4c68-9b27-ece888e1966a --r2 AVATAR_BUCKET=linksim-avatars --binding ALLOW_INSECURE_DEV_AUTH=true --binding DEV_AUTH_USER_ID=local-dev-user --binding ADMIN_USER_IDS=local-dev-user --local --persist-to .wrangler/state"
     ports:
-      - "8788:8788"
+      - "${LINKSIM_DOCKER_BIND_ADDRESS:-127.0.0.1}:8788:8788"
     volumes:
       - .:/app
       - /app/node_modules

--- a/docs/repository-guide.md
+++ b/docs/repository-guide.md
@@ -58,6 +58,14 @@ npm run dev:edge
 
 It serves the built app and local Cloudflare bindings at `http://localhost:8788`. Docker Compose provides equivalent `dev`, `edge`, and production-style `web` services when a container workflow is preferred.
 
+Docker Compose publishes the `dev` and `edge` services on loopback by default. To make those development services reachable from another trusted machine, opt in explicitly for that invocation:
+
+```bash
+LINKSIM_DOCKER_BIND_ADDRESS=0.0.0.0 docker compose up dev edge
+```
+
+Do not use a public bind address on an untrusted network. The standalone calculation API ignores caller-supplied forwarding headers and uses its direct peer address for rate limiting. When it is intentionally placed behind a reverse proxy, set Uvicorn's `FORWARDED_ALLOW_IPS` only to the known proxy IP address or CIDR; do not use a wildcard trust value.
+
 ## Build, Test, Smoke
 
 Core commands:

--- a/functions/_lib/proxy.ts
+++ b/functions/_lib/proxy.ts
@@ -1,0 +1,22 @@
+const SENSITIVE_PROXY_RESPONSE_HEADERS = [
+  "authorization",
+  "cookie",
+  "set-cookie",
+  "www-authenticate",
+  "proxy-authenticate",
+  "cf-access-authenticated-user-email",
+  "cf-access-authenticated-user-id",
+  "cf-access-authenticated-user-name",
+  "cf-access-jwt-assertion",
+  "cf-access-client-id",
+  "cf-access-client-secret",
+  "cf-connecting-ip",
+  "x-forwarded-for",
+  "x-forwarded-proto",
+  "x-real-ip",
+] as const;
+
+export const stripSensitiveProxyResponseHeaders = (headers: Headers): Headers => {
+  for (const name of SENSITIVE_PROXY_RESPONSE_HEADERS) headers.delete(name);
+  return headers;
+};

--- a/functions/_lib/rateLimit.test.ts
+++ b/functions/_lib/rateLimit.test.ts
@@ -2,16 +2,23 @@ import { describe, expect, it } from "vitest";
 import { getClientAddress, takeRateLimitToken } from "./rateLimit";
 
 describe("rate limit helpers", () => {
-  it("extracts client address from Cloudflare and forwarded headers", () => {
+  it("uses only Cloudflare-established client identity", () => {
     const cfReq = new Request("https://example.test", {
-      headers: { "cf-connecting-ip": " 203.0.113.9 " },
+      headers: {
+        "cf-connecting-ip": " 203.0.113.9 ",
+        "x-forwarded-for": "198.51.100.10, 10.0.0.2",
+      },
     });
     expect(getClientAddress(cfReq)).toBe("203.0.113.9");
 
-    const fwdReq = new Request("https://example.test", {
-      headers: { "x-forwarded-for": "198.51.100.10, 10.0.0.2" },
+    const spoofedReq = new Request("https://example.test", {
+      headers: {
+        "x-forwarded-for": "198.51.100.10, 10.0.0.2",
+        "cf-access-authenticated-user-email": "attacker@example.test",
+        "user-agent": "attacker-selected",
+      },
     });
-    expect(getClientAddress(fwdReq)).toBe("198.51.100.10");
+    expect(getClientAddress(spoofedReq)).toBe("unknown");
 
     const unknownReq = new Request("https://example.test");
     expect(getClientAddress(unknownReq)).toBe("unknown");

--- a/functions/_lib/rateLimit.ts
+++ b/functions/_lib/rateLimit.ts
@@ -32,11 +32,11 @@ const toSafeLimit = (value: number): number => {
   return Math.max(1, Math.floor(value));
 };
 
+// Pages callers may trust CF-Connecting-IP because Cloudflare establishes it.
+// Generic forwarding headers remain caller-controlled and are never identities.
 export const getClientAddress = (request: Request): string => {
   const cfIp = (request.headers.get("cf-connecting-ip") ?? "").trim();
   if (cfIp) return cfIp;
-  const forwarded = (request.headers.get("x-forwarded-for") ?? "").split(",")[0]?.trim();
-  if (forwarded) return forwarded;
   return "unknown";
 };
 

--- a/functions/_lib/selfHostedProxyConfig.test.ts
+++ b/functions/_lib/selfHostedProxyConfig.test.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const readRepoFile = (path: string): string => readFileSync(resolve(process.cwd(), path), "utf8");
+
+describe("self-hosted proxy configuration", () => {
+  const nginx = readRepoFile("nginx/default.conf");
+
+  it("allows only the exact passive MeshMap resource contract", () => {
+    expect(nginx).toContain("location = /meshmap/nodes.json {");
+    expect(nginx).toMatch(/if \(\$args != ""\) \{\s+return 400;/);
+    expect(nginx).toMatch(/if \(\$request_method !~ \^\(GET\|HEAD\)\$\) \{\s+return 405;/);
+    expect(nginx).toContain("location = /meshmap {");
+    expect(nginx).toContain("location ^~ /meshmap/ {");
+    expect(nginx.match(/return 404 "Not found\\n";/g)).toHaveLength(2);
+    expect(nginx.match(/add_header Cache-Control no-store always;/g)).toHaveLength(2);
+  });
+
+  it("does not relay caller credentials or forwarding identity", () => {
+    expect(nginx).toContain("proxy_pass_request_headers off;");
+    expect(nginx).toContain("proxy_pass_request_body off;");
+    expect(nginx).toContain("proxy_set_header Host meshmap.net;");
+    expect(nginx).toContain("proxy_set_header Accept application/json;");
+    for (const header of [
+      "Authorization",
+      "Cookie",
+      "Set-Cookie",
+      "CF-Access-Authenticated-User-Email",
+      "CF-Access-Authenticated-User-Id",
+      "CF-Access-Authenticated-User-Name",
+      "CF-Access-Jwt-Assertion",
+      "CF-Connecting-IP",
+      "X-Forwarded-For",
+      "X-Real-IP",
+    ]) {
+      expect(nginx).toContain(`proxy_hide_header ${header};`);
+    }
+  });
+
+  it("does not relay origin-active upstream response headers", () => {
+    expect(nginx).toContain(
+      "proxy_ignore_headers X-Accel-Redirect X-Accel-Expires X-Accel-Limit-Rate X-Accel-Buffering X-Accel-Charset;",
+    );
+    for (const header of [
+      "Clear-Site-Data",
+      "Refresh",
+      "Location",
+      "Content-Location",
+      "Alt-Svc",
+      "Content-Security-Policy",
+      "Content-Security-Policy-Report-Only",
+      "Permissions-Policy",
+      "Origin-Trial",
+      "Accept-CH",
+      "Critical-CH",
+      "Report-To",
+      "Reporting-Endpoints",
+      "NEL",
+      "Link",
+      "Access-Control-Allow-Origin",
+      "Access-Control-Allow-Credentials",
+      "Access-Control-Expose-Headers",
+      "Strict-Transport-Security",
+    ]) {
+      expect(nginx).toContain(`proxy_hide_header ${header};`);
+    }
+  });
+
+  it("forces passive response handling and direct-peer rate limiting", () => {
+    expect(nginx).toContain("limit_req_zone $binary_remote_addr zone=meshmap_per_ip:10m rate=120r/m;");
+    expect(nginx).toContain("limit_req_status 429;");
+    expect(nginx).toContain('add_header Content-Type "application/json; charset=utf-8" always;');
+    expect(nginx).toContain('add_header Content-Disposition "attachment; filename=nodes.json" always;');
+    expect(nginx).toContain("add_header X-Content-Type-Options nosniff always;");
+    expect(nginx).toMatch(/~\^2\s+"public, max-age=1800";/);
+    expect(nginx).toMatch(/default\s+"no-store";/);
+  });
+
+  it("binds only Docker development and edge ports to loopback by default", () => {
+    const compose = readRepoFile("docker-compose.yml");
+    expect(compose).toContain('${LINKSIM_DOCKER_BIND_ADDRESS:-127.0.0.1}:5173:5173');
+    expect(compose).toContain('${LINKSIM_DOCKER_BIND_ADDRESS:-127.0.0.1}:8788:8788');
+    expect(compose).toContain('- "8080:80"');
+    expect(compose).toContain('- "8000:8000"');
+  });
+});

--- a/functions/copernicus/[[path]].test.ts
+++ b/functions/copernicus/[[path]].test.ts
@@ -73,7 +73,7 @@ describe("copernicus proxy", () => {
     );
     expect(takeRateLimitTokenMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        key: "proxy:copernicus:tile:user:node@linksim.test",
+        key: "proxy:copernicus:tile:ip:203.0.113.9",
         limit: 1500,
       }),
     );
@@ -99,7 +99,7 @@ describe("copernicus proxy", () => {
     expect(res.status).toBe(200);
     expect(takeRateLimitTokenMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        key: "proxy:copernicus:tilelist:user:node@linksim.test",
+        key: "proxy:copernicus:tilelist:ip:203.0.113.9",
         limit: 40,
       }),
     );
@@ -150,6 +150,62 @@ describe("copernicus proxy", () => {
     expect(res.status).toBe(429);
     expect(res.headers.get("x-rate-limit-source")).toBe("upstream");
     expect(res.headers.get("x-cache-status")).toBe("MISS");
+  });
+
+  it("does not use Access identity or user agent as a fallback limiter bucket", async () => {
+    getClientAddressMock.mockReturnValueOnce("unknown");
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response("tif", { status: 200, headers: { "content-type": "image/tiff" } }),
+    );
+    const req = new Request(
+      "https://example.test/copernicus/30m/Copernicus_DSM_COG_10_N60_00_E009_00_DEM/Copernicus_DSM_COG_10_N60_00_E009_00_DEM.tif",
+      {
+        headers: {
+          "cf-access-authenticated-user-email": "attacker@example.test",
+          "user-agent": "attacker-selected",
+        },
+      },
+    );
+
+    await onRequest(mkCtx(req));
+
+    expect(takeRateLimitTokenMock).toHaveBeenCalledWith(
+      expect.objectContaining({ key: "proxy:copernicus:tile:unknown" }),
+    );
+  });
+
+  it("strips sensitive headers from successful and failed upstream responses", async () => {
+    const sensitiveHeaders = {
+      "set-cookie": "secret=1",
+      authorization: "Bearer secret",
+      "cf-access-authenticated-user-email": "upstream@example.test",
+      "cf-access-authenticated-user-id": "upstream-id",
+      "cf-access-authenticated-user-name": "Upstream Name",
+      "cf-access-jwt-assertion": "upstream-jwt",
+      "x-forwarded-for": "192.0.2.1",
+    };
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(
+        new Response("tif", { status: 200, headers: { "content-type": "image/tiff", ...sensitiveHeaders } }),
+      )
+      .mockResolvedValueOnce(
+        new Response("failed", { status: 502, headers: { "content-type": "text/plain", ...sensitiveHeaders } }),
+      );
+    const requestUrl =
+      "https://example.test/copernicus/30m/Copernicus_DSM_COG_10_N60_00_E009_00_DEM/Copernicus_DSM_COG_10_N60_00_E009_00_DEM.tif";
+
+    const success = await onRequest(mkCtx(new Request(requestUrl)));
+    const failure = await onRequest(mkCtx(new Request(requestUrl)));
+
+    for (const response of [success, failure]) {
+      expect(response.headers.get("set-cookie")).toBeNull();
+      expect(response.headers.get("authorization")).toBeNull();
+      expect(response.headers.get("cf-access-authenticated-user-email")).toBeNull();
+      expect(response.headers.get("cf-access-authenticated-user-id")).toBeNull();
+      expect(response.headers.get("cf-access-authenticated-user-name")).toBeNull();
+      expect(response.headers.get("cf-access-jwt-assertion")).toBeNull();
+      expect(response.headers.get("x-forwarded-for")).toBeNull();
+    }
   });
 
   it("serves cached tile from edge cache on cache hit", async () => {

--- a/functions/copernicus/[[path]].ts
+++ b/functions/copernicus/[[path]].ts
@@ -1,4 +1,5 @@
 import { handleOptions } from "../_lib/http";
+import { stripSensitiveProxyResponseHeaders } from "../_lib/proxy";
 import { getClientAddress, takeRateLimitToken } from "../_lib/rateLimit";
 import type { Env } from "../_lib/types";
 
@@ -18,13 +19,9 @@ const DATASET_TO_BUCKET: Record<string, string> = {
 const RATE_LIMIT_SOURCE_HEADER = "X-Rate-Limit-Source";
 
 const rateLimitIdentityFor = (request: Request): string => {
-  const accessEmail = (request.headers.get("cf-access-authenticated-user-email") ?? "").trim().toLowerCase();
-  if (accessEmail) return `user:${accessEmail}`;
   const clientIp = getClientAddress(request);
   if (clientIp && clientIp !== "unknown") return `ip:${clientIp}`;
-  const userAgent = (request.headers.get("user-agent") ?? "").trim().toLowerCase();
-  if (userAgent) return `ua:${userAgent}`;
-  return "anon";
+  return "unknown";
 };
 
 const addRateLimitHeaders = (headers: Headers, limiter: { allowed: boolean; remaining: number; retryAfterSec: number }, limit: number): void => {
@@ -68,7 +65,7 @@ export const onRequest: PagesFunction<Env> = async ({ request, env }) => {
 
   const cached = shouldUseCache ? await cache.match(cacheKey) : null;
   if (cached) {
-    const headers = new Headers(cached.headers);
+    const headers = stripSensitiveProxyResponseHeaders(new Headers(cached.headers));
     headers.set("X-Cache-Status", "HIT");
     headers.set(RATE_LIMIT_SOURCE_HEADER, "none");
     return new Response(cached.body, { status: cached.status, statusText: cached.statusText, headers });
@@ -97,11 +94,10 @@ export const onRequest: PagesFunction<Env> = async ({ request, env }) => {
   });
 
   if (response.ok) {
-    const headers = new Headers(response.headers);
+    const headers = stripSensitiveProxyResponseHeaders(new Headers(response.headers));
     headers.set("X-Cache-Status", "MISS");
     headers.set(RATE_LIMIT_SOURCE_HEADER, "none");
     headers.set("cache-control", isTileList ? "public, max-age=3600, s-maxage=21600" : "public, max-age=86400, s-maxage=604800");
-    headers.delete("set-cookie");
     addRateLimitHeaders(headers, limiter, limit);
     const cacheable = new Response(response.body, { status: response.status, statusText: response.statusText, headers });
     if (shouldUseCache) {
@@ -110,7 +106,7 @@ export const onRequest: PagesFunction<Env> = async ({ request, env }) => {
     return cacheable;
   }
 
-  const missHeaders = new Headers(response.headers);
+  const missHeaders = stripSensitiveProxyResponseHeaders(new Headers(response.headers));
   missHeaders.set("X-Cache-Status", "MISS");
   missHeaders.set(RATE_LIMIT_SOURCE_HEADER, response.status === 429 ? "upstream" : "none");
   missHeaders.set("cache-control", "no-store");

--- a/functions/meshmap/[[path]].test.ts
+++ b/functions/meshmap/[[path]].test.ts
@@ -32,34 +32,154 @@ describe("meshmap proxy", () => {
     const res = await onRequest(mkCtx(req));
 
     expect(res.status).toBe(405);
+    expect(res.headers.get("cache-control")).toBe("no-store");
     expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(takeRateLimitTokenMock).not.toHaveBeenCalled();
   });
 
-  it("returns 429 when rate limiter blocks request", async () => {
+  it.each([
+    "https://example.test/meshmap",
+    "https://example.test/meshmap/",
+    "https://example.test/meshmap/index.html",
+    "https://example.test/meshmap/nodes.json/extra",
+  ])("rejects disallowed path %s", async (url) => {
+    const res = await onRequest(mkCtx(new Request(url)));
+
+    expect(res.status).toBe(404);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(takeRateLimitTokenMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects every query parameter", async () => {
+    const res = await onRequest(mkCtx(new Request("https://example.test/meshmap/nodes.json?region=no")));
+
+    expect(res.status).toBe(400);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(takeRateLimitTokenMock).not.toHaveBeenCalled();
+  });
+
+  it("returns diagnostic headers when the proxy limiter blocks the request", async () => {
     takeRateLimitTokenMock.mockReturnValueOnce({ allowed: false, remaining: 0, retryAfterSec: 9 });
-    const req = new Request("https://example.test/meshmap/nodes.json");
-    const res = await onRequest(mkCtx(req));
+    const res = await onRequest(mkCtx(new Request("https://example.test/meshmap/nodes.json")));
 
     expect(res.status).toBe(429);
     expect(res.headers.get("retry-after")).toBe("9");
+    expect(res.headers.get("x-rate-limit-source")).toBe("proxy");
+    expect(res.headers.get("cache-control")).toBe("no-store");
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
-  it("forwards allowed GET requests to meshmap upstream", async () => {
+  it("forwards only the fixed passive request contract", async () => {
     vi.mocked(globalThis.fetch).mockResolvedValueOnce(
-      new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } }),
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json; charset=utf-8" },
+      }),
     );
-    const req = new Request("https://example.test/meshmap/nodes.json?region=no", {
-      headers: { accept: "application/json" },
+    const req = new Request("https://example.test/meshmap/nodes.json", {
+      headers: {
+        accept: "text/html",
+        authorization: "Bearer secret",
+        cookie: "session=secret",
+        "cf-access-authenticated-user-email": "user@example.test",
+        "cf-access-authenticated-user-id": "user-id",
+        "cf-access-authenticated-user-name": "User Name",
+        "cf-access-jwt-assertion": "secret-jwt",
+        "x-forwarded-for": "203.0.113.99",
+      },
     });
 
     const res = await onRequest(mkCtx(req));
 
     expect(res.status).toBe(200);
-    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
-    expect(String(vi.mocked(globalThis.fetch).mock.calls[0]?.[0])).toBe("https://meshmap.net/nodes.json?region=no");
-    expect(vi.mocked(globalThis.fetch).mock.calls[0]?.[1]).toMatchObject({
+    expect(globalThis.fetch).toHaveBeenCalledWith("https://meshmap.net/nodes.json", {
       method: "GET",
+      headers: { accept: "application/json" },
+    });
+    expect(res.headers.get("content-type")).toBe("application/json; charset=utf-8");
+    expect(res.headers.get("content-disposition")).toBe('attachment; filename="nodes.json"');
+    expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(res.headers.get("cache-control")).toBe("public, max-age=1800");
+  });
+
+  it("does not relay sensitive upstream response headers", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response("{}", {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+          "set-cookie": "upstream=secret",
+          authorization: "Bearer upstream",
+          "cf-access-authenticated-user-email": "upstream@example.test",
+          "cf-access-authenticated-user-id": "upstream-id",
+          "cf-access-authenticated-user-name": "Upstream Name",
+          "cf-access-jwt-assertion": "upstream-jwt",
+          "x-forwarded-for": "192.0.2.1",
+        },
+      }),
+    );
+
+    const res = await onRequest(mkCtx(new Request("https://example.test/meshmap/nodes.json")));
+
+    expect(res.headers.get("set-cookie")).toBeNull();
+    expect(res.headers.get("authorization")).toBeNull();
+    expect(res.headers.get("cf-access-authenticated-user-email")).toBeNull();
+    expect(res.headers.get("cf-access-authenticated-user-id")).toBeNull();
+    expect(res.headers.get("cf-access-authenticated-user-name")).toBeNull();
+    expect(res.headers.get("cf-access-jwt-assertion")).toBeNull();
+    expect(res.headers.get("x-forwarded-for")).toBeNull();
+  });
+
+  it.each(["text/html", "application/javascript", null])(
+    "rejects active or missing upstream content type %s",
+    async (contentType) => {
+      const headers = contentType ? { "content-type": contentType } : undefined;
+      vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+        new Response("<script>alert(1)</script>", { status: 200, headers }),
+      );
+
+      const res = await onRequest(mkCtx(new Request("https://example.test/meshmap/nodes.json")));
+
+      expect(res.status).toBe(502);
+      expect(res.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+      expect(res.headers.get("content-disposition")).toBe('attachment; filename="nodes.txt"');
+      expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+      expect(res.headers.get("cache-control")).toBe("no-store");
+      expect(await res.text()).not.toContain("<script>");
+    },
+  );
+
+  it("labels upstream throttling without relaying its response body or credentials", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response("<html>upstream throttle</html>", {
+        status: 429,
+        headers: { "retry-after": "7", "content-type": "text/html", "set-cookie": "bad=1" },
+      }),
+    );
+
+    const res = await onRequest(mkCtx(new Request("https://example.test/meshmap/nodes.json")));
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get("retry-after")).toBe("7");
+    expect(res.headers.get("x-rate-limit-source")).toBe("upstream");
+    expect(res.headers.get("set-cookie")).toBeNull();
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    expect(await res.text()).not.toContain("<html>");
+  });
+
+  it("supports HEAD without returning a body", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(null, { status: 200, headers: { "content-type": "application/json" } }),
+    );
+
+    const res = await onRequest(mkCtx(new Request("https://example.test/meshmap/nodes.json", { method: "HEAD" })));
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("");
+    expect(globalThis.fetch).toHaveBeenCalledWith("https://meshmap.net/nodes.json", {
+      method: "HEAD",
       headers: { accept: "application/json" },
     });
   });

--- a/functions/meshmap/[[path]].ts
+++ b/functions/meshmap/[[path]].ts
@@ -1,8 +1,10 @@
-import { handleOptions } from "../_lib/http";
+import { stripSensitiveProxyResponseHeaders } from "../_lib/proxy";
 import { getClientAddress, takeRateLimitToken } from "../_lib/rateLimit";
 import type { Env } from "../_lib/types";
 
-export const onRequestOptions: PagesFunction<Env> = async ({ request }) => handleOptions(request);
+const MESHMAP_PATH = "/meshmap/nodes.json";
+const MESHMAP_UPSTREAM = "https://meshmap.net/nodes.json";
+const SUCCESS_CACHE_CONTROL = "public, max-age=1800";
 
 const parsePerMinuteLimit = (raw: string | undefined, fallback: number): number => {
   const parsed = Number(raw ?? "");
@@ -10,45 +12,73 @@ const parsePerMinuteLimit = (raw: string | undefined, fallback: number): number 
   return Math.max(1, Math.floor(parsed));
 };
 
-export const onRequest: PagesFunction<Env> = async ({ request, env }) => {
-  if (request.method !== "GET" && request.method !== "HEAD") {
-    return new Response("Method not allowed", { status: 405 });
-  }
+const passiveHeaders = (
+  contentType: string,
+  filename: string,
+  cacheControl: string,
+  extra?: HeadersInit,
+): Headers => {
+  const headers = new Headers(extra);
+  headers.set("content-type", contentType);
+  headers.set("content-disposition", `attachment; filename="${filename}"`);
+  headers.set("x-content-type-options", "nosniff");
+  headers.set("cache-control", cacheControl);
+  return stripSensitiveProxyResponseHeaders(headers);
+};
 
-  const ip = getClientAddress(request);
+const localError = (message: string, status: number, extra?: HeadersInit): Response =>
+  new Response(message, {
+    status,
+    headers: passiveHeaders("text/plain; charset=utf-8", "nodes.txt", "no-store", extra),
+  });
+
+const isJsonContentType = (value: string | null): boolean =>
+  value?.split(";", 1)[0]?.trim().toLowerCase() === "application/json";
+
+export const onRequest: PagesFunction<Env> = async ({ request, env }) => {
+  const url = new URL(request.url);
+  if (url.pathname !== MESHMAP_PATH) return localError("Not found", 404);
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return localError("Method not allowed", 405, { allow: "GET, HEAD" });
+  }
+  if (url.search) return localError("Query parameters are not allowed", 400);
+
   const limiter = takeRateLimitToken({
-    key: `proxy:meshmap:${ip}`,
+    key: `proxy:meshmap:${getClientAddress(request)}`,
     limit: parsePerMinuteLimit(env.PROXY_RATE_LIMIT_PER_MINUTE, 120),
   });
   if (!limiter.allowed) {
-    return new Response("Rate limit reached", {
-      status: 429,
-      headers: {
-        "retry-after": String(limiter.retryAfterSec),
-      },
+    return localError("Rate limit reached", 429, {
+      "retry-after": String(limiter.retryAfterSec),
+      "x-rate-limit-source": "proxy",
     });
   }
 
-  const url = new URL(request.url);
-  const upstreamPath = url.pathname.replace(/^\/meshmap/, "");
-  const upstream = new URL(`https://meshmap.net${upstreamPath}${url.search}`);
-
-  const response = await fetch(upstream.toString(), {
-    method: request.method,
-    headers: {
-      accept: request.headers.get("accept") ?? "*/*",
-    },
-  });
-
-  const responseHeaders = new Headers(response.headers);
-  if (response.ok) {
-    responseHeaders.set("Cache-Control", "public, max-age=1800");
-  } else {
-    responseHeaders.set("Cache-Control", "no-store");
+  let response: Response;
+  try {
+    response = await fetch(MESHMAP_UPSTREAM, {
+      method: request.method,
+      headers: { accept: "application/json" },
+    });
+  } catch {
+    return localError("MeshMap upstream request failed", 502);
   }
-  return new Response(response.body, {
+
+  if (!response.ok) {
+    const extra = new Headers();
+    const retryAfter = response.headers.get("retry-after");
+    if (retryAfter) extra.set("retry-after", retryAfter);
+    if (response.status === 429) extra.set("x-rate-limit-source", "upstream");
+    return localError("MeshMap upstream request failed", response.status, extra);
+  }
+
+  if (!isJsonContentType(response.headers.get("content-type"))) {
+    return localError("MeshMap upstream returned an unsupported content type", 502);
+  }
+
+  return new Response(request.method === "HEAD" ? null : response.body, {
     status: response.status,
     statusText: response.statusText,
-    headers: responseHeaders,
+    headers: passiveHeaders("application/json; charset=utf-8", "nodes.json", SUCCESS_CACHE_CONTROL),
   });
 };

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,3 +1,10 @@
+limit_req_zone $binary_remote_addr zone=meshmap_per_ip:10m rate=120r/m;
+
+map $upstream_status $meshmap_cache_control {
+  ~^2     "public, max-age=1800";
+  default "no-store";
+}
+
 server {
   listen 80;
   server_name _;
@@ -5,16 +12,85 @@ server {
   root /usr/share/nginx/html;
   index index.html;
 
-  location / {
-    try_files $uri $uri/ /index.html;
+  location = /meshmap {
+    default_type text/plain;
+    add_header X-Content-Type-Options nosniff always;
+    add_header Cache-Control no-store always;
+    return 404 "Not found\n";
   }
 
-  location /meshmap/ {
-    proxy_pass https://meshmap.net/;
+  location = /meshmap/nodes.json {
+    if ($args != "") {
+      return 400;
+    }
+    if ($request_method !~ ^(GET|HEAD)$) {
+      return 405;
+    }
+
+    limit_req zone=meshmap_per_ip burst=30 nodelay;
+    limit_req_status 429;
+
+    proxy_pass https://meshmap.net/nodes.json;
     proxy_ssl_server_name on;
+    proxy_pass_request_headers off;
+    proxy_pass_request_body off;
     proxy_set_header Host meshmap.net;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Accept application/json;
+    proxy_ignore_headers X-Accel-Redirect X-Accel-Expires X-Accel-Limit-Rate X-Accel-Buffering X-Accel-Charset;
+
+    proxy_hide_header Authorization;
+    proxy_hide_header Cookie;
+    proxy_hide_header Set-Cookie;
+    proxy_hide_header WWW-Authenticate;
+    proxy_hide_header Proxy-Authenticate;
+    proxy_hide_header CF-Access-Authenticated-User-Email;
+    proxy_hide_header CF-Access-Authenticated-User-Id;
+    proxy_hide_header CF-Access-Authenticated-User-Name;
+    proxy_hide_header CF-Access-Jwt-Assertion;
+    proxy_hide_header CF-Access-Client-Id;
+    proxy_hide_header CF-Access-Client-Secret;
+    proxy_hide_header CF-Connecting-IP;
+    proxy_hide_header X-Forwarded-For;
+    proxy_hide_header X-Forwarded-Proto;
+    proxy_hide_header X-Real-IP;
+    proxy_hide_header Content-Type;
+    proxy_hide_header Content-Disposition;
+    proxy_hide_header X-Content-Type-Options;
+    proxy_hide_header Cache-Control;
+    proxy_hide_header Clear-Site-Data;
+    proxy_hide_header Refresh;
+    proxy_hide_header Location;
+    proxy_hide_header Content-Location;
+    proxy_hide_header Alt-Svc;
+    proxy_hide_header Content-Security-Policy;
+    proxy_hide_header Content-Security-Policy-Report-Only;
+    proxy_hide_header Permissions-Policy;
+    proxy_hide_header Origin-Trial;
+    proxy_hide_header Accept-CH;
+    proxy_hide_header Critical-CH;
+    proxy_hide_header Report-To;
+    proxy_hide_header Reporting-Endpoints;
+    proxy_hide_header NEL;
+    proxy_hide_header Link;
+    proxy_hide_header Access-Control-Allow-Origin;
+    proxy_hide_header Access-Control-Allow-Credentials;
+    proxy_hide_header Access-Control-Expose-Headers;
+    proxy_hide_header Strict-Transport-Security;
+
+    add_header Content-Type "application/json; charset=utf-8" always;
+    add_header Content-Disposition "attachment; filename=nodes.json" always;
+    add_header X-Content-Type-Options nosniff always;
+    add_header Cache-Control $meshmap_cache_control always;
+  }
+
+  location ^~ /meshmap/ {
+    default_type text/plain;
+    add_header X-Content-Type-Options nosniff always;
+    add_header Cache-Control no-store always;
+    return 404 "Not found\n";
+  }
+
+  location / {
+    try_files $uri $uri/ /index.html;
   }
 }

--- a/tests/calculation_api/test_api.py
+++ b/tests/calculation_api/test_api.py
@@ -148,3 +148,33 @@ def test_rate_limit_returns_429_after_limit_is_exceeded() -> None:
     assert third.status_code == 429
     assert third.json()["detail"] == "Rate limit exceeded"
     assert int(third.headers["Retry-After"]) > 0
+
+
+def test_rate_limit_does_not_trust_spoofed_forwarded_addresses() -> None:
+    rate_limited_client = TestClient(create_app(rate_limit_per_min=2, rate_limit_window_sec=60))
+    payload = {
+        "calculation": "link_budget",
+        "input": {
+            "from_site": "Site A",
+            "to_site": "Site B",
+            "frequency_mhz": 868,
+            "nodes": [
+                _node("Site A", 59.9139, 10.7522),
+                _node("Site B", 59.9170, 10.7600),
+            ],
+        },
+    }
+
+    first = rate_limited_client.post(
+        "/api/v1/calculate", json=payload, headers={"X-Forwarded-For": "198.51.100.1"}
+    )
+    second = rate_limited_client.post(
+        "/api/v1/calculate", json=payload, headers={"X-Forwarded-For": "198.51.100.2"}
+    )
+    third = rate_limited_client.post(
+        "/api/v1/calculate", json=payload, headers={"X-Forwarded-For": "198.51.100.3"}
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert third.status_code == 429


### PR DESCRIPTION
## Summary

- constrain the Pages and self-hosted MeshMap proxies to `GET`/`HEAD /meshmap/nodes.json` with no query parameters and passive JSON handling
- strip credential, Cloudflare Access identity, cookie, and forwarding headers at third-party proxy boundaries while preserving Copernicus range, cache, and rate-limit diagnostics
- use Cloudflare-established identity for Pages rate limits and direct/trusted peer identity for the standalone calculation API and nginx
- bind Docker development and edge ports to loopback by default with an explicit documented opt-in

## Authority and scope

Implements the explicitly approved focused plan for #1051. No UI, D1 migration, version change, Terraform, Cloudflare configuration, production change, or live infrastructure mutation is included.

## Verification

- `npm test` — 164 files / 1,087 tests passed
- `npm run build` — passed
- focused proxy/config tests — 36 passed
- required deep-link/API/store tests — 35 / 9 / 32 passed
- Python calculation API tests — 7 passed
- changed-file ESLint — passed
- `npm run security:scan` — passed
- `npm run agents:validate` — passed
- default and public-opt-in `docker compose config` — passed
- `npm run dev:check` — no LinkSim servers found
- `git diff --check` — passed

The production Docker build was attempted but could not run because no Docker daemon was available. The production image now runs `nginx -t` during its build, so invalid nginx configuration fails the image build.

## Independent pre-PR review

- reviewed base: `c0e7cd573e851acbf23bce5b7347d5ab6bd06ebe`
- reviewed head: `b7d510c754fb332491b02904d029a79652ace184`
- verdict: `pass`, no findings
- native review feedback on origin-active nginx response headers was addressed by suppressing browser-active metadata and disabling upstream `X-Accel-*` processing
- residual: nginx runtime behavior remains locally unexecuted without a Docker daemon; staging/live verification has not been performed

## Documentation and versioning

`docs/repository-guide.md` documents loopback defaults and narrowly trusted reverse-proxy opt-in. The existing `0.27.0` development line is retained.

Closes #1051 after shared-staging verification and maintainer sign-off.

— Forge · AI coding agent
<!-- linksim-ai:v1 agent=Forge bot=true run=e92d0ce2-2a1c-4a4d-87a1-ecf179a2af9b source=pr:1051 commit=b7d510c754fb332491b02904d029a79652ace184 -->
