### PR TITLE
fix(security): bound Library ingress work

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ LinkSim is a web app for terrain-aware radio path planning and simulation.
 | Ship a release | [Release flow](./docs/release-flow.md) |
 | Configure authentication | [Cloudflare Access and D1](./docs/cloudflare-auth-setup.md) |
 | Manage Cloudflare with Terraform | [Terraform guide](./docs/terraform-iac.md) |
+| Review ingestion safety contracts | [Resource limits](./docs/resource-limits.md) |
 | Reuse UI patterns | UI Gallery (`/ui-gallery`) |
 | Review policies | [Security](./SECURITY.md), [Privacy](./docs/legal/PRIVACY.md), [Terms](./docs/legal/TERMS.md) |
 

--- a/docs/resource-limits.md
+++ b/docs/resource-limits.md
@@ -1,0 +1,42 @@
+# Resource limits
+
+LinkSim rejects untrusted input before it can create disproportionate parsing,
+storage, or database work. These are application safety contracts, not
+Cloudflare account or billing limits.
+
+## Library writes
+
+`PUT /api/library` applies these limits before calling the existing Library
+database helpers:
+
+| Resource | Limit |
+| --- | ---: |
+| Encoded request body | 2 MiB |
+| JSON nesting | 20 levels |
+| Combined Sites and Simulations per request | 20 |
+| Encoded Site record | 32 KiB |
+| Encoded Simulation record | 256 KiB |
+| Sites in one Simulation | 250 |
+| Paths in one Simulation | 1,000 |
+| Grants on one record | 100 |
+| Sites owned by one user | 500 |
+| Simulations owned by one user | 100 |
+| Public/shared Sites owned by one user | 100 |
+| Public/shared Simulations owned by one user | 25 |
+
+The client sends larger sync sets as sequential 20-record batches. If a batch
+fails, it stops and retains the dirty set so the normal sync recovery path can
+retry safely. The server never silently truncates a batch.
+
+Owners already above a storage quota can continue to update, export,
+privatize, or delete existing records. They cannot create a record or make a
+record public when that would increase an exceeded quota.
+
+Known Site and Simulation fields are validated for object shape, identifiers,
+names, finite numeric values, coordinates, visibility, grants, and collection
+counts. Unknown extension fields remain compatible as long as the complete
+record stays inside its encoded-byte limit.
+
+Failures are JSON responses: `413` for request bytes, `422` for malformed or
+over-quota content, and the existing authentication/authorization statuses for
+access failures. A rejected request does not silently discard records.

--- a/docs/resource-limits.md
+++ b/docs/resource-limits.md
@@ -30,8 +30,9 @@ retry safely. The server never silently truncates a batch.
 
 Owners already above a storage quota can continue to update, export,
 privatize, or delete existing records. Authenticated Site deletion removes the
-owned cloud record before detaching its local references; deletion is
-idempotent so an interrupted retry can recover. Platform admins may
+owned cloud record before detaching its local references; the existing change
+history carries deletion tombstones to stale clients and prevents recreation.
+Deletion is idempotent so an interrupted retry can recover. Platform admins may
 also delete a Site. Collaborators cannot delete someone else's Site. Owners
 cannot create a record or make a record public when that would increase an
 exceeded quota.

--- a/docs/resource-limits.md
+++ b/docs/resource-limits.md
@@ -29,8 +29,12 @@ fails, it stops and retains the dirty set so the normal sync recovery path can
 retry safely. The server never silently truncates a batch.
 
 Owners already above a storage quota can continue to update, export,
-privatize, or delete existing records. They cannot create a record or make a
-record public when that would increase an exceeded quota.
+privatize, or delete existing records. Authenticated Site deletion removes the
+owned cloud record before detaching its local references; deletion is
+idempotent so an interrupted retry can recover. Platform admins may
+also delete a Site. Collaborators cannot delete someone else's Site. Owners
+cannot create a record or make a record public when that would increase an
+exceeded quota.
 
 Known Site and Simulation fields are validated for object shape, identifiers,
 names, finite numeric values, coordinates, visibility, grants, and collection

--- a/docs/resource-limits.md
+++ b/docs/resource-limits.md
@@ -27,6 +27,8 @@ database helpers:
 The client sends larger sync sets as sequential 20-record batches. If a batch
 fails, it stops and retains the dirty set so the normal sync recovery path can
 retry safely. The server never silently truncates a batch.
+Soft-deleted Simulations retain their payload for lifecycle recovery and
+therefore continue to count toward both Simulation storage quotas.
 
 Owners already above a storage quota can continue to update, export,
 privatize, or delete existing records. Authenticated Site deletion removes the

--- a/functions/_lib/db.sharedSimulation.test.ts
+++ b/functions/_lib/db.sharedSimulation.test.ts
@@ -152,6 +152,11 @@ class FakeStatement {
       this.db.deleteSiteForConcurrentRace(this.db.deleteSiteBeforeGuardedWrite);
       this.db.deleteSiteBeforeGuardedWrite = null;
     }
+    if (this.db.mutateBeforeGuardedWrite && (this.sql.includes("INSERT INTO sites") || this.sql.includes("INSERT INTO simulations"))) {
+      const mutate = this.db.mutateBeforeGuardedWrite;
+      this.db.mutateBeforeGuardedWrite = null;
+      mutate();
+    }
     const changes = quotaGuardRejected ? 0 : this.db.run(this.sql, this.bound);
     return { success: true, meta: { changes } };
   }
