### PR TITLE
Bound calculation workloads

### DIFF
--- a/calculation_api/calculators/link_budget.py
+++ b/calculation_api/calculators/link_budget.py
@@ -1,6 +1,7 @@
 from math import asin, cos, log10, radians, sin, sqrt
 
 from calculation_api.models import LinkBudgetInput, LinkBudgetResult, Node
+from calculation_api.limits import MAX_SYNC_DISTANCE_KM
 
 
 def _haversine_km(a: Node, b: Node) -> float:
@@ -33,6 +34,8 @@ def calculate_link_budget(payload: LinkBudgetInput) -> LinkBudgetResult:
         raise LookupError(f"Site not found: {payload.to_site}")
 
     distance_km = _haversine_km(from_node, to_node)
+    if distance_km > MAX_SYNC_DISTANCE_KM:
+        raise ValueError(f"Distance {distance_km:.1f} km exceeds maximum sync distance of {MAX_SYNC_DISTANCE_KM} km.")
     path_loss_db = _fspl_db(distance_km, payload.frequency_mhz)
     eirp_dbm = from_node.tx_power_dbm + from_node.tx_gain_dbi - from_node.cable_loss_db
     rx_dbm = eirp_dbm + to_node.rx_gain_dbi - path_loss_db

--- a/calculation_api/limits.py
+++ b/calculation_api/limits.py
@@ -1,0 +1,92 @@
+import json
+
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+MAX_CALCULATION_BODY_BYTES = 64 * 1024
+MAX_CALCULATION_JSON_DEPTH = 10
+MAX_NODES = 20
+MAX_NAME_LENGTH = 80
+MAX_SYNC_DISTANCE_KM = 500
+
+
+def json_depth(raw: bytes) -> int:
+    depth = maximum = 0
+    in_string = escaped = False
+    for byte in raw:
+        char = chr(byte)
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+        elif char == '"':
+            in_string = True
+        elif char in "[{":
+            depth += 1
+            maximum = max(maximum, depth)
+        elif char in "]}":
+            depth -= 1
+    return maximum
+
+
+def _reject_non_finite(value: str):
+    raise ValueError(value)
+
+
+class BoundedCalculationBodyMiddleware:
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http" or scope["method"] != "POST" or scope["path"] != "/api/v1/calculate":
+            await self.app(scope, receive, send)
+            return
+
+        headers = dict(scope.get("headers", []))
+        declared = headers.get(b"content-length")
+        if declared:
+            try:
+                if int(declared) > MAX_CALCULATION_BODY_BYTES:
+                    await JSONResponse(status_code=413, content={"detail": f"Request body exceeds {MAX_CALCULATION_BODY_BYTES} bytes."})(scope, receive, send)
+                    return
+            except ValueError:
+                pass
+
+        chunks: list[bytes] = []
+        total = 0
+        more = True
+        while more:
+            message = await receive()
+            if message["type"] == "http.disconnect":
+                return
+            chunk = message.get("body", b"")
+            total += len(chunk)
+            more = bool(message.get("more_body", False))
+            if total > MAX_CALCULATION_BODY_BYTES:
+                await JSONResponse(status_code=413, content={"detail": f"Request body exceeds {MAX_CALCULATION_BODY_BYTES} bytes."})(scope, receive, send)
+                return
+            chunks.append(chunk)
+
+        body = b"".join(chunks)
+        if json_depth(body) > MAX_CALCULATION_JSON_DEPTH:
+            await JSONResponse(status_code=422, content={"detail": f"JSON nesting may not exceed {MAX_CALCULATION_JSON_DEPTH} levels."})(scope, receive, send)
+            return
+        try:
+            json.loads(body, parse_constant=_reject_non_finite)
+        except (UnicodeDecodeError, json.JSONDecodeError, ValueError):
+            await JSONResponse(status_code=422, content={"detail": "Request body must be valid finite-number JSON."})(scope, receive, send)
+            return
+
+        delivered = False
+
+        async def replay_receive() -> Message:
+            nonlocal delivered
+            if delivered:
+                return {"type": "http.disconnect"}
+            delivered = True
+            return {"type": "http.request", "body": body, "more_body": False}
+
+        await self.app(scope, replay_receive, send)

--- a/calculation_api/main.py
+++ b/calculation_api/main.py
@@ -6,9 +6,9 @@ from starlette.middleware.base import BaseHTTPMiddleware
 
 from calculation_api.calculators import calculate_link_budget
 from calculation_api.engine import CalculationEngine
+from calculation_api.limits import BoundedCalculationBodyMiddleware
 from calculation_api.models import CalculationRequest, CalculationResponse
 from calculation_api.rate_limit import InMemoryRateLimiter
-
 
 class RateLimitMiddleware(BaseHTTPMiddleware):
     def __init__(self, app: FastAPI, limiter: InMemoryRateLimiter) -> None:
@@ -43,6 +43,7 @@ def _env_int(name: str, default: int) -> int:
 
 def create_app(*, rate_limit_per_min: int | None = None, rate_limit_window_sec: int | None = None) -> FastAPI:
     app = FastAPI(title="LinkSim Calculation API", version="0.1.0")
+    app.add_middleware(BoundedCalculationBodyMiddleware)
 
     engine = CalculationEngine()
     engine.register("link_budget", calculate_link_budget)