@@ -167,6 +172,7 @@ class FakeDb {
   readonly adminUserIds = new Set<string>();
   rejectNextQuotaGuardedWrite = false;
   deleteSiteBeforeGuardedWrite: string | null = null;
+  mutateBeforeGuardedWrite: (() => void) | null = null;
   reassignSiteOwnerBeforeBatch: { siteId: string; ownerUserId: string } | null = null;
 
   deleteSiteForConcurrentRace(siteId: string): void {
@@ -328,7 +334,7 @@ class FakeDb {
     }
     if (sql.includes("COUNT(*) AS total_count") && sql.includes("FROM simulations")) {
       return bound.map((ownerId) => {
-        const rows = [...this.simulations.values()].filter((row) => row.owner_user_id === ownerId && row.status === "active");
+        const rows = [...this.simulations.values()].filter((row) => row.owner_user_id === ownerId);
         return {
           owner_user_id: ownerId,
           total_count: rows.length,
@@ -357,11 +363,13 @@ class FakeDb {
     }
     if (sql.includes("tombstone.resource_id AS id")) {
       const userId = String(bound[0] ?? "");
+      const restrictAudience = sql.includes("json_extract(tombstone.snapshot_json, '$.ownerUserId')");
       return this.resourceChanges
         .filter((change) => change.resource_kind === "site" && change.note === "Deleted Site")
         .filter((change, index, changes) => changes.findLastIndex((entry) => entry.resource_id === change.resource_id) === index)
         .filter((change) => !this.sites.has(String(change.resource_id)))
         .filter((change) => {
+          if (!restrictAudience) return true;
           const snapshot = JSON.parse(String(change.snapshot_json ?? "{}")) as AnyRow;
           return snapshot.ownerUserId === userId
             || snapshot.visibility === "public"
@@ -402,16 +410,22 @@ class FakeDb {
     if (sql.includes("INSERT INTO simulations")) {
       const [id, ownerUserId, createdByUserId, lastEditedByUserId, createdAt, lastEditedAt, name, visibility, payloadJson, updatedAt] =
         bound;
+      const existing = this.simulations.get(String(id));
+      const actorId = String(bound[3] ?? "");
+      const isAdmin = Number(bound[bound.length - 2] ?? 0) === 1;
+      const role = this.simulationRoles.get(`${String(id)}:${actorId}`);
+      if (existing && !(isAdmin || existing.owner_user_id === actorId || role === "admin" || role === "editor")) return 0;
       this.simulations.set(String(id), {
+        ...existing,
         id,
-        owner_user_id: ownerUserId,
-        created_by_user_id: createdByUserId,
+        owner_user_id: existing?.owner_user_id ?? ownerUserId,
+        created_by_user_id: existing?.created_by_user_id ?? createdByUserId,
         last_edited_by_user_id: lastEditedByUserId,
         created_at: createdAt,
         last_edited_at: lastEditedAt,
         name,
         visibility,
-        status: "active",
+        status: existing?.status ?? "active",
         payload_json: payloadJson,
         updated_at: updatedAt,
       });
@@ -424,10 +438,16 @@ class FakeDb {
         (change) => change.resource_kind === "site" && change.resource_id === id && change.note === "Deleted Site",
       );
       if (sql.includes("NOT EXISTS") && !this.sites.has(String(id)) && hasTombstone) return 0;
+      const existing = this.sites.get(String(id));
+      const actorId = String(bound[3] ?? "");
+      const isAdmin = Number(bound[bound.length - 2] ?? 0) === 1;
+      const role = this.siteRoles.get(`${String(id)}:${actorId}`);
+      if (existing && !(isAdmin || existing.owner_user_id === actorId || role === "admin" || role === "editor")) return 0;
       this.sites.set(String(id), {
+        ...existing,
         id,
-        owner_user_id: ownerUserId,
-        created_by_user_id: createdByUserId,
+        owner_user_id: existing?.owner_user_id ?? ownerUserId,
+        created_by_user_id: existing?.created_by_user_id ?? createdByUserId,
         last_edited_by_user_id: lastEditedByUserId,
         created_at: createdAt,
         last_edited_at: lastEditedAt,
@@ -476,10 +496,22 @@ class FakeDb {
       return 1;
     }
     if (sql.includes("INSERT INTO site_roles")) {
+      if (bound.length > 4) {
+        const [resourceId, , , , guardId, updatedAt, actorId, payloadJson] = bound;
+        const site = this.sites.get(String(guardId));
+        if (!site || site.updated_at !== updatedAt || site.last_edited_by_user_id !== actorId || site.payload_json !== payloadJson) return 0;
+        if (resourceId !== guardId) return 0;
+      }
       this.siteRoles.set(`${String(bound[0] ?? "")}:${String(bound[1] ?? "")}`, String(bound[2] ?? ""));
       return 1;
     }
     if (sql.includes("INSERT INTO simulation_roles")) {
+      if (bound.length > 4) {
+        const [resourceId, , , , guardId, updatedAt, actorId, payloadJson] = bound;
+        const simulation = this.simulations.get(String(guardId));
+        if (!simulation || simulation.updated_at !== updatedAt || simulation.last_edited_by_user_id !== actorId || simulation.payload_json !== payloadJson) return 0;
+        if (resourceId !== guardId) return 0;
+      }
       this.simulationRoles.set(`${String(bound[0] ?? "")}:${String(bound[1] ?? "")}`, String(bound[2] ?? ""));
       return 1;
     }
@@ -500,6 +532,10 @@ class FakeDb {
     }
     if (sql.includes("DELETE FROM site_roles")) {
       const resourceId = String(bound[0] ?? "");
+      if (bound.length > 1) {
+        const site = this.sites.get(String(bound[1]));
+        if (!site || site.updated_at !== bound[2] || site.last_edited_by_user_id !== bound[3] || site.payload_json !== bound[4]) return 0;
+      }
       for (const key of this.siteRoles.keys()) {
         if (key.startsWith(`${resourceId}:`)) this.siteRoles.delete(key);
       }
@@ -507,6 +543,10 @@ class FakeDb {
     }
     if (sql.includes("DELETE FROM simulation_roles")) {
       const resourceId = String(bound[0] ?? "");
+      if (bound.length > 1) {
+        const simulation = this.simulations.get(String(bound[1]));
+        if (!simulation || simulation.updated_at !== bound[2] || simulation.last_edited_by_user_id !== bound[3] || simulation.payload_json !== bound[4]) return 0;
+      }
       for (const key of this.simulationRoles.keys()) {
         if (key.startsWith(`${resourceId}:`)) this.simulationRoles.delete(key);
       }
@@ -626,14 +666,19 @@ describe("upsertLibrarySnapshot shared simulations", () => {
     db.sites.set("site-deleted", {
       id: "site-deleted",
       owner_user_id: "owner-1",
-      visibility: "public_read",
-      payload_json: JSON.stringify({ id: "site-deleted", name: "Deleted Site", visibility: "public", sharedWith: [] }),
+      visibility: "private",
+      payload_json: JSON.stringify({
+        id: "site-deleted", name: "Deleted Site", visibility: "private",
+        sharedWith: [{ userId: "reader-1", role: "viewer" }],
+      }),
     });
     const env = { DB: db } as unknown as Parameters<typeof deleteSiteResource>[0];
 
     await expect(deleteSiteResource(env, { id: "owner-1", isAdmin: false, isModerator: false }, "site-deleted"))
       .resolves.toEqual({ ok: true, siteId: "site-deleted" });
     await expect(fetchLibraryForUser(env, "reader-1")).resolves.toMatchObject({ deletedSiteIds: ["site-deleted"] });
+    db.adminUserIds.add("admin-1");
+    await expect(fetchLibraryForUser(env, "admin-1")).resolves.toMatchObject({ deletedSiteIds: ["site-deleted"] });
     await expect(upsertLibrarySnapshot(
       env,
       { id: "owner-1", isAdmin: false, isModerator: false },
@@ -660,6 +705,55 @@ describe("upsertLibrarySnapshot shared simulations", () => {
       { siteLibrary: [{ id: "site-concurrent", name: "Stale edit", visibility: "private" }], simulationPresets: [] },
     )).resolves.toMatchObject({ upsertedSites: 0, conflicts: ["site_deleted"] });
     expect(db.sites.has("site-concurrent")).toBe(false);
+  });
+
+  it("fails closed when Site ownership changes after authorization", async () => {
+    const db = new FakeDb();
+    db.sites.set("site-owner-race", {
+      id: "site-owner-race", owner_user_id: "owner-1", created_at: "2026-08-14T00:00:00.000Z",
+      visibility: "private", name: "Original", payload_json: JSON.stringify({ id: "site-owner-race", name: "Original" }),
+    });
+    db.mutateBeforeGuardedWrite = () => {
+      db.sites.set("site-owner-race", { ...db.sites.get("site-owner-race"), owner_user_id: "owner-2" });
+    };
+    const env = { DB: db } as unknown as Parameters<typeof upsertLibrarySnapshot>[0];
+
+    await expect(upsertLibrarySnapshot(env, { id: "owner-1", isAdmin: false, isModerator: false }, {
+      siteLibrary: [{ id: "site-owner-race", name: "Stale overwrite", visibility: "private" }], simulationPresets: [],
+    })).resolves.toMatchObject({ upsertedSites: 0, conflicts: ["forbidden_site"] });
+    expect(db.sites.get("site-owner-race")?.name).toBe("Original");
+  });
+
+  it("fails closed when a collaborator role is revoked after authorization", async () => {
+    const db = new FakeDb();
+    db.sites.set("site-role-race", {
+      id: "site-role-race", owner_user_id: "owner-1", created_at: "2026-08-14T00:00:00.000Z",
+      visibility: "public_write", name: "Original", payload_json: JSON.stringify({ id: "site-role-race", name: "Original" }),
+    });
+    db.siteRoles.set("site-role-race:editor-1", "editor");
+    db.mutateBeforeGuardedWrite = () => db.siteRoles.delete("site-role-race:editor-1");
+    const env = { DB: db } as unknown as Parameters<typeof upsertLibrarySnapshot>[0];
+
+    await expect(upsertLibrarySnapshot(env, { id: "editor-1", isAdmin: false, isModerator: false }, {
+      siteLibrary: [{ id: "site-role-race", name: "Stale editor", visibility: "shared" }], simulationPresets: [],
+    })).resolves.toMatchObject({ upsertedSites: 0, conflicts: ["forbidden_site"] });
+    expect(db.sites.get("site-role-race")?.name).toBe("Original");
+  });
+
+  it("fails closed when another owner concurrently creates the requested ID", async () => {
+    const db = new FakeDb();
+    db.mutateBeforeGuardedWrite = () => {
+      db.sites.set("site-collision", {
+        id: "site-collision", owner_user_id: "owner-2", created_at: "2026-08-14T00:00:00.000Z",
+        visibility: "private", name: "Other owner", payload_json: JSON.stringify({ id: "site-collision", name: "Other owner" }),
+      });
+    };
+    const env = { DB: db } as unknown as Parameters<typeof upsertLibrarySnapshot>[0];
+
+    await expect(upsertLibrarySnapshot(env, { id: "owner-1", isAdmin: false, isModerator: false }, {
+      siteLibrary: [{ id: "site-collision", name: "Colliding create", visibility: "private" }], simulationPresets: [],
+    })).resolves.toMatchObject({ upsertedSites: 0, conflicts: ["forbidden_site"] });
+    expect(db.sites.get("site-collision")?.owner_user_id).toBe("owner-2");
   });
 
   it("rejects oversized batches instead of silently truncating them", async () => {
@@ -768,6 +862,33 @@ describe("upsertLibrarySnapshot shared simulations", () => {
       siteLibrary: [],
       simulationPresets: [{ id: "sim-0", name: "Updated Simulation", visibility: "public" }],
     })).resolves.toMatchObject({ upsertedSimulations: 1, conflicts: [] });
+  });
+
+  it("counts retained deleted Simulations toward total and public storage quotas", async () => {
+    const db = new FakeDb();
+    for (let index = 0; index < LIBRARY_MAX_SIMULATIONS_PER_USER; index += 1) {
+      db.simulations.set(`deleted-${index}`, {
+        id: `deleted-${index}`, owner_user_id: "owner-1", visibility: "private", status: "deleted",
+        payload_json: JSON.stringify({ id: `deleted-${index}`, name: `Deleted ${index}` }),
+      });
+    }
+    const env = { DB: db } as unknown as Parameters<typeof upsertLibrarySnapshot>[0];
+    const actor = { id: "owner-1", isAdmin: false, isModerator: false };
+
+    await expect(upsertLibrarySnapshot(env, actor, {
+      siteLibrary: [], simulationPresets: [{ id: "sim-new", name: "New Simulation", visibility: "private" }],
+    })).rejects.toThrow("Simulation Library quota exceeded");
+
+    db.simulations.clear();
+    for (let index = 0; index < LIBRARY_MAX_PUBLIC_SIMULATIONS_PER_USER; index += 1) {
+      db.simulations.set(`deleted-public-${index}`, {
+        id: `deleted-public-${index}`, owner_user_id: "owner-1", visibility: "public_read", status: "deleted",
+        payload_json: JSON.stringify({ id: `deleted-public-${index}`, name: `Deleted Public ${index}` }),
+      });
+    }
+    await expect(upsertLibrarySnapshot(env, actor, {
+      siteLibrary: [], simulationPresets: [{ id: "sim-public", name: "New Public", visibility: "public" }],
+    })).rejects.toThrow("Public Simulation Library quota exceeded");
   });
 
   it("allows a shared simulation to reference a private site entry", async () => {

--- a/functions/_lib/db.sharedSimulation.test.ts
+++ b/functions/_lib/db.sharedSimulation.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  deleteSiteResource,
   fetchUserDiagnosticAccessState,
   fetchLibraryForUser,
   fetchPublicSimulationBundle,
@@ -12,6 +13,8 @@ import {
 import {
   LIBRARY_BATCH_MAX_RECORDS,
   LIBRARY_MAX_PUBLIC_SITES_PER_USER,
+  LIBRARY_MAX_PUBLIC_SIMULATIONS_PER_USER,
+  LIBRARY_MAX_SIMULATIONS_PER_USER,
   LIBRARY_MAX_SITES_PER_USER,
 } from "../../src/lib/libraryLimits";
 
@@ -207,6 +210,10 @@ class FakeDb {
     }
     if (sql.includes("SELECT id, owner_user_id, status, payload_json FROM simulations")) {
       return this.simulations.get(String(bound[0] ?? "")) ?? null;
+    }
+    if (sql.includes("SELECT id, owner_user_id FROM sites WHERE id = ?")) {
+      const row = this.sites.get(String(bound[0] ?? ""));
+      return row ? { id: row.id, owner_user_id: row.owner_user_id } : null;
     }
     if (sql.includes("FROM simulations t") && sql.includes("LEFT JOIN simulation_roles")) {
       const id = String(bound[1] ?? "");
@@ -422,6 +429,10 @@ class FakeDb {
       }
       return;
     }
+    if (sql.includes("DELETE FROM sites WHERE id = ?")) {
+      this.sites.delete(String(bound[0] ?? ""));
+      return;
+    }
   }
 }
 
@@ -472,6 +483,24 @@ describe("user identity privacy and diagnostic access", () => {
 });
 
 describe("upsertLibrarySnapshot shared simulations", () => {
+  it("deletes Sites only for their owner or a platform admin", async () => {
+    const db = new FakeDb();
+    db.sites.set("site-owner", { id: "site-owner", owner_user_id: "owner-1", visibility: "private" });
+    const env = { DB: db } as unknown as Parameters<typeof deleteSiteResource>[0];
+
+    await expect(deleteSiteResource(env, { id: "other-1", isAdmin: false, isModerator: false }, "site-owner"))
+      .resolves.toEqual({ ok: false, reason: "forbidden" });
+    expect(db.sites.has("site-owner")).toBe(true);
+
+    await expect(deleteSiteResource(env, { id: "owner-1", isAdmin: false, isModerator: false }, "site-owner"))
+      .resolves.toEqual({ ok: true, siteId: "site-owner" });
+    expect(db.sites.has("site-owner")).toBe(false);
+
+    db.sites.set("site-admin", { id: "site-admin", owner_user_id: "owner-2", visibility: "private" });
+    await expect(deleteSiteResource(env, { id: "admin-1", isAdmin: true, isModerator: false }, "site-admin"))
+      .resolves.toEqual({ ok: true, siteId: "site-admin" });
+  });
+
   it("rejects oversized batches instead of silently truncating them", async () => {
     const db = new FakeDb();
     const env = { DB: db } as unknown as Parameters<typeof upsertLibrarySnapshot>[0];
@@ -548,6 +577,36 @@ describe("upsertLibrarySnapshot shared simulations", () => {
       { siteLibrary: [{ id: "site-race", name: "Race Site", visibility: "private" }], simulationPresets: [] },
     )).resolves.toEqual({ upsertedSites: 0, upsertedSimulations: 0, conflicts: ["site_quota_exceeded"] });
     expect(db.sites.has("site-race")).toBe(false);
+  });
+
+  it("enforces Simulation owner/public boundaries and grandfathers non-increasing updates", async () => {
+    const db = new FakeDb();
+    for (let index = 0; index < LIBRARY_MAX_SIMULATIONS_PER_USER; index += 1) {
+      db.simulations.set(`sim-${index}`, {
+        id: `sim-${index}`,
+        owner_user_id: "owner-1",
+        created_at: "2026-08-14T00:00:00.000Z",
+        name: `Simulation ${index}`,
+        visibility: index < LIBRARY_MAX_PUBLIC_SIMULATIONS_PER_USER ? "public_read" : "private",
+        status: "active",
+        payload_json: JSON.stringify({ id: `sim-${index}`, name: `Simulation ${index}`, visibility: "private" }),
+      });
+    }
+    const env = { DB: db } as unknown as Parameters<typeof upsertLibrarySnapshot>[0];
+    const actor = { id: "owner-1", isAdmin: false, isModerator: false };
+
+    await expect(upsertLibrarySnapshot(env, actor, {
+      siteLibrary: [],
+      simulationPresets: [{ id: "sim-new", name: "New Simulation", visibility: "private" }],
+    })).rejects.toThrow("Simulation Library quota exceeded");
+    await expect(upsertLibrarySnapshot(env, actor, {
+      siteLibrary: [],
+      simulationPresets: [{ id: `sim-${LIBRARY_MAX_PUBLIC_SIMULATIONS_PER_USER}`, name: "Existing Simulation", visibility: "public" }],
+    })).rejects.toThrow("Public Simulation Library quota exceeded");
+    await expect(upsertLibrarySnapshot(env, actor, {
+      siteLibrary: [],
+      simulationPresets: [{ id: "sim-0", name: "Updated Simulation", visibility: "public" }],
+    })).resolves.toMatchObject({ upsertedSimulations: 1, conflicts: [] });
   });
 
   it("allows a shared simulation to reference a private site entry", async () => {

--- a/functions/_lib/db.sharedSimulation.test.ts
+++ b/functions/_lib/db.sharedSimulation.test.ts
@@ -9,6 +9,11 @@ import {
   setSimulationLifecycleStatus,
   upsertLibrarySnapshot,
 } from "./db";
+import {
+  LIBRARY_BATCH_MAX_RECORDS,
+  LIBRARY_MAX_PUBLIC_SITES_PER_USER,
+  LIBRARY_MAX_SITES_PER_USER,
+} from "../../src/lib/libraryLimits";
 
 type AnyRow = Record<string, unknown>;
 
@@ -137,9 +142,11 @@ class FakeStatement {
     return { results: this.db.all(this.sql, this.bound) as T[] };
   }
 
-  async run(): Promise<{ success: boolean }> {
-    this.db.run(this.sql, this.bound);
-    return { success: true };
+  async run(): Promise<{ success: boolean; meta: { changes: number } }> {
+    const quotaGuardRejected = this.db.rejectNextQuotaGuardedWrite && this.sql.includes("WHERE (? = 0 OR");
+    if (quotaGuardRejected) this.db.rejectNextQuotaGuardedWrite = false;
+    else this.db.run(this.sql, this.bound);
+    return { success: true, meta: { changes: quotaGuardRejected ? 0 : 1 } };
   }
 }
 
@@ -151,6 +158,7 @@ class FakeDb {
   readonly simulationRoles = new Map<string, string>();
   readonly resourceChanges: AnyRow[] = [];
   readonly adminUserIds = new Set<string>();
+  rejectNextQuotaGuardedWrite = false;
 
   prepare(sql: string): FakeStatement {
     return new FakeStatement(this, sql);
@@ -255,6 +263,32 @@ class FakeDb {
       return (TABLE_COLUMNS[table] ?? []).map((name) => ({ name }));
     }
     if (sql.includes("FROM users ORDER BY created_at DESC")) return this.users;
+    if (sql.includes("SELECT id, owner_user_id, visibility FROM sites WHERE id IN")) {
+      return bound.map((id) => this.sites.get(String(id))).filter((row): row is AnyRow => Boolean(row));
+    }
+    if (sql.includes("SELECT id, owner_user_id, visibility FROM simulations WHERE id IN")) {
+      return bound.map((id) => this.simulations.get(String(id))).filter((row): row is AnyRow => Boolean(row));
+    }
+    if (sql.includes("COUNT(*) AS total_count") && sql.includes("FROM sites")) {
+      return bound.map((ownerId) => {
+        const rows = [...this.sites.values()].filter((row) => row.owner_user_id === ownerId);
+        return {
+          owner_user_id: ownerId,
+          total_count: rows.length,
+          public_count: rows.filter((row) => row.visibility !== "private").length,
+        };
+      });
+    }
+    if (sql.includes("COUNT(*) AS total_count") && sql.includes("FROM simulations")) {
+      return bound.map((ownerId) => {
+        const rows = [...this.simulations.values()].filter((row) => row.owner_user_id === ownerId && row.status === "active");
+        return {
+          owner_user_id: ownerId,
+          total_count: rows.length,
+          public_count: rows.filter((row) => row.visibility !== "private").length,
+        };
+      });
+    }
     if (sql.includes("SELECT id, payload_json, visibility FROM sites WHERE id IN")) {
       return bound.map((id) => this.sites.get(String(id))).filter((row): row is AnyRow => Boolean(row));
     }
@@ -438,6 +472,84 @@ describe("user identity privacy and diagnostic access", () => {
 });
 
 describe("upsertLibrarySnapshot shared simulations", () => {
+  it("rejects oversized batches instead of silently truncating them", async () => {
+    const db = new FakeDb();
+    const env = { DB: db } as unknown as Parameters<typeof upsertLibrarySnapshot>[0];
+    await expect(upsertLibrarySnapshot(
+      env,
+      { id: "owner-1", isAdmin: false, isModerator: false },
+      {
+        siteLibrary: Array.from({ length: LIBRARY_BATCH_MAX_RECORDS + 1 }, (_, index) => ({
+          id: `site-${index}`,
+          name: `Site ${index}`,
+        })),
+        simulationPresets: [],
+      },
+    )).rejects.toThrow(`at most ${LIBRARY_BATCH_MAX_RECORDS} records`);
+    expect(db.sites.size).toBe(0);
+  });
+
+  it("preflights owner and public quotas before writing any record", async () => {
+    const db = new FakeDb();
+    for (let index = 0; index < LIBRARY_MAX_SITES_PER_USER; index += 1) {
+      db.sites.set(`site-${index}`, {
+        id: `site-${index}`,
+        owner_user_id: "owner-1",
+        name: `Site ${index}`,
+        visibility: index < LIBRARY_MAX_PUBLIC_SITES_PER_USER ? "public_read" : "private",
+        payload_json: JSON.stringify({ id: `site-${index}`, name: `Site ${index}` }),
+      });
+    }
+    const env = { DB: db } as unknown as Parameters<typeof upsertLibrarySnapshot>[0];
+
+    await expect(upsertLibrarySnapshot(
+      env,
+      { id: "owner-1", isAdmin: false, isModerator: false },
+      { siteLibrary: [{ id: "site-new", name: "New Site", visibility: "private" }], simulationPresets: [] },
+    )).rejects.toThrow("Site Library quota exceeded");
+    expect(db.sites.has("site-new")).toBe(false);
+
+    await expect(upsertLibrarySnapshot(
+      env,
+      { id: "owner-1", isAdmin: false, isModerator: false },
+      { siteLibrary: [{ id: `site-${LIBRARY_MAX_PUBLIC_SITES_PER_USER}`, name: "Existing", visibility: "public" }], simulationPresets: [] },
+    )).rejects.toThrow("Public Site Library quota exceeded");
+  });
+
+  it("grandfathers over-quota owners when an update does not increase usage", async () => {
+    const db = new FakeDb();
+    for (let index = 0; index <= LIBRARY_MAX_SITES_PER_USER; index += 1) {
+      db.sites.set(`site-${index}`, {
+        id: `site-${index}`,
+        owner_user_id: "owner-1",
+        created_at: "2026-08-14T00:00:00.000Z",
+        name: `Site ${index}`,
+        visibility: "private",
+        payload_json: JSON.stringify({ id: `site-${index}`, name: `Site ${index}`, visibility: "private" }),
+      });
+    }
+    const env = { DB: db } as unknown as Parameters<typeof upsertLibrarySnapshot>[0];
+
+    await expect(upsertLibrarySnapshot(
+      env,
+      { id: "owner-1", isAdmin: false, isModerator: false },
+      { siteLibrary: [{ id: "site-0", name: "Updated Site", visibility: "private" }], simulationPresets: [] },
+    )).resolves.toMatchObject({ upsertedSites: 1, conflicts: [] });
+  });
+
+  it("fails closed if the atomic write guard detects a concurrent quota race", async () => {
+    const db = new FakeDb();
+    db.rejectNextQuotaGuardedWrite = true;
+    const env = { DB: db } as unknown as Parameters<typeof upsertLibrarySnapshot>[0];
+
+    await expect(upsertLibrarySnapshot(
+      env,
+      { id: "owner-1", isAdmin: false, isModerator: false },
+      { siteLibrary: [{ id: "site-race", name: "Race Site", visibility: "private" }], simulationPresets: [] },
+    )).resolves.toEqual({ upsertedSites: 0, upsertedSimulations: 0, conflicts: ["site_quota_exceeded"] });
+    expect(db.sites.has("site-race")).toBe(false);
+  });
+
   it("allows a shared simulation to reference a private site entry", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-17T12:00:00.000Z"));

--- a/functions/_lib/db.sharedSimulation.test.ts
+++ b/functions/_lib/db.sharedSimulation.test.ts
@@ -412,7 +412,7 @@ class FakeDb {
         bound;
       const existing = this.simulations.get(String(id));
       const actorId = String(bound[3] ?? "");
-      const isAdmin = Number(bound[bound.length - 2] ?? 0) === 1;
+      const isAdmin = Number(bound[bound.length - 3] ?? 0) === 1;
       const role = this.simulationRoles.get(`${String(id)}:${actorId}`);
       if (existing && !(isAdmin || existing.owner_user_id === actorId || role === "admin" || role === "editor")) return 0;
       if (existing?.status === "deleted" && sql.includes("simulations.status = 'active'")) return 0;
@@ -447,7 +447,7 @@ class FakeDb {
       if (sql.includes("NOT EXISTS") && !this.sites.has(String(id)) && hasTombstone) return 0;
       const existing = this.sites.get(String(id));
       const actorId = String(bound[3] ?? "");
-      const isAdmin = Number(bound[bound.length - 2] ?? 0) === 1;
+      const isAdmin = Number(bound[bound.length - 3] ?? 0) === 1;
       const role = this.siteRoles.get(`${String(id)}:${actorId}`);
       if (existing && !(isAdmin || existing.owner_user_id === actorId || role === "admin" || role === "editor")) return 0;
       if (existing && visibility !== "private" && existing.visibility === "private") {
@@ -792,6 +792,31 @@ describe("upsertLibrarySnapshot shared simulations", () => {
       siteLibrary: [{ id: "site-republish", name: "Republish", visibility: "public" }], simulationPresets: [],
     })).resolves.toMatchObject({ upsertedSites: 0, conflicts: ["site_quota_exceeded"] });
     expect(db.sites.get("site-republish")).toMatchObject({ owner_user_id: "owner-2", visibility: "private", name: "Original" });
+  });
+
+  it("allows an admin public Site update when the live owner remains below quota", async () => {
+    const db = new FakeDb();
+    db.sites.set("site-republish", {
+      id: "site-republish", owner_user_id: "owner-1", created_at: "2026-08-14T00:00:00.000Z",
+      visibility: "public_read", name: "Original", payload_json: JSON.stringify({ id: "site-republish", name: "Original" }),
+    });
+    db.mutateBeforeGuardedWrite = () => {
+      db.sites.set("site-republish", {
+        ...db.sites.get("site-republish"), owner_user_id: "owner-2", visibility: "private",
+      });
+      for (let index = 0; index < LIBRARY_MAX_PUBLIC_SITES_PER_USER - 1; index += 1) {
+        db.sites.set(`owner-2-public-${index}`, {
+          id: `owner-2-public-${index}`, owner_user_id: "owner-2", visibility: "public_read",
+          name: `Public ${index}`, payload_json: "{}",
+        });
+      }
+    };
+    const env = { DB: db } as unknown as Parameters<typeof upsertLibrarySnapshot>[0];
+
+    await expect(upsertLibrarySnapshot(env, { id: "admin-1", isAdmin: true, isModerator: false }, {
+      siteLibrary: [{ id: "site-republish", name: "Republish", visibility: "public" }], simulationPresets: [],
+    })).resolves.toMatchObject({ upsertedSites: 1, conflicts: [] });
+    expect(db.sites.get("site-republish")).toMatchObject({ owner_user_id: "owner-2", visibility: "public_read", name: "Republish" });
   });
 
   it("rejects a stale Simulation update when soft-deletion wins after the precheck", async () => {

--- a/functions/_lib/db.sharedSimulation.test.ts
+++ b/functions/_lib/db.sharedSimulation.test.ts
@@ -148,8 +148,12 @@ class FakeStatement {
   async run(): Promise<{ success: boolean; meta: { changes: number } }> {
     const quotaGuardRejected = this.db.rejectNextQuotaGuardedWrite && this.sql.includes("WHERE (? = 0 OR");
     if (quotaGuardRejected) this.db.rejectNextQuotaGuardedWrite = false;
-    else this.db.run(this.sql, this.bound);
-    return { success: true, meta: { changes: quotaGuardRejected ? 0 : 1 } };
+    if (this.db.deleteSiteBeforeGuardedWrite && this.sql.includes("INSERT INTO sites")) {
+      this.db.deleteSiteForConcurrentRace(this.db.deleteSiteBeforeGuardedWrite);
+      this.db.deleteSiteBeforeGuardedWrite = null;
+    }
+    const changes = quotaGuardRejected ? 0 : this.db.run(this.sql, this.bound);
+    return { success: true, meta: { changes } };
   }
 }
 
@@ -162,12 +166,37 @@ class FakeDb {
   readonly resourceChanges: AnyRow[] = [];
   readonly adminUserIds = new Set<string>();
   rejectNextQuotaGuardedWrite = false;
+  deleteSiteBeforeGuardedWrite: string | null = null;
+  reassignSiteOwnerBeforeBatch: { siteId: string; ownerUserId: string } | null = null;
+
+  deleteSiteForConcurrentRace(siteId: string): void {
+    const site = this.sites.get(siteId);
+    if (!site) return;
+    this.resourceChanges.push({
+      id: this.resourceChanges.length + 1,
+      resource_kind: "site",
+      resource_id: siteId,
+      action: "updated",
+      actor_user_id: site.owner_user_id,
+      changed_at: "2026-08-14T00:00:00.000Z",
+      note: "Deleted Site",
+      details_json: null,
+      snapshot_json: site.payload_json,
+    });
+    this.sites.delete(siteId);
+  }
 
   prepare(sql: string): FakeStatement {
     return new FakeStatement(this, sql);
   }
 
   async batch(statements: Array<{ run: () => Promise<unknown> }>): Promise<unknown[]> {
+    if (this.reassignSiteOwnerBeforeBatch) {
+      const { siteId, ownerUserId } = this.reassignSiteOwnerBeforeBatch;
+      const site = this.sites.get(siteId);
+      if (site) this.sites.set(siteId, { ...site, owner_user_id: ownerUserId });
+      this.reassignSiteOwnerBeforeBatch = null;
+    }
     const results: unknown[] = [];
     for (const statement of statements) {
       results.push(await statement.run());
@@ -214,6 +243,17 @@ class FakeDb {
     if (sql.includes("SELECT id, owner_user_id FROM sites WHERE id = ?")) {
       const row = this.sites.get(String(bound[0] ?? ""));
       return row ? { id: row.id, owner_user_id: row.owner_user_id } : null;
+    }
+    if (sql.includes("FROM resource_changes") && sql.includes("note = 'Deleted Site'") && sql.includes("LIMIT 1")) {
+      const resourceId = String(bound[0] ?? "");
+      const tombstone = [...this.resourceChanges]
+        .reverse()
+        .find((change) => change.resource_kind === "site" && change.resource_id === resourceId && change.note === "Deleted Site");
+      return tombstone ? { id: tombstone.id } : null;
+    }
+    if (sql.includes("SELECT owner_user_id FROM sites WHERE id = ?")) {
+      const row = this.sites.get(String(bound[0] ?? ""));
+      return row ? { owner_user_id: row.owner_user_id } : null;
     }
     if (sql.includes("FROM simulations t") && sql.includes("LEFT JOIN simulation_roles")) {
       const id = String(bound[1] ?? "");
@@ -315,6 +355,23 @@ class FakeDb {
         .filter((row) => row.status === "deleted" && (row.owner_user_id === userId || row.visibility !== "private"))
         .map((row) => ({ id: row.id }));
     }
+    if (sql.includes("tombstone.resource_id AS id")) {
+      const userId = String(bound[0] ?? "");
+      return this.resourceChanges
+        .filter((change) => change.resource_kind === "site" && change.note === "Deleted Site")
+        .filter((change, index, changes) => changes.findLastIndex((entry) => entry.resource_id === change.resource_id) === index)
+        .filter((change) => !this.sites.has(String(change.resource_id)))
+        .filter((change) => {
+          const snapshot = JSON.parse(String(change.snapshot_json ?? "{}")) as AnyRow;
+          return snapshot.ownerUserId === userId
+            || snapshot.visibility === "public"
+            || snapshot.visibility === "shared"
+            || (Array.isArray(snapshot.sharedWith) && snapshot.sharedWith.some((grant) => (
+              grant && typeof grant === "object" && (grant as AnyRow).userId === userId
+            )));
+        })
+        .map((change) => ({ id: change.resource_id }));
+    }
     if (sql.includes("SELECT s.payload_json") && sql.includes("FROM simulations s")) {
       const userId = String(bound[2] ?? "");
       const isAdmin = Number(bound[1] ?? 0) === 1;
@@ -341,7 +398,7 @@ class FakeDb {
     return [];
   }
 
-  run(sql: string, bound: unknown[]): void {
+  run(sql: string, bound: unknown[]): number {
     if (sql.includes("INSERT INTO simulations")) {
       const [id, ownerUserId, createdByUserId, lastEditedByUserId, createdAt, lastEditedAt, name, visibility, payloadJson, updatedAt] =
         bound;
@@ -358,11 +415,15 @@ class FakeDb {
         payload_json: payloadJson,
         updated_at: updatedAt,
       });
-      return;
+      return 1;
     }
     if (sql.includes("INSERT INTO sites")) {
       const [id, ownerUserId, createdByUserId, lastEditedByUserId, createdAt, lastEditedAt, name, visibility, payloadJson, updatedAt] =
         bound;
+      const hasTombstone = this.resourceChanges.some(
+        (change) => change.resource_kind === "site" && change.resource_id === id && change.note === "Deleted Site",
+      );
+      if (sql.includes("NOT EXISTS") && !this.sites.has(String(id)) && hasTombstone) return 0;
       this.sites.set(String(id), {
         id,
         owner_user_id: ownerUserId,
@@ -375,7 +436,29 @@ class FakeDb {
         payload_json: payloadJson,
         updated_at: updatedAt,
       });
-      return;
+      return 1;
+    }
+    if (sql.includes("INSERT INTO resource_changes") && sql.includes("'Deleted Site'")) {
+      const [actorUserId, changedAt, resourceId, isAdmin, actorId] = bound;
+      const site = this.sites.get(String(resourceId));
+      if (!site || !(Number(isAdmin) === 1 || site.owner_user_id === actorId)) return 0;
+      const payload = JSON.parse(String(site.payload_json ?? "{}")) as AnyRow;
+      this.resourceChanges.push({
+        id: this.resourceChanges.length + 1,
+        resource_kind: "site",
+        resource_id: resourceId,
+        action: "updated",
+        actor_user_id: actorUserId,
+        changed_at: changedAt,
+        note: "Deleted Site",
+        details_json: null,
+        snapshot_json: JSON.stringify({
+          ...payload,
+          ownerUserId: site.owner_user_id,
+          visibility: site.visibility === "public_read" ? "public" : site.visibility === "public_write" ? "shared" : "private",
+        }),
+      });
+      return 1;
     }
     if (sql.includes("INSERT INTO resource_changes")) {
       const [resourceKind, resourceId, action, actorUserId, changedAt, note, detailsJson, snapshotJson] = bound;
@@ -390,15 +473,15 @@ class FakeDb {
         details_json: detailsJson,
         snapshot_json: snapshotJson,
       });
-      return;
+      return 1;
     }
     if (sql.includes("INSERT INTO site_roles")) {
       this.siteRoles.set(`${String(bound[0] ?? "")}:${String(bound[1] ?? "")}`, String(bound[2] ?? ""));
-      return;
+      return 1;
     }
     if (sql.includes("INSERT INTO simulation_roles")) {
       this.simulationRoles.set(`${String(bound[0] ?? "")}:${String(bound[1] ?? "")}`, String(bound[2] ?? ""));
-      return;
+      return 1;
     }
     if (sql.includes("UPDATE simulations") && sql.includes("SET status = ?")) {
       const [status, payloadJson, updatedAt, lastEditedAt, lastEditedByUserId, id] = bound;
@@ -413,26 +496,34 @@ class FakeDb {
           last_edited_by_user_id: lastEditedByUserId,
         });
       }
-      return;
+      return 1;
     }
     if (sql.includes("DELETE FROM site_roles")) {
       const resourceId = String(bound[0] ?? "");
       for (const key of this.siteRoles.keys()) {
         if (key.startsWith(`${resourceId}:`)) this.siteRoles.delete(key);
       }
-      return;
+      return 1;
     }
     if (sql.includes("DELETE FROM simulation_roles")) {
       const resourceId = String(bound[0] ?? "");
       for (const key of this.simulationRoles.keys()) {
         if (key.startsWith(`${resourceId}:`)) this.simulationRoles.delete(key);
       }
-      return;
+      return 1;
     }
     if (sql.includes("DELETE FROM sites WHERE id = ?")) {
-      this.sites.delete(String(bound[0] ?? ""));
-      return;
+      const [resourceId, isAdmin, actorId] = bound;
+      const id = String(resourceId ?? "");
+      const site = this.sites.get(id);
+      if (!site || !(Number(isAdmin) === 1 || site.owner_user_id === actorId)) return 0;
+      this.sites.delete(id);
+      for (const key of this.siteRoles.keys()) {
+        if (key.startsWith(`${id}:`)) this.siteRoles.delete(key);
+      }
+      return 1;
     }
+    return 1;
   }
 }
 
@@ -485,7 +576,12 @@ describe("user identity privacy and diagnostic access", () => {
 describe("upsertLibrarySnapshot shared simulations", () => {
   it("deletes Sites only for their owner or a platform admin", async () => {
     const db = new FakeDb();
-    db.sites.set("site-owner", { id: "site-owner", owner_user_id: "owner-1", visibility: "private" });
+    db.sites.set("site-owner", {
+      id: "site-owner",
+      owner_user_id: "owner-1",
+      visibility: "private",
+      payload_json: JSON.stringify({ id: "site-owner", name: "Owner Site", sharedWith: [] }),
+    });
     const env = { DB: db } as unknown as Parameters<typeof deleteSiteResource>[0];
 
     await expect(deleteSiteResource(env, { id: "other-1", isAdmin: false, isModerator: false }, "site-owner"))
@@ -496,9 +592,74 @@ describe("upsertLibrarySnapshot shared simulations", () => {
       .resolves.toEqual({ ok: true, siteId: "site-owner" });
     expect(db.sites.has("site-owner")).toBe(false);
 
-    db.sites.set("site-admin", { id: "site-admin", owner_user_id: "owner-2", visibility: "private" });
+    db.sites.set("site-admin", {
+      id: "site-admin",
+      owner_user_id: "owner-2",
+      visibility: "private",
+      payload_json: JSON.stringify({ id: "site-admin", name: "Admin Site", sharedWith: [] }),
+    });
     await expect(deleteSiteResource(env, { id: "admin-1", isAdmin: true, isModerator: false }, "site-admin"))
       .resolves.toEqual({ ok: true, siteId: "site-admin" });
+  });
+
+  it("atomically guards Site deletion when ownership changes after the access read", async () => {
+    const db = new FakeDb();
+    db.sites.set("site-race", {
+      id: "site-race",
+      owner_user_id: "owner-1",
+      visibility: "private",
+      payload_json: JSON.stringify({ id: "site-race", name: "Race Site", sharedWith: [] }),
+    });
+    db.siteRoles.set("site-race:editor-1", "editor");
+    db.reassignSiteOwnerBeforeBatch = { siteId: "site-race", ownerUserId: "owner-2" };
+    const env = { DB: db } as unknown as Parameters<typeof deleteSiteResource>[0];
+
+    await expect(deleteSiteResource(env, { id: "owner-1", isAdmin: false, isModerator: false }, "site-race"))
+      .resolves.toEqual({ ok: false, reason: "forbidden" });
+    expect(db.sites.get("site-race")?.owner_user_id).toBe("owner-2");
+    expect(db.siteRoles.get("site-race:editor-1")).toBe("editor");
+    expect(db.resourceChanges).toEqual([]);
+  });
+
+  it("returns Site tombstones to former readers and rejects stale recreation", async () => {
+    const db = new FakeDb();
+    db.sites.set("site-deleted", {
+      id: "site-deleted",
+      owner_user_id: "owner-1",
+      visibility: "public_read",
+      payload_json: JSON.stringify({ id: "site-deleted", name: "Deleted Site", visibility: "public", sharedWith: [] }),
+    });
+    const env = { DB: db } as unknown as Parameters<typeof deleteSiteResource>[0];
+
+    await expect(deleteSiteResource(env, { id: "owner-1", isAdmin: false, isModerator: false }, "site-deleted"))
+      .resolves.toEqual({ ok: true, siteId: "site-deleted" });
+    await expect(fetchLibraryForUser(env, "reader-1")).resolves.toMatchObject({ deletedSiteIds: ["site-deleted"] });
+    await expect(upsertLibrarySnapshot(
+      env,
+      { id: "owner-1", isAdmin: false, isModerator: false },
+      { siteLibrary: [{ id: "site-deleted", name: "Stale copy", visibility: "private" }], simulationPresets: [] },
+    )).resolves.toMatchObject({ upsertedSites: 0, conflicts: ["site_deleted"] });
+    expect(db.sites.has("site-deleted")).toBe(false);
+  });
+
+  it("atomically rejects recreation when deletion wins after the stale-client read", async () => {
+    const db = new FakeDb();
+    db.sites.set("site-concurrent", {
+      id: "site-concurrent",
+      owner_user_id: "owner-1",
+      created_at: "2026-08-14T00:00:00.000Z",
+      visibility: "private",
+      payload_json: JSON.stringify({ id: "site-concurrent", name: "Concurrent Site", visibility: "private" }),
+    });
+    db.deleteSiteBeforeGuardedWrite = "site-concurrent";
+    const env = { DB: db } as unknown as Parameters<typeof upsertLibrarySnapshot>[0];
+
+    await expect(upsertLibrarySnapshot(
+      env,
+      { id: "owner-1", isAdmin: false, isModerator: false },
+      { siteLibrary: [{ id: "site-concurrent", name: "Stale edit", visibility: "private" }], simulationPresets: [] },
+    )).resolves.toMatchObject({ upsertedSites: 0, conflicts: ["site_deleted"] });
+    expect(db.sites.has("site-concurrent")).toBe(false);
   });
 
   it("rejects oversized batches instead of silently truncating them", async () => {

--- a/functions/_lib/db.sharedSimulation.test.ts
+++ b/functions/_lib/db.sharedSimulation.test.ts
@@ -627,6 +627,31 @@ describe("user identity privacy and diagnostic access", () => {
 });
 
 describe("upsertLibrarySnapshot shared simulations", () => {
+  it("persists one-character and longer resource names under the existing non-empty contract", async () => {
+    const db = new FakeDb();
+    const env = { DB: db } as unknown as Parameters<typeof upsertLibrarySnapshot>[0];
+    const longName = "L".repeat(160);
+
+    await expect(upsertLibrarySnapshot(
+      env,
+      { id: "owner-1", isAdmin: false, isModerator: false },
+      {
+        siteLibrary: [
+          { id: "site-short", name: "X", visibility: "private" },
+          { id: "site-long", name: longName, visibility: "private" },
+        ],
+        simulationPresets: [
+          { id: "sim-short", name: "X", visibility: "private" },
+          { id: "sim-long", name: longName, visibility: "private" },
+        ],
+      },
+    )).resolves.toMatchObject({ upsertedSites: 2, upsertedSimulations: 2, conflicts: [] });
+    expect(db.sites.get("site-short")?.name).toBe("X");
+    expect(db.sites.get("site-long")?.name).toBe(longName);
+    expect(db.simulations.get("sim-short")?.name).toBe("X");
+    expect(db.simulations.get("sim-long")?.name).toBe(longName);
+  });
+
   it("deletes Sites only for their owner or a platform admin", async () => {
     const db = new FakeDb();
     db.sites.set("site-owner", {

--- a/functions/_lib/db.sharedSimulation.test.ts
+++ b/functions/_lib/db.sharedSimulation.test.ts
@@ -415,6 +415,13 @@ class FakeDb {
       const isAdmin = Number(bound[bound.length - 2] ?? 0) === 1;
       const role = this.simulationRoles.get(`${String(id)}:${actorId}`);
       if (existing && !(isAdmin || existing.owner_user_id === actorId || role === "admin" || role === "editor")) return 0;
+      if (existing?.status === "deleted" && sql.includes("simulations.status = 'active'")) return 0;
+      if (existing && visibility !== "private" && existing.visibility === "private") {
+        const publicCount = [...this.simulations.values()].filter(
+          (row) => row.owner_user_id === existing.owner_user_id && row.visibility !== "private",
+        ).length;
+        if (publicCount >= LIBRARY_MAX_PUBLIC_SIMULATIONS_PER_USER) return 0;
+      }
       this.simulations.set(String(id), {
         ...existing,
         id,
@@ -443,6 +450,12 @@ class FakeDb {
       const isAdmin = Number(bound[bound.length - 2] ?? 0) === 1;
       const role = this.siteRoles.get(`${String(id)}:${actorId}`);
       if (existing && !(isAdmin || existing.owner_user_id === actorId || role === "admin" || role === "editor")) return 0;
+      if (existing && visibility !== "private" && existing.visibility === "private") {
+        const publicCount = [...this.sites.values()].filter(
+          (row) => row.owner_user_id === existing.owner_user_id && row.visibility !== "private",
+        ).length;
+        if (publicCount >= LIBRARY_MAX_PUBLIC_SITES_PER_USER) return 0;
+      }
       this.sites.set(String(id), {
         ...existing,
         id,
@@ -509,7 +522,7 @@ class FakeDb {
       if (bound.length > 4) {
         const [resourceId, , , , guardId, updatedAt, actorId, payloadJson] = bound;
         const simulation = this.simulations.get(String(guardId));
-        if (!simulation || simulation.updated_at !== updatedAt || simulation.last_edited_by_user_id !== actorId || simulation.payload_json !== payloadJson) return 0;
+        if (!simulation || simulation.status === "deleted" || simulation.updated_at !== updatedAt || simulation.last_edited_by_user_id !== actorId || simulation.payload_json !== payloadJson) return 0;
         if (resourceId !== guardId) return 0;
       }
       this.simulationRoles.set(`${String(bound[0] ?? "")}:${String(bound[1] ?? "")}`, String(bound[2] ?? ""));
@@ -545,7 +558,7 @@ class FakeDb {
       const resourceId = String(bound[0] ?? "");
       if (bound.length > 1) {
         const simulation = this.simulations.get(String(bound[1]));
-        if (!simulation || simulation.updated_at !== bound[2] || simulation.last_edited_by_user_id !== bound[3] || simulation.payload_json !== bound[4]) return 0;
+        if (!simulation || simulation.status === "deleted" || simulation.updated_at !== bound[2] || simulation.last_edited_by_user_id !== bound[3] || simulation.payload_json !== bound[4]) return 0;
       }
       for (const key of this.simulationRoles.keys()) {
         if (key.startsWith(`${resourceId}:`)) this.simulationRoles.delete(key);
@@ -754,6 +767,51 @@ describe("upsertLibrarySnapshot shared simulations", () => {
       siteLibrary: [{ id: "site-collision", name: "Colliding create", visibility: "private" }], simulationPresets: [],
     })).resolves.toMatchObject({ upsertedSites: 0, conflicts: ["forbidden_site"] });
     expect(db.sites.get("site-collision")?.owner_user_id).toBe("owner-2");
+  });
+
+  it("uses live visibility and owner state for the atomic public Site quota", async () => {
+    const db = new FakeDb();
+    db.sites.set("site-republish", {
+      id: "site-republish", owner_user_id: "owner-1", created_at: "2026-08-14T00:00:00.000Z",
+      visibility: "public_read", name: "Original", payload_json: JSON.stringify({ id: "site-republish", name: "Original" }),
+    });
+    db.mutateBeforeGuardedWrite = () => {
+      db.sites.set("site-republish", {
+        ...db.sites.get("site-republish"), owner_user_id: "owner-2", visibility: "private",
+      });
+      for (let index = 0; index < LIBRARY_MAX_PUBLIC_SITES_PER_USER; index += 1) {
+        db.sites.set(`owner-2-public-${index}`, {
+          id: `owner-2-public-${index}`, owner_user_id: "owner-2", visibility: "public_read",
+          name: `Public ${index}`, payload_json: "{}",
+        });
+      }
+    };
+    const env = { DB: db } as unknown as Parameters<typeof upsertLibrarySnapshot>[0];
+
+    await expect(upsertLibrarySnapshot(env, { id: "admin-1", isAdmin: true, isModerator: false }, {
+      siteLibrary: [{ id: "site-republish", name: "Republish", visibility: "public" }], simulationPresets: [],
+    })).resolves.toMatchObject({ upsertedSites: 0, conflicts: ["site_quota_exceeded"] });
+    expect(db.sites.get("site-republish")).toMatchObject({ owner_user_id: "owner-2", visibility: "private", name: "Original" });
+  });
+
+  it("rejects a stale Simulation update when soft-deletion wins after the precheck", async () => {
+    const db = new FakeDb();
+    db.simulations.set("sim-delete-race", {
+      id: "sim-delete-race", owner_user_id: "owner-1", created_at: "2026-08-14T00:00:00.000Z",
+      visibility: "private", status: "active", name: "Original",
+      payload_json: JSON.stringify({ id: "sim-delete-race", name: "Original" }),
+    });
+    db.simulationRoles.set("sim-delete-race:viewer-1", "viewer");
+    db.mutateBeforeGuardedWrite = () => {
+      db.simulations.set("sim-delete-race", { ...db.simulations.get("sim-delete-race"), status: "deleted" });
+    };
+    const env = { DB: db } as unknown as Parameters<typeof upsertLibrarySnapshot>[0];
+
+    await expect(upsertLibrarySnapshot(env, { id: "owner-1", isAdmin: false, isModerator: false }, {
+      siteLibrary: [], simulationPresets: [{ id: "sim-delete-race", name: "Stale overwrite", visibility: "private" }],
+    })).resolves.toMatchObject({ upsertedSimulations: 0, conflicts: ["simulation_deleted"] });
+    expect(db.simulations.get("sim-delete-race")).toMatchObject({ status: "deleted", name: "Original" });
+    expect(db.simulationRoles.get("sim-delete-race:viewer-1")).toBe("viewer");
   });
 
   it("rejects oversized batches instead of silently truncating them", async () => {

--- a/functions/_lib/db.ts
+++ b/functions/_lib/db.ts
@@ -2155,7 +2155,6 @@ const upsertOwnedResource = async (
     return { ok: false, reason: `would_lose_access_${kind}` };
   }
 
-  const wasPublic = existing ? existing.visibility !== "private" : false;
   const maxOwnerRecords = kind === "site" ? LIBRARY_MAX_SITES_PER_USER : LIBRARY_MAX_SIMULATIONS_PER_USER;
   const maxOwnerPublicRecords = kind === "site" ? LIBRARY_MAX_PUBLIC_SITES_PER_USER : LIBRARY_MAX_PUBLIC_SIMULATIONS_PER_USER;
   const activeQuotaClause = "";
@@ -2173,7 +2172,7 @@ const upsertOwnedResource = async (
        (id, owner_user_id, created_by_user_id, last_edited_by_user_id, created_at, last_edited_at, name, visibility, payload_json, updated_at)
        SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
        WHERE (? = 0 OR (SELECT COUNT(*) FROM ${table} WHERE owner_user_id = ?${activeQuotaClause}) < ?)
-         AND (? = 'private' OR ? = 1 OR (SELECT COUNT(*) FROM ${table} WHERE owner_user_id = ? AND visibility != 'private'${activeQuotaClause}) < ?)
+         AND (? = 0 OR ? = 'private' OR (SELECT COUNT(*) FROM ${table} WHERE owner_user_id = ? AND visibility != 'private'${activeQuotaClause}) < ?)
          ${siteTombstoneGuard}
        ON CONFLICT(id) DO UPDATE SET
          name = excluded.name,
@@ -2184,12 +2183,22 @@ const upsertOwnedResource = async (
          last_edited_by_user_id = excluded.last_edited_by_user_id,
          created_by_user_id = COALESCE(${table}.created_by_user_id, excluded.created_by_user_id),
          created_at = COALESCE(${table}.created_at, excluded.created_at)
-       WHERE ${table}.owner_user_id = ?
-          OR ? = 1
-          OR EXISTS (
+       WHERE (
+         ${table}.owner_user_id = ?
+         OR ? = 1
+         OR EXISTS (
             SELECT 1 FROM ${rolesTable}
             WHERE ${kind}_id = excluded.id AND user_id = ? AND role IN ('admin', 'editor')
-          )`,
+          )
+       )
+       ${kind === "simulation" ? "AND simulations.status = 'active'" : ""}
+       AND (
+         excluded.visibility = 'private'
+         OR ${table}.visibility != 'private'
+         OR (SELECT COUNT(*) FROM ${table} quota_rows
+             WHERE quota_rows.owner_user_id = ${table}.owner_user_id
+               AND quota_rows.visibility != 'private') < ?
+       )`,
     )
     .bind(
       id,
@@ -2205,18 +2214,20 @@ const upsertOwnedResource = async (
       isCreate ? 1 : 0,
       ownerId,
       maxOwnerRecords,
+      isCreate ? 1 : 0,
       visibilityDb,
-      wasPublic ? 1 : 0,
       ownerId,
       maxOwnerPublicRecords,
       ...(kind === "site" ? [id, id] : []),
       actor.id,
       actor.isAdmin ? 1 : 0,
       actor.id,
+      maxOwnerPublicRecords,
     );
   const wroteCurrentPayloadGuard = `EXISTS (
     SELECT 1 FROM ${table}
     WHERE id = ? AND updated_at = ? AND last_edited_by_user_id = ? AND payload_json = ?
+      ${kind === "simulation" ? "AND status = 'active'" : ""}
   )`;
   const roleStatements = [
     env.DB
@@ -2248,13 +2259,16 @@ const upsertOwnedResource = async (
     }
     const current = await env.DB
       .prepare(
-        `SELECT t.owner_user_id, t.visibility, r.role AS actor_role
+        `SELECT t.owner_user_id, t.visibility${kind === "simulation" ? ", t.status" : ""}, r.role AS actor_role
          FROM ${table} t
          LEFT JOIN ${rolesTable} r ON r.${kind}_id = t.id AND r.user_id = ?
          WHERE t.id = ? LIMIT 1`,
       )
       .bind(actor.id, id)
-      .first<{ owner_user_id: string; visibility: DbVisibility; actor_role?: string | null }>();
+      .first<{ owner_user_id: string; visibility: DbVisibility; status?: "active" | "deleted"; actor_role?: string | null }>();
+    if (kind === "simulation" && current?.status === "deleted") {
+      return { ok: false, reason: "simulation_deleted" };
+    }
     if (current && !canEditResource(
       actor,
       current.owner_user_id,

--- a/functions/_lib/db.ts
+++ b/functions/_lib/db.ts
@@ -2158,7 +2158,7 @@ const upsertOwnedResource = async (
   const wasPublic = existing ? existing.visibility !== "private" : false;
   const maxOwnerRecords = kind === "site" ? LIBRARY_MAX_SITES_PER_USER : LIBRARY_MAX_SIMULATIONS_PER_USER;
   const maxOwnerPublicRecords = kind === "site" ? LIBRARY_MAX_PUBLIC_SITES_PER_USER : LIBRARY_MAX_PUBLIC_SIMULATIONS_PER_USER;
-  const activeQuotaClause = kind === "simulation" ? " AND status = 'active'" : "";
+  const activeQuotaClause = "";
   const siteTombstoneGuard = kind === "site"
     ? ` AND (
           EXISTS (SELECT 1 FROM sites WHERE id = ?)
@@ -2168,8 +2168,7 @@ const upsertOwnedResource = async (
           )
         )`
     : "";
-  const writeResult = await env.DB
-    .prepare(
+  const writeStatement = env.DB.prepare(
       `INSERT INTO ${table}
        (id, owner_user_id, created_by_user_id, last_edited_by_user_id, created_at, last_edited_at, name, visibility, payload_json, updated_at)
        SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
@@ -2184,7 +2183,13 @@ const upsertOwnedResource = async (
          last_edited_at = excluded.last_edited_at,
          last_edited_by_user_id = excluded.last_edited_by_user_id,
          created_by_user_id = COALESCE(${table}.created_by_user_id, excluded.created_by_user_id),
-         created_at = COALESCE(${table}.created_at, excluded.created_at)`,
+         created_at = COALESCE(${table}.created_at, excluded.created_at)
+       WHERE ${table}.owner_user_id = ?
+          OR ? = 1
+          OR EXISTS (
+            SELECT 1 FROM ${rolesTable}
+            WHERE ${kind}_id = excluded.id AND user_id = ? AND role IN ('admin', 'editor')
+          )`,
     )
     .bind(
       id,
@@ -2205,8 +2210,30 @@ const upsertOwnedResource = async (
       ownerId,
       maxOwnerPublicRecords,
       ...(kind === "site" ? [id, id] : []),
-    )
-    .run();
+      actor.id,
+      actor.isAdmin ? 1 : 0,
+      actor.id,
+    );
+  const wroteCurrentPayloadGuard = `EXISTS (
+    SELECT 1 FROM ${table}
+    WHERE id = ? AND updated_at = ? AND last_edited_by_user_id = ? AND payload_json = ?
+  )`;
+  const roleStatements = [
+    env.DB
+      .prepare(`DELETE FROM ${rolesTable} WHERE ${kind}_id = ? AND ${wroteCurrentPayloadGuard}`)
+      .bind(id, id, now, actor.id, payload),
+    ...sharedWith
+      .filter((grant) => grant.userId !== ownerId)
+      .map((grant) => env.DB
+        .prepare(
+          `INSERT INTO ${rolesTable} (${kind}_id, user_id, role, created_at)
+           SELECT ?, ?, ?, ?
+           WHERE ${wroteCurrentPayloadGuard}
+           ON CONFLICT(${kind}_id, user_id) DO UPDATE SET role = excluded.role`,
+        )
+        .bind(id, grant.userId, grant.role, now, id, now, actor.id, payload)),
+  ];
+  const [writeResult] = await env.DB.batch([writeStatement, ...roleStatements]) as D1Result[];
   if (writeResult.meta?.changes === 0) {
     if (kind === "site") {
       const tombstone = await env.DB
@@ -2219,25 +2246,24 @@ const upsertOwnedResource = async (
         .first<{ id: number }>();
       if (tombstone) return { ok: false, reason: "site_deleted" };
     }
-    return { ok: false, reason: `${kind}_quota_exceeded` };
-  }
-
-  await env.DB.prepare(`DELETE FROM ${rolesTable} WHERE ${kind}_id = ?`).bind(id).run();
-  if (sharedWith.length) {
-    const statements = sharedWith
-      .filter((grant) => grant.userId !== ownerId)
-      .map((grant) =>
-        env.DB
-          .prepare(
-            `INSERT INTO ${rolesTable} (${kind}_id, user_id, role, created_at)
-             VALUES (?, ?, ?, ?)
-             ON CONFLICT(${kind}_id, user_id) DO UPDATE SET role = excluded.role`,
-          )
-          .bind(id, grant.userId, grant.role, now),
-      );
-    if (statements.length) {
-      await env.DB.batch(statements);
+    const current = await env.DB
+      .prepare(
+        `SELECT t.owner_user_id, t.visibility, r.role AS actor_role
+         FROM ${table} t
+         LEFT JOIN ${rolesTable} r ON r.${kind}_id = t.id AND r.user_id = ?
+         WHERE t.id = ? LIMIT 1`,
+      )
+      .bind(actor.id, id)
+      .first<{ owner_user_id: string; visibility: DbVisibility; actor_role?: string | null }>();
+    if (current && !canEditResource(
+      actor,
+      current.owner_user_id,
+      visibilityFromDbVisibility(current.visibility),
+      typeof current.actor_role === "string" ? current.actor_role : null,
+    )) {
+      return { ok: false, reason: `forbidden_${kind}` };
     }
+    return { ok: false, reason: `${kind}_quota_exceeded` };
   }
 
   const changeDetails: string[] = [];
@@ -2318,7 +2344,7 @@ const preflightResourceQuotas = async (
   const existingById = new Map(existingRows.results.map((row) => [row.id, row]));
   const ownerIds = [...new Set(items.map((item) => existingById.get(item.id.trim())?.owner_user_id ?? actor.id))];
   const ownerPlaceholders = ownerIds.map(() => "?").join(", ");
-  const activeClause = kind === "simulation" ? " AND status = 'active'" : "";
+  const activeClause = "";
   const counts = await env.DB
     .prepare(
       `SELECT owner_user_id,
@@ -2469,9 +2495,17 @@ export const fetchLibraryForUser = async (
     .bind(userId, canReadAllResources ? 1 : 0, userId, ...(opts?.since ? [opts.since] : []))
     .all<LibraryRow>();
 
-  const deletedSiteRows = canReadAllResources
-    ? { results: [] as Array<{ id: string }> }
-    : await env.DB
+  const deletedSiteAudienceClause = canReadAllResources
+    ? ""
+    : ` AND (
+          json_extract(tombstone.snapshot_json, '$.ownerUserId') = ?
+          OR json_extract(tombstone.snapshot_json, '$.visibility') IN ('public', 'shared')
+          OR EXISTS (
+            SELECT 1 FROM json_each(COALESCE(json_extract(tombstone.snapshot_json, '$.sharedWith'), '[]')) grant_entry
+            WHERE json_extract(grant_entry.value, '$.userId') = ?
+          )
+        )`;
+  const deletedSiteRows = await env.DB
         .prepare(
           `SELECT tombstone.resource_id AS id
            FROM resource_changes tombstone
@@ -2483,16 +2517,9 @@ export const fetchLibraryForUser = async (
                WHERE latest.resource_kind = 'site' AND latest.resource_id = tombstone.resource_id
              )
              AND NOT EXISTS (SELECT 1 FROM sites live WHERE live.id = tombstone.resource_id)
-             AND (
-               json_extract(tombstone.snapshot_json, '$.ownerUserId') = ?
-               OR json_extract(tombstone.snapshot_json, '$.visibility') IN ('public', 'shared')
-               OR EXISTS (
-                 SELECT 1 FROM json_each(COALESCE(json_extract(tombstone.snapshot_json, '$.sharedWith'), '[]')) grant_entry
-                 WHERE json_extract(grant_entry.value, '$.userId') = ?
-               )
-             )${opts?.since ? "\n             AND tombstone.changed_at > ?" : ""}`,
+             ${deletedSiteAudienceClause}${opts?.since ? "\n             AND tombstone.changed_at > ?" : ""}`,
         )
-        .bind(userId, userId, ...(opts?.since ? [opts.since] : []))
+        .bind(...(canReadAllResources ? [] : [userId, userId]), ...(opts?.since ? [opts.since] : []))
         .all<{ id: string }>();
 
   const deletedSimulationRows = canReadAllResources

--- a/functions/_lib/db.ts
+++ b/functions/_lib/db.ts
@@ -1903,10 +1903,36 @@ export const deleteSiteResource = async (
   if (!(actor.isAdmin || existing.owner_user_id === actor.id)) {
     return { ok: false, reason: "forbidden" };
   }
-  await env.DB.batch([
-    env.DB.prepare("DELETE FROM site_roles WHERE site_id = ?").bind(id),
-    env.DB.prepare("DELETE FROM sites WHERE id = ? AND owner_user_id = ?").bind(id, existing.owner_user_id),
-  ]);
+  const now = new Date().toISOString();
+  const results = await env.DB.batch([
+    env.DB.prepare(
+      `INSERT INTO resource_changes
+         (resource_kind, resource_id, action, actor_user_id, changed_at, note, details_json, snapshot_json)
+       SELECT 'site', id, 'updated', ?, ?, 'Deleted Site', NULL,
+              json_set(
+                payload_json,
+                '$.ownerUserId', owner_user_id,
+                '$.visibility', CASE visibility
+                  WHEN 'public_read' THEN 'public'
+                  WHEN 'public_write' THEN 'shared'
+                  ELSE 'private'
+                END
+              )
+       FROM sites
+       WHERE id = ? AND (? = 1 OR owner_user_id = ?)`,
+    ).bind(actor.id, now, id, actor.isAdmin ? 1 : 0, actor.id),
+    env.DB
+      .prepare("DELETE FROM sites WHERE id = ? AND (? = 1 OR owner_user_id = ?)")
+      .bind(id, actor.isAdmin ? 1 : 0, actor.id),
+  ]) as D1Result[];
+  const deleted = Number(results[1]?.meta?.changes ?? 0) > 0;
+  if (!deleted) {
+    const current = await env.DB
+      .prepare("SELECT owner_user_id FROM sites WHERE id = ? LIMIT 1")
+      .bind(id)
+      .first<{ owner_user_id: string }>();
+    return { ok: false, reason: current ? "forbidden" : "missing" };
+  }
   return { ok: true, siteId: id };
 };
 
@@ -2044,6 +2070,20 @@ const upsertOwnedResource = async (
     }
   }
 
+  if (kind === "site" && !existing) {
+    const tombstone = await env.DB
+      .prepare(
+        `SELECT id
+         FROM resource_changes
+         WHERE resource_kind = 'site' AND resource_id = ? AND note = 'Deleted Site'
+         ORDER BY id DESC
+         LIMIT 1`,
+      )
+      .bind(id)
+      .first<{ id: number }>();
+    if (tombstone) return { ok: false, reason: "site_deleted" };
+  }
+
   const ownerId = existing?.owner_user_id ?? actor.id;
   const sharedWith = requestedSharedWith.filter((grant) => grant.userId !== ownerId);
 
@@ -2119,6 +2159,15 @@ const upsertOwnedResource = async (
   const maxOwnerRecords = kind === "site" ? LIBRARY_MAX_SITES_PER_USER : LIBRARY_MAX_SIMULATIONS_PER_USER;
   const maxOwnerPublicRecords = kind === "site" ? LIBRARY_MAX_PUBLIC_SITES_PER_USER : LIBRARY_MAX_PUBLIC_SIMULATIONS_PER_USER;
   const activeQuotaClause = kind === "simulation" ? " AND status = 'active'" : "";
+  const siteTombstoneGuard = kind === "site"
+    ? ` AND (
+          EXISTS (SELECT 1 FROM sites WHERE id = ?)
+          OR NOT EXISTS (
+            SELECT 1 FROM resource_changes
+            WHERE resource_kind = 'site' AND resource_id = ? AND note = 'Deleted Site'
+          )
+        )`
+    : "";
   const writeResult = await env.DB
     .prepare(
       `INSERT INTO ${table}
@@ -2126,6 +2175,7 @@ const upsertOwnedResource = async (
        SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
        WHERE (? = 0 OR (SELECT COUNT(*) FROM ${table} WHERE owner_user_id = ?${activeQuotaClause}) < ?)
          AND (? = 'private' OR ? = 1 OR (SELECT COUNT(*) FROM ${table} WHERE owner_user_id = ? AND visibility != 'private'${activeQuotaClause}) < ?)
+         ${siteTombstoneGuard}
        ON CONFLICT(id) DO UPDATE SET
          name = excluded.name,
          visibility = excluded.visibility,
@@ -2154,9 +2204,23 @@ const upsertOwnedResource = async (
       wasPublic ? 1 : 0,
       ownerId,
       maxOwnerPublicRecords,
+      ...(kind === "site" ? [id, id] : []),
     )
     .run();
-  if (writeResult.meta?.changes === 0) return { ok: false, reason: `${kind}_quota_exceeded` };
+  if (writeResult.meta?.changes === 0) {
+    if (kind === "site") {
+      const tombstone = await env.DB
+        .prepare(
+          `SELECT id FROM resource_changes
+           WHERE resource_kind = 'site' AND resource_id = ? AND note = 'Deleted Site'
+           ORDER BY id DESC LIMIT 1`,
+        )
+        .bind(id)
+        .first<{ id: number }>();
+      if (tombstone) return { ok: false, reason: "site_deleted" };
+    }
+    return { ok: false, reason: `${kind}_quota_exceeded` };
+  }
 
   await env.DB.prepare(`DELETE FROM ${rolesTable} WHERE ${kind}_id = ?`).bind(id).run();
   if (sharedWith.length) {
@@ -2370,7 +2434,7 @@ export const fetchLibraryForUser = async (
   env: Env,
   userId: string,
   opts?: { since?: string },
-): Promise<{ siteLibrary: CloudResourceRecord[]; simulationPresets: CloudResourceRecord[]; deletedSimulationIds: string[] }> => {
+): Promise<{ siteLibrary: CloudResourceRecord[]; simulationPresets: CloudResourceRecord[]; deletedSiteIds: string[]; deletedSimulationIds: string[] }> => {
   await ensureSchema(env);
   const me = await fetchUserProfile(env, userId);
   const canReadAllResources = Boolean(me?.isAdmin);
@@ -2404,6 +2468,32 @@ export const fetchLibraryForUser = async (
     )
     .bind(userId, canReadAllResources ? 1 : 0, userId, ...(opts?.since ? [opts.since] : []))
     .all<LibraryRow>();
+
+  const deletedSiteRows = canReadAllResources
+    ? { results: [] as Array<{ id: string }> }
+    : await env.DB
+        .prepare(
+          `SELECT tombstone.resource_id AS id
+           FROM resource_changes tombstone
+           WHERE tombstone.resource_kind = 'site'
+             AND tombstone.note = 'Deleted Site'
+             AND tombstone.id = (
+               SELECT MAX(latest.id)
+               FROM resource_changes latest
+               WHERE latest.resource_kind = 'site' AND latest.resource_id = tombstone.resource_id
+             )
+             AND NOT EXISTS (SELECT 1 FROM sites live WHERE live.id = tombstone.resource_id)
+             AND (
+               json_extract(tombstone.snapshot_json, '$.ownerUserId') = ?
+               OR json_extract(tombstone.snapshot_json, '$.visibility') IN ('public', 'shared')
+               OR EXISTS (
+                 SELECT 1 FROM json_each(COALESCE(json_extract(tombstone.snapshot_json, '$.sharedWith'), '[]')) grant_entry
+                 WHERE json_extract(grant_entry.value, '$.userId') = ?
+               )
+             )${opts?.since ? "\n             AND tombstone.changed_at > ?" : ""}`,
+        )
+        .bind(userId, userId, ...(opts?.since ? [opts.since] : []))
+        .all<{ id: string }>();
 
   const deletedSimulationRows = canReadAllResources
     ? { results: [] as Array<{ id: string }> }
@@ -2503,6 +2593,7 @@ export const fetchLibraryForUser = async (
   return {
     siteLibrary: mapRows(siteRows.results),
     simulationPresets: mapRows(simulationRows.results),
+    deletedSiteIds: deletedSiteRows.results.map((row) => row.id),
     deletedSimulationIds: deletedSimulationRows.results.map((row) => row.id),
   };
 };

--- a/functions/_lib/db.ts
+++ b/functions/_lib/db.ts
@@ -4,6 +4,17 @@ import {
   normalizeUserSimulationDefaultsPreference,
   type UserSimulationDefaultsPreference,
 } from "../../src/lib/simulationDefaults";
+import {
+  LIBRARY_BATCH_MAX_RECORDS,
+  LIBRARY_MAX_GRANTS,
+  LIBRARY_MAX_PUBLIC_SIMULATIONS_PER_USER,
+  LIBRARY_MAX_PUBLIC_SITES_PER_USER,
+  LIBRARY_MAX_SIMULATIONS_PER_USER,
+  LIBRARY_MAX_SITES_PER_USER,
+  LIBRARY_SIMULATION_MAX_BYTES,
+  LIBRARY_SITE_MAX_BYTES,
+  LibraryValidationError,
+} from "../../src/lib/libraryLimits";
 
 const VISIBILITIES: Visibility[] = ["private", "public", "shared"];
 const DB_VISIBILITIES: DbVisibility[] = ["private", "public_read", "public_write"];
@@ -1983,6 +1994,9 @@ const upsertOwnedResource = async (
 
   const visibility = sanitizeVisibility(item.visibility);
   const visibilityDb = dbVisibilityFromVisibility(visibility);
+  if (Array.isArray(item.sharedWith) && item.sharedWith.length > LIBRARY_MAX_GRANTS) {
+    return { ok: false, reason: `too_many_grants_${kind}` };
+  }
   const requestedSharedWith = sanitizeGrants(item.sharedWith);
   const now = new Date().toISOString();
 
@@ -2045,6 +2059,9 @@ const upsertOwnedResource = async (
     ...(kind === "simulation" ? { slug: simulationSlug, slugAliases } : {}),
   };
   const payload = JSON.stringify(nextRecord);
+  const payloadBytes = new TextEncoder().encode(payload).byteLength;
+  const maxPayloadBytes = kind === "site" ? LIBRARY_SITE_MAX_BYTES : LIBRARY_SIMULATION_MAX_BYTES;
+  if (payloadBytes > maxPayloadBytes) return { ok: false, reason: `${kind}_too_large` };
 
   const isCreate = !existing;
   const changed =
@@ -2075,11 +2092,17 @@ const upsertOwnedResource = async (
     return { ok: false, reason: `would_lose_access_${kind}` };
   }
 
-  await env.DB
+  const wasPublic = existing ? existing.visibility !== "private" : false;
+  const maxOwnerRecords = kind === "site" ? LIBRARY_MAX_SITES_PER_USER : LIBRARY_MAX_SIMULATIONS_PER_USER;
+  const maxOwnerPublicRecords = kind === "site" ? LIBRARY_MAX_PUBLIC_SITES_PER_USER : LIBRARY_MAX_PUBLIC_SIMULATIONS_PER_USER;
+  const activeQuotaClause = kind === "simulation" ? " AND status = 'active'" : "";
+  const writeResult = await env.DB
     .prepare(
       `INSERT INTO ${table}
        (id, owner_user_id, created_by_user_id, last_edited_by_user_id, created_at, last_edited_at, name, visibility, payload_json, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+       WHERE (? = 0 OR (SELECT COUNT(*) FROM ${table} WHERE owner_user_id = ?${activeQuotaClause}) < ?)
+         AND (? = 'private' OR ? = 1 OR (SELECT COUNT(*) FROM ${table} WHERE owner_user_id = ? AND visibility != 'private'${activeQuotaClause}) < ?)
        ON CONFLICT(id) DO UPDATE SET
          name = excluded.name,
          visibility = excluded.visibility,
@@ -2090,8 +2113,27 @@ const upsertOwnedResource = async (
          created_by_user_id = COALESCE(${table}.created_by_user_id, excluded.created_by_user_id),
          created_at = COALESCE(${table}.created_at, excluded.created_at)`,
     )
-    .bind(id, ownerId, ownerId, actor.id, existing?.created_at ?? now, now, name, visibilityDb, payload, now)
+    .bind(
+      id,
+      ownerId,
+      ownerId,
+      actor.id,
+      existing?.created_at ?? now,
+      now,
+      name,
+      visibilityDb,
+      payload,
+      now,
+      isCreate ? 1 : 0,
+      ownerId,
+      maxOwnerRecords,
+      visibilityDb,
+      wasPublic ? 1 : 0,
+      ownerId,
+      maxOwnerPublicRecords,
+    )
     .run();
+  if (writeResult.meta?.changes === 0) return { ok: false, reason: `${kind}_quota_exceeded` };
 
   await env.DB.prepare(`DELETE FROM ${rolesTable} WHERE ${kind}_id = ?`).bind(id).run();
   if (sharedWith.length) {
@@ -2157,23 +2199,103 @@ const upsertOwnedResource = async (
   return { ok: true };
 };
 
+type QuotaResourceRow = {
+  id: string;
+  owner_user_id: string;
+  visibility: DbVisibility;
+};
+
+type OwnerQuotaRow = {
+  owner_user_id: string;
+  total_count: number;
+  public_count: number;
+};
+
+const preflightResourceQuotas = async (
+  env: Env,
+  kind: "site" | "simulation",
+  actor: ActorPolicy,
+  items: CloudResourceRecord[],
+): Promise<void> => {
+  if (items.length === 0) return;
+  const table = kind === "site" ? "sites" : "simulations";
+  const ids = items.map((item) => typeof item.id === "string" ? item.id.trim() : "");
+  if (ids.some((id) => !id) || new Set(ids).size !== ids.length) {
+    throw new LibraryValidationError(`Library request contains invalid or duplicate ${kind === "site" ? "Site" : "Simulation"} IDs.`);
+  }
+  const placeholders = ids.map(() => "?").join(", ");
+  const existingRows = await env.DB
+    .prepare(`SELECT id, owner_user_id, visibility FROM ${table} WHERE id IN (${placeholders})`)
+    .bind(...ids)
+    .all<QuotaResourceRow>();
+  const existingById = new Map(existingRows.results.map((row) => [row.id, row]));
+  const ownerIds = [...new Set(items.map((item) => existingById.get(item.id.trim())?.owner_user_id ?? actor.id))];
+  const ownerPlaceholders = ownerIds.map(() => "?").join(", ");
+  const activeClause = kind === "simulation" ? " AND status = 'active'" : "";
+  const counts = await env.DB
+    .prepare(
+      `SELECT owner_user_id,
+              COUNT(*) AS total_count,
+              SUM(CASE WHEN visibility != 'private' THEN 1 ELSE 0 END) AS public_count
+       FROM ${table}
+       WHERE owner_user_id IN (${ownerPlaceholders})${activeClause}
+       GROUP BY owner_user_id`,
+    )
+    .bind(...ownerIds)
+    .all<OwnerQuotaRow>();
+  const state = new Map(ownerIds.map((ownerId) => {
+    const row = counts.results.find((entry) => entry.owner_user_id === ownerId);
+    const total = Number(row?.total_count ?? 0);
+    const publicCount = Number(row?.public_count ?? 0);
+    return [ownerId, { initialTotal: total, initialPublic: publicCount, total, publicCount }];
+  }));
+
+  for (const item of items) {
+    const id = item.id.trim();
+    const existing = existingById.get(id);
+    const ownerId = existing?.owner_user_id ?? actor.id;
+    const ownerState = state.get(ownerId)!;
+    const nextVisibility = dbVisibilityFromVisibility(sanitizeVisibility(item.visibility));
+    if (!existing) ownerState.total += 1;
+    const wasPublic = existing ? existing.visibility !== "private" : false;
+    const willBePublic = nextVisibility !== "private";
+    if (wasPublic !== willBePublic) ownerState.publicCount += willBePublic ? 1 : -1;
+  }
+
+  const maxTotal = kind === "site" ? LIBRARY_MAX_SITES_PER_USER : LIBRARY_MAX_SIMULATIONS_PER_USER;
+  const maxPublic = kind === "site" ? LIBRARY_MAX_PUBLIC_SITES_PER_USER : LIBRARY_MAX_PUBLIC_SIMULATIONS_PER_USER;
+  for (const quota of state.values()) {
+    if (quota.total > maxTotal && quota.total > quota.initialTotal) {
+      throw new LibraryValidationError(`${kind === "site" ? "Site" : "Simulation"} Library quota exceeded.`);
+    }
+    if (quota.publicCount > maxPublic && quota.publicCount > quota.initialPublic) {
+      throw new LibraryValidationError(`Public ${kind === "site" ? "Site" : "Simulation"} Library quota exceeded.`);
+    }
+  }
+};
+
 export const upsertLibrarySnapshot = async (
   env: Env,
   actor: ActorPolicy,
   payload: { siteLibrary: CloudResourceRecord[]; simulationPresets: CloudResourceRecord[] },
 ): Promise<{ upsertedSites: number; upsertedSimulations: number; conflicts: string[] }> => {
   await ensureSchema(env);
+  if (payload.siteLibrary.length + payload.simulationPresets.length > LIBRARY_BATCH_MAX_RECORDS) {
+    throw new LibraryValidationError(`Library request may contain at most ${LIBRARY_BATCH_MAX_RECORDS} records.`);
+  }
+  await preflightResourceQuotas(env, "site", actor, payload.siteLibrary);
+  await preflightResourceQuotas(env, "simulation", actor, payload.simulationPresets);
   const conflicts: string[] = [];
   let upsertedSites = 0;
   let upsertedSimulations = 0;
 
-  for (const site of payload.siteLibrary.slice(0, 4000)) {
+  for (const site of payload.siteLibrary) {
     const result = await upsertOwnedResource(env, "site", actor, site);
     if (result.ok) upsertedSites += 1;
     else if (result.reason) conflicts.push(result.reason);
   }
 
-  for (const simulation of payload.simulationPresets.slice(0, 4000)) {
+  for (const simulation of payload.simulationPresets) {
     const result = await upsertOwnedResource(env, "simulation", actor, simulation);
     if (result.ok) upsertedSimulations += 1;
     else if (result.reason) conflicts.push(result.reason);

--- a/functions/_lib/db.ts
+++ b/functions/_lib/db.ts
@@ -69,6 +69,12 @@ const sanitizeName = (value: unknown): string | null => {
   return name;
 };
 
+const sanitizeResourceName = (value: unknown): string | null => {
+  if (typeof value !== "string") return null;
+  const name = value.trim().replace(/\s+/g, " ");
+  return name || null;
+};
+
 const slugifyName = (value: string): string =>
   value
     .trim()
@@ -2038,7 +2044,7 @@ const upsertOwnedResource = async (
   const rolesTable = kind === "site" ? "site_roles" : "simulation_roles";
 
   const id = typeof item.id === "string" ? item.id.trim() : "";
-  const name = sanitizeName(item.name);
+  const name = sanitizeResourceName(item.name);
   if (!id || !name) return { ok: false, reason: `invalid_${kind}` };
 
   const visibility = sanitizeVisibility(item.visibility);

--- a/functions/_lib/db.ts
+++ b/functions/_lib/db.ts
@@ -1887,6 +1887,29 @@ const canEditResource = (
 
 type ResourceChangeAccessReason = "missing" | "forbidden";
 
+export const deleteSiteResource = async (
+  env: Env,
+  actor: ActorPolicy,
+  siteId: string,
+): Promise<{ ok: true; siteId: string } | { ok: false; reason: "missing" | "forbidden" }> => {
+  await ensureSchema(env);
+  const id = siteId.trim();
+  if (!id) return { ok: false, reason: "missing" };
+  const existing = await env.DB
+    .prepare("SELECT id, owner_user_id FROM sites WHERE id = ? LIMIT 1")
+    .bind(id)
+    .first<{ id: string; owner_user_id: string }>();
+  if (!existing) return { ok: false, reason: "missing" };
+  if (!(actor.isAdmin || existing.owner_user_id === actor.id)) {
+    return { ok: false, reason: "forbidden" };
+  }
+  await env.DB.batch([
+    env.DB.prepare("DELETE FROM site_roles WHERE site_id = ?").bind(id),
+    env.DB.prepare("DELETE FROM sites WHERE id = ? AND owner_user_id = ?").bind(id, existing.owner_user_id),
+  ]);
+  return { ok: true, siteId: id };
+};
+
 const resolveResourceChangeAccess = async (
   env: Env,
   kind: "site" | "simulation",

--- a/functions/_lib/http.test.ts
+++ b/functions/_lib/http.test.ts
@@ -5,9 +5,36 @@ import {
   getCorsOriginDecision,
   handleOptions,
   normalizeApiErrorMessage,
+  readBoundedJson,
   statusFromErrorMessage,
   withCors,
 } from "./http";
+
+describe("bounded JSON reader", () => {
+  it("accepts a body exactly at the byte boundary", async () => {
+    const request = new Request("https://linksim.link/api/library", { method: "PUT", body: "{\"a\":1}" });
+    await expect(readBoundedJson(request, { maxBytes: 7, maxDepth: 2 })).resolves.toEqual({ a: 1 });
+  });
+
+  it("rejects streamed bytes above the boundary without relying on Content-Length", async () => {
+    const request = new Request("https://linksim.link/api/library", { method: "PUT", body: "{\"a\":1}" });
+    await expect(readBoundedJson(request, { maxBytes: 6, maxDepth: 2 })).rejects.toMatchObject({
+      status: 413,
+      code: "request_too_large",
+    });
+  });
+
+  it("ignores braces in strings while enforcing structural depth", async () => {
+    const accepted = new Request("https://linksim.link/api/library", { method: "PUT", body: "{\"value\":\"{{{{\"}" });
+    await expect(readBoundedJson(accepted, { maxBytes: 64, maxDepth: 1 })).resolves.toEqual({ value: "{{{{" });
+
+    const rejected = new Request("https://linksim.link/api/library", { method: "PUT", body: "{\"a\":{\"b\":1}}" });
+    await expect(readBoundedJson(rejected, { maxBytes: 64, maxDepth: 1 })).rejects.toMatchObject({
+      status: 422,
+      code: "json_too_deep",
+    });
+  });
+});
 
 describe("credentialed CORS policy", () => {
   it.each([

--- a/functions/_lib/http.ts
+++ b/functions/_lib/http.ts
@@ -9,6 +9,84 @@ export const json = (body: unknown, init?: ResponseInit): Response => {
   });
 };
 
+export class ApiRequestError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly code: string,
+  ) {
+    super(message);
+  }
+}
+
+const assertJsonDepth = (text: string, maxDepth: number): void => {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (const char of text) {
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === "\"") inString = false;
+      continue;
+    }
+    if (char === "\"") {
+      inString = true;
+    } else if (char === "{" || char === "[") {
+      depth += 1;
+      if (depth > maxDepth) {
+        throw new ApiRequestError(`JSON nesting may not exceed ${maxDepth} levels.`, 422, "json_too_deep");
+      }
+    } else if (char === "}" || char === "]") {
+      depth -= 1;
+    }
+  }
+};
+
+export const readBoundedJson = async <T>(
+  request: Request,
+  options: { maxBytes: number; maxDepth: number },
+): Promise<T> => {
+  const declaredLength = Number(request.headers.get("content-length"));
+  if (Number.isFinite(declaredLength) && declaredLength > options.maxBytes) {
+    throw new ApiRequestError(`Request body exceeds ${options.maxBytes} bytes.`, 413, "request_too_large");
+  }
+  if (!request.body) throw new ApiRequestError("Request body is required.", 422, "invalid_json");
+
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    totalBytes += value.byteLength;
+    if (totalBytes > options.maxBytes) {
+      await reader.cancel();
+      throw new ApiRequestError(`Request body exceeds ${options.maxBytes} bytes.`, 413, "request_too_large");
+    }
+    chunks.push(value);
+  }
+
+  const bytes = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  let text: string;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    throw new ApiRequestError("Request body must be valid UTF-8 JSON.", 422, "invalid_json");
+  }
+  assertJsonDepth(text, options.maxDepth);
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    throw new ApiRequestError("Request body must be valid JSON.", 422, "invalid_json");
+  }
+};
+
 export type CorsOriginDecision = "allowed" | "originless" | "denied";
 
 const LOCAL_VITE_ORIGIN = "http://localhost:5174";
@@ -127,7 +205,13 @@ const codeFromErrorMessage = (message: string): string | null => {
 
 export const errorResponse = (request: Request, error: unknown, fallback = 500): Response => {
   const message = error instanceof Error ? error.message : String(error);
-  const code = codeFromErrorMessage(message);
+  const explicitStatus = error && typeof error === "object" && "status" in error && typeof error.status === "number"
+    ? error.status
+    : null;
+  const explicitCode = error && typeof error === "object" && "code" in error && typeof error.code === "string"
+    ? error.code
+    : null;
+  const code = explicitCode ?? codeFromErrorMessage(message);
   return withCors(
     request,
     json(
@@ -139,7 +223,7 @@ export const errorResponse = (request: Request, error: unknown, fallback = 500):
         : {
             error: normalizeApiErrorMessage(message),
           },
-      { status: statusFromErrorMessage(message, fallback) },
+      { status: explicitStatus ?? statusFromErrorMessage(message, fallback) },
     ),
   );
 };

--- a/functions/api/library.test.ts
+++ b/functions/api/library.test.ts
@@ -205,4 +205,33 @@ describe("api/library", () => {
       { siteLibrary: sites, simulationPresets: simulations },
     );
   });
+
+  it("accepts legacy Simulation snapshots without Radio Systems or Networks", async () => {
+    const withoutSystems = validSimulation("2026-08-14T00:00:00.000Z") as {
+      id: string;
+      snapshot: Record<string, unknown>;
+    };
+    withoutSystems.id = "sim-without-systems";
+    delete withoutSystems.snapshot.systems;
+    const withoutNetworks = validSimulation("2026-08-14T00:00:00.000Z") as {
+      id: string;
+      snapshot: Record<string, unknown>;
+    };
+    withoutNetworks.id = "sim-without-networks";
+    delete withoutNetworks.snapshot.networks;
+    const simulations = [withoutSystems, withoutNetworks];
+    const req = new Request("https://example.test/api/library", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ siteLibrary: [], simulationPresets: simulations }),
+    });
+
+    const res = await onRequestPut(mkCtx(req));
+    expect(res.status).toBe(200);
+    expect(upsertLibrarySnapshotMock).toHaveBeenCalledWith(
+      env,
+      expect.objectContaining({ id: "u1" }),
+      { siteLibrary: [], simulationPresets: simulations },
+    );
+  });
 });

--- a/functions/api/library.test.ts
+++ b/functions/api/library.test.ts
@@ -23,9 +23,25 @@ vi.mock("../_lib/db", () => ({
 }));
 
 import { onRequestGet, onRequestPut } from "./library";
+import { LIBRARY_BATCH_MAX_RECORDS, LIBRARY_REQUEST_MAX_BYTES } from "../../src/lib/libraryLimits";
 
 const env = { DB: {} } as unknown as { DB: D1Database };
 const mkCtx = (request: Request) => ({ request, env } as unknown as Parameters<typeof onRequestGet>[0]);
+
+const validSite = (id = "site-1") => ({
+  id,
+  name: "Hilltop",
+  visibility: "private",
+  sharedWith: [],
+  position: { lat: 59.9, lon: 10.7 },
+  groundElevationM: 120,
+  antennaHeightM: 12,
+  txPowerDbm: 22,
+  txGainDbi: 5,
+  rxGainDbi: 5,
+  cableLossDb: 1,
+  createdAt: "2026-08-14T00:00:00.000Z",
+});
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -66,7 +82,7 @@ describe("api/library", () => {
     // isDelta should be falsy
   });
 
-  it("normalizes non-array payloads on PUT", async () => {
+  it("rejects non-array Library collections on PUT", async () => {
     const req = new Request("https://example.test/api/library", {
       method: "PUT",
       headers: { "content-type": "application/json" },
@@ -74,11 +90,68 @@ describe("api/library", () => {
     });
 
     const res = await onRequestPut(mkCtx(req));
+    expect(res.status).toBe(422);
+    expect(upsertLibrarySnapshotMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a declared body larger than the approved limit before parsing", async () => {
+    const req = new Request("https://example.test/api/library", {
+      method: "PUT",
+      headers: {
+        "content-type": "application/json",
+        "content-length": String(LIBRARY_REQUEST_MAX_BYTES + 1),
+      },
+      body: "{}",
+    });
+
+    const res = await onRequestPut(mkCtx(req));
+    expect(res.status).toBe(413);
+    expect(upsertLibrarySnapshotMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects JSON nested beyond the approved depth", async () => {
+    let nested: unknown = "leaf";
+    for (let index = 0; index < 21; index += 1) nested = { nested };
+    const req = new Request("https://example.test/api/library", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(nested),
+    });
+
+    const res = await onRequestPut(mkCtx(req));
+    expect(res.status).toBe(422);
+    expect(upsertLibrarySnapshotMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects more than the approved number of records instead of truncating", async () => {
+    const req = new Request("https://example.test/api/library", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        siteLibrary: Array.from({ length: LIBRARY_BATCH_MAX_RECORDS + 1 }, (_, index) => validSite(`site-${index}`)),
+        simulationPresets: [],
+      }),
+    });
+
+    const res = await onRequestPut(mkCtx(req));
+    expect(res.status).toBe(422);
+    expect(upsertLibrarySnapshotMock).not.toHaveBeenCalled();
+  });
+
+  it("passes a validated Library batch to the existing database helper", async () => {
+    const site = validSite();
+    const req = new Request("https://example.test/api/library", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ siteLibrary: [site], simulationPresets: [] }),
+    });
+
+    const res = await onRequestPut(mkCtx(req));
     expect(res.status).toBe(200);
     expect(upsertLibrarySnapshotMock).toHaveBeenCalledWith(
       env,
       expect.objectContaining({ id: "u1" }),
-      { siteLibrary: [], simulationPresets: [] },
+      { siteLibrary: [site], simulationPresets: [] },
     );
   });
 });

--- a/functions/api/library.test.ts
+++ b/functions/api/library.test.ts
@@ -180,4 +180,29 @@ describe("api/library", () => {
       { siteLibrary: [site], simulationPresets: [] },
     );
   });
+
+  it("accepts previously supported non-empty Site and Simulation name lengths", async () => {
+    const longName = "L".repeat(160);
+    const sites = [
+      { ...validSite("site-short"), name: "X" },
+      { ...validSite("site-long"), name: longName },
+    ];
+    const simulations = [
+      { ...validSimulation("2026-08-14T00:00:00.000Z"), id: "sim-short", name: "X" },
+      { ...validSimulation("2026-08-14T00:00:00.000Z"), id: "sim-long", name: longName },
+    ];
+    const req = new Request("https://example.test/api/library", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ siteLibrary: sites, simulationPresets: simulations }),
+    });
+
+    const res = await onRequestPut(mkCtx(req));
+    expect(res.status).toBe(200);
+    expect(upsertLibrarySnapshotMock).toHaveBeenCalledWith(
+      env,
+      expect.objectContaining({ id: "u1" }),
+      { siteLibrary: sites, simulationPresets: simulations },
+    );
+  });
 });

--- a/functions/api/library.test.ts
+++ b/functions/api/library.test.ts
@@ -43,6 +43,15 @@ const validSite = (id = "site-1") => ({
   createdAt: "2026-08-14T00:00:00.000Z",
 });
 
+const validSimulation = (updatedAt: unknown) => ({
+  id: "sim-1",
+  name: "Relay plan",
+  visibility: "private",
+  sharedWith: [],
+  updatedAt,
+  snapshot: { sites: [], links: [], systems: [], networks: [] },
+});
+
 beforeEach(() => {
   vi.clearAllMocks();
   verifyAuthMock.mockResolvedValue({ userId: "u1", tokenPayload: {}, source: "headers" });
@@ -137,6 +146,23 @@ describe("api/library", () => {
     expect(res.status).toBe(422);
     expect(upsertLibrarySnapshotMock).not.toHaveBeenCalled();
   });
+
+  it.each([undefined, { unsafe: true }])(
+    "rejects a missing or malformed render-critical Simulation updatedAt (%j)",
+    async (updatedAt) => {
+      const simulation = validSimulation(updatedAt);
+      if (updatedAt === undefined) delete (simulation as { updatedAt?: unknown }).updatedAt;
+      const req = new Request("https://example.test/api/library", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ siteLibrary: [], simulationPresets: [simulation] }),
+      });
+
+      const res = await onRequestPut(mkCtx(req));
+      expect(res.status).toBe(422);
+      expect(upsertLibrarySnapshotMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("passes a validated Library batch to the existing database helper", async () => {
     const site = validSite();

--- a/functions/api/library.ts
+++ b/functions/api/library.ts
@@ -1,9 +1,12 @@
 import { verifyAuth } from "../_lib/auth";
 import { assertUserAccess, ensureUser, fetchLibraryForUser, upsertLibrarySnapshot } from "../_lib/db";
-import { errorResponse, handleOptions, json, withCors } from "../_lib/http";
+import { errorResponse, handleOptions, json, readBoundedJson, withCors } from "../_lib/http";
 import type { CloudResourceRecord, Env, LibrarySnapshotPayload } from "../_lib/types";
-
-const normalizeArray = (value: unknown): CloudResourceRecord[] => (Array.isArray(value) ? (value as CloudResourceRecord[]) : []);
+import {
+  LIBRARY_JSON_MAX_DEPTH,
+  LIBRARY_REQUEST_MAX_BYTES,
+  validateLibraryPayload,
+} from "../../src/lib/libraryLimits";
 
 export const onRequestOptions: PagesFunction<Env> = async ({ request }) => handleOptions(request);
 
@@ -35,9 +38,13 @@ export const onRequestPut: PagesFunction<Env> = async ({ request, env }) => {
     await ensureUser(env, auth.userId, auth.tokenPayload);
     const me = await assertUserAccess(env, auth.userId);
 
-    const body = (await request.json()) as LibrarySnapshotPayload;
-    const siteLibrary = normalizeArray(body.siteLibrary);
-    const simulationPresets = normalizeArray(body.simulationPresets);
+    const body = await readBoundedJson<LibrarySnapshotPayload>(request, {
+      maxBytes: LIBRARY_REQUEST_MAX_BYTES,
+      maxDepth: LIBRARY_JSON_MAX_DEPTH,
+    });
+    const validated = validateLibraryPayload(body);
+    const siteLibrary = validated.siteLibrary as CloudResourceRecord[];
+    const simulationPresets = validated.simulationPresets as CloudResourceRecord[];
 
     const result = await upsertLibrarySnapshot(
       env,

--- a/functions/api/library/sites/[id].test.ts
+++ b/functions/api/library/sites/[id].test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { verifyAuthMock, ensureUserMock, assertUserAccessMock, deleteSiteResourceMock } = vi.hoisted(() => ({
+  verifyAuthMock: vi.fn(),
+  ensureUserMock: vi.fn(),
+  assertUserAccessMock: vi.fn(),
+  deleteSiteResourceMock: vi.fn(),
+}));
+
+vi.mock("../../../_lib/auth", () => ({ verifyAuth: verifyAuthMock }));
+vi.mock("../../../_lib/db", () => ({
+  ensureUser: ensureUserMock,
+  assertUserAccess: assertUserAccessMock,
+  deleteSiteResource: deleteSiteResourceMock,
+}));
+
+import { onRequestDelete } from "./[id]";
+
+const env = { DB: {} } as unknown as { DB: D1Database };
+const mkCtx = (id = "site-1") => ({
+  request: new Request(`https://example.test/api/library/sites/${id}`, { method: "DELETE" }),
+  env,
+  params: { id },
+} as unknown as Parameters<typeof onRequestDelete>[0]);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  verifyAuthMock.mockResolvedValue({ userId: "owner-1", tokenPayload: {} });
+  assertUserAccessMock.mockResolvedValue({ id: "owner-1", isAdmin: false, isModerator: false });
+  deleteSiteResourceMock.mockResolvedValue({ ok: true, siteId: "site-1" });
+});
+
+describe("api/library/sites/[id]", () => {
+  it("deletes an owned Site through the existing authenticated Library boundary", async () => {
+    const response = await onRequestDelete(mkCtx());
+    expect(response.status).toBe(200);
+    expect(deleteSiteResourceMock).toHaveBeenCalledWith(
+      env,
+      expect.objectContaining({ id: "owner-1", isAdmin: false }),
+      "site-1",
+    );
+  });
+
+  it("maps forbidden deletion and treats an already-missing Site as an idempotent success", async () => {
+    deleteSiteResourceMock.mockResolvedValueOnce({ ok: false, reason: "forbidden" });
+    expect((await onRequestDelete(mkCtx())).status).toBe(403);
+    deleteSiteResourceMock.mockResolvedValueOnce({ ok: false, reason: "missing" });
+    const missing = await onRequestDelete(mkCtx());
+    expect(missing.status).toBe(200);
+    await expect(missing.json()).resolves.toMatchObject({ ok: true, siteId: "site-1", alreadyDeleted: true });
+  });
+
+  it("requires authentication", async () => {
+    verifyAuthMock.mockResolvedValueOnce(null);
+    expect((await onRequestDelete(mkCtx())).status).toBe(401);
+    expect(deleteSiteResourceMock).not.toHaveBeenCalled();
+  });
+});

--- a/functions/api/library/sites/[id].ts
+++ b/functions/api/library/sites/[id].ts
@@ -1,0 +1,27 @@
+import { verifyAuth } from "../../../_lib/auth";
+import { assertUserAccess, deleteSiteResource, ensureUser } from "../../../_lib/db";
+import { errorResponse, handleOptions, json, withCors } from "../../../_lib/http";
+import type { Env } from "../../../_lib/types";
+
+export const onRequestOptions: PagesFunction<Env> = async ({ request }) => handleOptions(request);
+
+export const onRequestDelete: PagesFunction<Env> = async ({ request, env, params }) => {
+  try {
+    const auth = await verifyAuth(request, env);
+    if (!auth) return withCors(request, json({ error: "Unauthorized" }, { status: 401 }));
+    await ensureUser(env, auth.userId, auth.tokenPayload);
+    const me = await assertUserAccess(env, auth.userId);
+    const siteId = typeof params.id === "string" ? params.id.trim() : "";
+    if (!siteId) return withCors(request, json({ error: "Missing Site id" }, { status: 400 }));
+    const result = await deleteSiteResource(
+      env,
+      { id: me.id, isAdmin: me.isAdmin, isModerator: Boolean(me.isModerator) },
+      siteId,
+    );
+    if (result.ok) return withCors(request, json(result));
+    if (result.reason === "missing") return withCors(request, json({ ok: true, siteId, alreadyDeleted: true }));
+    return withCors(request, json({ error: "Forbidden" }, { status: 403 }));
+  } catch (error) {
+    return errorResponse(request, error, 500);
+  }
+};

--- a/src/components/LibraryPanel.tsx
+++ b/src/components/LibraryPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { ExternalLink, Filter, Info, MapPlus, Menu, Pencil, X } from "lucide-react";
 import {
   DEFAULT_LIBRARY_FILTER_STATE,
+  canDeleteLibraryItem,
   filterAndSortLibraryItems,
   type LibraryFilterRole,
   type LibraryFilterSource,
@@ -71,15 +72,6 @@ const canEditResource = (
         resource.effectiveRole === "admin" ||
         resource.effectiveRole === "editor"),
   );
-
-const canDeleteResource = (
-  resource: { ownerUserId?: string; effectiveRole?: string },
-  currentUser: { id: string; isAdmin?: boolean } | null,
-) => Boolean(currentUser && (
-  currentUser.isAdmin
-  || resource.ownerUserId === currentUser.id
-  || resource.effectiveRole === "owner"
-));
 
 export function LibraryPanel({
   initialTab,
@@ -558,7 +550,7 @@ export function LibraryPanel({
                 <ActionButton
                   disabled={Array.from(selectedSiteIds).some((id) => {
                     const entry = siteLibrary.find((candidate) => candidate.id === id);
-                    return !entry || !canDeleteResource(entry, currentUser);
+                    return !entry || !canDeleteLibraryItem(entry, currentUser);
                   })}
                   onClick={() => setDeleteSelection(Array.from(selectedSiteIds))}
                   type="button"

--- a/src/components/LibraryPanel.tsx
+++ b/src/components/LibraryPanel.tsx
@@ -10,6 +10,7 @@ import {
 } from "../lib/libraryFilters";
 import { persistLibraryFilterState, readLibraryFilterState } from "../lib/libraryFilterUi";
 import { formatDate } from "../lib/locale";
+import { getUiErrorMessage } from "../lib/uiError";
 import { toAccessVisibility } from "../lib/uiFormatting";
 import { useAppStore, type LibraryTab } from "../store/appStore";
 import { ActionButton } from "./ActionButton";
@@ -71,6 +72,15 @@ const canEditResource = (
         resource.effectiveRole === "editor"),
   );
 
+const canDeleteResource = (
+  resource: { ownerUserId?: string; effectiveRole?: string },
+  currentUser: { id: string; isAdmin?: boolean } | null,
+) => Boolean(currentUser && (
+  currentUser.isAdmin
+  || resource.ownerUserId === currentUser.id
+  || resource.effectiveRole === "owner"
+));
+
 export function LibraryPanel({
   initialTab,
   isMobile,
@@ -108,6 +118,8 @@ export function LibraryPanel({
   const [mobileDetailOpen, setMobileDetailOpen] = useState(true);
   const [selectedSiteIds, setSelectedSiteIds] = useState<Set<string>>(new Set());
   const [deleteSelection, setDeleteSelection] = useState<string[] | null>(null);
+  const [deleteBusy, setDeleteBusy] = useState(false);
+  const [deleteError, setDeleteError] = useState("");
   const filterTriggerRef = useRef<HTMLButtonElement | null>(null);
   const listRef = useRef<HTMLDivElement | null>(null);
   const scrollPositionsRef = useRef<Record<LibraryTab, number>>({ sites: 0, simulations: 0 });
@@ -546,7 +558,7 @@ export function LibraryPanel({
                 <ActionButton
                   disabled={Array.from(selectedSiteIds).some((id) => {
                     const entry = siteLibrary.find((candidate) => candidate.id === id);
-                    return !entry || !canEditResource(entry, currentUserId);
+                    return !entry || !canDeleteResource(entry, currentUser);
                   })}
                   onClick={() => setDeleteSelection(Array.from(selectedSiteIds))}
                   type="button"
@@ -726,12 +738,26 @@ export function LibraryPanel({
 
       {deleteSelection ? (
         <ConfirmActionModal
+          busy={deleteBusy}
+          error={deleteError}
           message={`Delete ${deleteSelection.length} selected Site${deleteSelection.length === 1 ? "" : "s"} from the Library? Referenced Simulation data will be detached but preserved.`}
-          onCancel={() => setDeleteSelection(null)}
+          onCancel={() => {
+            if (!deleteBusy) {
+              setDeleteError("");
+              setDeleteSelection(null);
+            }
+          }}
           onConfirm={() => {
-            deleteSiteLibraryEntries(deleteSelection);
-            setSelectedSiteIds(new Set());
-            setDeleteSelection(null);
+            if (deleteBusy) return;
+            setDeleteBusy(true);
+            setDeleteError("");
+            void deleteSiteLibraryEntries(deleteSelection)
+              .then(() => {
+                setSelectedSiteIds(new Set());
+                setDeleteSelection(null);
+              })
+              .catch((error) => setDeleteError(`Delete failed: ${getUiErrorMessage(error)}`))
+              .finally(() => setDeleteBusy(false));
           }}
           title="Delete Sites"
         />

--- a/src/components/map/MapEditorPanel.test.tsx
+++ b/src/components/map/MapEditorPanel.test.tsx
@@ -557,6 +557,21 @@ describe("MapEditorPanel", () => {
     await waitFor(() => expect(useAppStore.getState().mapEditor).toBeNull());
   });
 
+  it("does not offer Site deletion to a collaborator who can edit", async () => {
+    useAppStore.setState((state) => ({
+      currentUser: { ...state.currentUser!, id: "editor-1", isAdmin: false },
+      siteLibrary: state.siteLibrary.map((site) => ({
+        ...site,
+        ownerUserId: "owner-1",
+        effectiveRole: "editor" as const,
+      })),
+    }));
+    render(<MapEditorPanel isMobile={false} />);
+
+    expect(await screen.findByRole("button", { name: "Save Site" })).toBeEnabled();
+    expect(screen.queryByRole("button", { name: "Delete Site" })).not.toBeInTheDocument();
+  });
+
   it("opens the shared profile popover from metadata and change-log identities", async () => {
     render(<MapEditorPanel isMobile={false} />);
 

--- a/src/components/map/MapEditorPanel.test.tsx
+++ b/src/components/map/MapEditorPanel.test.tsx
@@ -545,7 +545,7 @@ describe("MapEditorPanel", () => {
   });
 
   it("confirms deletion from editable Site details", async () => {
-    const deleteSiteLibraryEntry = vi.fn();
+    const deleteSiteLibraryEntry = vi.fn(async () => undefined);
     useAppStore.setState({ deleteSiteLibraryEntry });
     render(<MapEditorPanel isMobile={false} />);
 
@@ -554,7 +554,7 @@ describe("MapEditorPanel", () => {
     await userEvent.click(within(dialog).getByRole("button", { name: "Delete" }));
 
     expect(deleteSiteLibraryEntry).toHaveBeenCalledWith("site-lib-1");
-    expect(useAppStore.getState().mapEditor).toBeNull();
+    await waitFor(() => expect(useAppStore.getState().mapEditor).toBeNull());
   });
 
   it("opens the shared profile popover from metadata and change-log identities", async () => {

--- a/src/components/map/MapEditorPanel.tsx
+++ b/src/components/map/MapEditorPanel.tsx
@@ -9,6 +9,7 @@ import {
 } from "../../lib/cloudUser";
 import { formatDate } from "../../lib/locale";
 import { getUiErrorMessage } from "../../lib/uiError";
+import { canDeleteLibraryItem } from "../../lib/libraryFilters";
 import { useAppStore } from "../../store/appStore";
 import { useMapEditorFormState } from "./useMapEditorFormState";
 import { AccessSettingsEditor } from "../AccessSettingsEditor";
@@ -258,6 +259,7 @@ function SiteEditorCard({
   onRequestDelete,
   onOpenChangeLog,
   onOpenUserProfile,
+  canDelete,
 }: {
   isNew: boolean;
   form: ReturnType<typeof useMapEditorFormState>;
@@ -265,6 +267,7 @@ function SiteEditorCard({
   onRequestDelete: () => void;
   onOpenChangeLog: (kind: ResourceKindWithChanges, resourceId: string, label: string) => void;
   onOpenUserProfile: (userId: string, anchor: HTMLElement) => void;
+  canDelete: boolean;
 }) {
   const mapEditor = useAppStore((state) => state.mapEditor);
   const isReadOnly = Boolean(mapEditor?.readOnly && !isNew) || (!form.canWrite && !isNew);
@@ -768,7 +771,7 @@ function SiteEditorCard({
             {isNew ? "Create Site" : "Save Site"}
           </ActionButton>
         ) : null}
-        {!isNew && !isReadOnly ? (
+        {!isNew && !isReadOnly && canDelete ? (
           <ActionButton onClick={onRequestDelete} type="button" variant="danger">
             Delete Site
           </ActionButton>
@@ -1213,6 +1216,7 @@ export function MapEditorPanel({ isMobile }: MapEditorPanelProps) {
   const deleteSimulationPreset = useAppStore((state) => state.deleteSimulationPreset);
   const restoreSimulationPreset = useAppStore((state) => state.restoreSimulationPreset);
   const simulationPresets = useAppStore((state) => state.simulationPresets);
+  const siteLibrary = useAppStore((state) => state.siteLibrary);
   const currentUser = useAppStore((state) => state.currentUser);
   const form = useMapEditorFormState();
 
@@ -1320,8 +1324,12 @@ export function MapEditorPanel({ isMobile }: MapEditorPanelProps) {
 
   const editorContent = (() => {
     if (mapEditor.kind === "site") {
+      const site = mapEditor.resourceId
+        ? siteLibrary.find((entry) => entry.id === mapEditor.resourceId)
+        : undefined;
       return (
         <SiteEditorCard
+          canDelete={Boolean(site && canDeleteLibraryItem(site, currentUser))}
           form={form}
           isNew={mapEditor.isNew}
           onClose={closeMapEditor}

--- a/src/components/map/MapEditorPanel.tsx
+++ b/src/components/map/MapEditorPanel.tsx
@@ -1397,9 +1397,16 @@ export function MapEditorPanel({ isMobile }: MapEditorPanelProps) {
       }}
       onConfirm={() => {
         if (deleteTarget.kind === "site") {
-          deleteSiteLibraryEntry(deleteTarget.resourceId);
-          setDeleteTarget(null);
-          closeMapEditor();
+          if (lifecycleBusy) return;
+          setLifecycleBusy(true);
+          setLifecycleError("");
+          void deleteSiteLibraryEntry(deleteTarget.resourceId)
+            .then(() => {
+              setDeleteTarget(null);
+              closeMapEditor();
+            })
+            .catch((error) => setLifecycleError(`Delete failed: ${getUiErrorMessage(error)}`))
+            .finally(() => setLifecycleBusy(false));
           return;
         }
         if (lifecycleBusy) return;

--- a/src/lib/cloudLibrary.test.ts
+++ b/src/lib/cloudLibrary.test.ts
@@ -59,18 +59,31 @@ describe("cloudLibrary client", () => {
     );
 
     const result = await fetchCloudLibrary();
-    expect(result).toEqual({ siteLibrary: [{ id: "s1" }], simulationPresets: [], deletedSimulationIds: [] });
+    expect(result).toEqual({
+      siteLibrary: [{ id: "s1" }],
+      simulationPresets: [],
+      deletedSiteIds: [],
+      deletedSimulationIds: [],
+    });
   });
 
   it("normalizes deletion tombstones from Library responses", async () => {
     vi.mocked(globalThis.fetch).mockResolvedValueOnce(
-      new Response(JSON.stringify({ siteLibrary: [], simulationPresets: [], deletedSimulationIds: ["sim-1", 42] }), {
+      new Response(JSON.stringify({
+        siteLibrary: [],
+        simulationPresets: [],
+        deletedSiteIds: ["site-1", null],
+        deletedSimulationIds: ["sim-1", 42],
+      }), {
         status: 200,
         headers: { "content-type": "application/json" },
       }),
     );
 
-    await expect(fetchCloudLibrary()).resolves.toMatchObject({ deletedSimulationIds: ["sim-1"] });
+    await expect(fetchCloudLibrary()).resolves.toMatchObject({
+      deletedSiteIds: ["site-1"],
+      deletedSimulationIds: ["sim-1"],
+    });
   });
 
   it("uses dedicated lifecycle requests for Site delete and Simulation delete/restore", async () => {

--- a/src/lib/cloudLibrary.test.ts
+++ b/src/lib/cloudLibrary.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  deleteCloudSite,
   deleteCloudSimulation,
   fetchCloudLibrary,
   pushCloudLibrary,
@@ -72,21 +73,28 @@ describe("cloudLibrary client", () => {
     await expect(fetchCloudLibrary()).resolves.toMatchObject({ deletedSimulationIds: ["sim-1"] });
   });
 
-  it("uses dedicated lifecycle requests for delete and restore", async () => {
+  it("uses dedicated lifecycle requests for Site delete and Simulation delete/restore", async () => {
     vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, siteId: "site-1" }), { status: 200 }))
       .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, simulationId: "sim-1", status: "deleted" }), { status: 200 }))
       .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, simulationId: "sim-1", status: "active" }), { status: 200 }));
 
+    await deleteCloudSite("site-1");
     await deleteCloudSimulation("sim-1");
     await restoreCloudSimulation("sim-1");
 
     expect(vi.mocked(globalThis.fetch)).toHaveBeenNthCalledWith(
       1,
-      "/api/library/simulations/sim-1",
+      "/api/library/sites/site-1",
       expect.objectContaining({ method: "DELETE" }),
     );
     expect(vi.mocked(globalThis.fetch)).toHaveBeenNthCalledWith(
       2,
+      "/api/library/simulations/sim-1",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+    expect(vi.mocked(globalThis.fetch)).toHaveBeenNthCalledWith(
+      3,
       "/api/library/simulations/sim-1",
       expect.objectContaining({ method: "PATCH", body: JSON.stringify({ status: "active" }) }),
     );
@@ -165,6 +173,29 @@ describe("cloudLibrary client", () => {
       simulationPresets: [],
     })).rejects.toThrow("Library quota exceeded");
     expect(vi.mocked(globalThis.fetch)).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops before later chunks when a batch returns HTTP-200 conflicts", async () => {
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: false, conflicts: ["site_quota_exceeded"] }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, conflicts: [] }), { status: 200 }));
+
+    await expect(pushCloudLibrary({
+      siteLibrary: Array.from({ length: LIBRARY_BATCH_MAX_RECORDS + 1 }, (_, index) => ({
+        id: `site-${index}`,
+        name: `Site ${index}`,
+      })),
+      simulationPresets: [],
+    })).rejects.toThrow("site_quota_exceeded");
+    expect(vi.mocked(globalThis.fetch)).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects an oversized non-first record before emitting any batch", async () => {
+    await expect(pushCloudLibrary({
+      siteLibrary: [{ id: "site-small", name: "Small" }, { id: "site-large", name: "Large", padding: "x".repeat(LIBRARY_REQUEST_MAX_BYTES) }],
+      simulationPresets: [],
+    })).rejects.toThrow("cannot fit");
+    expect(vi.mocked(globalThis.fetch)).not.toHaveBeenCalled();
   });
 
   it("throws parsed API error for non-OK responses", async () => {

--- a/src/lib/cloudLibrary.test.ts
+++ b/src/lib/cloudLibrary.test.ts
@@ -5,6 +5,7 @@ import {
   pushCloudLibrary,
   restoreCloudSimulation,
 } from "./cloudLibrary";
+import { LIBRARY_BATCH_MAX_RECORDS, LIBRARY_REQUEST_MAX_BYTES } from "./libraryLimits";
 
 beforeEach(() => {
   vi.restoreAllMocks();
@@ -105,6 +106,65 @@ describe("cloudLibrary client", () => {
         simulationPresets: [{ id: "sim-2", name: "Relay Plan" }],
       }),
     ).rejects.toThrow("Simulation name already exists: Relay Plan. Use unique Simulation names.");
+  });
+
+  it("pushes large payloads sequentially in bounded mixed-resource batches", async () => {
+    vi.mocked(globalThis.fetch).mockImplementation(async () =>
+      new Response(JSON.stringify({ ok: true, conflicts: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }));
+    const payload = {
+      siteLibrary: Array.from({ length: 25 }, (_, index) => ({ id: `site-${index}`, name: `Site ${index}` })),
+      simulationPresets: Array.from({ length: 18 }, (_, index) => ({ id: `sim-${index}`, name: `Simulation ${index}` })),
+    };
+
+    await pushCloudLibrary(payload);
+
+    expect(vi.mocked(globalThis.fetch)).toHaveBeenCalledTimes(3);
+    const batches = vi.mocked(globalThis.fetch).mock.calls.map(([, init]) =>
+      JSON.parse(String(init?.body)) as { siteLibrary: unknown[]; simulationPresets: unknown[] });
+    expect(batches.map((batch) => batch.siteLibrary.length + batch.simulationPresets.length)).toEqual([
+      LIBRARY_BATCH_MAX_RECORDS,
+      LIBRARY_BATCH_MAX_RECORDS,
+      3,
+    ]);
+    expect(batches.flatMap((batch) => batch.siteLibrary)).toHaveLength(25);
+    expect(batches.flatMap((batch) => batch.simulationPresets)).toHaveLength(18);
+  });
+
+  it("also chunks by encoded request bytes when records are individually valid but collectively large", async () => {
+    vi.mocked(globalThis.fetch).mockImplementation(async () =>
+      new Response(JSON.stringify({ ok: true, conflicts: [] }), { status: 200 }));
+    const padding = "x".repeat(250 * 1024);
+
+    await pushCloudLibrary({
+      siteLibrary: [],
+      simulationPresets: Array.from({ length: 10 }, (_, index) => ({ id: `sim-${index}`, name: `Simulation ${index}`, padding })),
+    });
+
+    expect(vi.mocked(globalThis.fetch).mock.calls.length).toBeGreaterThan(1);
+    for (const [, init] of vi.mocked(globalThis.fetch).mock.calls) {
+      expect(new TextEncoder().encode(String(init?.body)).byteLength).toBeLessThanOrEqual(LIBRARY_REQUEST_MAX_BYTES);
+    }
+  });
+
+  it("stops at a rejected chunk so appStore can retain the full dirty set for retry", async () => {
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, conflicts: [] }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ error: "Library quota exceeded." }), {
+        status: 422,
+        statusText: "Unprocessable Content",
+      }));
+
+    await expect(pushCloudLibrary({
+      siteLibrary: Array.from({ length: LIBRARY_BATCH_MAX_RECORDS + 1 }, (_, index) => ({
+        id: `site-${index}`,
+        name: `Site ${index}`,
+      })),
+      simulationPresets: [],
+    })).rejects.toThrow("Library quota exceeded");
+    expect(vi.mocked(globalThis.fetch)).toHaveBeenCalledTimes(2);
   });
 
   it("throws parsed API error for non-OK responses", async () => {

--- a/src/lib/cloudLibrary.ts
+++ b/src/lib/cloudLibrary.ts
@@ -1,4 +1,5 @@
 import { parseApiErrorMessage } from "./apiError";
+import { LIBRARY_BATCH_MAX_RECORDS, LIBRARY_REQUEST_MAX_BYTES } from "./libraryLimits";
 
 export type CloudLibraryPayload = {
   siteLibrary: unknown[];
@@ -9,6 +10,36 @@ export type CloudLibraryPayload = {
 type CloudPushResult = {
   ok?: boolean;
   conflicts?: string[];
+};
+
+type TaggedLibraryRecord = { kind: "site" | "simulation"; value: unknown };
+
+const pushBodyForRecords = (records: TaggedLibraryRecord[]): CloudLibraryPayload => ({
+  siteLibrary: records.filter((entry) => entry.kind === "site").map((entry) => entry.value),
+  simulationPresets: records.filter((entry) => entry.kind === "simulation").map((entry) => entry.value),
+});
+
+const buildPushBatches = (records: TaggedLibraryRecord[]): CloudLibraryPayload[] => {
+  if (records.length === 0) return [pushBodyForRecords([])];
+  const encoder = new TextEncoder();
+  const batches: CloudLibraryPayload[] = [];
+  let current: TaggedLibraryRecord[] = [];
+  for (const record of records) {
+    const candidate = [...current, record];
+    const candidateBody = pushBodyForRecords(candidate);
+    const candidateBytes = encoder.encode(JSON.stringify(candidateBody)).byteLength;
+    if (current.length === 0 && candidateBytes > LIBRARY_REQUEST_MAX_BYTES) {
+      throw new Error(`Library record cannot fit within the ${LIBRARY_REQUEST_MAX_BYTES}-byte request limit.`);
+    }
+    if (current.length > 0 && (candidate.length > LIBRARY_BATCH_MAX_RECORDS || candidateBytes > LIBRARY_REQUEST_MAX_BYTES)) {
+      batches.push(pushBodyForRecords(current));
+      current = [record];
+      continue;
+    }
+    current = candidate;
+  }
+  batches.push(pushBodyForRecords(current));
+  return batches;
 };
 
 const listSimulationNames = (payload: CloudLibraryPayload): string[] =>
@@ -84,11 +115,19 @@ export const fetchPublicSimulationLibrary = async (params: {
 };
 
 export const pushCloudLibrary = async (payload: CloudLibraryPayload): Promise<void> => {
-  const result = await apiCall<CloudPushResult>("/api/library", {
-    method: "PUT",
-    body: JSON.stringify(payload),
-  });
-  const allConflicts = Array.isArray(result.conflicts) ? result.conflicts : [];
+  const records = [
+    ...payload.siteLibrary.map((value) => ({ kind: "site" as const, value })),
+    ...payload.simulationPresets.map((value) => ({ kind: "simulation" as const, value })),
+  ];
+  const batches = buildPushBatches(records);
+  const allConflicts: string[] = [];
+  for (const batch of batches) {
+    const result = await apiCall<CloudPushResult>("/api/library", {
+      method: "PUT",
+      body: JSON.stringify(batch),
+    });
+    if (Array.isArray(result.conflicts)) allConflicts.push(...result.conflicts);
+  }
   if (!allConflicts.length) return;
   if (allConflicts.includes("simulation_name_taken")) {
     const simulationNames = listSimulationNames(payload);

--- a/src/lib/cloudLibrary.ts
+++ b/src/lib/cloudLibrary.ts
@@ -25,12 +25,13 @@ const buildPushBatches = (records: TaggedLibraryRecord[]): CloudLibraryPayload[]
   const batches: CloudLibraryPayload[] = [];
   let current: TaggedLibraryRecord[] = [];
   for (const record of records) {
+    const singleRecordBytes = encoder.encode(JSON.stringify(pushBodyForRecords([record]))).byteLength;
+    if (singleRecordBytes > LIBRARY_REQUEST_MAX_BYTES) {
+      throw new Error(`Library record cannot fit within the ${LIBRARY_REQUEST_MAX_BYTES}-byte request limit.`);
+    }
     const candidate = [...current, record];
     const candidateBody = pushBodyForRecords(candidate);
     const candidateBytes = encoder.encode(JSON.stringify(candidateBody)).byteLength;
-    if (current.length === 0 && candidateBytes > LIBRARY_REQUEST_MAX_BYTES) {
-      throw new Error(`Library record cannot fit within the ${LIBRARY_REQUEST_MAX_BYTES}-byte request limit.`);
-    }
     if (current.length > 0 && (candidate.length > LIBRARY_BATCH_MAX_RECORDS || candidateBytes > LIBRARY_REQUEST_MAX_BYTES)) {
       batches.push(pushBodyForRecords(current));
       current = [record];
@@ -85,6 +86,10 @@ export const deleteCloudSimulation = async (simulationId: string): Promise<void>
   await apiCall(`/api/library/simulations/${encodeURIComponent(simulationId)}`, { method: "DELETE" });
 };
 
+export const deleteCloudSite = async (siteId: string): Promise<void> => {
+  await apiCall(`/api/library/sites/${encodeURIComponent(siteId)}`, { method: "DELETE" });
+};
+
 export const restoreCloudSimulation = async (simulationId: string): Promise<void> => {
   await apiCall(`/api/library/simulations/${encodeURIComponent(simulationId)}`, {
     method: "PATCH",
@@ -120,19 +125,18 @@ export const pushCloudLibrary = async (payload: CloudLibraryPayload): Promise<vo
     ...payload.simulationPresets.map((value) => ({ kind: "simulation" as const, value })),
   ];
   const batches = buildPushBatches(records);
-  const allConflicts: string[] = [];
   for (const batch of batches) {
     const result = await apiCall<CloudPushResult>("/api/library", {
       method: "PUT",
       body: JSON.stringify(batch),
     });
-    if (Array.isArray(result.conflicts)) allConflicts.push(...result.conflicts);
+    const conflicts = Array.isArray(result.conflicts) ? result.conflicts : [];
+    if (!conflicts.length) continue;
+    if (conflicts.includes("simulation_name_taken")) {
+      const simulationNames = listSimulationNames(payload);
+      const suffix = simulationNames.length ? `: ${simulationNames.join(", ")}` : "";
+      throw new Error(`Simulation name already exists${suffix}. Use unique Simulation names.`);
+    }
+    throw new Error(`Cloud rejected ${conflicts.length} item(s): ${conflicts.join(", ")}`);
   }
-  if (!allConflicts.length) return;
-  if (allConflicts.includes("simulation_name_taken")) {
-    const simulationNames = listSimulationNames(payload);
-    const suffix = simulationNames.length ? `: ${simulationNames.join(", ")}` : "";
-    throw new Error(`Simulation name already exists${suffix}. Use unique Simulation names.`);
-  }
-  throw new Error(`Cloud rejected ${allConflicts.length} item(s): ${allConflicts.join(", ")}`);
 };

--- a/src/lib/cloudLibrary.ts
+++ b/src/lib/cloudLibrary.ts
@@ -4,6 +4,7 @@ import { LIBRARY_BATCH_MAX_RECORDS, LIBRARY_REQUEST_MAX_BYTES } from "./libraryL
 export type CloudLibraryPayload = {
   siteLibrary: unknown[];
   simulationPresets: unknown[];
+  deletedSiteIds?: string[];
   deletedSimulationIds?: string[];
 };
 
@@ -67,14 +68,17 @@ const apiCall = async <T>(path: string, init?: RequestInit): Promise<T> => {
   return (await response.json()) as T;
 };
 
-export const fetchCloudLibrary = async (opts?: { since?: string }): Promise<CloudLibraryPayload & { deletedSimulationIds: string[]; isDelta?: boolean }> => {
+export const fetchCloudLibrary = async (opts?: { since?: string }): Promise<CloudLibraryPayload & { deletedSiteIds: string[]; deletedSimulationIds: string[]; isDelta?: boolean }> => {
   const url = opts?.since ? `/api/library?since=${encodeURIComponent(opts.since)}` : "/api/library";
-  const data = await apiCall<{ siteLibrary?: unknown[]; simulationPresets?: unknown[]; deletedSimulationIds?: unknown[]; isDelta?: boolean }>(url, {
+  const data = await apiCall<{ siteLibrary?: unknown[]; simulationPresets?: unknown[]; deletedSiteIds?: unknown[]; deletedSimulationIds?: unknown[]; isDelta?: boolean }>(url, {
     method: "GET",
   });
   return {
     siteLibrary: Array.isArray(data.siteLibrary) ? data.siteLibrary : [],
     simulationPresets: Array.isArray(data.simulationPresets) ? data.simulationPresets : [],
+    deletedSiteIds: Array.isArray(data.deletedSiteIds)
+      ? data.deletedSiteIds.filter((id): id is string => typeof id === "string" && id.trim().length > 0)
+      : [],
     deletedSimulationIds: Array.isArray(data.deletedSimulationIds)
       ? data.deletedSimulationIds.filter((id): id is string => typeof id === "string" && id.trim().length > 0)
       : [],

--- a/src/lib/libraryFilters.test.ts
+++ b/src/lib/libraryFilters.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   DEFAULT_LIBRARY_FILTER_STATE,
+  canDeleteLibraryItem,
   filterAndSortLibraryItems,
   parsePersistedLibraryFilterState,
   serializeLibraryFilterState,
@@ -20,6 +21,12 @@ const items: MockItem[] = [
 const ids = (result: MockItem[]): string[] => result.map((item) => item.id);
 
 describe("libraryFilters", () => {
+  it("allows deletion only for owners and platform admins", () => {
+    expect(canDeleteLibraryItem(items[0]!, { id: "u1", isAdmin: false })).toBe(true);
+    expect(canDeleteLibraryItem(items[1]!, { id: "u1", isAdmin: false })).toBe(false);
+    expect(canDeleteLibraryItem(items[1]!, { id: "admin", isAdmin: true })).toBe(true);
+  });
+
   it("uses owned+collaborator default", () => {
     const result = filterAndSortLibraryItems(items, DEFAULT_LIBRARY_FILTER_STATE, "u1");
     expect(ids(result)).toEqual(["a", "b"]);

--- a/src/lib/libraryFilters.ts
+++ b/src/lib/libraryFilters.ts
@@ -20,6 +20,15 @@ export interface FilterableLibraryItem {
   visibility?: "private" | "public" | "shared" | "public_read" | "public_write";
 }
 
+export const canDeleteLibraryItem = (
+  item: Pick<FilterableLibraryItem, "ownerUserId" | "effectiveRole">,
+  currentUser: { id: string; isAdmin?: boolean } | null,
+): boolean => Boolean(currentUser && (
+  currentUser.isAdmin
+  || item.ownerUserId === currentUser.id
+  || item.effectiveRole === "owner"
+));
+
 type PersistedLibraryFilterState = {
   version: 1 | 2;
   searchQuery: string;

--- a/src/lib/libraryLimits.test.ts
+++ b/src/lib/libraryLimits.test.ts
@@ -32,8 +32,8 @@ const validSimulation = () => ({
   snapshot: {
     sites: [] as unknown[],
     links: [] as unknown[],
-    systems: [],
-    networks: [],
+    systems: [] as unknown[],
+    networks: [] as unknown[],
   },
 });
 
@@ -50,6 +50,33 @@ describe("Library ingestion limits", () => {
       siteLibrary: [{ ...validSite(), position: { lat: 91, lon: 10 }, futureField: { supported: true } }],
       simulationPresets: [],
     })).toThrow("Site position must contain valid latitude and longitude");
+  });
+
+  it("rejects missing required Site and malformed Radio System or Network fields", () => {
+    const missingSiteNumber = validSite() as Record<string, unknown>;
+    delete missingSiteNumber.txPowerDbm;
+    expect(() => validateLibraryPayload({ siteLibrary: [missingSiteNumber], simulationPresets: [] })).toThrow(
+      "Site txPowerDbm must be a finite number",
+    );
+
+    const malformedSystem = validSimulation();
+    malformedSystem.snapshot.systems = [null];
+    expect(() => validateLibraryPayload({ siteLibrary: [], simulationPresets: [malformedSystem] })).toThrow(
+      "Radio System must be an object",
+    );
+
+    const malformedNetwork = validSimulation();
+    malformedNetwork.snapshot.networks = [{
+      id: "network-1",
+      name: "Network",
+      frequencyMHz: 868,
+      bandwidthKhz: 125,
+      spreadFactor: 8,
+      codingRate: 5,
+    }];
+    expect(() => validateLibraryPayload({ siteLibrary: [], simulationPresets: [malformedNetwork] })).toThrow(
+      "Network memberships must be an array",
+    );
   });
 
   it("rejects Simulation collection counts above their approved boundaries", () => {

--- a/src/lib/libraryLimits.test.ts
+++ b/src/lib/libraryLimits.test.ts
@@ -45,6 +45,20 @@ describe("Library ingestion limits", () => {
     });
   });
 
+  it("preserves the existing non-empty Library name contract", () => {
+    const longName = "L".repeat(160);
+    expect(() => validateLibraryPayload({
+      siteLibrary: [
+        { ...validSite("site-short"), name: "X" },
+        { ...validSite("site-long"), name: longName },
+      ],
+      simulationPresets: [
+        { ...validSimulation(), id: "sim-short", name: "X" },
+        { ...validSimulation(), id: "sim-long", name: longName },
+      ],
+    })).not.toThrow();
+  });
+
   it("rejects malformed known fields without rejecting compatible extension fields", () => {
     expect(() => validateLibraryPayload({
       siteLibrary: [{ ...validSite(), position: { lat: 91, lon: 10 }, futureField: { supported: true } }],

--- a/src/lib/libraryLimits.test.ts
+++ b/src/lib/libraryLimits.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  LIBRARY_JSON_MAX_DEPTH,
+  LIBRARY_SIMULATION_MAX_BYTES,
+  LIBRARY_SITE_MAX_BYTES,
+  SIMULATION_MAX_PATHS,
+  SIMULATION_MAX_SITES,
+  validateLibraryPayload,
+} from "./libraryLimits";
+
+const validSite = (id = "site-1") => ({
+  id,
+  name: "Hilltop",
+  visibility: "private",
+  sharedWith: [],
+  position: { lat: 59.9, lon: 10.7 },
+  groundElevationM: 120,
+  antennaHeightM: 12,
+  txPowerDbm: 22,
+  txGainDbi: 5,
+  rxGainDbi: 5,
+  cableLossDb: 1,
+  createdAt: "2026-08-14T00:00:00.000Z",
+});
+
+const validSimulation = () => ({
+  id: "sim-1",
+  name: "Relay plan",
+  visibility: "private",
+  sharedWith: [],
+  updatedAt: "2026-08-14T00:00:00.000Z",
+  snapshot: {
+    sites: [] as unknown[],
+    links: [] as unknown[],
+    systems: [],
+    networks: [],
+  },
+});
+
+describe("Library ingestion limits", () => {
+  it("accepts the current Site and Simulation shapes", () => {
+    expect(validateLibraryPayload({ siteLibrary: [validSite()], simulationPresets: [validSimulation()] })).toEqual({
+      siteLibrary: [validSite()],
+      simulationPresets: [validSimulation()],
+    });
+  });
+
+  it("rejects malformed known fields without rejecting compatible extension fields", () => {
+    expect(() => validateLibraryPayload({
+      siteLibrary: [{ ...validSite(), position: { lat: 91, lon: 10 }, futureField: { supported: true } }],
+      simulationPresets: [],
+    })).toThrow("Site position must contain valid latitude and longitude");
+  });
+
+  it("rejects Simulation collection counts above their approved boundaries", () => {
+    const simulation = validSimulation();
+    simulation.snapshot.sites = Array.from({ length: SIMULATION_MAX_SITES + 1 }, (_, index) => validSite(`site-${index}`));
+    expect(() => validateLibraryPayload({ siteLibrary: [], simulationPresets: [simulation] })).toThrow(
+      `Simulation may contain at most ${SIMULATION_MAX_SITES} Sites`,
+    );
+
+    simulation.snapshot.sites = [];
+    simulation.snapshot.links = Array.from({ length: SIMULATION_MAX_PATHS + 1 }, (_, index) => ({
+      id: `path-${index}`,
+      fromSiteId: "site-a",
+      toSiteId: "site-b",
+      frequencyMHz: 868,
+    }));
+    expect(() => validateLibraryPayload({ siteLibrary: [], simulationPresets: [simulation] })).toThrow(
+      `Simulation may contain at most ${SIMULATION_MAX_PATHS} Paths`,
+    );
+  });
+
+  it("accepts records exactly at their byte ceilings and rejects one byte more", () => {
+    const encoder = new TextEncoder();
+    const exactSite = { ...validSite(), extension: "" };
+    exactSite.extension = "x".repeat(LIBRARY_SITE_MAX_BYTES - encoder.encode(JSON.stringify(exactSite)).byteLength);
+    expect(() => validateLibraryPayload({ siteLibrary: [exactSite], simulationPresets: [] })).not.toThrow();
+    exactSite.extension += "x";
+    expect(() => validateLibraryPayload({ siteLibrary: [exactSite], simulationPresets: [] })).toThrow("Site record exceeds");
+
+    const exactSimulation = { ...validSimulation(), extension: "" };
+    exactSimulation.extension = "x".repeat(
+      LIBRARY_SIMULATION_MAX_BYTES - encoder.encode(JSON.stringify(exactSimulation)).byteLength,
+    );
+    expect(() => validateLibraryPayload({ siteLibrary: [], simulationPresets: [exactSimulation] })).not.toThrow();
+    exactSimulation.extension += "x";
+    expect(() => validateLibraryPayload({ siteLibrary: [], simulationPresets: [exactSimulation] })).toThrow(
+      "Simulation record exceeds",
+    );
+  });
+
+  it("exports the approved JSON depth contract", () => {
+    expect(LIBRARY_JSON_MAX_DEPTH).toBe(20);
+  });
+});

--- a/src/lib/libraryLimits.test.ts
+++ b/src/lib/libraryLimits.test.ts
@@ -79,6 +79,19 @@ describe("Library ingestion limits", () => {
     );
   });
 
+  it("rejects missing or malformed render-critical Simulation timestamps", () => {
+    const missingUpdatedAt = validSimulation() as Record<string, unknown>;
+    delete missingUpdatedAt.updatedAt;
+    expect(() => validateLibraryPayload({ siteLibrary: [], simulationPresets: [missingUpdatedAt] })).toThrow(
+      "Simulation updatedAt must be a valid date string",
+    );
+
+    expect(() => validateLibraryPayload({
+      siteLibrary: [],
+      simulationPresets: [{ ...validSimulation(), updatedAt: { unsafe: true } }],
+    })).toThrow("Simulation updatedAt must be a valid date string");
+  });
+
   it("rejects Simulation collection counts above their approved boundaries", () => {
     const simulation = validSimulation();
     simulation.snapshot.sites = Array.from({ length: SIMULATION_MAX_SITES + 1 }, (_, index) => validSite(`site-${index}`));

--- a/src/lib/libraryLimits.test.ts
+++ b/src/lib/libraryLimits.test.ts
@@ -59,6 +59,20 @@ describe("Library ingestion limits", () => {
     })).not.toThrow();
   });
 
+  it("accepts legacy Simulation snapshots without Radio Systems or Networks", () => {
+    const withoutSystems = validSimulation() as { id: string; snapshot: Record<string, unknown> };
+    withoutSystems.id = "sim-without-systems";
+    delete withoutSystems.snapshot.systems;
+    const withoutNetworks = validSimulation() as { id: string; snapshot: Record<string, unknown> };
+    withoutNetworks.id = "sim-without-networks";
+    delete withoutNetworks.snapshot.networks;
+
+    expect(() => validateLibraryPayload({
+      siteLibrary: [],
+      simulationPresets: [withoutSystems, withoutNetworks],
+    })).not.toThrow();
+  });
+
   it("rejects malformed known fields without rejecting compatible extension fields", () => {
     expect(() => validateLibraryPayload({
       siteLibrary: [{ ...validSite(), position: { lat: 91, lon: 10 }, futureField: { supported: true } }],

--- a/src/lib/libraryLimits.ts
+++ b/src/lib/libraryLimits.ts
@@ -1,0 +1,174 @@
+export const LIBRARY_REQUEST_MAX_BYTES = 2 * 1024 * 1024;
+export const LIBRARY_JSON_MAX_DEPTH = 20;
+export const LIBRARY_BATCH_MAX_RECORDS = 20;
+export const LIBRARY_SITE_MAX_BYTES = 32 * 1024;
+export const LIBRARY_SIMULATION_MAX_BYTES = 256 * 1024;
+export const LIBRARY_MAX_GRANTS = 100;
+export const LIBRARY_MAX_SITES_PER_USER = 500;
+export const LIBRARY_MAX_SIMULATIONS_PER_USER = 100;
+export const LIBRARY_MAX_PUBLIC_SITES_PER_USER = 100;
+export const LIBRARY_MAX_PUBLIC_SIMULATIONS_PER_USER = 25;
+export const SIMULATION_MAX_SITES = 250;
+export const SIMULATION_MAX_PATHS = 1000;
+
+const MAX_ID_LENGTH = 128;
+const MIN_NAME_LENGTH = 2;
+const MAX_NAME_LENGTH = 80;
+const textEncoder = new TextEncoder();
+
+export class LibraryValidationError extends Error {
+  readonly status = 422;
+  readonly code = "invalid_library_payload";
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+const assertId: (value: unknown, label: string) => asserts value is string = (value, label) => {
+  if (typeof value !== "string" || value.trim().length === 0 || value.trim().length > MAX_ID_LENGTH) {
+    throw new LibraryValidationError(`${label} must be a non-empty string no longer than ${MAX_ID_LENGTH} characters.`);
+  }
+};
+
+const assertName: (value: unknown, label: string) => asserts value is string = (value, label) => {
+  const name = typeof value === "string" ? value.trim() : "";
+  if (name.length < MIN_NAME_LENGTH || name.length > MAX_NAME_LENGTH) {
+    throw new LibraryValidationError(`${label} must be between ${MIN_NAME_LENGTH} and ${MAX_NAME_LENGTH} characters.`);
+  }
+};
+
+const assertFiniteIfPresent = (record: Record<string, unknown>, keys: string[], label: string): void => {
+  for (const key of keys) {
+    if (record[key] !== undefined && (typeof record[key] !== "number" || !Number.isFinite(record[key]))) {
+      throw new LibraryValidationError(`${label} ${key} must be a finite number.`);
+    }
+  }
+};
+
+const assertPosition = (value: unknown, label: string): void => {
+  if (!isRecord(value)
+    || typeof value.lat !== "number"
+    || !Number.isFinite(value.lat)
+    || value.lat < -90
+    || value.lat > 90
+    || typeof value.lon !== "number"
+    || !Number.isFinite(value.lon)
+    || value.lon < -180
+    || value.lon > 180) {
+    throw new LibraryValidationError(`${label} position must contain valid latitude and longitude.`);
+  }
+};
+
+const assertGrants = (value: unknown): void => {
+  if (value === undefined) return;
+  if (!Array.isArray(value)) throw new LibraryValidationError("sharedWith must be an array.");
+  if (value.length > LIBRARY_MAX_GRANTS) {
+    throw new LibraryValidationError(`A Library record may contain at most ${LIBRARY_MAX_GRANTS} grants.`);
+  }
+  for (const grant of value) {
+    if (!isRecord(grant)) throw new LibraryValidationError("Each Library grant must be an object.");
+    assertId(grant.userId, "Grant user ID");
+    if (!new Set(["viewer", "editor", "admin"]).has(String(grant.role))) {
+      throw new LibraryValidationError("Grant role must be viewer, editor, or admin.");
+    }
+  }
+};
+
+const assertCommonRecord = (value: unknown, label: string): Record<string, unknown> => {
+  if (!isRecord(value)) throw new LibraryValidationError(`${label} must be an object.`);
+  assertId(value.id, `${label} ID`);
+  assertName(value.name, `${label} name`);
+  if (value.visibility !== undefined && !new Set(["private", "public", "shared"]).has(String(value.visibility))) {
+    throw new LibraryValidationError(`${label} visibility must be private, public, or shared.`);
+  }
+  assertGrants(value.sharedWith);
+  return value;
+};
+
+const encodedBytes = (value: unknown): number => textEncoder.encode(JSON.stringify(value)).byteLength;
+
+const assertSite = (value: unknown, nested = false): void => {
+  const site = nested
+    ? (() => {
+        if (!isRecord(value)) throw new LibraryValidationError("Site must be an object.");
+        assertId(value.id, "Site ID");
+        if (typeof value.name !== "string" || value.name.trim().length === 0 || value.name.trim().length > MAX_NAME_LENGTH) {
+          throw new LibraryValidationError(`Site name must be between 1 and ${MAX_NAME_LENGTH} characters.`);
+        }
+        return value;
+      })()
+    : assertCommonRecord(value, "Site");
+  assertPosition(site.position, "Site");
+  assertFiniteIfPresent(site, [
+    "groundElevationM",
+    "antennaHeightM",
+    "txPowerDbm",
+    "txGainDbi",
+    "rxGainDbi",
+    "cableLossDb",
+    "antennaAzimuthDeg",
+    "antennaTiltDeg",
+    "antennaHorizontalBeamwidthDeg",
+    "antennaVerticalBeamwidthDeg",
+    "antennaMaxAttenuationDb",
+  ], "Site");
+  if (!nested && encodedBytes(site) > LIBRARY_SITE_MAX_BYTES) {
+    throw new LibraryValidationError(`Site record exceeds ${LIBRARY_SITE_MAX_BYTES} bytes.`);
+  }
+};
+
+const assertPath = (value: unknown): void => {
+  if (!isRecord(value)) throw new LibraryValidationError("Path must be an object.");
+  assertId(value.id, "Path ID");
+  assertId(value.fromSiteId, "Path fromSiteId");
+  assertId(value.toSiteId, "Path toSiteId");
+  assertFiniteIfPresent(value, ["frequencyMHz", "txPowerDbm", "txGainDbi", "rxGainDbi", "cableLossDb"], "Path");
+};
+
+const assertSimulation = (value: unknown): void => {
+  const simulation = assertCommonRecord(value, "Simulation");
+  if (!isRecord(simulation.snapshot)) throw new LibraryValidationError("Simulation snapshot must be an object.");
+  const { snapshot } = simulation;
+  if (!Array.isArray(snapshot.sites)) throw new LibraryValidationError("Simulation snapshot Sites must be an array.");
+  if (!Array.isArray(snapshot.links)) throw new LibraryValidationError("Simulation snapshot Paths must be an array.");
+  if (snapshot.sites.length > SIMULATION_MAX_SITES) {
+    throw new LibraryValidationError(`Simulation may contain at most ${SIMULATION_MAX_SITES} Sites.`);
+  }
+  if (snapshot.links.length > SIMULATION_MAX_PATHS) {
+    throw new LibraryValidationError(`Simulation may contain at most ${SIMULATION_MAX_PATHS} Paths.`);
+  }
+  snapshot.sites.forEach((site) => assertSite(site, true));
+  snapshot.links.forEach(assertPath);
+  for (const key of ["systems", "networks"]) {
+    if (!Array.isArray(snapshot[key])) throw new LibraryValidationError(`Simulation snapshot ${key} must be an array.`);
+  }
+  if (encodedBytes(simulation) > LIBRARY_SIMULATION_MAX_BYTES) {
+    throw new LibraryValidationError(`Simulation record exceeds ${LIBRARY_SIMULATION_MAX_BYTES} bytes.`);
+  }
+};
+
+export type ValidatedLibraryPayload = {
+  siteLibrary: Record<string, unknown>[];
+  simulationPresets: Record<string, unknown>[];
+};
+
+export const validateLibraryPayload = (value: unknown): ValidatedLibraryPayload => {
+  if (!isRecord(value)) throw new LibraryValidationError("Library payload must be an object.");
+  const siteLibrary = value.siteLibrary ?? [];
+  const simulationPresets = value.simulationPresets ?? [];
+  if (!Array.isArray(siteLibrary) || !Array.isArray(simulationPresets)) {
+    throw new LibraryValidationError("Library collections must be arrays.");
+  }
+  if (siteLibrary.length + simulationPresets.length > LIBRARY_BATCH_MAX_RECORDS) {
+    throw new LibraryValidationError(`Library request may contain at most ${LIBRARY_BATCH_MAX_RECORDS} records.`);
+  }
+  if (new Set(siteLibrary.map((site) => isRecord(site) ? site.id : undefined)).size !== siteLibrary.length) {
+    throw new LibraryValidationError("Library request contains duplicate Site IDs.");
+  }
+  if (new Set(simulationPresets.map((simulation) => isRecord(simulation) ? simulation.id : undefined)).size !== simulationPresets.length) {
+    throw new LibraryValidationError("Library request contains duplicate Simulation IDs.");
+  }
+  siteLibrary.forEach((site) => assertSite(site));
+  simulationPresets.forEach(assertSimulation);
+  return { siteLibrary, simulationPresets };
+};

--- a/src/lib/libraryLimits.ts
+++ b/src/lib/libraryLimits.ts
@@ -12,8 +12,6 @@ export const SIMULATION_MAX_SITES = 250;
 export const SIMULATION_MAX_PATHS = 1000;
 
 const MAX_ID_LENGTH = 128;
-const MIN_NAME_LENGTH = 2;
-const MAX_NAME_LENGTH = 80;
 const textEncoder = new TextEncoder();
 
 export class LibraryValidationError extends Error {
@@ -32,8 +30,8 @@ const assertId: (value: unknown, label: string) => asserts value is string = (va
 
 const assertName: (value: unknown, label: string) => asserts value is string = (value, label) => {
   const name = typeof value === "string" ? value.trim() : "";
-  if (name.length < MIN_NAME_LENGTH || name.length > MAX_NAME_LENGTH) {
-    throw new LibraryValidationError(`${label} must be between ${MIN_NAME_LENGTH} and ${MAX_NAME_LENGTH} characters.`);
+  if (!name) {
+    throw new LibraryValidationError(`${label} must be a non-empty string.`);
   }
 };
 
@@ -96,9 +94,7 @@ const assertCommonRecord = (value: unknown, label: string): Record<string, unkno
 const assertNestedNamedRecord = (value: unknown, label: string): Record<string, unknown> => {
   if (!isRecord(value)) throw new LibraryValidationError(`${label} must be an object.`);
   assertId(value.id, `${label} ID`);
-  if (typeof value.name !== "string" || value.name.trim().length === 0 || value.name.trim().length > MAX_NAME_LENGTH) {
-    throw new LibraryValidationError(`${label} name must be between 1 and ${MAX_NAME_LENGTH} characters.`);
-  }
+  assertName(value.name, `${label} name`);
   return value;
 };
 
@@ -115,9 +111,7 @@ const assertSite = (value: unknown, nested = false): void => {
     ? (() => {
         if (!isRecord(value)) throw new LibraryValidationError("Site must be an object.");
         assertId(value.id, "Site ID");
-        if (typeof value.name !== "string" || value.name.trim().length === 0 || value.name.trim().length > MAX_NAME_LENGTH) {
-          throw new LibraryValidationError(`Site name must be between 1 and ${MAX_NAME_LENGTH} characters.`);
-        }
+        assertName(value.name, "Site name");
         return value;
       })()
     : assertCommonRecord(value, "Site");

--- a/src/lib/libraryLimits.ts
+++ b/src/lib/libraryLimits.ts
@@ -183,10 +183,12 @@ const assertSimulation = (value: unknown): void => {
   }
   snapshot.sites.forEach((site) => assertSite(site, true));
   snapshot.links.forEach(assertPath);
-  if (!Array.isArray(snapshot.systems)) throw new LibraryValidationError("Simulation snapshot systems must be an array.");
-  if (!Array.isArray(snapshot.networks)) throw new LibraryValidationError("Simulation snapshot networks must be an array.");
-  snapshot.systems.forEach(assertRadioSystem);
-  snapshot.networks.forEach(assertNetwork);
+  const systems = snapshot.systems === undefined ? [] : snapshot.systems;
+  const networks = snapshot.networks === undefined ? [] : snapshot.networks;
+  if (!Array.isArray(systems)) throw new LibraryValidationError("Simulation snapshot systems must be an array.");
+  if (!Array.isArray(networks)) throw new LibraryValidationError("Simulation snapshot networks must be an array.");
+  systems.forEach(assertRadioSystem);
+  networks.forEach(assertNetwork);
   if (encodedBytes(simulation) > LIBRARY_SIMULATION_MAX_BYTES) {
     throw new LibraryValidationError(`Simulation record exceeds ${LIBRARY_SIMULATION_MAX_BYTES} bytes.`);
   }

--- a/src/lib/libraryLimits.ts
+++ b/src/lib/libraryLimits.ts
@@ -104,6 +104,12 @@ const assertNestedNamedRecord = (value: unknown, label: string): Record<string, 
 
 const encodedBytes = (value: unknown): number => textEncoder.encode(JSON.stringify(value)).byteLength;
 
+const assertRequiredDateString = (value: unknown, label: string): void => {
+  if (typeof value !== "string" || value.trim().length === 0 || !Number.isFinite(Date.parse(value))) {
+    throw new LibraryValidationError(`${label} must be a valid date string.`);
+  }
+};
+
 const assertSite = (value: unknown, nested = false): void => {
   const site = nested
     ? (() => {
@@ -170,6 +176,7 @@ const assertNetwork = (value: unknown): void => {
 
 const assertSimulation = (value: unknown): void => {
   const simulation = assertCommonRecord(value, "Simulation");
+  assertRequiredDateString(simulation.updatedAt, "Simulation updatedAt");
   if (!isRecord(simulation.snapshot)) throw new LibraryValidationError("Simulation snapshot must be an object.");
   const { snapshot } = simulation;
   if (!Array.isArray(snapshot.sites)) throw new LibraryValidationError("Simulation snapshot Sites must be an array.");

--- a/src/lib/libraryLimits.ts
+++ b/src/lib/libraryLimits.ts
@@ -45,6 +45,14 @@ const assertFiniteIfPresent = (record: Record<string, unknown>, keys: string[], 
   }
 };
 
+const assertFiniteRequired = (record: Record<string, unknown>, keys: string[], label: string): void => {
+  for (const key of keys) {
+    if (typeof record[key] !== "number" || !Number.isFinite(record[key])) {
+      throw new LibraryValidationError(`${label} ${key} must be a finite number.`);
+    }
+  }
+};
+
 const assertPosition = (value: unknown, label: string): void => {
   if (!isRecord(value)
     || typeof value.lat !== "number"
@@ -85,6 +93,15 @@ const assertCommonRecord = (value: unknown, label: string): Record<string, unkno
   return value;
 };
 
+const assertNestedNamedRecord = (value: unknown, label: string): Record<string, unknown> => {
+  if (!isRecord(value)) throw new LibraryValidationError(`${label} must be an object.`);
+  assertId(value.id, `${label} ID`);
+  if (typeof value.name !== "string" || value.name.trim().length === 0 || value.name.trim().length > MAX_NAME_LENGTH) {
+    throw new LibraryValidationError(`${label} name must be between 1 and ${MAX_NAME_LENGTH} characters.`);
+  }
+  return value;
+};
+
 const encodedBytes = (value: unknown): number => textEncoder.encode(JSON.stringify(value)).byteLength;
 
 const assertSite = (value: unknown, nested = false): void => {
@@ -99,13 +116,15 @@ const assertSite = (value: unknown, nested = false): void => {
       })()
     : assertCommonRecord(value, "Site");
   assertPosition(site.position, "Site");
-  assertFiniteIfPresent(site, [
+  assertFiniteRequired(site, [
     "groundElevationM",
     "antennaHeightM",
     "txPowerDbm",
     "txGainDbi",
     "rxGainDbi",
     "cableLossDb",
+  ], "Site");
+  assertFiniteIfPresent(site, [
     "antennaAzimuthDeg",
     "antennaTiltDeg",
     "antennaHorizontalBeamwidthDeg",
@@ -122,7 +141,31 @@ const assertPath = (value: unknown): void => {
   assertId(value.id, "Path ID");
   assertId(value.fromSiteId, "Path fromSiteId");
   assertId(value.toSiteId, "Path toSiteId");
-  assertFiniteIfPresent(value, ["frequencyMHz", "txPowerDbm", "txGainDbi", "rxGainDbi", "cableLossDb"], "Path");
+  assertFiniteRequired(value, ["frequencyMHz"], "Path");
+  assertFiniteIfPresent(value, ["txPowerDbm", "txGainDbi", "rxGainDbi", "cableLossDb"], "Path");
+};
+
+const assertRadioSystem = (value: unknown): void => {
+  const system = assertNestedNamedRecord(value, "Radio System");
+  assertFiniteRequired(system, [
+    "txPowerDbm",
+    "txGainDbi",
+    "rxGainDbi",
+    "cableLossDb",
+    "antennaHeightM",
+  ], "Radio System");
+};
+
+const assertNetwork = (value: unknown): void => {
+  const network = assertNestedNamedRecord(value, "Network");
+  assertFiniteRequired(network, ["frequencyMHz", "bandwidthKhz", "spreadFactor", "codingRate"], "Network");
+  assertFiniteIfPresent(network, ["frequencyOverrideMHz"], "Network");
+  if (!Array.isArray(network.memberships)) throw new LibraryValidationError("Network memberships must be an array.");
+  for (const membership of network.memberships) {
+    if (!isRecord(membership)) throw new LibraryValidationError("Network membership must be an object.");
+    assertId(membership.siteId, "Network membership Site ID");
+    assertId(membership.systemId, "Network membership Radio System ID");
+  }
 };
 
 const assertSimulation = (value: unknown): void => {
@@ -139,9 +182,10 @@ const assertSimulation = (value: unknown): void => {
   }
   snapshot.sites.forEach((site) => assertSite(site, true));
   snapshot.links.forEach(assertPath);
-  for (const key of ["systems", "networks"]) {
-    if (!Array.isArray(snapshot[key])) throw new LibraryValidationError(`Simulation snapshot ${key} must be an array.`);
-  }
+  if (!Array.isArray(snapshot.systems)) throw new LibraryValidationError("Simulation snapshot systems must be an array.");
+  if (!Array.isArray(snapshot.networks)) throw new LibraryValidationError("Simulation snapshot networks must be an array.");
+  snapshot.systems.forEach(assertRadioSystem);
+  snapshot.networks.forEach(assertNetwork);
   if (encodedBytes(simulation) > LIBRARY_SIMULATION_MAX_BYTES) {
     throw new LibraryValidationError(`Simulation record exceeds ${LIBRARY_SIMULATION_MAX_BYTES} bytes.`);
   }

--- a/src/store/appStore.syncDirty.test.ts
+++ b/src/store/appStore.syncDirty.test.ts
@@ -178,4 +178,52 @@ describe("appStore delta sync", () => {
     expect(payload.siteLibrary[0]?.id).toBe(addedSiteId);
     expect(payload.siteLibrary[0]?.name).toBe("Gamma");
   });
+
+  it("applies a Site tombstone before a manual retry builds its push payload", async () => {
+    const pushedBodies: Array<{ siteLibrary: Array<{ id: string }> }> = [];
+    let getCount = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (url.includes("/api/library") && method === "GET") {
+        getCount += 1;
+        if (getCount === 2) {
+          return makeResponse({
+            ...cloneJson(baselinePayload),
+            deletedSiteIds: ["site-deleted"],
+            deletedSimulationIds: [],
+          });
+        }
+        return makeResponse({ ...cloneJson(baselinePayload), deletedSiteIds: [], deletedSimulationIds: [] });
+      }
+      if (url.includes("/api/library") && method === "PUT") {
+        pushedBodies.push(JSON.parse(String(init?.body ?? "{}")) as { siteLibrary: Array<{ id: string }> });
+        return makeResponse({ ok: true, conflicts: [] });
+      }
+      throw new Error(`Unexpected fetch: ${method} ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { useAppStore } = await import("./appStore");
+    useAppStore.setState({
+      currentUser: mkUser(), authState: "signed_in", isOnline: true,
+      siteLibrary: [], simulationPresets: cloneJson(baselinePayload.simulationPresets),
+      sites: [], links: [], systems: [], networks: [],
+      syncStatus: "synced", syncPending: false, syncBusy: false, isInitializing: false,
+    });
+    await useAppStore.getState().initializeCloudSync();
+    useAppStore.setState({
+      siteLibrary: [{
+        id: "site-deleted", name: "Stale cached Site", ownerUserId: "owner-1", effectiveRole: "owner",
+        createdAt: "2026-01-01T00:00:00.000Z", position: { lat: 60, lon: 11 }, groundElevationM: 100,
+        antennaHeightM: 2, txPowerDbm: 20, txGainDbi: 2, rxGainDbi: 2, cableLossDb: 1,
+      }],
+    });
+
+    await useAppStore.getState().performManualCloudSync();
+
+    expect(pushedBodies).toHaveLength(1);
+    expect(pushedBodies[0]?.siteLibrary).toEqual([]);
+    expect(useAppStore.getState().siteLibrary.some((site) => site.id === "site-deleted")).toBe(false);
+  });
 });

--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -40,6 +40,7 @@ vi.mock("../lib/cloudLibrary", async () => {
   const actual = await vi.importActual<typeof import("../lib/cloudLibrary")>("../lib/cloudLibrary");
   return {
     ...actual,
+    deleteCloudSite: vi.fn(async () => undefined),
     deleteCloudSimulation: vi.fn(async () => undefined),
     restoreCloudSimulation: vi.fn(async () => undefined),
   };
@@ -48,7 +49,7 @@ vi.mock("../lib/cloudLibrary", async () => {
 import { useAppStore } from "./appStore";
 import { useCoverageStore } from "./coverageStore";
 import { fetchElevations } from "../lib/elevationService";
-import { deleteCloudSimulation, restoreCloudSimulation } from "../lib/cloudLibrary";
+import { deleteCloudSite, deleteCloudSimulation, restoreCloudSimulation } from "../lib/cloudLibrary";
 import { simulationDefaultsFromPreset } from "../lib/simulationDefaults";
 
 describe("appStore auth session state", () => {
@@ -269,14 +270,16 @@ describe("appStore auth guards", () => {
       bio: "",
     });
 
-    useAppStore.getState().deleteSiteLibraryEntry("lib-1");
+    await expect(useAppStore.getState().deleteSiteLibraryEntry("lib-1")).rejects.toThrow(
+      "Only the Site owner or a platform admin",
+    );
     await expect(useAppStore.getState().deleteSimulationPreset("sim-1")).rejects.toThrow(
       "Only the Simulation owner or a platform admin",
     );
 
     expect(useAppStore.getState().siteLibrary.some((entry) => entry.id === "lib-1")).toBe(true);
     expect(useAppStore.getState().simulationPresets.some((preset) => preset.id === "sim-1")).toBe(true);
-    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   it("does not auto-sync online elevations when adding a site", async () => {
@@ -768,7 +771,7 @@ describe("appStore unified Library state", () => {
     expect(useAppStore.getState().libraryRequest).toBeNull();
   });
 
-  it("detaches a deleted Library Site from the live workspace and saved snapshots", () => {
+  it("deletes a cloud Site before detaching it from the live workspace and saved snapshots", async () => {
     const linkedSite = {
       id: "site-1",
       name: "Ridge",
@@ -820,12 +823,69 @@ describe("appStore unified Library state", () => {
       ],
     });
 
-    useAppStore.getState().deleteSiteLibraryEntry("library-site-1");
+    await useAppStore.getState().deleteSiteLibraryEntry("library-site-1");
 
+    expect(vi.mocked(deleteCloudSite)).toHaveBeenCalledWith("library-site-1");
     expect(useAppStore.getState().sites[0]).not.toHaveProperty("libraryEntryId");
     expect(useAppStore.getState().simulationPresets[0]?.snapshot.sites[0]).not.toHaveProperty(
       "libraryEntryId",
     );
+  });
+
+  it("keeps the local Site when cloud deletion fails", async () => {
+    vi.mocked(deleteCloudSite).mockRejectedValueOnce(new Error("Delete unavailable"));
+    useAppStore.setState({
+      currentUser: { ...useAppStore.getState().currentUser!, id: "owner-1", isAdmin: false },
+      siteLibrary: [{
+        id: "library-site-1",
+        name: "Ridge",
+        ownerUserId: "owner-1",
+        effectiveRole: "owner",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        position: { lat: 60, lon: 11 },
+        groundElevationM: 100,
+        antennaHeightM: 2,
+        txPowerDbm: 20,
+        txGainDbi: 2,
+        rxGainDbi: 2,
+        cableLossDb: 1,
+      }],
+    });
+
+    await expect(useAppStore.getState().deleteSiteLibraryEntry("library-site-1")).rejects.toThrow("Delete unavailable");
+    expect(useAppStore.getState().siteLibrary).toHaveLength(1);
+  });
+
+  it("recovers a partially completed bulk Site deletion on retry", async () => {
+    const deleteSiteMock = vi.mocked(deleteCloudSite);
+    deleteSiteMock.mockClear();
+    deleteSiteMock
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("Delete unavailable"))
+      .mockResolvedValueOnce(undefined);
+    const makeSite = (id: string) => ({
+      id,
+      name: id,
+      ownerUserId: "owner-1",
+      effectiveRole: "owner" as const,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      position: { lat: 60, lon: 11 },
+      groundElevationM: 100,
+      antennaHeightM: 2,
+      txPowerDbm: 20,
+      txGainDbi: 2,
+      rxGainDbi: 2,
+      cableLossDb: 1,
+    });
+    useAppStore.setState({ siteLibrary: [makeSite("site-a"), makeSite("site-b")] });
+
+    await expect(useAppStore.getState().deleteSiteLibraryEntries(["site-a", "site-b"]))
+      .rejects.toThrow("Delete unavailable");
+    expect(useAppStore.getState().siteLibrary.map((site) => site.id)).toEqual(["site-b"]);
+
+    await useAppStore.getState().deleteSiteLibraryEntries(["site-a", "site-b"]);
+    expect(useAppStore.getState().siteLibrary).toEqual([]);
+    expect(deleteSiteMock.mock.calls).toEqual([["site-a"], ["site-b"], ["site-b"]]);
   });
 
   it("clears the workspace and persisted active references when deleting the active Simulation", async () => {

--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -947,6 +947,59 @@ describe("appStore unified Library state", () => {
     expect(useAppStore.getState().selectedScenarioId).toBe("");
     expect(useAppStore.getState().sites).toEqual([]);
   });
+
+  it("applies remote Site deletion tombstones before a stale client can sync them", () => {
+    const linkedSite = {
+      id: "workspace-site",
+      name: "Linked",
+      libraryEntryId: "site-deleted",
+      position: { lat: 60, lon: 11 },
+      groundElevationM: 100,
+      antennaHeightM: 2,
+      txPowerDbm: 20,
+      txGainDbi: 2,
+      rxGainDbi: 2,
+      cableLossDb: 1,
+    };
+    useAppStore.setState({
+      sites: [linkedSite],
+      siteLibrary: [{
+        id: "site-deleted",
+        name: "Deleted remotely",
+        ownerUserId: "owner-1",
+        effectiveRole: "owner",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        position: { lat: 60, lon: 11 },
+        groundElevationM: 100,
+        antennaHeightM: 2,
+        txPowerDbm: 20,
+        txGainDbi: 2,
+        rxGainDbi: 2,
+        cableLossDb: 1,
+      }],
+      simulationPresets: [{
+        id: "sim-with-stale-ref",
+        name: "Stale reference",
+        ownerUserId: "owner-1",
+        effectiveRole: "owner",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        snapshot: {
+          sites: [linkedSite], links: [], systems: [], networks: [],
+          selectedSiteId: "workspace-site", selectedLinkId: "", selectedNetworkId: "",
+          selectedCoverageResolution: "24", propagationModel: "ITM",
+          selectedFrequencyPresetId: "custom", rxSensitivityTargetDbm: -120,
+          environmentLossDb: 0, propagationEnvironment: useAppStore.getState().propagationEnvironment,
+          autoPropagationEnvironment: true, terrainDataset: "copernicus30",
+        },
+      }],
+    });
+
+    useAppStore.getState().applyDeletedSiteTombstones(["site-deleted"]);
+
+    expect(useAppStore.getState().siteLibrary).toEqual([]);
+    expect(useAppStore.getState().sites[0]).not.toHaveProperty("libraryEntryId");
+    expect(useAppStore.getState().simulationPresets[0]?.snapshot.sites[0]).not.toHaveProperty("libraryEntryId");
+  });
 });
 
 describe("appStore new simulation default frequency preset", () => {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -14,6 +14,7 @@ import { haversineDistanceKm } from "../lib/geo";
 import { resolveTrackedSiteOrientation, resolveTrackedSiteOrientations } from "../lib/antennaPattern";
 import { getUiErrorMessage } from "../lib/uiError";
 import {
+  deleteCloudSite,
   deleteCloudSimulation,
   fetchCloudLibrary,
   pushCloudLibrary,
@@ -626,8 +627,8 @@ type AppState = {
       >
     >,
   ) => void;
-  deleteSiteLibraryEntry: (entryId: string) => void;
-  deleteSiteLibraryEntries: (entryIds: string[]) => void;
+  deleteSiteLibraryEntry: (entryId: string) => Promise<void>;
+  deleteSiteLibraryEntries: (entryIds: string[]) => Promise<void>;
   saveCurrentSimulationPreset: (name: string) => string | null;
   createSimulationCopyFromCurrent: (
     name: string,
@@ -2790,46 +2791,69 @@ export const useAppStore = create<AppState>((set, get) => ({
     useCoverageStore.getState().recomputeCoverage();
     get().updateCurrentSimulationSnapshot();
   },
-  deleteSiteLibraryEntry: (entryId) => {
-    get().deleteSiteLibraryEntries([entryId]);
+  deleteSiteLibraryEntry: async (entryId) => {
+    await get().deleteSiteLibraryEntries([entryId]);
   },
-  deleteSiteLibraryEntries: (entryIds) => {
+  deleteSiteLibraryEntries: async (entryIds) => {
     const { currentUser } = get();
     const user = requireAuth(currentUser, "deleteSiteLibraryEntries");
-    if (!user) return;
-    const requested = new Set(entryIds);
-    if (!requested.size) return;
+    if (!user) throw new Error("Sign in to delete a Site.");
+    const requested = [...new Set(entryIds.filter(Boolean))];
+    if (!requested.length) return;
     const state = get();
-    for (const entryId of entryIds) {
+    const requestedEntries: SiteLibraryEntry[] = [];
+    for (const entryId of requested) {
       const entry = state.siteLibrary.find((e) => e.id === entryId);
-      if (entry && !canEditItem(entry, user)) {
-        console.warn(`[appStore] deleteSiteLibraryEntries: User ${user.id} cannot delete entry ${entryId}`);
-        return;
+      if (!entry) continue;
+      const ownsSite = entry.ownerUserId === user.id || entry.effectiveRole === "owner";
+      if (!user.isAdmin && !ownsSite) {
+        throw new Error("Only the Site owner or a platform admin can delete it.");
       }
+      requestedEntries.push(entry);
     }
-    set((state) => {
-      const next = state.siteLibrary.filter((entry) => !requested.has(entry.id));
-      writeStorage(SITE_LIBRARY_KEY, next);
-      const detachLibraryReference = <T extends { libraryEntryId?: string }>(site: T): T => {
-        if (!site.libraryEntryId || !requested.has(site.libraryEntryId)) return site;
-        const { libraryEntryId: _removedLibraryEntryId, ...detached } = site;
-        return detached as T;
-      };
-      const nextSites = state.sites.map(detachLibraryReference);
-      const updatedPresets = state.simulationPresets.map((preset) => {
-        const hasRef = preset.snapshot.sites.some((site) => site.libraryEntryId && requested.has(site.libraryEntryId));
-        if (!hasRef) return preset;
-        return {
-          ...preset,
-          snapshot: {
-            ...preset.snapshot,
-            sites: preset.snapshot.sites.map(detachLibraryReference),
-          },
+
+    for (const { id: entryId } of requestedEntries) {
+      await deleteCloudSite(entryId);
+      const deleted = new Set([entryId]);
+      const affectedSimulationIds: string[] = [];
+      set((current) => {
+        const next = current.siteLibrary.filter((entry) => entry.id !== entryId);
+        writeStorage(SITE_LIBRARY_KEY, next);
+        const detachLibraryReference = <T extends { libraryEntryId?: string }>(site: T): T => {
+          if (!site.libraryEntryId || !deleted.has(site.libraryEntryId)) return site;
+          const detached = { ...site };
+          delete detached.libraryEntryId;
+          return detached;
         };
+        const nextSites = current.sites.map(detachLibraryReference);
+        const updatedPresets = current.simulationPresets.map((preset) => {
+          const hasRef = preset.snapshot.sites.some((site) => site.libraryEntryId === entryId);
+          if (!hasRef) return preset;
+          affectedSimulationIds.push(preset.id);
+          return {
+            ...preset,
+            snapshot: {
+              ...preset.snapshot,
+              sites: preset.snapshot.sites.map(detachLibraryReference),
+            },
+          };
+        });
+        writeStorage(SIM_PRESETS_KEY, updatedPresets);
+        return { siteLibrary: next, sites: nextSites, simulationPresets: updatedPresets };
       });
-      writeStorage(SIM_PRESETS_KEY, updatedPresets);
-      return { siteLibrary: next, sites: nextSites, simulationPresets: updatedPresets };
-    });
+      dirtySiteIds.delete(entryId);
+      affectedSimulationIds.forEach(markDirtySim);
+    }
+
+    if (dirtySimIds.size === 0) {
+      const current = get();
+      lastSyncedPayloadSignature = buildEditableSyncPayloadInfo(
+        current.siteLibrary,
+        current.simulationPresets,
+        current.currentUser,
+      ).signature;
+      writeStorage(SYNC_SIGNATURE_KEY, lastSyncedPayloadSignature);
+    }
   },
   saveCurrentSimulationPreset: (name) => {
     const { currentUser } = get();

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -13,6 +13,7 @@ import {
 import { haversineDistanceKm } from "../lib/geo";
 import { resolveTrackedSiteOrientation, resolveTrackedSiteOrientations } from "../lib/antennaPattern";
 import { getUiErrorMessage } from "../lib/uiError";
+import { canDeleteLibraryItem } from "../lib/libraryFilters";
 import {
   deleteCloudSite,
   deleteCloudSimulation,
@@ -364,6 +365,27 @@ type SyncPayload = {
   simulationPresets: SimulationPreset[];
 };
 
+const detachDeletedSiteLibraryReferences = <T extends { libraryEntryId?: string }>(
+  sites: T[],
+  deletedIds: ReadonlySet<string>,
+): T[] => sites.map((site) => {
+  if (!site.libraryEntryId || !deletedIds.has(site.libraryEntryId)) return site;
+  const detached = { ...site };
+  delete detached.libraryEntryId;
+  return detached;
+});
+
+const detachDeletedSiteReferencesFromPresets = (
+  presets: SimulationPreset[],
+  deletedIds: ReadonlySet<string>,
+): SimulationPreset[] => presets.map((preset) => ({
+  ...preset,
+  snapshot: {
+    ...preset.snapshot,
+    sites: detachDeletedSiteLibraryReferences(preset.snapshot.sites, deletedIds),
+  },
+}));
+
 type EditableSyncPayloadInfo = {
   payload: SyncPayload;
   skippedCount: number;
@@ -677,6 +699,7 @@ type AppState = {
   deleteSimulationPreset: (presetId: string) => Promise<void>;
   restoreSimulationPreset: (presetId: string) => Promise<void>;
   applyDeletedSimulationTombstones: (presetIds: string[]) => void;
+  applyDeletedSiteTombstones: (siteIds: string[]) => void;
   importLibraryData: (
     bundle: { siteLibrary?: SiteLibraryEntry[]; simulationPresets?: SimulationPreset[] },
     mode: "merge" | "replace",
@@ -1508,9 +1531,14 @@ export const useAppStore = create<AppState>((set, get) => ({
 
       // Delta fetch: merge server items by ID (server wins), keep local items not returned
       if (cloud.isDelta) {
+        const deletedSiteIds = new Set(cloud.deletedSiteIds);
+        get().applyDeletedSiteTombstones(cloud.deletedSiteIds);
         get().applyDeletedSimulationTombstones(cloud.deletedSimulationIds);
         const deltaSites = cloud.siteLibrary as SiteLibraryEntry[];
-        const deltaSims = cloud.simulationPresets as SimulationPreset[];
+        const deltaSims = detachDeletedSiteReferencesFromPresets(
+          cloud.simulationPresets as SimulationPreset[],
+          deletedSiteIds,
+        );
         set((state) => {
           const siteById = new Map(deltaSites.map((s) => [s.id, s]));
           const simById = new Map(deltaSims.map((s) => [s.id, s]));
@@ -1546,7 +1574,12 @@ export const useAppStore = create<AppState>((set, get) => ({
       let remotePayloadSignature: string | null = null;
 
       const cloudSites = Array.isArray(cloud.siteLibrary) ? cloud.siteLibrary as SiteLibraryEntry[] : [];
-      const cloudSims = Array.isArray(cloud.simulationPresets) ? cloud.simulationPresets as SimulationPreset[] : [];
+      const deletedSiteIds = new Set(cloud.deletedSiteIds);
+      const cloudSims = detachDeletedSiteReferencesFromPresets(
+        Array.isArray(cloud.simulationPresets) ? cloud.simulationPresets as SimulationPreset[] : [],
+        deletedSiteIds,
+      );
+      get().applyDeletedSiteTombstones(cloud.deletedSiteIds);
       get().applyDeletedSimulationTombstones(cloud.deletedSimulationIds);
 
       if (currentUser?.id) {
@@ -1947,8 +1980,11 @@ export const useAppStore = create<AppState>((set, get) => ({
         sites: cloud.siteLibrary.length,
         simulations: cloud.simulationPresets.length,
       });
-      const cloudPresets =
-        (cloud.simulationPresets as Parameters<typeof importLibraryData>[0]["simulationPresets"] | undefined) ?? [];
+      const cloudPresets = detachDeletedSiteReferencesFromPresets(
+        (cloud.simulationPresets as SimulationPreset[] | undefined) ?? [],
+        new Set(cloud.deletedSiteIds),
+      ) as Parameters<typeof importLibraryData>[0]["simulationPresets"];
+      get().applyDeletedSiteTombstones(cloud.deletedSiteIds);
       get().applyDeletedSimulationTombstones(cloud.deletedSimulationIds);
       console.log("[appStore] Merging cloud data with local...");
       const result = importLibraryData(
@@ -2805,8 +2841,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     for (const entryId of requested) {
       const entry = state.siteLibrary.find((e) => e.id === entryId);
       if (!entry) continue;
-      const ownsSite = entry.ownerUserId === user.id || entry.effectiveRole === "owner";
-      if (!user.isAdmin && !ownsSite) {
+      if (!canDeleteLibraryItem(entry, user)) {
         throw new Error("Only the Site owner or a platform admin can delete it.");
       }
       requestedEntries.push(entry);
@@ -3514,6 +3549,19 @@ export const useAppStore = create<AppState>((set, get) => ({
       return { simulationPresets: next };
     });
     if (deletingActiveSimulation) get().clearSimulationWorkspace();
+  },
+  applyDeletedSiteTombstones: (siteIds) => {
+    const deletedIds = new Set((siteIds ?? []).filter(Boolean));
+    if (!deletedIds.size) return;
+    set((state) => {
+      const next = state.siteLibrary.filter((site) => !deletedIds.has(site.id));
+      const nextSites = detachDeletedSiteLibraryReferences(state.sites, deletedIds);
+      const nextPresets = detachDeletedSiteReferencesFromPresets(state.simulationPresets, deletedIds);
+      writeStorage(SITE_LIBRARY_KEY, next);
+      writeStorage(SIM_PRESETS_KEY, nextPresets);
+      return { siteLibrary: next, sites: nextSites, simulationPresets: nextPresets };
+    });
+    deletedIds.forEach((id) => dirtySiteIds.delete(id));
   },
   deleteSimulationPreset: async (presetId) => {
     const { currentUser } = get();

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1960,6 +1960,9 @@ export const useAppStore = create<AppState>((set, get) => ({
     syncInFlight = true;
     set({ syncBusy: true, syncStatus: "syncing", syncStatusMessage: "Syncing..." });
     try {
+      const deletionState = await fetchCloudLibrary();
+      get().applyDeletedSiteTombstones(deletionState.deletedSiteIds);
+      get().applyDeletedSimulationTombstones(deletionState.deletedSimulationIds);
       const { siteLibrary, simulationPresets, currentUser, importLibraryData } = get();
       const editableSites = siteLibrary.filter((site) => canEditLibraryItem(site, currentUser));
       const editableSims = simulationPresets.filter((sim) => sim.status !== "deleted" && canEditLibraryItem(sim, currentUser));


### PR DESCRIPTION
## Summary

Implements issue #1053 Batch 1 of 5: bound untrusted Library ingestion before parsing, persistence, or fan-out.

- streams and rejects Library request bodies above 2 MiB before `JSON.parse`, with a 20-level nesting ceiling;
- validates current Site, Simulation, Path, Radio System, Network, grant, coordinate, finite-number, timestamp, record-byte, and collection-count contracts while retaining bounded extension fields;
- chunks client writes into sequential batches capped at 20 records and 2 MiB, stopping immediately on HTTP or per-item conflicts;
- enforces measured storage quotas atomically from live D1 state, including ownership/role changes, concurrent ID collisions, public/private transitions, soft deletion, and hard-deletion tombstones;
- reuses existing Library auth/access, `resource_changes`, local sync, confirmation-modal, UI-error, and D1 helpers; no schema addition or new UI element;
- adds server-first owner/admin Site deletion with idempotent recovery and tombstone application before stale manual sync;
- documents the application limits in `docs/resource-limits.md`.

The approved limits are 2 MiB/request, 20 records/request, 32 KiB/Site, 256 KiB/Simulation, 250 Sites/Simulation, 1,000 Paths/Simulation, 100 grants/record, 500 Sites/user, 100 retained Simulations/user, 100 public/shared Sites/user, and 25 public/shared retained Simulations/user. These are LinkSim safety contracts, not claimed Cloudflare production-account limits.

## Validation

- `npm test` — 166 files, 1,133 tests passed
- `npm run build` — passed
- required deep-link/API/store set — 3 files, 79 tests passed
- `npm run security:scan` — passed
- SQLite execution probes — tombstone audience, guarded deletion/recreation, current authorization, live public quota, and deleted-Simulation predicates passed
- `git diff --check` — passed
- `npm run dev:check` — no LinkSim dev/watch server found
- changed-file lint — no new finding; three touched staging-baseline findings remain (LibraryPanel effect state update, appStore `_key`, syncDirty test `any`)
- independent read-only pre-PR review — PASS for exact head `065b2310236226a3a437d499547b99ae2e3bbd37`

No version bump: `staging` is already on the 0.27.0 development line. No browser/staging test, merge, deployment, production action, issue closure, or native Codex review was performed. Batches 2–5 remain separate and wait for this batch to be merged.

Refs #1053

— Forge · AI coding agent
<!-- linksim-ai:v1 agent=Forge bot=true run=ee996a9a-27a9-46e0-9887-2d1277189167 source=pr:1053-batch-1 commit=065b2310236226a3a437d499547b99ae2e3bbd37 -->