@@ -66,6 +67,8 @@ def create_app(*, rate_limit_per_min: int | None = None, rate_limit_window_sec: 
         except LookupError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
         except KeyError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
         return CalculationResponse(calculation=request.calculation, result=result)

--- a/calculation_api/models.py
+++ b/calculation_api/models.py
@@ -1,10 +1,16 @@
 from typing import Literal
 
-from pydantic import AliasChoices, BaseModel, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field
+
+from calculation_api.limits import MAX_NAME_LENGTH, MAX_NODES
 
 
-class Node(BaseModel):
-    name: str = Field(min_length=1)
+class FiniteModel(BaseModel):
+    model_config = ConfigDict(allow_inf_nan=False, strict=True, str_strip_whitespace=True)
+
+
+class Node(FiniteModel):
+    name: str = Field(min_length=1, max_length=MAX_NAME_LENGTH)
     lat: float = Field(ge=-90, le=90)
     lon: float = Field(ge=-180, le=180)
     antenna_height_m: float = Field(default=2, gt=0)
@@ -14,17 +20,17 @@ class Node(BaseModel):
     cable_loss_db: float = Field(default=1, ge=0)
 
 
-class LinkBudgetInput(BaseModel):
-    from_site: str = Field(min_length=1, validation_alias=AliasChoices("from_site", "from_node"))
-    to_site: str = Field(min_length=1, validation_alias=AliasChoices("to_site", "to_node"))
+class LinkBudgetInput(FiniteModel):
+    from_site: str = Field(min_length=1, max_length=MAX_NAME_LENGTH, validation_alias=AliasChoices("from_site", "from_node"))
+    to_site: str = Field(min_length=1, max_length=MAX_NAME_LENGTH, validation_alias=AliasChoices("to_site", "to_node"))
     frequency_mhz: float = Field(gt=0)
     rx_target_dbm: float = -100
     include_verdict: bool = True
     include_rx_dbm: bool = True
-    nodes: list[Node] = Field(min_length=2)
+    nodes: list[Node] = Field(min_length=2, max_length=MAX_NODES)
 
 
-class CalculationRequest(BaseModel):
+class CalculationRequest(FiniteModel):
     calculation: Literal["link_budget"]
     input: LinkBudgetInput
 

--- a/docs/repository-guide.md
+++ b/docs/repository-guide.md
@@ -97,6 +97,10 @@ Behavior notes:
 - If node ground elevation is omitted, the API samples terrain and uses that elevation with `2m` default antenna height
 - Result includes app-style pass/fail text, for example `LOS clear + fail at 83.39 km (-133.6 dBm after env loss)`
 - Edge rate limit: `CALC_API_PROXY_RATE_LIMIT_PER_MINUTE` (default `120`)
+- Request limits: `64 KiB` JSON body, at most `10` JSON nesting levels, `20` nodes, and `80` characters per site name
+- Distance limits: `500 km` for synchronous calculations and `2,000 km` for asynchronous terrain jobs
+- Terrain sampling limits: `72` synchronous samples and `500` asynchronous samples
+- Asynchronous terrain jobs have an absolute `5 minute` deadline; terminal job records are retained for up to `24 hours` with at most `1,000` retained
 
 Example request:
 

--- a/functions/_lib/calculateShared.test.ts
+++ b/functions/_lib/calculateShared.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { estimateSampleCount, estimateSyncSampleCount, haversineKm, MAX_CALCULATION_BODY_BYTES, MAX_NODE_NAME_LENGTH, normalizeCalculationRequest } from "./calculateShared";
+
+const payload = () => ({ calculation: "link_budget", input: { from_site: "A", to_site: "B", frequency_mhz: 868, nodes: [
+  { name: "A", lat: 1, lon: 1 }, { name: "B", lat: 2, lon: 2 },
+] } });
+
+describe("calculation request limits", () => {
+  it("documents the exact 64 KiB body quota", () => expect(MAX_CALCULATION_BODY_BYTES).toBe(65_536));
+  it("accepts names at the boundary and rejects names beyond it", () => {
+    const valid = payload(); valid.input.nodes[0].name = "x".repeat(MAX_NODE_NAME_LENGTH); valid.input.from_site = valid.input.nodes[0].name;
+    expect(normalizeCalculationRequest(valid).input.nodes[0].name).toHaveLength(80);
+    valid.input.nodes[0].name += "x";
+    expect(() => normalizeCalculationRequest(valid)).toThrow("may not exceed 80 characters");
+  });
+  it("counts astral Unicode names by characters", () => {
+    const valid = payload(); valid.input.nodes[0].name = "😀".repeat(80); valid.input.from_site = valid.input.nodes[0].name;
+    expect(normalizeCalculationRequest(valid).input.nodes[0].name).toBe("😀".repeat(80));
+    valid.input.nodes[0].name += "😀";
+    expect(() => normalizeCalculationRequest(valid)).toThrow("may not exceed 80 characters");
+  });
+  it("accepts 20 nodes and rejects 21", () => {
+    const valid = payload();
+    valid.input.nodes = Array.from({ length: 20 }, (_, index) => ({ name: index === 0 ? "A" : index === 1 ? "B" : `node-${index}`, lat: 1, lon: 1 }));
+    expect(normalizeCalculationRequest(valid).input.nodes).toHaveLength(20);
+    valid.input.nodes.push({ name: "node-21", lat: 1, lon: 1 });
+    expect(() => normalizeCalculationRequest(valid)).toThrow("maximum of 20 sites");
+  });
+  it.each(["frequency_mhz", "rx_target_dbm", "environment_loss_db"])("rejects non-finite %s", (field) => {
+    const invalid = payload(); (invalid.input as unknown as Record<string, unknown>)[field] = Number.POSITIVE_INFINITY;
+    expect(() => normalizeCalculationRequest(invalid)).toThrow("must be a valid number");
+  });
+  it.each(["frequency_mhz", "rx_target_dbm", "environment_loss_db"])("rejects string and boolean numeric coercion for %s", (field) => {
+    for (const value of ["1", true]) {
+      const invalid = payload(); (invalid.input as unknown as Record<string, unknown>)[field] = value;
+      expect(() => normalizeCalculationRequest(invalid)).toThrow("must be a valid number");
+    }
+  });
+  it("rejects non-finite optional node numbers rather than passing them through", () => {
+    const invalid = payload(); (invalid.input.nodes[0] as Record<string, unknown>).tx_power_dbm = Number.NaN;
+    expect(() => normalizeCalculationRequest(invalid)).toThrow("nodes[0].tx_power_dbm must be a valid number");
+  });
+  it.each([
+    "lat", "lon", "tx_power_dbm", "tx_gain_dbi", "rx_gain_dbi", "cable_loss_db", "antenna_height_m",
+    "ground_elevation_m", "antenna_azimuth_deg", "antenna_tilt_deg", "antenna_horizontal_beamwidth_deg",
+    "antenna_vertical_beamwidth_deg", "antenna_max_attenuation_db",
+  ])("rejects wrong-type and non-finite node numeric field %s", (field) => {
+    const wrongType = payload(); (wrongType.input.nodes[0] as Record<string, unknown>)[field] = "1";
+    expect(() => normalizeCalculationRequest(wrongType)).toThrow("must be a valid number");
+    const nonFinite = payload(); (nonFinite.input.nodes[0] as Record<string, unknown>)[field] = Number.NEGATIVE_INFINITY;
+    expect(() => normalizeCalculationRequest(nonFinite)).toThrow("must be a valid number");
+  });
+  it("keeps exact distance and terrain sample contracts", () => {
+    const longitudeFor = (distanceKm: number) => distanceKm / 6371 * 180 / Math.PI;
+    expect(haversineKm({ lat: 0, lon: 0 }, { lat: 0, lon: longitudeFor(500) })).toBeCloseTo(500, 9);
+    expect(haversineKm({ lat: 0, lon: 0 }, { lat: 0, lon: longitudeFor(2000) })).toBeCloseTo(2000, 9);
+    expect(estimateSampleCount(0)).toBe(24);
+    expect(estimateSampleCount(2000)).toBe(500);
+    expect(estimateSyncSampleCount(0)).toBe(24);
+    expect(estimateSyncSampleCount(500)).toBe(72);
+  });
+});

--- a/functions/_lib/calculateShared.ts
+++ b/functions/_lib/calculateShared.ts
@@ -37,9 +37,17 @@ export type CalculationRequest = {
 };
 
 export const MAX_NODES = 20;
+export const MAX_CALCULATION_BODY_BYTES = 64 * 1024;
+export const MAX_CALCULATION_JSON_DEPTH = 10;
+export const MAX_NODE_NAME_LENGTH = 80;
 export const MAX_SYNC_DISTANCE_KM = 500;
 export const MAX_TERRAIN_DISTANCE_KM = 2000;
 export const MAX_SAMPLES = 500;
+export const MAX_SYNC_TERRAIN_SAMPLES = 72;
+export const MAX_JOB_RUNTIME_MS = 5 * 60 * 1000;
+export const MAX_JOB_ERROR_LENGTH = 1024;
+export const TERMINAL_JOB_RETENTION_HOURS = 24;
+export const MAX_TERMINAL_JOBS = 1000;
 
 const asRecord = (value: unknown, errorMessage: string): Record<string, unknown> => {
   if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(errorMessage);
@@ -57,7 +65,11 @@ const asString = (value: unknown, fieldName: string): string => {
   if (typeof value !== "string" || value.trim().length === 0) {
     throw new Error(`${fieldName} is required.`);
   }
-  return value.trim();
+  const normalized = value.trim();
+  if (Array.from(normalized).length > MAX_NODE_NAME_LENGTH) {
+    throw new Error(`${fieldName} may not exceed ${MAX_NODE_NAME_LENGTH} characters.`);
+  }
+  return normalized;
 };
 
 const normalizeBool = (value: unknown, fallback: boolean): boolean =>
@@ -91,12 +103,12 @@ const normalizeNode = (value: unknown, index: number): NodeInput => {
     name: asString(row.name, `nodes[${index}].name`),
     lat,
     lon,
-    tx_power_dbm: typeof row.tx_power_dbm === "number" ? row.tx_power_dbm : 14,
-    tx_gain_dbi: typeof row.tx_gain_dbi === "number" ? row.tx_gain_dbi : 2,
-    rx_gain_dbi: typeof row.rx_gain_dbi === "number" ? row.rx_gain_dbi : 2,
-    cable_loss_db: typeof row.cable_loss_db === "number" ? row.cable_loss_db : 1,
-    antenna_height_m: typeof row.antenna_height_m === "number" ? row.antenna_height_m : 2,
-    ground_elevation_m: typeof row.ground_elevation_m === "number" ? row.ground_elevation_m : undefined,
+    tx_power_dbm: row.tx_power_dbm === undefined ? 14 : asFiniteNumber(row.tx_power_dbm, `nodes[${index}].tx_power_dbm`),
+    tx_gain_dbi: row.tx_gain_dbi === undefined ? 2 : asFiniteNumber(row.tx_gain_dbi, `nodes[${index}].tx_gain_dbi`),
+    rx_gain_dbi: row.rx_gain_dbi === undefined ? 2 : asFiniteNumber(row.rx_gain_dbi, `nodes[${index}].rx_gain_dbi`),
+    cable_loss_db: row.cable_loss_db === undefined ? 1 : asFiniteNumber(row.cable_loss_db, `nodes[${index}].cable_loss_db`),
+    antenna_height_m: row.antenna_height_m === undefined ? 2 : asFiniteNumber(row.antenna_height_m, `nodes[${index}].antenna_height_m`),
+    ground_elevation_m: row.ground_elevation_m === undefined ? undefined : asFiniteNumber(row.ground_elevation_m, `nodes[${index}].ground_elevation_m`),
     antenna_mode: normalizeAntennaMode(row.antenna_mode, `nodes[${index}].antenna_mode`),
     antenna_azimuth_deg: optionalNumberInRange(row.antenna_azimuth_deg, `nodes[${index}].antenna_azimuth_deg`, 0, 359.999),
     antenna_tilt_deg: optionalNumberInRange(row.antenna_tilt_deg, `nodes[${index}].antenna_tilt_deg`, -90, 90),
@@ -124,8 +136,8 @@ export const normalizeCalculationRequest = (value: unknown): CalculationRequest 
     from_site: asString(fromSite, "input.from_site"),
     to_site: asString(toSite, "input.to_site"),
     frequency_mhz: asFiniteNumber(input.frequency_mhz, "input.frequency_mhz"),
-    rx_target_dbm: typeof input.rx_target_dbm === "number" ? input.rx_target_dbm : -100,
-    environment_loss_db: typeof input.environment_loss_db === "number" ? input.environment_loss_db : 0,
+    rx_target_dbm: input.rx_target_dbm === undefined ? -100 : asFiniteNumber(input.rx_target_dbm, "input.rx_target_dbm"),
+    environment_loss_db: input.environment_loss_db === undefined ? 0 : asFiniteNumber(input.environment_loss_db, "input.environment_loss_db"),
     mode: normalizeMode(input.mode),
     include_verdict: normalizeBool(input.include_verdict, true),
     include_rx_dbm: normalizeBool(input.include_rx_dbm, true),
@@ -227,4 +239,9 @@ export const effectiveApiLinkGains = (
 export const estimateSampleCount = (distanceKm: number): number => {
   const byDistance = Math.ceil(distanceKm / 0.5);
   return Math.max(24, Math.min(MAX_SAMPLES, byDistance));
+};
+
+export const estimateSyncSampleCount = (distanceKm: number): number => {
+  const byDistance = Math.ceil(distanceKm / 0.75);
+  return Math.max(24, Math.min(MAX_SYNC_TERRAIN_SAMPLES, byDistance));
 };

--- a/functions/_lib/calculationJobs.test.ts
+++ b/functions/_lib/calculationJobs.test.ts
@@ -1,6 +1,6 @@
 import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
-import { boundedJobError, cleanupCalculationJobs, createCalculationJob, ensureCalculationJobsTable, finishCalculationJobBeforeDeadline, getCalculationJob, JOB_STATUS, transitionCalculationJob } from "./calculationJobs";
+import { boundedJobError, cleanupCalculationJobs, createCalculationJob, ensureCalculationJobsTable, failCalculationJobBeforeDeadline, finishCalculationJobBeforeDeadline, getCalculationJob, JOB_STATUS, transitionCalculationJob } from "./calculationJobs";
 
 class Statement {
   private values: unknown[] = [];
@@ -29,6 +29,16 @@ describe("calculation job lifecycle", () => {
     db.db.prepare("INSERT INTO calculation_jobs VALUES ('job', 'running', '{}', NULL, NULL, datetime('now', '-5 minutes'), datetime('now'))").run();
     expect(await finishCalculationJobBeforeDeadline(env, "job", status, status === JOB_STATUS.COMPLETED ? "{}" : null, status === JOB_STATUS.FAILED ? "failed" : null)).toBe(false);
     expect((await getCalculationJob(env, "job"))?.status).toBe(JOB_STATUS.RUNNING);
+  });
+
+  it("can record a pre-start failure only while a queued job is inside its deadline", async () => {
+    const db = new TestD1(); const env = envFor(db); await ensureCalculationJobsTable(env);
+    db.db.prepare("INSERT INTO calculation_jobs VALUES ('fresh', 'queued', '{}', NULL, NULL, datetime('now'), datetime('now'))").run();
+    db.db.prepare("INSERT INTO calculation_jobs VALUES ('stale', 'queued', '{}', NULL, NULL, datetime('now', '-5 minutes'), datetime('now'))").run();
+    expect(await failCalculationJobBeforeDeadline(env, "fresh", "read failed")).toBe(true);
+    expect(await failCalculationJobBeforeDeadline(env, "stale", "read failed")).toBe(false);
+    expect((await getCalculationJob(env, "fresh"))?.status).toBe(JOB_STATUS.FAILED);
+    expect((await getCalculationJob(env, "stale"))?.status).toBe(JOB_STATUS.QUEUED);
   });
 
   it("removes terminal rows older than 24 hours and deterministically caps newer rows at 1000", async () => {

--- a/functions/_lib/calculationJobs.test.ts
+++ b/functions/_lib/calculationJobs.test.ts
@@ -1,0 +1,69 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { boundedJobError, cleanupCalculationJobs, createCalculationJob, ensureCalculationJobsTable, finishCalculationJobBeforeDeadline, getCalculationJob, JOB_STATUS, transitionCalculationJob } from "./calculationJobs";
+
+class Statement {
+  private values: unknown[] = [];
+  constructor(private db: DatabaseSync, private sql: string) {}
+  bind(...values: unknown[]) { this.values = values; return this; }
+  async first<T>() { return (this.db.prepare(this.sql).get(...this.values as never[]) as T | undefined) ?? null; }
+  async run() { const result = this.db.prepare(this.sql).run(...this.values as never[]); return { success: true, meta: { changes: Number(result.changes) } }; }
+}
+class TestD1 { db = new DatabaseSync(":memory:"); prepare(sql: string) { return new Statement(this.db, sql); } }
+const envFor = (db: TestD1) => ({ DB: db as unknown as D1Database });
+
+describe("calculation job lifecycle", () => {
+  it("bounds stored errors by UTF-8 bytes", () => {
+    expect(new TextEncoder().encode(boundedJobError("💥".repeat(1000))).byteLength).toBeLessThanOrEqual(1024);
+  });
+  it("uses compare-and-set transitions so a timeout cannot be overwritten", async () => {
+    const db = new TestD1(); const env = envFor(db); await ensureCalculationJobsTable(env); await createCalculationJob(env, "job", "{}");
+    expect(await transitionCalculationJob(env, "job", [JOB_STATUS.QUEUED], JOB_STATUS.RUNNING, null, null)).toBe(true);
+    expect(await transitionCalculationJob(env, "job", [JOB_STATUS.RUNNING], JOB_STATUS.TIMED_OUT, null, "timeout")).toBe(true);
+    expect(await transitionCalculationJob(env, "job", [JOB_STATUS.RUNNING], JOB_STATUS.COMPLETED, "{}", null)).toBe(false);
+    expect((await getCalculationJob(env, "job"))?.status).toBe(JOB_STATUS.TIMED_OUT);
+  });
+
+  it.each([JOB_STATUS.COMPLETED, JOB_STATUS.FAILED] as const)("does not commit %s at the deadline boundary", async (status) => {
+    const db = new TestD1(); const env = envFor(db); await ensureCalculationJobsTable(env);
+    db.db.prepare("INSERT INTO calculation_jobs VALUES ('job', 'running', '{}', NULL, NULL, datetime('now', '-5 minutes'), datetime('now'))").run();
+    expect(await finishCalculationJobBeforeDeadline(env, "job", status, status === JOB_STATUS.COMPLETED ? "{}" : null, status === JOB_STATUS.FAILED ? "failed" : null)).toBe(false);
+    expect((await getCalculationJob(env, "job"))?.status).toBe(JOB_STATUS.RUNNING);
+  });
+
+  it("removes terminal rows older than 24 hours and deterministically caps newer rows at 1000", async () => {
+    const db = new TestD1(); const env = envFor(db); await ensureCalculationJobsTable(env);
+    const insert = db.db.prepare("INSERT INTO calculation_jobs VALUES (?, ?, '{}', NULL, NULL, ?, ?)");
+    insert.run("old", "completed", "2000-01-01 00:00:00", "2000-01-01 00:00:00");
+    db.db.prepare("INSERT INTO calculation_jobs VALUES ('boundary', 'failed', '{}', NULL, NULL, datetime('now', '-25 hours'), datetime('now', '-24 hours'))").run();
+    db.db.prepare("INSERT INTO calculation_jobs VALUES ('queued', 'queued', '{}', NULL, NULL, datetime('now'), datetime('now'))").run();
+    for (let i = 0; i < 1002; i += 1) insert.run(`terminal-${String(i).padStart(4, "0")}`, "completed", "2999-01-01 00:00:00", "2999-01-01 00:00:00");
+    db.db.prepare("UPDATE calculation_jobs SET created_at = '2998-01-01 00:00:00' WHERE id = 'terminal-1001'").run();
+    await cleanupCalculationJobs(env);
+    expect(db.db.prepare("SELECT count(*) count FROM calculation_jobs WHERE status = 'completed'").get()).toEqual({ count: 1000 });
+    expect(db.db.prepare("SELECT id FROM calculation_jobs WHERE id = 'queued'").get()).toEqual({ id: "queued" });
+    expect(db.db.prepare("SELECT id FROM calculation_jobs WHERE id IN ('old', 'boundary', 'terminal-1001')").all()).toEqual([]);
+    expect(db.db.prepare("SELECT id FROM calculation_jobs WHERE status = 'completed' ORDER BY id LIMIT 1").get()).toEqual({ id: "terminal-0001" });
+  });
+
+  it("moves abandoned active rows into the terminal cap while excluding fresh active rows", async () => {
+    const db = new TestD1(); const env = envFor(db); await ensureCalculationJobsTable(env);
+    db.db.prepare("INSERT INTO calculation_jobs VALUES ('stale', 'queued', '{}', NULL, NULL, datetime('now', '-5 minutes'), datetime('now', '-5 minutes'))").run();
+    db.db.prepare("INSERT INTO calculation_jobs VALUES ('fresh', 'running', '{}', NULL, NULL, datetime('now', '-5 minutes', '+1 second'), datetime('now'))").run();
+    const insert = db.db.prepare("INSERT INTO calculation_jobs VALUES (?, 'completed', '{}', '{}', NULL, '2999-01-01 00:00:00', '2999-01-01 00:00:00')");
+    for (let index = 0; index < 1000; index += 1) insert.run(`terminal-${String(index).padStart(4, "0")}`);
+    await cleanupCalculationJobs(env);
+    expect(db.db.prepare("SELECT id FROM calculation_jobs WHERE id = 'stale'").get()).toBeUndefined();
+    expect(db.db.prepare("SELECT status FROM calculation_jobs WHERE id = 'fresh'").get()).toEqual({ status: JOB_STATUS.RUNNING });
+    expect(db.db.prepare("SELECT count(*) count FROM calculation_jobs WHERE status IN ('completed', 'failed', 'timed_out')").get()).toEqual({ count: 1000 });
+  });
+
+  it("prevents late completion after global cleanup times out an abandoned worker", async () => {
+    const db = new TestD1(); const env = envFor(db); await ensureCalculationJobsTable(env);
+    db.db.prepare("INSERT INTO calculation_jobs VALUES ('stale', 'running', '{}', NULL, NULL, datetime('now', '-5 minutes'), datetime('now', '-5 minutes'))").run();
+    await cleanupCalculationJobs(env);
+    expect((await getCalculationJob(env, "stale"))?.status).toBe(JOB_STATUS.TIMED_OUT);
+    expect(await transitionCalculationJob(env, "stale", [JOB_STATUS.RUNNING], JOB_STATUS.COMPLETED, "{}", null)).toBe(false);
+    expect((await getCalculationJob(env, "stale"))?.status).toBe(JOB_STATUS.TIMED_OUT);
+  });
+});

--- a/functions/_lib/calculationJobs.ts
+++ b/functions/_lib/calculationJobs.ts
@@ -1,0 +1,122 @@
+import {
+  MAX_JOB_ERROR_LENGTH,
+  MAX_JOB_RUNTIME_MS,
+  MAX_TERMINAL_JOBS,
+  TERMINAL_JOB_RETENTION_HOURS,
+} from "./calculateShared";
+import type { Env } from "./types";
+
+export const JOB_STATUS = {
+  QUEUED: "queued",
+  RUNNING: "running",
+  COMPLETED: "completed",
+  FAILED: "failed",
+  TIMED_OUT: "timed_out",
+} as const;
+
+export type JobStatus = (typeof JOB_STATUS)[keyof typeof JOB_STATUS];
+export type JobRow = {
+  id: string;
+  status: string;
+  input_json: string;
+  result_json: string | null;
+  error_message: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+const terminalStatuses = [JOB_STATUS.COMPLETED, JOB_STATUS.FAILED, JOB_STATUS.TIMED_OUT] as const;
+const jobRuntimeMinutes = MAX_JOB_RUNTIME_MS / 60_000;
+
+export const boundedJobError = (message: string): string => {
+  let result = "";
+  let bytes = 0;
+  for (const char of message) {
+    const charBytes = new TextEncoder().encode(char).byteLength;
+    if (bytes + charBytes > MAX_JOB_ERROR_LENGTH) break;
+    result += char;
+    bytes += charBytes;
+  }
+  return result;
+};
+
+export const ensureCalculationJobsTable = async (env: Env): Promise<void> => {
+  await env.DB.prepare(
+    "CREATE TABLE IF NOT EXISTS calculation_jobs (id TEXT PRIMARY KEY, status TEXT NOT NULL DEFAULT 'queued', input_json TEXT NOT NULL, result_json TEXT, error_message TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL)",
+  ).run();
+};
+
+export const getCalculationJob = async (env: Env, jobId: string): Promise<JobRow | null> =>
+  env.DB.prepare(
+    "SELECT id, status, input_json, result_json, error_message, created_at, updated_at FROM calculation_jobs WHERE id = ?",
+  ).bind(jobId).first<JobRow>();
+
+export const createCalculationJob = async (env: Env, jobId: string, inputJson: string): Promise<void> => {
+  await env.DB.prepare(
+    "INSERT INTO calculation_jobs (id, status, input_json, created_at, updated_at) VALUES (?, ?, ?, datetime('now'), datetime('now'))",
+  ).bind(jobId, JOB_STATUS.QUEUED, inputJson).run();
+};
+
+export const transitionCalculationJob = async (
+  env: Env,
+  jobId: string,
+  fromStatuses: readonly JobStatus[],
+  status: JobStatus,
+  resultJson: string | null,
+  errorMessage: string | null,
+): Promise<boolean> => {
+  const placeholders = fromStatuses.map(() => "?").join(", ");
+  const result = await env.DB.prepare(
+    `UPDATE calculation_jobs SET status = ?, result_json = ?, error_message = ?, updated_at = datetime('now') WHERE id = ? AND status IN (${placeholders})`,
+  ).bind(status, resultJson, errorMessage === null ? null : boundedJobError(errorMessage), jobId, ...fromStatuses).run();
+  return Number(result.meta?.changes ?? 0) > 0;
+};
+
+export const finishCalculationJobBeforeDeadline = async (
+  env: Env,
+  jobId: string,
+  status: typeof JOB_STATUS.COMPLETED | typeof JOB_STATUS.FAILED,
+  resultJson: string | null,
+  errorMessage: string | null,
+): Promise<boolean> => {
+  const result = await env.DB.prepare(
+    `UPDATE calculation_jobs SET status = ?, result_json = ?, error_message = ?, updated_at = datetime('now') WHERE id = ? AND status = ? AND created_at > datetime('now', '-${jobRuntimeMinutes} minutes')`,
+  ).bind(
+    status,
+    resultJson,
+    errorMessage === null ? null : boundedJobError(errorMessage),
+    jobId,
+    JOB_STATUS.RUNNING,
+  ).run();
+  return Number(result.meta?.changes ?? 0) > 0;
+};
+
+export const timeoutCalculationJob = async (env: Env, jobId: string): Promise<boolean> =>
+  transitionCalculationJob(env, jobId, [JOB_STATUS.RUNNING], JOB_STATUS.TIMED_OUT, null, "Terrain job timed out.");
+
+export const getAddressedCalculationJob = async (env: Env, jobId: string): Promise<JobRow | null> => {
+  await env.DB.prepare(
+    `UPDATE calculation_jobs SET status = ?, result_json = NULL, error_message = ?, updated_at = datetime('now') WHERE id = ? AND status IN (?, ?) AND created_at <= datetime('now', '-${jobRuntimeMinutes} minutes')`,
+  ).bind(JOB_STATUS.TIMED_OUT, "Terrain job timed out.", jobId, JOB_STATUS.QUEUED, JOB_STATUS.RUNNING).run();
+  await env.DB.prepare(
+    `DELETE FROM calculation_jobs WHERE id = ? AND status IN (?, ?, ?) AND updated_at <= datetime('now', '-${TERMINAL_JOB_RETENTION_HOURS} hours')`,
+  ).bind(jobId, ...terminalStatuses).run();
+  return getCalculationJob(env, jobId);
+};
+
+export const cleanupCalculationJobs = async (env: Env): Promise<void> => {
+  await env.DB.prepare("CREATE INDEX IF NOT EXISTS idx_calculation_jobs_status ON calculation_jobs(status)").run();
+  await env.DB.prepare("CREATE INDEX IF NOT EXISTS idx_calculation_jobs_created_at ON calculation_jobs(created_at)").run();
+  await env.DB.prepare(
+    `UPDATE calculation_jobs SET status = ?, result_json = NULL, error_message = ?, updated_at = datetime('now') WHERE status IN (?, ?) AND created_at <= datetime('now', '-${jobRuntimeMinutes} minutes')`,
+  ).bind(JOB_STATUS.TIMED_OUT, "Terrain job timed out.", JOB_STATUS.QUEUED, JOB_STATUS.RUNNING).run();
+  await env.DB.prepare(
+    `DELETE FROM calculation_jobs WHERE status IN (?, ?, ?) AND updated_at <= datetime('now', '-${TERMINAL_JOB_RETENTION_HOURS} hours')`,
+  ).bind(...terminalStatuses).run();
+  await env.DB.prepare(
+    `DELETE FROM calculation_jobs WHERE id IN (
+      SELECT id FROM calculation_jobs WHERE status IN (?, ?, ?)
+      ORDER BY updated_at DESC, created_at DESC, id DESC LIMIT -1 OFFSET ${MAX_TERMINAL_JOBS}
+    )`,
+  ).bind(...terminalStatuses).run();
+};

--- a/functions/_lib/calculationJobs.ts
+++ b/functions/_lib/calculationJobs.ts
@@ -78,21 +78,38 @@ export const finishCalculationJobBeforeDeadline = async (
   status: typeof JOB_STATUS.COMPLETED | typeof JOB_STATUS.FAILED,
   resultJson: string | null,
   errorMessage: string | null,
+  fromStatuses: readonly JobStatus[] = [JOB_STATUS.RUNNING],
 ): Promise<boolean> => {
+  const placeholders = fromStatuses.map(() => "?").join(", ");
   const result = await env.DB.prepare(
-    `UPDATE calculation_jobs SET status = ?, result_json = ?, error_message = ?, updated_at = datetime('now') WHERE id = ? AND status = ? AND created_at > datetime('now', '-${jobRuntimeMinutes} minutes')`,
+    `UPDATE calculation_jobs SET status = ?, result_json = ?, error_message = ?, updated_at = datetime('now') WHERE id = ? AND status IN (${placeholders}) AND created_at > datetime('now', '-${jobRuntimeMinutes} minutes')`,
   ).bind(
     status,
     resultJson,
     errorMessage === null ? null : boundedJobError(errorMessage),
     jobId,
-    JOB_STATUS.RUNNING,
+    ...fromStatuses,
   ).run();
   return Number(result.meta?.changes ?? 0) > 0;
 };
 
+export const failCalculationJobBeforeDeadline = async (
+  env: Env,
+  jobId: string,
+  errorMessage: string,
+): Promise<boolean> => {
+  return finishCalculationJobBeforeDeadline(
+    env,
+    jobId,
+    JOB_STATUS.FAILED,
+    null,
+    errorMessage,
+    [JOB_STATUS.QUEUED, JOB_STATUS.RUNNING],
+  );
+};
+
 export const timeoutCalculationJob = async (env: Env, jobId: string): Promise<boolean> =>
-  transitionCalculationJob(env, jobId, [JOB_STATUS.RUNNING], JOB_STATUS.TIMED_OUT, null, "Terrain job timed out.");
+  transitionCalculationJob(env, jobId, [JOB_STATUS.QUEUED, JOB_STATUS.RUNNING], JOB_STATUS.TIMED_OUT, null, "Terrain job timed out.");
 
 export const getAddressedCalculationJob = async (env: Env, jobId: string): Promise<JobRow | null> => {
   await env.DB.prepare(

--- a/functions/_lib/rateLimit.test.ts
+++ b/functions/_lib/rateLimit.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { getClientAddress, takeRateLimitToken } from "./rateLimit";
+import { getClientAddress, parsePerMinuteLimit, takeRateLimitToken } from "./rateLimit";
 
 describe("rate limit helpers", () => {
+  it("parses configured per-minute limits without losing route fallbacks", () => {
+    expect(parsePerMinuteLimit(undefined, 120)).toBe(120);
+    expect(parsePerMinuteLimit("", 60)).toBe(60);
+    expect(parsePerMinuteLimit("invalid", 120)).toBe(120);
+    expect(parsePerMinuteLimit("2.9", 120)).toBe(2);
+    expect(parsePerMinuteLimit("0", 120)).toBe(1);
+  });
   it("uses only Cloudflare-established client identity", () => {
     const cfReq = new Request("https://example.test", {
       headers: {

--- a/functions/_lib/rateLimit.ts
+++ b/functions/_lib/rateLimit.ts
@@ -21,6 +21,13 @@ let callsSinceSweep = 0;
 
 const DEFAULT_WINDOW_MS = 60_000;
 
+export const parsePerMinuteLimit = (raw: string | undefined, fallback: number): number => {
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(1, Math.floor(parsed));
+};
+
 const sweepExpiredBuckets = (nowMs: number) => {
   for (const [key, bucket] of buckets.entries()) {
     if (bucket.windowStartMs + DEFAULT_WINDOW_MS * 4 < nowMs) buckets.delete(key);

--- a/functions/_lib/terrainAnalysis.test.ts
+++ b/functions/_lib/terrainAnalysis.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const { readRastersMock } = vi.hoisted(() => ({ readRastersMock: vi.fn() }));
+
 vi.mock("geotiff", () => ({
   fromArrayBuffer: vi.fn(async () => ({
     getImage: async () => ({
@@ -7,7 +9,7 @@ vi.mock("geotiff", () => ({
       getHeight: () => 3601,
       getBoundingBox: () => [9, 60, 10, 61],
       getGDALNoData: () => null,
-      readRasters: async () => new Int16Array([100, 101, 102, 103]),
+      readRasters: readRastersMock,
     }),
   })),
 }));
@@ -17,6 +19,8 @@ import { loadCopernicusTilesForPath } from "./terrainAnalysis";
 describe("calculation API GLO-30 terrain loading", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    readRastersMock.mockReset();
+    readRastersMock.mockResolvedValue(new Int16Array([100, 101, 102, 103]));
   });
 
   it("requests deterministic GLO-30 objects without tile lists or GLO-90", async () => {
@@ -46,5 +50,24 @@ describe("calculation API GLO-30 terrain loading", () => {
         "https://linksim.link/api/v1/calculate",
       ),
     ).resolves.toEqual({ tiles: [], tileKeys: [] });
+  });
+
+  it("observes cancellation while GeoTIFF raster decoding is in progress", async () => {
+    let finishDecode: ((value: Int16Array) => void) | undefined;
+    readRastersMock.mockReturnValueOnce(new Promise<Int16Array>((resolve) => { finishDecode = resolve; }));
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(new Uint8Array([1]), { status: 200 })));
+    const controller = new AbortController();
+
+    const loading = loadCopernicusTilesForPath(
+      { lat: 60.1, lon: 9.1 },
+      { lat: 60.2, lon: 9.2 },
+      "https://linksim.link/api/v1/calculate",
+      controller.signal,
+    );
+    await vi.waitFor(() => expect(readRastersMock).toHaveBeenCalledTimes(1));
+    controller.abort();
+    finishDecode?.(new Int16Array([100, 101, 102, 103]));
+
+    await expect(loading).rejects.toMatchObject({ name: "AbortError" });
   });
 });

--- a/functions/_lib/terrainAnalysis.ts
+++ b/functions/_lib/terrainAnalysis.ts
@@ -70,9 +70,13 @@ const parseCopernicusTile = async (
   key: string,
   buffer: ArrayBuffer,
   bounds: TerrainBounds,
+  signal?: AbortSignal,
 ): Promise<CompactTerrainTile | null> => {
+  signal?.throwIfAborted();
   const tiff = await fromArrayBuffer(buffer);
+  signal?.throwIfAborted();
   const image = await tiff.getImage();
+  signal?.throwIfAborted();
   const width = image.getWidth();
   const height = image.getHeight();
   const [minLon, minLat, maxLon, maxLat] = image.getBoundingBox();
@@ -121,10 +125,12 @@ const parseCopernicusTile = async (
     width: targetW,
     height: targetH,
   });
+  signal?.throwIfAborted();
   const nodataNumeric = nodata === null ? NaN : Number(nodata);
   const result = new Int16Array(targetW * targetH);
 
   for (let i = 0; i < result.length; i += 1) {
+    if (i % 1024 === 0) signal?.throwIfAborted();
     const value = Number((raster as ArrayLike<number>)[i]);
     if (!Number.isFinite(value) || (Number.isFinite(nodataNumeric) && Math.abs(value - nodataNumeric) <= 0.01)) {
       result[i] = -32768;
@@ -146,11 +152,12 @@ const parseCopernicusTile = async (
   };
 };
 
-const fetchTile = async (origin: string, key: string, bounds: TerrainBounds): Promise<CompactTerrainTile | null> => {
-  const response = await fetch(`${origin}${copernicus30PathForTileKey(key)}`);
+const fetchTile = async (origin: string, key: string, bounds: TerrainBounds, signal?: AbortSignal): Promise<CompactTerrainTile | null> => {
+  const response = await fetch(`${origin}${copernicus30PathForTileKey(key)}`, { signal });
   if (!response.ok) return null;
   const buffer = await response.arrayBuffer();
-  return parseCopernicusTile(key, buffer, bounds);
+  signal?.throwIfAborted();
+  return parseCopernicusTile(key, buffer, bounds, signal);
 };
 
 const sampleTerrainElevation = (
@@ -180,6 +187,7 @@ export const loadCopernicusTilesForPath = async (
   from: { lat: number; lon: number },
   to: { lat: number; lon: number },
   requestUrl: string,
+  signal?: AbortSignal,
 ): Promise<{ tiles: CompactTerrainTile[]; tileKeys: string[] }> => {
   const origin = new URL(requestUrl).origin;
   const bounds = toTerrainBounds(from, to);
@@ -189,7 +197,8 @@ export const loadCopernicusTilesForPath = async (
   const tiles: CompactTerrainTile[] = [];
   const fetchedKeys: string[] = [];
   for (const key of neededKeys) {
-    const tile = await fetchTile(origin, key, bounds);
+    signal?.throwIfAborted();
+    const tile = await fetchTile(origin, key, bounds, signal);
     if (!tile) continue;
     tiles.push(tile);
     fetchedKeys.push(`${key}:copernicus30`);
@@ -205,13 +214,16 @@ export const analyzeTerrainLink = async (
   toSite: { lat: number; lon: number; name: string; txPowerDbm: number; txGainDbi: number; rxGainDbi: number; cableLossDb: number; antennaHeightM: number; groundElevationM?: number },
   frequencyMhz: number,
   samples: number,
+  signal?: AbortSignal,
 ): Promise<TerrainAnalysisResult> => {
   void env;
   const { tiles, tileKeys } = await loadCopernicusTilesForPath(
     { lat: fromSite.lat, lon: fromSite.lon },
     { lat: toSite.lat, lon: toSite.lon },
     requestUrl,
+    signal,
   );
+  signal?.throwIfAborted();
   if (!tiles.length) {
     throw new Error("No terrain tiles available for this region");
   }
@@ -253,10 +265,12 @@ export const analyzeTerrainLink = async (
     cableLossDb: from.cableLossDb,
   };
 
+  signal?.throwIfAborted();
   const analysis = analyzeLink(link, from, to, "ITM", terrainSampler, {
     terrainSamples: Math.max(24, Math.round(samples)),
     environment: defaultPropagationEnvironment(),
   });
+  signal?.throwIfAborted();
 
   const maxIntrusionM = Math.max(0, -analysis.worstFresnelClearanceM);
   return {

--- a/functions/api/v1/calculate.jobs.jobId.test.ts
+++ b/functions/api/v1/calculate.jobs.jobId.test.ts
@@ -1,13 +1,29 @@
+import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it, vi } from "vitest";
+import { JOB_STATUS, transitionCalculationJob } from "../../_lib/calculationJobs";
 import { onRequestGet, onRequestOptions } from "./calculate.jobs.jobId";
 
 const makeEnv = (row: unknown = null) => {
   const first = vi.fn(async () => row);
   const bind = vi.fn(() => ({ first }));
   const run = vi.fn(async () => ({ success: true }));
-  const prepare = vi.fn((sql: string) => sql.startsWith("CREATE TABLE") ? { run } : { bind });
+  const prepare = vi.fn((sql: string) => sql.startsWith("CREATE TABLE") ? { run } : sql.startsWith("UPDATE") || sql.startsWith("DELETE") ? { bind: () => ({ run }) } : { bind });
   return { env: { DB: { prepare } } as unknown as Parameters<typeof onRequestGet>[0]["env"], first };
 };
+
+class Statement {
+  private values: unknown[] = [];
+  constructor(private db: DatabaseSync, private sql: string) {}
+  bind(...values: unknown[]) { this.values = values; return this; }
+  async first<T>() { return (this.db.prepare(this.sql).get(...this.values as never[]) as T | undefined) ?? null; }
+  async run() { const result = this.db.prepare(this.sql).run(...this.values as never[]); return { success: true, meta: { changes: Number(result.changes) } }; }
+}
+class TestD1 {
+  db = new DatabaseSync(":memory:");
+  constructor() { this.db.exec("CREATE TABLE calculation_jobs (id TEXT PRIMARY KEY, status TEXT NOT NULL, input_json TEXT NOT NULL, result_json TEXT, error_message TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL)"); }
+  prepare(sql: string) { return new Statement(this.db, sql); }
+}
+const envFor = (db: TestD1) => ({ DB: db as unknown as D1Database });
 
 describe("api/v1/calculate job status CORS", () => {
   it("keeps an originless API client free of CORS authorization headers", async () => {
@@ -18,6 +34,7 @@ describe("api/v1/calculate job status CORS", () => {
     });
 
     expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "Job not found." });
     expect(response.headers.get("access-control-allow-origin")).toBeNull();
     expect(response.headers.get("access-control-allow-credentials")).toBeNull();
   });
@@ -44,6 +61,24 @@ describe("api/v1/calculate job status CORS", () => {
     expect(response.headers.get("access-control-allow-credentials")).toBe("true");
   });
 
+  it("preserves malformed stored result strings for polling compatibility", async () => {
+    const { env } = makeEnv({
+      id: "job-1", status: "completed", input_json: "{}", result_json: "not-json", error_message: null,
+      created_at: "2026-08-13T00:00:00Z", updated_at: "2026-08-13T00:00:01Z",
+    });
+    const response = await onRequestGet({ request: new Request("https://linksim.link/api/v1/calculate/jobs/job-1"), env });
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ status: "completed", result: "not-json" });
+  });
+
+  it("does not impose a guessed job ID length quota", async () => {
+    const { env } = makeEnv();
+    const longId = "job-" + "x".repeat(1024);
+    const response = await onRequestGet({ request: new Request(`https://linksim.link/api/v1/calculate/jobs/${longId}`), env });
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "Job not found." });
+  });
+
   it("uses the shared preflight policy for the local Vite exception", async () => {
     const { env } = makeEnv();
     const response = await onRequestOptions({
@@ -60,5 +95,33 @@ describe("api/v1/calculate job status CORS", () => {
     expect(response.status).toBe(204);
     expect(response.headers.get("access-control-allow-origin")).toBe("http://localhost:5174");
     expect(response.headers.get("access-control-allow-credentials")).toBe("true");
+  });
+
+  it.each([JOB_STATUS.QUEUED, JOB_STATUS.RUNNING])("atomically times out addressed stale %s jobs at the five-minute boundary", async (status) => {
+    const db = new TestD1();
+    db.db.prepare("INSERT INTO calculation_jobs VALUES (?, ?, '{}', NULL, NULL, datetime('now', '-5 minutes'), datetime('now', '-5 minutes'))").run(`stale-${status}`, status);
+    const response = await onRequestGet({ request: new Request(`https://linksim.link/api/v1/calculate/jobs/stale-${status}`), env: envFor(db) });
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ status: JOB_STATUS.TIMED_OUT, error: "Job timed out before completion." });
+    expect(await transitionCalculationJob(envFor(db), `stale-${status}`, [JOB_STATUS.RUNNING], JOB_STATUS.COMPLETED, "{}", null)).toBe(false);
+    expect(db.db.prepare("SELECT status FROM calculation_jobs WHERE id = ?").get(`stale-${status}`)).toEqual({ status: JOB_STATUS.TIMED_OUT });
+  });
+
+  it("expires an addressed terminal job at the inclusive 24-hour boundary", async () => {
+    const db = new TestD1();
+    db.db.prepare("INSERT INTO calculation_jobs VALUES ('expired', 'completed', '{}', '{}', NULL, datetime('now', '-25 hours'), datetime('now', '-24 hours'))").run();
+    const response = await onRequestGet({ request: new Request("https://linksim.link/api/v1/calculate/jobs/expired"), env: envFor(db) });
+    expect(response.status).toBe(404);
+    expect(db.db.prepare("SELECT id FROM calculation_jobs WHERE id = 'expired'").get()).toBeUndefined();
+  });
+
+  it("keeps addressed active and terminal jobs immediately inside their boundaries", async () => {
+    const db = new TestD1();
+    db.db.prepare("INSERT INTO calculation_jobs VALUES ('active', 'queued', '{}', NULL, NULL, datetime('now', '-5 minutes', '+1 second'), datetime('now'))").run();
+    db.db.prepare("INSERT INTO calculation_jobs VALUES ('terminal', 'failed', '{}', NULL, 'failed', datetime('now', '-25 hours'), datetime('now', '-24 hours', '+1 second'))").run();
+    const active = await onRequestGet({ request: new Request("https://linksim.link/api/v1/calculate/jobs/active"), env: envFor(db) });
+    const terminal = await onRequestGet({ request: new Request("https://linksim.link/api/v1/calculate/jobs/terminal"), env: envFor(db) });
+    await expect(active.json()).resolves.toMatchObject({ status: JOB_STATUS.QUEUED });
+    await expect(terminal.json()).resolves.toMatchObject({ status: JOB_STATUS.FAILED });
   });
 });

--- a/functions/api/v1/calculate.jobs.jobId.ts
+++ b/functions/api/v1/calculate.jobs.jobId.ts
@@ -1,103 +1,24 @@
-import { handleOptions, withCors } from "../../_lib/http";
+import { errorResponse, handleOptions, json, withCors } from "../../_lib/http";
+import { boundedJobError, ensureCalculationJobsTable, getAddressedCalculationJob, JOB_STATUS } from "../../_lib/calculationJobs";
 import type { Env } from "../../_lib/types";
 
-type Context = {
-  request: Request;
-  env: Env;
-};
-
-const JOB_STATUS = {
-  QUEUED: "queued",
-  RUNNING: "running",
-  COMPLETED: "completed",
-  FAILED: "failed",
-  TIMED_OUT: "timed_out",
-} as const;
-
-const ensureCalculationJobsTable = async (env: Env): Promise<void> => {
-  await env.DB.prepare(
-    "CREATE TABLE IF NOT EXISTS calculation_jobs (id TEXT PRIMARY KEY, status TEXT NOT NULL DEFAULT 'queued', input_json TEXT NOT NULL, result_json TEXT, error_message TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL)",
-  ).run();
-};
-
-const getJob = async (env: Env, jobId: string) => {
-  const stmt = env.DB.prepare(
-    "SELECT id, status, input_json, result_json, error_message, created_at, updated_at FROM calculation_jobs WHERE id = ?",
-  );
-  const row = await stmt.bind(jobId).first<{
-    id: string;
-    status: string;
-    input_json: string;
-    result_json: string | null;
-    error_message: string | null;
-    created_at: string;
-    updated_at: string;
-  }>();
-  return row;
-};
+type Context = { request: Request; env: Env };
 
 export const onRequestOptions = async ({ request }: Context) => handleOptions(request);
 
 export const onRequestGet = async ({ request, env }: Context) => {
-  const url = new URL(request.url);
-  const jobId = url.pathname.split("/").pop();
-
-  if (!jobId) {
-    return withCors(request, new Response(JSON.stringify({ error: "Job ID is required." }), {
-      status: 400,
-      headers: { "content-type": "application/json" },
-    }));
-  }
-
+  const jobId = new URL(request.url).pathname.split("/").pop();
+  if (!jobId) return withCors(request, json({ error: "Job ID is required." }, { status: 400 }));
   try {
     await ensureCalculationJobsTable(env);
-    const job = await getJob(env, jobId);
-
-    if (!job) {
-      return withCors(request, new Response(
-        JSON.stringify({ error: "Job not found." }),
-        {
-          status: 404,
-          headers: { "content-type": "application/json" },
-        },
-      ));
-    }
-
-    const response: Record<string, unknown> = {
-      job_id: job.id,
-      status: job.status,
-      created_at: job.created_at,
-      updated_at: job.updated_at,
-    };
-
+    const job = await getAddressedCalculationJob(env, jobId);
+    if (!job) return withCors(request, json({ error: "Job not found." }, { status: 404 }));
+    const response: Record<string, unknown> = { job_id: job.id, status: job.status, created_at: job.created_at, updated_at: job.updated_at };
     if (job.status === JOB_STATUS.COMPLETED && job.result_json) {
-      try {
-        response.result = JSON.parse(job.result_json);
-      } catch {
-        response.result = job.result_json;
-      }
+      try { response.result = JSON.parse(job.result_json); } catch { response.result = job.result_json; }
     }
-
-    if (job.status === JOB_STATUS.FAILED && job.error_message) {
-      response.error = job.error_message;
-    }
-
-    if (job.status === JOB_STATUS.TIMED_OUT) {
-      response.error = "Job timed out before completion.";
-    }
-
-    return withCors(request, new Response(JSON.stringify(response), {
-      status: 200,
-      headers: { "content-type": "application/json" },
-    }));
-  } catch (error) {
-    const message = error instanceof Error ? error.message : "Internal error";
-    return withCors(request, new Response(
-      JSON.stringify({ error: message }),
-      {
-        status: 500,
-        headers: { "content-type": "application/json" },
-      },
-    ));
-  }
+    if (job.status === JOB_STATUS.FAILED && job.error_message) response.error = boundedJobError(job.error_message);
+    if (job.status === JOB_STATUS.TIMED_OUT) response.error = "Job timed out before completion.";
+    return withCors(request, json(response));
+  } catch (error) { return errorResponse(request, error, 500); }
 };

--- a/functions/api/v1/calculate.jobs.test.ts
+++ b/functions/api/v1/calculate.jobs.test.ts
@@ -1,5 +1,5 @@
 import { DatabaseSync } from "node:sqlite";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { analyzeTerrainLinkMock } = vi.hoisted(() => ({ analyzeTerrainLinkMock: vi.fn() }));
 vi.mock("../../_lib/terrainAnalysis", () => ({ analyzeTerrainLink: analyzeTerrainLinkMock }));
@@ -9,15 +9,23 @@ import { JOB_STATUS } from "../../_lib/calculationJobs";
 
 class Statement {
   private values: unknown[] = [];
-  constructor(private db: DatabaseSync, private sql: string, private beforeRun?: (sql: string, values: unknown[]) => void | Promise<void>) {}
+  constructor(
+    private db: DatabaseSync,
+    private sql: string,
+    private beforeRun?: (sql: string, values: unknown[]) => void | Promise<void>,
+    private beforeFirst?: (sql: string, values: unknown[]) => void | Promise<void>,
+  ) {}
   bind(...values: unknown[]) { this.values = values; return this; }
-  async first<T>() { return (this.db.prepare(this.sql).get(...this.values as never[]) as T | undefined) ?? null; }
+  async first<T>() { await this.beforeFirst?.(this.sql, this.values); return (this.db.prepare(this.sql).get(...this.values as never[]) as T | undefined) ?? null; }
   async run() { await this.beforeRun?.(this.sql, this.values); const result = this.db.prepare(this.sql).run(...this.values as never[]); return { success: true, meta: { changes: Number(result.changes) } }; }
 }
 class TestD1 {
   db = new DatabaseSync(":memory:");
-  constructor(private beforeRun?: (sql: string, values: unknown[]) => void | Promise<void>) {}
-  prepare(sql: string) { return new Statement(this.db, sql, this.beforeRun); }
+  constructor(
+    private beforeRun?: (sql: string, values: unknown[]) => void | Promise<void>,
+    private beforeFirst?: (sql: string, values: unknown[]) => void | Promise<void>,
+  ) {}
+  prepare(sql: string) { return new Statement(this.db, sql, this.beforeRun, this.beforeFirst); }
 }
 const envFor = (db: TestD1) => ({ DB: db as unknown as D1Database });
 const input = JSON.stringify({ calculation: "link_budget", input: { from_site: "A", to_site: "B", frequency_mhz: 868, mode: "terrain", nodes: [
@@ -36,6 +44,7 @@ const bodyAtDepth = (depth: number): string => {
   return JSON.stringify({ ...JSON.parse(input) as Record<string, unknown>, padding });
 };
 
+beforeEach(() => vi.clearAllMocks());
 afterEach(() => vi.useRealTimers());
 describe("terrain calculation jobs", () => {
   it("accepts exactly 2000 km with the 500-sample cap and rejects above it", () => {
@@ -114,6 +123,25 @@ describe("terrain calculation jobs", () => {
     const row = db.db.prepare("SELECT status, error_message FROM calculation_jobs WHERE id = 'job'").get() as { status: string; error_message: string };
     expect(row.status).toBe("failed");
     expect(new TextEncoder().encode(row.error_message).byteLength).toBeLessThanOrEqual(1024);
+  });
+
+  it("records a transient initial job lookup failure instead of leaving the job queued", async () => {
+    let failFirstRead = true;
+    const db = new TestD1(undefined, (sql) => {
+      if (failFirstRead && sql.startsWith("SELECT")) {
+        failFirstRead = false;
+        throw new Error("Transient D1 read failure");
+      }
+    });
+    db.db.exec("CREATE TABLE calculation_jobs (id TEXT PRIMARY KEY, status TEXT NOT NULL, input_json TEXT NOT NULL, result_json TEXT, error_message TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL)");
+    db.db.prepare("INSERT INTO calculation_jobs VALUES ('job', 'queued', ?, NULL, NULL, datetime('now'), datetime('now'))").run(input);
+
+    await expect(processTerrainJob(envFor(db), "job", "https://linksim.link/api/v1/calculate/jobs")).resolves.toBeUndefined();
+    expect(db.db.prepare("SELECT status, error_message FROM calculation_jobs WHERE id = 'job'").get()).toEqual({
+      status: JOB_STATUS.FAILED,
+      error_message: "Transient D1 read failure",
+    });
+    expect(analyzeTerrainLinkMock).not.toHaveBeenCalled();
   });
 
   it("times out when terrain resolves before the deadline but the completion write crosses it", async () => {

--- a/functions/api/v1/calculate.jobs.test.ts
+++ b/functions/api/v1/calculate.jobs.test.ts
@@ -1,0 +1,131 @@
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { analyzeTerrainLinkMock } = vi.hoisted(() => ({ analyzeTerrainLinkMock: vi.fn() }));
+vi.mock("../../_lib/terrainAnalysis", () => ({ analyzeTerrainLink: analyzeTerrainLinkMock }));
+import { onRequestPost, processTerrainJob, validateTerrainRequest } from "./calculate.jobs";
+import { normalizeCalculationRequest } from "../../_lib/calculateShared";
+import { JOB_STATUS } from "../../_lib/calculationJobs";
+
+class Statement {
+  private values: unknown[] = [];
+  constructor(private db: DatabaseSync, private sql: string, private beforeRun?: (sql: string, values: unknown[]) => void | Promise<void>) {}
+  bind(...values: unknown[]) { this.values = values; return this; }
+  async first<T>() { return (this.db.prepare(this.sql).get(...this.values as never[]) as T | undefined) ?? null; }
+  async run() { await this.beforeRun?.(this.sql, this.values); const result = this.db.prepare(this.sql).run(...this.values as never[]); return { success: true, meta: { changes: Number(result.changes) } }; }
+}
+class TestD1 {
+  db = new DatabaseSync(":memory:");
+  constructor(private beforeRun?: (sql: string, values: unknown[]) => void | Promise<void>) {}
+  prepare(sql: string) { return new Statement(this.db, sql, this.beforeRun); }
+}
+const envFor = (db: TestD1) => ({ DB: db as unknown as D1Database });
+const input = JSON.stringify({ calculation: "link_budget", input: { from_site: "A", to_site: "B", frequency_mhz: 868, mode: "terrain", nodes: [
+  { name: "A", lat: 1, lon: 1 }, { name: "B", lat: 2, lon: 2 },
+] } });
+const terrainResult = { distanceKm: 10, baselineFsplDb: 100, terrainPenaltyDb: 1, totalPathLossDb: 101,
+  terrainObstructed: false, maxIntrusionM: 0, fresnelClearancePercent: 100, samplesUsed: 24,
+  tilesFetched: ["N00E000:copernicus30"], fromGroundM: 0, toGroundM: 0 };
+const bodyAtSize = (size: number): string => {
+  const base = JSON.stringify({ ...JSON.parse(input) as Record<string, unknown>, padding: "" });
+  return `${base.slice(0, -2)}${"x".repeat(size - new TextEncoder().encode(base).byteLength)}"}`;
+};
+const bodyAtDepth = (depth: number): string => {
+  let padding: unknown = 0;
+  for (let level = 1; level < depth; level += 1) padding = [padding];
+  return JSON.stringify({ ...JSON.parse(input) as Record<string, unknown>, padding });
+};
+
+afterEach(() => vi.useRealTimers());
+describe("terrain calculation jobs", () => {
+  it("accepts exactly 2000 km with the 500-sample cap and rejects above it", () => {
+    const payloadFor = (distanceKm: number) => normalizeCalculationRequest({ calculation: "link_budget", input: {
+      from_site: "A", to_site: "B", frequency_mhz: 868, mode: "terrain",
+      nodes: [{ name: "A", lat: 0, lon: 0 }, { name: "B", lat: 0, lon: distanceKm / 6371 * 180 / Math.PI }],
+    } });
+    expect(validateTerrainRequest(payloadFor(2000))).toMatchObject({ distanceKm: expect.closeTo(2000, 9), samples: 500 });
+    expect(() => validateTerrainRequest(payloadFor(2000.001))).toThrow("exceeds maximum of 2000 km");
+  });
+  it("accepts exactly 64 KiB and depth 10, then rejects plus one and depth 11", async () => {
+    analyzeTerrainLinkMock.mockResolvedValue(terrainResult);
+    const submit = async (body: string) => {
+      const db = new TestD1(); let processing: Promise<unknown> | undefined;
+      const response = await onRequestPost({ request: new Request("https://linksim.link/api/v1/calculate/jobs", { method: "POST", body }), env: envFor(db), waitUntil: (promise) => { processing = promise; } });
+      if (processing) await processing;
+      return response;
+    };
+    expect((await submit(bodyAtSize(65_536))).status).toBe(202);
+    expect((await submit(bodyAtSize(65_537))).status).toBe(413);
+    expect((await submit(bodyAtDepth(10))).status).toBe(202);
+    expect((await submit(bodyAtDepth(11))).status).toBe(422);
+  });
+
+  it("preserves direct POST job charging through the existing configured limiter", async () => {
+    analyzeTerrainLinkMock.mockResolvedValue(terrainResult);
+    const submit = async () => {
+      const db = new TestD1(); let processing: Promise<unknown> | undefined;
+      const response = await onRequestPost({
+        request: new Request("https://linksim.link/api/v1/calculate/jobs", {
+          method: "POST",
+          headers: { "cf-connecting-ip": "198.51.100.201" },
+          body: input,
+        }),
+        env: { ...envFor(db), CALC_API_PROXY_RATE_LIMIT_PER_MINUTE: "1" },
+        waitUntil: (promise) => { processing = promise; },
+      });
+      if (processing) await processing;
+      return response;
+    };
+
+    expect((await submit()).status).toBe(202);
+    const limited = await submit();
+    expect(limited.status).toBe(429);
+    expect(limited.headers.get("retry-after")).not.toBeNull();
+  });
+
+  it.each(["resolve", "reject"] as const)("enforces the creation deadline, aborts, clears its timer, and ignores a late terrain %s", async (lateOutcome) => {
+    vi.useFakeTimers();
+    const db = new TestD1();
+    db.db.exec("CREATE TABLE calculation_jobs (id TEXT PRIMARY KEY, status TEXT NOT NULL, input_json TEXT NOT NULL, result_json TEXT, error_message TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL)");
+    db.db.prepare("INSERT INTO calculation_jobs VALUES (?, 'queued', ?, NULL, NULL, ?, ?)").run("job", input, "2000-01-01T00:00:00Z", "2000-01-01T00:00:00Z");
+    let signal: AbortSignal | undefined;
+    let settleTerrain: (() => void) | undefined;
+    analyzeTerrainLinkMock.mockImplementationOnce((...args: unknown[]) => new Promise((resolve, reject) => {
+      signal = args.at(-1) as AbortSignal;
+      settleTerrain = () => lateOutcome === "resolve" ? resolve(terrainResult) : reject(new Error("late failure"));
+    }));
+    const processing = processTerrainJob(envFor(db), "job", "https://linksim.link/api/v1/calculate/jobs");
+    await vi.runAllTimersAsync();
+    await processing;
+    expect(signal?.aborted).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+    expect(db.db.prepare("SELECT status, error_message FROM calculation_jobs WHERE id = 'job'").get()).toEqual({ status: "timed_out", error_message: "Terrain job timed out." });
+    settleTerrain?.();
+    await Promise.resolve();
+    expect(db.db.prepare("SELECT status FROM calculation_jobs WHERE id = 'job'").get()).toEqual({ status: "timed_out" });
+  });
+
+  it("records ordinary terrain failures as bounded failed jobs", async () => {
+    const db = new TestD1();
+    db.db.exec("CREATE TABLE calculation_jobs (id TEXT PRIMARY KEY, status TEXT NOT NULL, input_json TEXT NOT NULL, result_json TEXT, error_message TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL)");
+    db.db.prepare("INSERT INTO calculation_jobs VALUES (?, 'queued', ?, NULL, NULL, datetime('now'), datetime('now'))").run("job", input);
+    analyzeTerrainLinkMock.mockRejectedValueOnce(new Error("💥".repeat(1000)));
+    await processTerrainJob(envFor(db), "job", "https://linksim.link/api/v1/calculate/jobs");
+    const row = db.db.prepare("SELECT status, error_message FROM calculation_jobs WHERE id = 'job'").get() as { status: string; error_message: string };
+    expect(row.status).toBe("failed");
+    expect(new TextEncoder().encode(row.error_message).byteLength).toBeLessThanOrEqual(1024);
+  });
+
+  it("times out when terrain resolves before the deadline but the completion write crosses it", async () => {
+    const db = new TestD1((sql, values) => {
+      if (sql.includes("created_at >") && values[0] === JOB_STATUS.COMPLETED) {
+        db.db.prepare("UPDATE calculation_jobs SET created_at = datetime('now', '-5 minutes') WHERE id = 'job'").run();
+      }
+    });
+    db.db.exec("CREATE TABLE calculation_jobs (id TEXT PRIMARY KEY, status TEXT NOT NULL, input_json TEXT NOT NULL, result_json TEXT, error_message TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL)");
+    db.db.prepare("INSERT INTO calculation_jobs VALUES ('job', 'queued', ?, NULL, NULL, datetime('now'), datetime('now'))").run(input);
+    analyzeTerrainLinkMock.mockResolvedValueOnce(terrainResult);
+    await processTerrainJob(envFor(db), "job", "https://linksim.link/api/v1/calculate/jobs");
+    expect(db.db.prepare("SELECT status, result_json FROM calculation_jobs WHERE id = 'job'").get()).toEqual({ status: JOB_STATUS.TIMED_OUT, result_json: null });
+  });
+});

--- a/functions/api/v1/calculate.jobs.ts
+++ b/functions/api/v1/calculate.jobs.ts
@@ -1,50 +1,20 @@
-import { errorResponse, handleOptions, json, withCors } from "../../_lib/http";
-import { getClientAddress, takeRateLimitToken } from "../../_lib/rateLimit";
+import { errorResponse, handleOptions, json, readBoundedJson, withCors } from "../../_lib/http";
+import { getClientAddress, parsePerMinuteLimit, takeRateLimitToken } from "../../_lib/rateLimit";
 import { analyzeTerrainLink } from "../../_lib/terrainAnalysis";
 import {
-  estimateSampleCount,
-  effectiveApiLinkGains,
-  findEndpointNodes,
-  haversineKm,
-  MAX_TERRAIN_DISTANCE_KM,
-  normalizeCalculationRequest,
+  estimateSampleCount, effectiveApiLinkGains, findEndpointNodes, haversineKm,
+  MAX_CALCULATION_BODY_BYTES, MAX_CALCULATION_JSON_DEPTH, MAX_JOB_RUNTIME_MS,
+  MAX_TERRAIN_DISTANCE_KM, normalizeCalculationRequest,
   type CalculationRequest,
 } from "../../_lib/calculateShared";
+import {
+  cleanupCalculationJobs, createCalculationJob, ensureCalculationJobsTable,
+  finishCalculationJobBeforeDeadline, getCalculationJob, JOB_STATUS, transitionCalculationJob,
+  timeoutCalculationJob,
+} from "../../_lib/calculationJobs";
 import type { Env } from "../../_lib/types";
 
-type Context = {
-  request: Request;
-  env: Env;
-  waitUntil?: (promise: Promise<unknown>) => void;
-};
-
-const JOB_STATUS = {
-  QUEUED: "queued",
-  RUNNING: "running",
-  COMPLETED: "completed",
-  FAILED: "failed",
-  TIMED_OUT: "timed_out",
-} as const;
-
-type JobStatus = (typeof JOB_STATUS)[keyof typeof JOB_STATUS];
-
-type JobRow = {
-  id: string;
-  status: string;
-  input_json: string;
-  result_json: string | null;
-  error_message: string | null;
-  created_at: string;
-  updated_at: string;
-};
-
-const MAX_RUNTIME_MS = 300000;
-
-const parsePerMinuteLimit = (raw: string | undefined, fallback: number): number => {
-  const parsed = Number(raw ?? "");
-  if (!Number.isFinite(parsed)) return fallback;
-  return Math.max(1, Math.floor(parsed));
-};
+type Context = { request: Request; env: Env; waitUntil?: (promise: Promise<unknown>) => void };
 
 const generateJobId = (): string => {
   const chars = "abcdefghijklmnopqrstuvwxyz0123456789";
@@ -53,187 +23,101 @@ const generateJobId = (): string => {
   return result;
 };
 
-const ensureCalculationJobsTable = async (env: Env): Promise<void> => {
-  await env.DB.prepare(
-    "CREATE TABLE IF NOT EXISTS calculation_jobs (id TEXT PRIMARY KEY, status TEXT NOT NULL DEFAULT 'queued', input_json TEXT NOT NULL, result_json TEXT, error_message TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL)",
-  ).run();
-  await env.DB.prepare("CREATE INDEX IF NOT EXISTS idx_calculation_jobs_status ON calculation_jobs(status)").run();
-  await env.DB.prepare("CREATE INDEX IF NOT EXISTS idx_calculation_jobs_created_at ON calculation_jobs(created_at)").run();
-};
-
-const getJob = async (env: Env, jobId: string): Promise<JobRow | null> => {
-  const stmt = env.DB.prepare(
-    "SELECT id, status, input_json, result_json, error_message, created_at, updated_at FROM calculation_jobs WHERE id = ?",
-  );
-  return stmt.bind(jobId).first<JobRow>();
-};
-
-const createJob = async (env: Env, jobId: string, inputJson: string): Promise<void> => {
-  const stmt = env.DB.prepare(
-    "INSERT INTO calculation_jobs (id, status, input_json, created_at, updated_at) VALUES (?, ?, ?, datetime('now'), datetime('now'))",
-  );
-  await stmt.bind(jobId, JOB_STATUS.QUEUED, inputJson).run();
-};
-
-const updateJob = async (
-  env: Env,
-  jobId: string,
-  status: JobStatus,
-  resultJson: string | null,
-  errorMessage: string | null,
-): Promise<void> => {
-  const stmt = env.DB.prepare(
-    "UPDATE calculation_jobs SET status = ?, result_json = ?, error_message = ?, updated_at = datetime('now') WHERE id = ?",
-  );
-  await stmt.bind(status, resultJson, errorMessage, jobId).run();
-};
-
-const validateTerrainRequest = (payload: CalculationRequest): { distanceKm: number; samples: number } => {
+export const validateTerrainRequest = (payload: CalculationRequest): { distanceKm: number; samples: number } => {
   const { fromNode, toNode } = findEndpointNodes(payload);
   const distanceKm = haversineKm(fromNode, toNode);
-  if (distanceKm > MAX_TERRAIN_DISTANCE_KM) {
-    throw new Error(
-      `Distance ${distanceKm.toFixed(1)} km exceeds maximum of ${MAX_TERRAIN_DISTANCE_KM} km for terrain jobs.`,
-    );
-  }
+  if (distanceKm > MAX_TERRAIN_DISTANCE_KM) throw new Error(`Distance ${distanceKm.toFixed(1)} km exceeds maximum of ${MAX_TERRAIN_DISTANCE_KM} km for terrain jobs.`);
   return { distanceKm, samples: estimateSampleCount(distanceKm) };
 };
 
-const processTerrainJob = async (env: Env, jobId: string, requestUrl: string): Promise<void> => {
-  const startedAt = Date.now();
+export const processTerrainJob = async (env: Env, jobId: string, requestUrl: string): Promise<void> => {
+  const row = await getCalculationJob(env, jobId);
+  if (!row) return;
+  const createdAt = row.created_at.includes("T") ? row.created_at : `${row.created_at.replace(" ", "T")}Z`;
+  const createdAtMs = Date.parse(createdAt);
+  const deadlineMs = (Number.isFinite(createdAtMs) ? createdAtMs : Date.now()) + MAX_JOB_RUNTIME_MS;
+  if (!await transitionCalculationJob(env, jobId, [JOB_STATUS.QUEUED], JOB_STATUS.RUNNING, null, null)) return;
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      controller.abort();
+      reject(new DOMException("Terrain job timed out.", "TimeoutError"));
+    }, Math.max(0, deadlineMs - Date.now()));
+  });
   try {
-    await updateJob(env, jobId, JOB_STATUS.RUNNING, null, null);
-    const row = await getJob(env, jobId);
-    if (!row) throw new Error("Job not found while processing.");
     const payload = normalizeCalculationRequest(JSON.parse(row.input_json));
     const { fromNode, toNode } = findEndpointNodes(payload);
     const { samples } = validateTerrainRequest(payload);
-
-    const terrain = await analyzeTerrainLink(
-      env,
-      requestUrl,
-      {
-        lat: fromNode.lat,
-        lon: fromNode.lon,
-        name: fromNode.name,
-        txPowerDbm: fromNode.tx_power_dbm,
-        txGainDbi: fromNode.tx_gain_dbi,
-        rxGainDbi: fromNode.rx_gain_dbi,
-        cableLossDb: fromNode.cable_loss_db,
+    const terrain = await Promise.race([
+      analyzeTerrainLink(env, requestUrl, {
+        lat: fromNode.lat, lon: fromNode.lon, name: fromNode.name, txPowerDbm: fromNode.tx_power_dbm,
+        txGainDbi: fromNode.tx_gain_dbi, rxGainDbi: fromNode.rx_gain_dbi, cableLossDb: fromNode.cable_loss_db,
         antennaHeightM: fromNode.antenna_height_m ?? 2,
-      },
-      {
-        lat: toNode.lat,
-        lon: toNode.lon,
-        name: toNode.name,
-        txPowerDbm: toNode.tx_power_dbm,
-        txGainDbi: toNode.tx_gain_dbi,
-        rxGainDbi: toNode.rx_gain_dbi,
-        cableLossDb: toNode.cable_loss_db,
+      }, {
+        lat: toNode.lat, lon: toNode.lon, name: toNode.name, txPowerDbm: toNode.tx_power_dbm,
+        txGainDbi: toNode.tx_gain_dbi, rxGainDbi: toNode.rx_gain_dbi, cableLossDb: toNode.cable_loss_db,
         antennaHeightM: toNode.antenna_height_m ?? 2,
-      },
-      payload.input.frequency_mhz,
-      samples,
-    );
-
+      }, payload.input.frequency_mhz, samples, controller.signal),
+      timeout,
+    ]);
+    if (Date.now() >= deadlineMs) {
+      controller.abort();
+      await timeoutCalculationJob(env, jobId);
+      return;
+    }
     const directionalGains = effectiveApiLinkGains(payload, terrain.fromGroundM, terrain.toGroundM);
     const eirpDbm = fromNode.tx_power_dbm + directionalGains.txGainDbi - fromNode.cable_loss_db;
     const rxDbm = eirpDbm + directionalGains.rxGainDbi - terrain.totalPathLossDb;
-    const verdict = rxDbm >= payload.input.rx_target_dbm ? "PASS" : "FAIL";
-    const runtimeMs = Date.now() - startedAt;
-
-    if (runtimeMs > MAX_RUNTIME_MS) {
-      await updateJob(env, jobId, JOB_STATUS.TIMED_OUT, null, "Terrain job timed out.");
-      return;
-    }
-
+    const runtimeMs = Math.max(0, Date.now() - (Number.isFinite(createdAtMs) ? createdAtMs : Date.now()));
     const result = {
-      calculation: "link_budget",
-      mode: "terrain",
-      terrain_used: true,
-      terrain_status: "sampled",
-      result: {
-        from_site: fromNode.name,
-        to_site: toNode.name,
-        distance_km: terrain.distanceKm,
-        baseline_fspl_db: terrain.baselineFsplDb,
-        terrain_penalty_db: terrain.terrainPenaltyDb,
-        path_loss_db: terrain.totalPathLossDb,
-        rx_dbm: payload.input.include_rx_dbm ? rxDbm : null,
-        verdict: payload.input.include_verdict ? verdict : null,
-      },
-      meta: {
-        terrain_source: "copernicus",
-        tiles_fetched: terrain.tilesFetched,
-        samples_requested: samples,
-        samples_used: terrain.samplesUsed,
-        max_samples: 500,
-        max_intrusion_m: terrain.maxIntrusionM,
-        fresnel_clearance_percent: terrain.fresnelClearancePercent,
-        terrain_obstructed: terrain.terrainObstructed,
-        runtime_ms: runtimeMs,
-        max_runtime_ms: MAX_RUNTIME_MS,
-      },
+      calculation: "link_budget", mode: "terrain", terrain_used: true, terrain_status: "sampled",
+      result: { from_site: fromNode.name, to_site: toNode.name, distance_km: terrain.distanceKm,
+        baseline_fspl_db: terrain.baselineFsplDb, terrain_penalty_db: terrain.terrainPenaltyDb,
+        path_loss_db: terrain.totalPathLossDb, rx_dbm: payload.input.include_rx_dbm ? rxDbm : null,
+        verdict: payload.input.include_verdict ? (rxDbm >= payload.input.rx_target_dbm ? "PASS" : "FAIL") : null },
+      meta: { terrain_source: "copernicus", tiles_fetched: terrain.tilesFetched, samples_requested: samples,
+        samples_used: terrain.samplesUsed, max_samples: 500, max_intrusion_m: terrain.maxIntrusionM,
+        fresnel_clearance_percent: terrain.fresnelClearancePercent, terrain_obstructed: terrain.terrainObstructed,
+        runtime_ms: runtimeMs, max_runtime_ms: MAX_JOB_RUNTIME_MS },
     };
-
-    await updateJob(env, jobId, JOB_STATUS.COMPLETED, JSON.stringify(result), null);
+    if (!await finishCalculationJobBeforeDeadline(env, jobId, JOB_STATUS.COMPLETED, JSON.stringify(result), null)) {
+      await timeoutCalculationJob(env, jobId);
+    }
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    await updateJob(env, jobId, JOB_STATUS.FAILED, null, message);
+    const timedOut = controller.signal.aborted || (error instanceof DOMException && error.name === "TimeoutError");
+    if (timedOut) await timeoutCalculationJob(env, jobId);
+    else if (!await finishCalculationJobBeforeDeadline(
+      env,
+      jobId,
+      JOB_STATUS.FAILED,
+      null,
+      error instanceof Error ? error.message : String(error),
+    )) await timeoutCalculationJob(env, jobId);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+    await cleanupCalculationJobs(env).catch(() => undefined);
   }
 };
 
-export const queueTerrainCalculationJob = async (
-  request: Request,
-  env: Env,
-  payload: CalculationRequest,
-  waitUntil?: (promise: Promise<unknown>) => void,
-): Promise<Response> => {
+export const queueTerrainCalculationJob = async (request: Request, env: Env, payload: CalculationRequest, waitUntil?: (promise: Promise<unknown>) => void): Promise<Response> => {
   await ensureCalculationJobsTable(env);
-  const limitPerMinute = parsePerMinuteLimit(env.CALC_API_PROXY_RATE_LIMIT_PER_MINUTE, 60);
-  const address = getClientAddress(request);
-  const limiter = takeRateLimitToken({ key: `calc-jobs:${address}`, limit: limitPerMinute });
-  if (!limiter.allowed) {
-    return withCors(
-      request,
-      json(
-        { error: "Calculation jobs rate limit reached. Please wait and try again." },
-        { status: 429, headers: { "retry-after": String(limiter.retryAfterSec) } },
-      ),
-    );
-  }
-
-  if (payload.input.mode !== "terrain") {
-    throw new Error("Only terrain mode is supported on /api/v1/calculate/jobs.");
-  }
+  const limiter = takeRateLimitToken({ key: `calc-jobs:${getClientAddress(request)}`, limit: parsePerMinuteLimit(env.CALC_API_PROXY_RATE_LIMIT_PER_MINUTE, 60) });
+  if (!limiter.allowed) return withCors(request, json({ error: "Calculation jobs rate limit reached. Please wait and try again." }, { status: 429, headers: { "retry-after": String(limiter.retryAfterSec) } }));
+  if (payload.input.mode !== "terrain") throw new Error("Only terrain mode is supported on /api/v1/calculate/jobs.");
   validateTerrainRequest(payload);
-
+  await cleanupCalculationJobs(env);
   const jobId = generateJobId();
-  await createJob(env, jobId, JSON.stringify(payload));
+  await createCalculationJob(env, jobId, JSON.stringify(payload));
   const processing = processTerrainJob(env, jobId, request.url);
-  if (waitUntil) waitUntil(processing);
-  else await processing;
-
-  return withCors(
-    request,
-    json(
-      {
-        job_id: jobId,
-        status: JOB_STATUS.QUEUED,
-        message: "Job queued. Poll GET /api/v1/calculate/jobs/{job_id} for status.",
-      },
-      { status: 202 },
-    ),
-  );
+  if (waitUntil) waitUntil(processing); else await processing;
+  return withCors(request, json({ job_id: jobId, status: JOB_STATUS.QUEUED, message: "Job queued. Poll GET /api/v1/calculate/jobs/{job_id} for status." }, { status: 202 }));
 };
 
 export const onRequestOptions = async ({ request }: Context) => handleOptions(request);
-
 export const onRequestPost = async ({ request, env, waitUntil }: Context) => {
   try {
-    const payload = normalizeCalculationRequest(await request.json());
-    return queueTerrainCalculationJob(request, env, payload, waitUntil);
-  } catch (error) {
-    return errorResponse(request, error, 400);
-  }
+    const raw = await readBoundedJson<unknown>(request, { maxBytes: MAX_CALCULATION_BODY_BYTES, maxDepth: MAX_CALCULATION_JSON_DEPTH });
+    return queueTerrainCalculationJob(request, env, normalizeCalculationRequest(raw), waitUntil);
+  } catch (error) { return errorResponse(request, error, 400); }
 };

--- a/functions/api/v1/calculate.jobs.ts
+++ b/functions/api/v1/calculate.jobs.ts
@@ -9,7 +9,7 @@ import {
 } from "../../_lib/calculateShared";
 import {
   cleanupCalculationJobs, createCalculationJob, ensureCalculationJobsTable,
-  finishCalculationJobBeforeDeadline, getCalculationJob, JOB_STATUS, transitionCalculationJob,
+  failCalculationJobBeforeDeadline, finishCalculationJobBeforeDeadline, getCalculationJob, JOB_STATUS, transitionCalculationJob,
   timeoutCalculationJob,
 } from "../../_lib/calculationJobs";
 import type { Env } from "../../_lib/types";
@@ -31,21 +31,22 @@ export const validateTerrainRequest = (payload: CalculationRequest): { distanceK
 };
 
 export const processTerrainJob = async (env: Env, jobId: string, requestUrl: string): Promise<void> => {
-  const row = await getCalculationJob(env, jobId);
-  if (!row) return;
-  const createdAt = row.created_at.includes("T") ? row.created_at : `${row.created_at.replace(" ", "T")}Z`;
-  const createdAtMs = Date.parse(createdAt);
-  const deadlineMs = (Number.isFinite(createdAtMs) ? createdAtMs : Date.now()) + MAX_JOB_RUNTIME_MS;
-  if (!await transitionCalculationJob(env, jobId, [JOB_STATUS.QUEUED], JOB_STATUS.RUNNING, null, null)) return;
-  const controller = new AbortController();
+  let controller: AbortController | undefined;
   let timer: ReturnType<typeof setTimeout> | undefined;
-  const timeout = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => {
-      controller.abort();
-      reject(new DOMException("Terrain job timed out.", "TimeoutError"));
-    }, Math.max(0, deadlineMs - Date.now()));
-  });
   try {
+    const row = await getCalculationJob(env, jobId);
+    if (!row) return;
+    const createdAt = row.created_at.includes("T") ? row.created_at : `${row.created_at.replace(" ", "T")}Z`;
+    const createdAtMs = Date.parse(createdAt);
+    const deadlineMs = (Number.isFinite(createdAtMs) ? createdAtMs : Date.now()) + MAX_JOB_RUNTIME_MS;
+    if (!await transitionCalculationJob(env, jobId, [JOB_STATUS.QUEUED], JOB_STATUS.RUNNING, null, null)) return;
+    controller = new AbortController();
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => {
+        controller?.abort();
+        reject(new DOMException("Terrain job timed out.", "TimeoutError"));
+      }, Math.max(0, deadlineMs - Date.now()));
+    });
     const payload = normalizeCalculationRequest(JSON.parse(row.input_json));
     const { fromNode, toNode } = findEndpointNodes(payload);
     const { samples } = validateTerrainRequest(payload);
@@ -85,13 +86,11 @@ export const processTerrainJob = async (env: Env, jobId: string, requestUrl: str
       await timeoutCalculationJob(env, jobId);
     }
   } catch (error) {
-    const timedOut = controller.signal.aborted || (error instanceof DOMException && error.name === "TimeoutError");
+    const timedOut = controller?.signal.aborted || (error instanceof DOMException && error.name === "TimeoutError");
     if (timedOut) await timeoutCalculationJob(env, jobId);
-    else if (!await finishCalculationJobBeforeDeadline(
+    else if (!await failCalculationJobBeforeDeadline(
       env,
       jobId,
-      JOB_STATUS.FAILED,
-      null,
       error instanceof Error ? error.message : String(error),
     )) await timeoutCalculationJob(env, jobId);
   } finally {

--- a/functions/api/v1/calculate.test.ts
+++ b/functions/api/v1/calculate.test.ts
@@ -9,6 +9,7 @@ const { getClientAddressMock, takeRateLimitTokenMock, analyzeTerrainLinkMock, te
 
 vi.mock("../../_lib/rateLimit", () => ({
   getClientAddress: getClientAddressMock,
+  parsePerMinuteLimit: (raw: string | undefined, fallback: number) => raw ? Number(raw) : fallback,
   takeRateLimitToken: takeRateLimitTokenMock,
 }));
 
@@ -71,6 +72,53 @@ describe("api/v1/calculate", () => {
     },
   });
 
+  const bodyAtSize = (size: number): string => {
+    const base = JSON.stringify({ ...mkPayload(), padding: "" });
+    return `${base.slice(0, -2)}${"x".repeat(size - new TextEncoder().encode(base).byteLength)}"}`;
+  };
+
+  const bodyAtDepth = (depth: number): string => {
+    let padding: unknown = 0;
+    for (let level = 1; level < depth; level += 1) padding = [padding];
+    return JSON.stringify({ ...mkPayload(), padding });
+  };
+
+  it("accepts exactly 64 KiB and rejects 64 KiB plus one with stable 413", async () => {
+    const accepted = await onRequestPost(mkCtx(new Request("https://linksim.link/api/v1/calculate", {
+      method: "POST", headers: { "content-type": "application/json" }, body: bodyAtSize(65_536),
+    }), { DB: {} }));
+    expect(accepted.status).toBe(200);
+    const callsAfterAccepted = analyzeTerrainLinkMock.mock.calls.length;
+    const rejected = await onRequestPost(mkCtx(new Request("https://linksim.link/api/v1/calculate", {
+      method: "POST", headers: { "content-type": "application/json" }, body: bodyAtSize(65_537),
+    }), { DB: {} }));
+    expect(rejected.status).toBe(413);
+    expect(analyzeTerrainLinkMock).toHaveBeenCalledTimes(callsAfterAccepted);
+  });
+
+  it("accepts depth 10, rejects depth 11 with stable 422, and ignores braces in strings", async () => {
+    const acceptedDepth = await onRequestPost(mkCtx(new Request("https://linksim.link/api/v1/calculate", {
+      method: "POST", headers: { "content-type": "application/json" }, body: bodyAtDepth(10),
+    }), { DB: {} }));
+    expect(acceptedDepth.status).toBe(200);
+    const rejectedDepth = await onRequestPost(mkCtx(new Request("https://linksim.link/api/v1/calculate", {
+      method: "POST", headers: { "content-type": "application/json" }, body: bodyAtDepth(11),
+    }), { DB: {} }));
+    expect(rejectedDepth.status).toBe(422);
+    const braces = mkPayload(); braces.input.nodes[0].name = "A {{{{{{{{{{{"; braces.input.from_site = braces.input.nodes[0].name;
+    const accepted = await onRequestPost(mkCtx(new Request("https://linksim.link/api/v1/calculate", {
+      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(braces),
+    }), { DB: {} }));
+    expect(accepted.status).toBe(200);
+  });
+
+  it("preserves bounded JSON 422 status for malformed JSON and invalid UTF-8", async () => {
+    for (const body of ["{", new Uint8Array([0xff])]) {
+      const response = await onRequestPost(mkCtx(new Request("https://linksim.link/api/v1/calculate", { method: "POST", body }), { DB: {} }));
+      expect(response.status).toBe(422);
+    }
+  });
+
   it("returns 429 when edge proxy limiter denies request", async () => {
     takeRateLimitTokenMock.mockReturnValueOnce({ allowed: false, remaining: 0, retryAfterSec: 9 });
     const req = new Request("https://linksim.link/api/v1/calculate", {
@@ -122,6 +170,22 @@ describe("api/v1/calculate", () => {
     expect(body.result.terrain_tiles_loaded).toEqual(["N59E010:copernicus30"]);
   });
 
+  it("accepts exactly 500 km and rejects above the synchronous distance ceiling", async () => {
+    const payloadFor = (distanceKm: number) => {
+      const value = mkPayload();
+      value.input.nodes = [{ name: "Site A", lat: 0, lon: 0 }, { name: "Site B", lat: 0, lon: distanceKm / 6371 * 180 / Math.PI }];
+      return value;
+    };
+    const exact = await onRequestPost(mkCtx(new Request("https://linksim.link/api/v1/calculate", {
+      method: "POST", body: JSON.stringify(payloadFor(500)),
+    }), { DB: {} }));
+    expect(exact.status).toBe(200);
+    const above = await onRequestPost(mkCtx(new Request("https://linksim.link/api/v1/calculate", {
+      method: "POST", body: JSON.stringify(payloadFor(500.001)),
+    }), { DB: {} }));
+    expect(above.status).toBe(400);
+  });
+
   it("supports from_node/to_node aliases", async () => {
     const req = new Request("https://linksim.link/api/v1/calculate", {
       method: "POST",
@@ -155,7 +219,7 @@ describe("api/v1/calculate", () => {
     const baselineResponse = await onRequestPost(mkCtx(baselineRequest, { DB: {} }));
     const baseline = (await baselineResponse.json()) as { result: { rx_dbm: number } };
 
-    const directional: any = mkPayload();
+    const directional = mkPayload();
     directional.input.nodes = directional.input.nodes.map((node, index) => ({
       ...node,
       antenna_mode: "directional",
@@ -177,8 +241,8 @@ describe("api/v1/calculate", () => {
   });
 
   it("validates directional API field ranges", async () => {
-    const payload: any = mkPayload();
-    payload.input.nodes[0] = { ...payload.input.nodes[0], antenna_mode: "directional", antenna_tilt_deg: 91 };
+    const payload = mkPayload();
+    Object.assign(payload.input.nodes[0], { antenna_mode: "directional", antenna_tilt_deg: 91 });
     const req = new Request("https://linksim.link/api/v1/calculate", {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -190,8 +254,8 @@ describe("api/v1/calculate", () => {
   });
 
   it("rejects unknown antenna modes instead of silently using omnidirectional", async () => {
-    const payload: any = mkPayload();
-    payload.input.nodes[0] = { ...payload.input.nodes[0], antenna_mode: "directionl" };
+    const payload = mkPayload();
+    Object.assign(payload.input.nodes[0], { antenna_mode: "directionl" });
     const req = new Request("https://linksim.link/api/v1/calculate", {
       method: "POST",
       headers: { "content-type": "application/json" },

--- a/functions/api/v1/calculate.ts
+++ b/functions/api/v1/calculate.ts
@@ -1,12 +1,15 @@
-import { getClientAddress, takeRateLimitToken } from "../../_lib/rateLimit";
-import { errorResponse, handleOptions, json, withCors } from "../../_lib/http";
+import { getClientAddress, parsePerMinuteLimit, takeRateLimitToken } from "../../_lib/rateLimit";
+import { ApiRequestError, errorResponse, handleOptions, json, readBoundedJson, withCors } from "../../_lib/http";
 import type { Env } from "../../_lib/types";
 import { queueTerrainCalculationJob } from "./calculate.jobs";
 import {
   findEndpointNodes,
   effectiveApiLinkGains,
+  estimateSyncSampleCount,
   haversineKm,
   MAX_SYNC_DISTANCE_KM,
+  MAX_CALCULATION_BODY_BYTES,
+  MAX_CALCULATION_JSON_DEPTH,
   normalizeCalculationRequest,
 } from "../../_lib/calculateShared";
 import { analyzeTerrainLink } from "../../_lib/terrainAnalysis";
@@ -16,19 +19,6 @@ type Context = {
   request: Request;
   env: Env;
   waitUntil?: (promise: Promise<unknown>) => void;
-};
-
-const MAX_SYNC_TERRAIN_SAMPLES = 72;
-
-const parsePerMinuteLimit = (raw: string | undefined, fallback: number): number => {
-  const parsed = Number(raw ?? "");
-  if (!Number.isFinite(parsed)) return fallback;
-  return Math.max(1, Math.floor(parsed));
-};
-
-const estimateSyncSamples = (distanceKm: number): number => {
-  const byDistance = Math.ceil(distanceKm / 0.75);
-  return Math.max(24, Math.min(MAX_SYNC_TERRAIN_SAMPLES, byDistance));
 };
 
 export const onRequestOptions = async ({ request }: Context) => handleOptions(request);
@@ -52,7 +42,10 @@ export const onRequestPost = async (ctx: Context) => {
       );
     }
 
-    const payload = normalizeCalculationRequest(await request.json());
+    const payload = normalizeCalculationRequest(await readBoundedJson<unknown>(request, {
+      maxBytes: MAX_CALCULATION_BODY_BYTES,
+      maxDepth: MAX_CALCULATION_JSON_DEPTH,
+    }));
     if (payload.input.mode === "terrain") {
       return queueTerrainCalculationJob(request, env, payload, waitUntil);
     }
@@ -97,7 +90,7 @@ export const onRequestPost = async (ctx: Context) => {
         groundElevationM: toNode.ground_elevation_m,
       },
       payload.input.frequency_mhz,
-      estimateSyncSamples(distanceKm),
+      estimateSyncSampleCount(distanceKm),
     );
 
     const directionalGains = effectiveApiLinkGains(payload, terrain.fromGroundM, terrain.toGroundM);
@@ -137,6 +130,7 @@ export const onRequestPost = async (ctx: Context) => {
       }),
     );
   } catch (error) {
+    if (error instanceof ApiRequestError) return errorResponse(request, error);
     const message = error instanceof Error ? error.message : String(error);
     if (message.startsWith("Site not found:")) {
       return withCors(request, json({ error: message }, { status: 404 }));

--- a/tests/calculation_api/test_api.py
+++ b/tests/calculation_api/test_api.py
@@ -1,6 +1,13 @@
+import asyncio
+import json
+
+import pytest
 from fastapi.testclient import TestClient
 
+from calculation_api.calculators.link_budget import calculate_link_budget
 from calculation_api.main import create_app
+from calculation_api.limits import BoundedCalculationBodyMiddleware
+from calculation_api.models import LinkBudgetInput
 
 
 client = TestClient(create_app())
@@ -178,3 +185,134 @@ def test_rate_limit_does_not_trust_spoofed_forwarded_addresses() -> None:
     assert first.status_code == 200
     assert second.status_code == 200
     assert third.status_code == 429
+
+
+def test_request_body_and_depth_limits() -> None:
+    oversized = client.post("/api/v1/calculate", content=b"{" + b" " * 65536 + b"}", headers={"content-type": "application/json"})
+    assert oversized.status_code == 413
+    too_deep = client.post("/api/v1/calculate", content=("[" * 11 + "0" + "]" * 11), headers={"content-type": "application/json"})
+    assert too_deep.status_code == 422
+
+
+def test_chunked_body_exact_size_and_depth_boundaries() -> None:
+    async def status_for(body: bytes, chunk_size: int) -> tuple[int, int]:
+        sent = []
+        chunks = [body[index:index + chunk_size] for index in range(0, len(body), chunk_size)] or [b""]
+        receive_calls = 0
+
+        async def receive():
+            nonlocal receive_calls
+            receive_calls += 1
+            chunk = chunks.pop(0)
+            return {"type": "http.request", "body": chunk, "more_body": bool(chunks)}
+
+        async def send(message):
+            sent.append(message)
+
+        async def inner(scope, receive_inner, send_inner):
+            await receive_inner()
+            await send_inner({"type": "http.response.start", "status": 204, "headers": []})
+            await send_inner({"type": "http.response.body", "body": b""})
+
+        middleware = BoundedCalculationBodyMiddleware(inner)
+        await middleware({"type": "http", "method": "POST", "path": "/api/v1/calculate", "headers": []}, receive, send)
+        status = next(message["status"] for message in sent if message["type"] == "http.response.start")
+        return status, receive_calls
+
+    base = b'{"value":""}'
+    exact = base[:-2] + b"x" * (65536 - len(base)) + b'"}'
+    assert asyncio.run(status_for(exact, 997))[0] == 204
+    assert asyncio.run(status_for(exact + b" ", 997))[0] == 413
+    oversized_status, oversized_reads = asyncio.run(status_for(exact + b" " * 5000, 997))
+    assert oversized_status == 413
+    assert oversized_reads < (len(exact) + 5000 + 996) // 997
+    assert asyncio.run(status_for((b"[" * 10) + b"0" + (b"]" * 10), 3))[0] == 204
+    assert asyncio.run(status_for((b"[" * 11) + b"0" + (b"]" * 11), 3))[0] == 422
+
+
+def test_node_count_name_and_finite_number_limits() -> None:
+    base = {
+        "calculation": "link_budget",
+        "input": {"from_site": "A", "to_site": "B", "frequency_mhz": 868,
+                  "nodes": [_node("A", 1, 1), _node("B", 2, 2)]},
+    }
+    base["input"]["nodes"] += [_node(f"extra-{index}", 1, 1) for index in range(18)]
+    assert client.post("/api/v1/calculate", json=base).status_code == 200
+    base["input"]["nodes"].append(_node("node-21", 1, 1))
+    assert client.post("/api/v1/calculate", json=base).status_code == 422
+    base["input"]["from_site"] = "A" * 80
+    base["input"]["nodes"] = [_node("A" * 80, 1, 1), _node("B", 2, 2)]
+    assert client.post("/api/v1/calculate", json=base).status_code == 200
+    base["input"]["from_site"] = "A"
+    base["input"]["nodes"] = [_node("A" * 81, 1, 1), _node("B", 2, 2)]
+    long_error = client.post("/api/v1/calculate", json=base)
+    assert long_error.status_code == 422
+    assert isinstance(long_error.json()["detail"], list)
+
+    base["input"]["from_site"] = "😀" * 80
+    base["input"]["nodes"] = [_node("😀" * 80, 1, 1), _node("B", 2, 2)]
+    assert client.post("/api/v1/calculate", json=base).status_code == 200
+    base["input"]["from_site"] += "😀"
+    base["input"]["nodes"][0]["name"] += "😀"
+    assert client.post("/api/v1/calculate", json=base).status_code == 422
+    base["input"]["nodes"] = [_node("A", 1, 1), _node("B", 2, 2)]
+    base["input"]["frequency_mhz"] = "NaN"
+    non_finite_json = json.dumps(base).replace('"NaN"', "NaN")
+    assert client.post("/api/v1/calculate", content=non_finite_json, headers={"content-type": "application/json"}).status_code == 422
+
+
+def test_strings_trim_and_numeric_fields_do_not_coerce_strings_or_bools() -> None:
+    payload = {
+        "calculation": "link_budget",
+        "input": {"from_site": " A ", "to_site": " B ", "frequency_mhz": 868,
+                  "nodes": [_node(" A ", 1, 1), _node(" B ", 2, 2)]},
+    }
+    accepted = client.post("/api/v1/calculate", json=payload)
+    assert accepted.status_code == 200
+    assert accepted.json()["result"]["from_site"] == "A"
+    payload["input"]["from_site"] = "   "
+    assert client.post("/api/v1/calculate", json=payload).status_code == 422
+    payload["input"]["from_site"] = "A"
+    payload["input"]["frequency_mhz"] = "868"
+    assert client.post("/api/v1/calculate", json=payload).status_code == 422
+    payload["input"]["frequency_mhz"] = 868
+    payload["input"]["nodes"][0]["lat"] = True
+    assert client.post("/api/v1/calculate", json=payload).status_code == 422
+
+
+def test_all_fastapi_numeric_inputs_are_strict() -> None:
+    for input_field in ["frequency_mhz", "rx_target_dbm"]:
+        for invalid in ["1", True]:
+            payload = {"calculation": "link_budget", "input": {"from_site": "A", "to_site": "B", "frequency_mhz": 868,
+                       "nodes": [_node("A", 1, 1), _node("B", 2, 2)]}}
+            payload["input"][input_field] = invalid
+            assert client.post("/api/v1/calculate", json=payload).status_code == 422
+    for node_field in ["lat", "lon", "antenna_height_m", "tx_power_dbm", "tx_gain_dbi", "rx_gain_dbi", "cable_loss_db"]:
+        for invalid in ["1", True]:
+            payload = {"calculation": "link_budget", "input": {"from_site": "A", "to_site": "B", "frequency_mhz": 868,
+                       "nodes": [_node("A", 1, 1), _node("B", 2, 2)]}}
+            payload["input"]["nodes"][0][node_field] = invalid
+            assert client.post("/api/v1/calculate", json=payload).status_code == 422
+
+
+def test_sync_distance_limit_is_500_km() -> None:
+    exact_longitude = 500 / 6371 * 180 / 3.141592653589793
+    exact = client.post("/api/v1/calculate", json={
+        "calculation": "link_budget",
+        "input": {"from_site": "A", "to_site": "B", "frequency_mhz": 868,
+                  "nodes": [_node("A", 0, 0), _node("B", 0, exact_longitude)]},
+    })
+    assert exact.status_code == 200
+    response = client.post("/api/v1/calculate", json={
+        "calculation": "link_budget",
+        "input": {"from_site": "A", "to_site": "B", "frequency_mhz": 868,
+                  "nodes": [_node("A", 0, 0), _node("B", 0, 5)]},
+    })
+    assert response.status_code == 400
+    assert "maximum sync distance of 500 km" in response.json()["detail"]
+
+    with pytest.raises(ValueError, match="maximum sync distance of 500 km"):
+        calculate_link_budget(LinkBudgetInput.model_validate({
+            "from_site": "A", "to_site": "B", "frequency_mhz": 868,
+            "nodes": [_node("A", 0, 0), _node("B", 0, 5)],
+        }))


### PR DESCRIPTION
## Summary

- Bound both Pages calculation POST endpoints to 64 KiB and JSON depth 10, enforce trimmed 80-character names and strict finite numeric fields, and preserve the existing 20-node contract.
- Preserve the existing 500 km synchronous, 2,000 km asynchronous, 72/500 terrain-sample, configured POST rate-limit, and routing semantics.
- Make the five-minute asynchronous deadline absolute from job creation, propagate cancellation through terrain fetch/decode stages, and guard terminal writes with deadline-aware compare-and-set transitions.
- Consolidate calculation-job persistence and lifecycle helpers; retain terminal jobs for 24 hours with a deterministic 1,000-record cap and sweep abandoned active jobs into that lifecycle.
- Mirror applicable bounds in the self-hosted FastAPI service and document endpoint limits.

## Quota basis

The approved maximal 20-node payload with 80-character names measured 8,707 bytes, leaving about 7.5x headroom at 64 KiB. A 1,000-record terminal cap bounds maximal stored inputs to 62.5 MiB; stored results are additional and are not included in that figure.

## Validation

- `npm test` — 170 files / 1,207 tests passed
- `npm run build` — passed
- `npm run test -- --run src/lib/deepLink.test.ts` — 35 passed
- `npm run test -- --run functions/api/v1/calculate.test.ts` — 13 passed
- `npm run test -- --run src/store/appStore.test.ts` — 35 passed
- self-hosted Calculation API — 13 passed
- changed-file ESLint — passed
- `git diff --check` — passed
- `npm run dev:check` — no LinkSim dev/watch servers

## Review and boundaries

- Independent Sentry pre-PR review: pass with no findings on `5b8be3b1f3fa784295ff45de9d089b2241ce6c27`.
- Follow-up native Codex review: no major issues on `5b8be3b1f3`.
- No UI, D1 schema migration, deployment, release, or production change.
- Documentation updated in `docs/repository-guide.md`.
- Version remains `0.27.0`; this continues the already-selected staging development line.
- References #1053; it does not close the multi-batch epic.

— Forge · AI coding agent
<!-- linksim-ai:v1 agent=Forge bot=true run=5862d261-27bb-4e39-ba85-30b4823889e1 source=pr:1053-batch-3 commit=5b8be3b1f3fa784295ff45de9d089b2241ce6c27 -->
