### PR TITLE
fix(security): bound terrain and stream work

### DIFF
--- a/docs/repository-guide.md
+++ b/docs/repository-guide.md
@@ -129,6 +129,31 @@ API nodes may optionally set `antenna_mode` to `directional` and provide
 behavior. Site-target tracking is an editor convenience; API requests use fixed
 angles.
 
+## Terrain and Node-Feed Workload Limits
+
+LinkSim bounds terrain and live-node processing before expensive parsing,
+decompression, fetching, or rendering begins:
+
+- MeshMap JSON responses are limited to `5 MiB` and `20,000` top-level node
+  records. Direct/custom node feeds use the same bounds.
+- The 868.no snapshot reader retains its `5 MiB`, `8 second` maximum, and
+  `1 second` post-burst idle limits, with at most `5,000` SSE records.
+- Normalized node caches retain at most `20,000` nodes per source and `25,000`
+  nodes after sources are combined. Map markers retain the existing `1,000`
+  in-view ceiling.
+- Panorama considers at most `1,000` deterministic candidates within its
+  existing `200 km` range before building signatures or running RF projection.
+- Manual SRTM files must contain exactly `1201 x 1201` or `3601 x 3601`
+  signed 16-bit samples. ZIP inputs are limited to `32 MiB`, `16` entries, and
+  exactly one supported HGT entry. A single ingestion processes at most `8`
+  files sequentially and commits only after every file parses successfully.
+- Terrain enumeration and loading stop above `256` unique GLO-30 tile keys.
+  Antimeridian-crossing bounds use their wrapped short interval.
+
+Node-feed rate-limit values and keys, Copernicus fetch concurrency and retries,
+catalog-confirmed ocean handling, and calculation-job cancellation/deadlines
+remain governed by their existing endpoint contracts.
+
 ## Deploy and Release
 
 Use [docs/release-flow.md](./release-flow.md) as the source of truth for

--- a/functions/_lib/boundedUpstream.test.ts
+++ b/functions/_lib/boundedUpstream.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { readBoundedJsonResponse } from "./boundedUpstream";
+
+describe("bounded upstream JSON", () => {
+  it("accepts the exact byte and record boundaries", async () => {
+    const body = JSON.stringify([{ id: 1 }]);
+    const result = await readBoundedJsonResponse<unknown[]>(new Response(body), {
+      maxBytes: new TextEncoder().encode(body).byteLength,
+      maxRecords: 1,
+    });
+    expect(result.value).toEqual([{ id: 1 }]);
+    expect(new TextDecoder().decode(result.bytes)).toBe(body);
+  });
+
+  it("rejects declared or streamed bytes above the cap and cancels the stream", async () => {
+    let declaredCancelled = false;
+    const declaredStream = new ReadableStream<Uint8Array>({
+      start(controller) { controller.enqueue(new TextEncoder().encode("[]")); },
+      cancel() { declaredCancelled = true; },
+    });
+    await expect(readBoundedJsonResponse(new Response(declaredStream, { headers: { "content-length": "11" } }), { maxBytes: 10, maxRecords: 1 }))
+      .rejects.toThrow("size limit");
+    expect(declaredCancelled).toBe(true);
+
+    let streamedCancelled = false;
+    const streamed = new ReadableStream<Uint8Array>({
+      start(controller) { controller.enqueue(new Uint8Array(11)); },
+      cancel() { streamedCancelled = true; },
+    });
+    await expect(readBoundedJsonResponse(new Response(streamed), { maxBytes: 10, maxRecords: 1 })).rejects.toThrow("size limit");
+    expect(streamedCancelled).toBe(true);
+  });
+
+  it("rejects malformed JSON, primitive roots, and records above the cap", async () => {
+    await expect(readBoundedJsonResponse(new Response("{"), { maxBytes: 10, maxRecords: 1 })).rejects.toThrow("valid JSON");
+    await expect(readBoundedJsonResponse(new Response("null"), { maxBytes: 10, maxRecords: 1 })).rejects.toThrow("object or array");
+    await expect(readBoundedJsonResponse(new Response("42"), { maxBytes: 10, maxRecords: 1 })).rejects.toThrow("object or array");
+    await expect(readBoundedJsonResponse(new Response("[1,2]"), { maxBytes: 10, maxRecords: 1 })).rejects.toThrow("record limit");
+  });
+});

--- a/functions/_lib/boundedUpstream.ts
+++ b/functions/_lib/boundedUpstream.ts
@@ -1,0 +1,1 @@
+export { BoundedUpstreamError, readBoundedJsonResponse } from "../../src/lib/nodeFeedLimits";

--- a/functions/_lib/rateLimit.test.ts
+++ b/functions/_lib/rateLimit.test.ts
@@ -8,6 +8,9 @@ describe("rate limit helpers", () => {
     expect(parsePerMinuteLimit("invalid", 120)).toBe(120);
     expect(parsePerMinuteLimit("2.9", 120)).toBe(2);
     expect(parsePerMinuteLimit("0", 120)).toBe(1);
+    expect(parsePerMinuteLimit(undefined, 120, 1)).toBe(1);
+    expect(parsePerMinuteLimit("   ", 30, 1)).toBe(1);
+    expect(parsePerMinuteLimit("7.9", 120, 1)).toBe(7);
   });
   it("uses only Cloudflare-established client identity", () => {
     const cfReq = new Request("https://example.test", {

--- a/functions/_lib/rateLimit.ts
+++ b/functions/_lib/rateLimit.ts
@@ -21,8 +21,12 @@ let callsSinceSweep = 0;
 
 const DEFAULT_WINDOW_MS = 60_000;
 
-export const parsePerMinuteLimit = (raw: string | undefined, fallback: number): number => {
-  if (raw === undefined || raw.trim() === "") return fallback;
+export const parsePerMinuteLimit = (
+  raw: string | undefined,
+  fallback: number,
+  blankFallback = fallback,
+): number => {
+  if (raw === undefined || raw.trim() === "") return Math.max(1, Math.floor(blankFallback));
   const parsed = Number(raw);
   if (!Number.isFinite(parsed)) return fallback;
   return Math.max(1, Math.floor(parsed));

--- a/functions/_lib/terrainAnalysis.test.ts
+++ b/functions/_lib/terrainAnalysis.test.ts
@@ -1,24 +1,34 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { readRastersMock } = vi.hoisted(() => ({ readRastersMock: vi.fn() }));
+const { analyzeLinkMock, boundingBoxMock, readRastersMock } = vi.hoisted(() => ({
+  analyzeLinkMock: vi.fn(),
+  boundingBoxMock: vi.fn(() => [9, 60, 10, 61]),
+  readRastersMock: vi.fn(),
+}));
+
+vi.mock("../../src/lib/propagation", () => ({ analyzeLink: analyzeLinkMock }));
 
 vi.mock("geotiff", () => ({
   fromArrayBuffer: vi.fn(async () => ({
     getImage: async () => ({
       getWidth: () => 3601,
       getHeight: () => 3601,
-      getBoundingBox: () => [9, 60, 10, 61],
+      getBoundingBox: boundingBoxMock,
       getGDALNoData: () => null,
       readRasters: readRastersMock,
     }),
   })),
 }));
 
-import { loadCopernicusTilesForPath } from "./terrainAnalysis";
+import { analyzeTerrainLink, loadCopernicusTilesForPath } from "./terrainAnalysis";
+import type { Env } from "./types";
 
 describe("calculation API GLO-30 terrain loading", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    analyzeLinkMock.mockReset();
+    boundingBoxMock.mockReset();
+    boundingBoxMock.mockReturnValue([9, 60, 10, 61]);
     readRastersMock.mockReset();
     readRastersMock.mockResolvedValue(new Int16Array([100, 101, 102, 103]));
   });
@@ -50,6 +60,77 @@ describe("calculation API GLO-30 terrain loading", () => {
         "https://linksim.link/api/v1/calculate",
       ),
     ).resolves.toEqual({ tiles: [], tileKeys: [] });
+  });
+
+  it("requests only adjacent longitude tiles across the antimeridian", async () => {
+    const fetchMock = vi.fn(async () => new Response("", { status: 404 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await loadCopernicusTilesForPath(
+      { lat: 10.1, lon: 179.9 },
+      { lat: 10.2, lon: -179.9 },
+      "https://linksim.link/api/v1/calculate",
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual(
+      expect.arrayContaining([expect.stringContaining("N10_00_E179"), expect.stringContaining("N10_00_W180")]),
+    );
+  });
+
+  it("rejects overlarge terrain enumeration before fetching", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      loadCopernicusTilesForPath(
+        { lat: -80, lon: 0.1 },
+        { lat: 80, lon: 2.1 },
+        "https://linksim.link/api/v1/calculate",
+      ),
+    ).rejects.toThrow("256 tiles");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps terrain sampling on the short antimeridian path", async () => {
+    boundingBoxMock
+      .mockReturnValueOnce([179, 10, 180, 11])
+      .mockReturnValueOnce([-180, 10, -179, 11]);
+    readRastersMock.mockImplementation(async (options: { width: number; height: number }) =>
+      new Int16Array(options.width * options.height).fill(100),
+    );
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(new Uint8Array([1]), { status: 200 })));
+    analyzeLinkMock.mockImplementation((_link, _from, to, _model, terrainSampler) => {
+      expect(to.position.lon).toBeCloseTo(180.1);
+      expect(terrainSampler({ lat: 10.15, lon: 180.05 })).toBe(100);
+      return {
+        distanceKm: 22,
+        fsplDb: 100,
+        pathLossDb: 101,
+        terrainObstructed: false,
+        worstFresnelClearanceM: 1,
+        worstFresnelClearancePercent: 100,
+      };
+    });
+    const site = {
+      name: "Site",
+      txPowerDbm: 20,
+      txGainDbi: 2,
+      rxGainDbi: 2,
+      cableLossDb: 1,
+      antennaHeightM: 2,
+    };
+
+    await analyzeTerrainLink(
+      {} as Env,
+      "https://linksim.link/api/v1/calculate",
+      { ...site, lat: 10.1, lon: 179.9 },
+      { ...site, lat: 10.2, lon: -179.9 },
+      868,
+      100,
+    );
+
+    expect(analyzeLinkMock).toHaveBeenCalledTimes(1);
   });
 
   it("observes cancellation while GeoTIFF raster decoding is in progress", async () => {

--- a/functions/_lib/terrainAnalysis.ts
+++ b/functions/_lib/terrainAnalysis.ts
@@ -2,6 +2,7 @@ import { fromArrayBuffer } from "geotiff";
 import { analyzeLink } from "../../src/lib/propagation";
 import { defaultPropagationEnvironment } from "../../src/lib/propagationEnvironment";
 import { copernicus30PathForTileKey } from "../../src/lib/copernicusTilePath";
+import { normalizeLongitude, tilesForBounds } from "../../src/lib/terrainTiles";
 import type { Env } from "./types";
 
 export type TerrainAnalysisResult = {
@@ -40,31 +41,27 @@ type CompactTerrainTile = {
 const TILE_MARGIN_DEG = 0.02;
 const MAX_TILE_CELLS = 90_000;
 
-const tileKey = (lat: number, lon: number): string => {
-  const ns = lat >= 0 ? "N" : "S";
-  const ew = lon >= 0 ? "E" : "W";
-  return `${ns}${String(Math.floor(Math.abs(lat))).padStart(2, "0")}${ew}${String(Math.floor(Math.abs(lon))).padStart(3, "0")}`;
-};
-
-const tilesForBounds = (minLat: number, maxLat: number, minLon: number, maxLon: number): string[] => {
-  const keys = new Set<string>();
-  for (let lat = Math.floor(minLat); lat <= Math.floor(maxLat); lat += 1) {
-    for (let lon = Math.floor(minLon); lon <= Math.floor(maxLon); lon += 1) {
-      keys.add(tileKey(lat, lon));
-    }
-  }
-  return Array.from(keys).sort();
+const longitudeNearestTo = (lon: number, referenceLon: number): number => {
+  const normalized = normalizeLongitude(lon);
+  const delta = normalized - referenceLon;
+  if (delta > 180) return normalized - 360;
+  if (delta < -180) return normalized + 360;
+  return normalized;
 };
 
 const toTerrainBounds = (
   from: { lat: number; lon: number },
   to: { lat: number; lon: number },
-): TerrainBounds => ({
-  minLat: Math.max(-90, Math.min(from.lat, to.lat) - TILE_MARGIN_DEG),
-  maxLat: Math.min(90, Math.max(from.lat, to.lat) + TILE_MARGIN_DEG),
-  minLon: Math.max(-180, Math.min(from.lon, to.lon) - TILE_MARGIN_DEG),
-  maxLon: Math.min(180, Math.max(from.lon, to.lon) + TILE_MARGIN_DEG),
-});
+): TerrainBounds => {
+  const fromLon = normalizeLongitude(from.lon);
+  const toLon = longitudeNearestTo(to.lon, fromLon);
+  return {
+    minLat: Math.max(-90, Math.min(from.lat, to.lat) - TILE_MARGIN_DEG),
+    maxLat: Math.min(90, Math.max(from.lat, to.lat) + TILE_MARGIN_DEG),
+    minLon: normalizeLongitude(Math.min(fromLon, toLon) - TILE_MARGIN_DEG),
+    maxLon: normalizeLongitude(Math.max(fromLon, toLon) + TILE_MARGIN_DEG),
+  };
+};
 
 const parseCopernicusTile = async (
   key: string,
@@ -80,13 +77,18 @@ const parseCopernicusTile = async (
   const width = image.getWidth();
   const height = image.getHeight();
   const [minLon, minLat, maxLon, maxLat] = image.getBoundingBox();
-  const overlapMinLon = Math.max(minLon, bounds.minLon);
-  const overlapMaxLon = Math.min(maxLon, bounds.maxLon);
+  const longitudeIntervals = bounds.minLon <= bounds.maxLon
+    ? [[bounds.minLon, bounds.maxLon]]
+    : [[bounds.minLon, 180], [-180, bounds.maxLon]];
+  const longitudeOverlap = longitudeIntervals
+    .map(([intervalMin, intervalMax]) => [Math.max(minLon, intervalMin), Math.min(maxLon, intervalMax)])
+    .find(([overlapMin, overlapMax]) => overlapMin < overlapMax);
   const overlapMinLat = Math.max(minLat, bounds.minLat);
   const overlapMaxLat = Math.min(maxLat, bounds.maxLat);
-  if (overlapMinLon >= overlapMaxLon || overlapMinLat >= overlapMaxLat) {
+  if (!longitudeOverlap || overlapMinLat >= overlapMaxLat) {
     return null;
   }
+  const [overlapMinLon, overlapMaxLon] = longitudeOverlap;
 
   const x0 = Math.max(0, Math.min(width - 1, Math.floor(((overlapMinLon - minLon) / (maxLon - minLon)) * width)));
   const x1 = Math.max(x0 + 1, Math.min(width, Math.ceil(((overlapMaxLon - minLon) / (maxLon - minLon)) * width)));
@@ -189,6 +191,7 @@ export const loadCopernicusTilesForPath = async (
   requestUrl: string,
   signal?: AbortSignal,
 ): Promise<{ tiles: CompactTerrainTile[]; tileKeys: string[] }> => {
+  signal?.throwIfAborted();
   const origin = new URL(requestUrl).origin;
   const bounds = toTerrainBounds(from, to);
   const { minLat, maxLat, minLon, maxLon } = bounds;
@@ -228,7 +231,8 @@ export const analyzeTerrainLink = async (
     throw new Error("No terrain tiles available for this region");
   }
 
-  const terrainSampler = ({ lat, lon }: { lat: number; lon: number }) => sampleTerrainElevation(tiles, lat, lon);
+  const terrainSampler = ({ lat, lon }: { lat: number; lon: number }) =>
+    sampleTerrainElevation(tiles, lat, normalizeLongitude(lon));
   const fromGroundM = terrainSampler({ lat: fromSite.lat, lon: fromSite.lon }) ?? fromSite.groundElevationM ?? 0;
   const toGroundM = terrainSampler({ lat: toSite.lat, lon: toSite.lon }) ?? toSite.groundElevationM ?? 0;
 
@@ -246,7 +250,7 @@ export const analyzeTerrainLink = async (
   const to = {
     id: "to",
     name: toSite.name,
-    position: { lat: toSite.lat, lon: toSite.lon },
+    position: { lat: toSite.lat, lon: longitudeNearestTo(toSite.lon, fromSite.lon) },
     groundElevationM: toGroundM,
     antennaHeightM: toSite.antennaHeightM,
     txPowerDbm: toSite.txPowerDbm,

--- a/functions/meshmap/[[path]].test.ts
+++ b/functions/meshmap/[[path]].test.ts
@@ -7,6 +7,8 @@ const { getClientAddressMock, takeRateLimitTokenMock } = vi.hoisted(() => ({
 
 vi.mock("../_lib/rateLimit", () => ({
   getClientAddress: getClientAddressMock,
+  parsePerMinuteLimit: (raw: string | undefined, fallback: number, blankFallback = fallback) =>
+    raw === undefined || raw.trim() === "" ? blankFallback : Number(raw),
   takeRateLimitToken: takeRateLimitTokenMock,
 }));
 
@@ -17,7 +19,7 @@ const env = { DB: {}, PROXY_RATE_LIMIT_PER_MINUTE: "120" } as unknown as {
   PROXY_RATE_LIMIT_PER_MINUTE?: string;
 };
 
-const mkCtx = (request: Request) => ({ request, env } as unknown as Parameters<typeof onRequest>[0]);
+const mkCtx = (request: Request, routeEnv = env) => ({ request, env: routeEnv } as unknown as Parameters<typeof onRequest>[0]);
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -27,6 +29,26 @@ beforeEach(() => {
 });
 
 describe("meshmap proxy", () => {
+  it.each([
+    [undefined, 1],
+    ["", 1],
+    ["   ", 1],
+    ["17", 17],
+  ])("preserves the deployed proxy limit for configured value %s", async (configured, expected) => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(new Response("{}", {
+      headers: { "content-type": "application/json" },
+    }));
+    await onRequest(mkCtx(
+      new Request("https://example.test/meshmap/nodes.json"),
+      { DB: {}, PROXY_RATE_LIMIT_PER_MINUTE: configured } as unknown as typeof env,
+    ));
+
+    expect(takeRateLimitTokenMock).toHaveBeenCalledWith({
+      key: "proxy:meshmap:198.51.100.10",
+      limit: expected,
+    });
+  });
+
   it("rejects methods other than GET/HEAD", async () => {
     const req = new Request("https://example.test/meshmap/nodes.json", { method: "POST", body: "{}" });
     const res = await onRequest(mkCtx(req));
@@ -182,5 +204,31 @@ describe("meshmap proxy", () => {
       method: "HEAD",
       headers: { accept: "application/json" },
     });
+  });
+
+  it("accepts exact node and byte boundaries and rejects overflow", async () => {
+    const exactNodes = Object.fromEntries(Array.from({ length: 20_000 }, (_, index) => [`!${index}`, { lat: 60, lon: 10 }]));
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(new Response(JSON.stringify(exactNodes), { headers: { "content-type": "application/json" } }));
+    expect((await onRequest(mkCtx(new Request("https://example.test/meshmap/nodes.json")))).status).toBe(200);
+
+    const tooMany = { ...exactNodes, "!overflow": { lat: 60, lon: 10 } };
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(new Response(JSON.stringify(tooMany), { headers: { "content-type": "application/json" } }));
+    expect((await onRequest(mkCtx(new Request("https://example.test/meshmap/nodes.json")))).status).toBe(502);
+
+    const exactBytes = `[]${" ".repeat(5 * 1024 * 1024 - 2)}`;
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(new Response(exactBytes, { headers: { "content-type": "application/json" } }));
+    expect((await onRequest(mkCtx(new Request("https://example.test/meshmap/nodes.json")))).status).toBe(200);
+
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(new Response(new Uint8Array(5 * 1024 * 1024 + 1), { headers: { "content-type": "application/json" } }));
+    expect((await onRequest(mkCtx(new Request("https://example.test/meshmap/nodes.json")))).status).toBe(502);
+  });
+
+  it.each(["null", "42", '"nodes"'])("rejects primitive JSON root %s", async (body) => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(new Response(body, { headers: { "content-type": "application/json" } }));
+
+    const response = await onRequest(mkCtx(new Request("https://example.test/meshmap/nodes.json")));
+
+    expect(response.status).toBe(502);
+    expect(await response.text()).toContain("invalid or oversized node feed");
   });
 });

--- a/functions/meshmap/[[path]].ts
+++ b/functions/meshmap/[[path]].ts
@@ -1,16 +1,12 @@
 import { stripSensitiveProxyResponseHeaders } from "../_lib/proxy";
-import { getClientAddress, takeRateLimitToken } from "../_lib/rateLimit";
+import { getClientAddress, parsePerMinuteLimit, takeRateLimitToken } from "../_lib/rateLimit";
+import { readBoundedJsonResponse } from "../_lib/boundedUpstream";
 import type { Env } from "../_lib/types";
+import { MESHMAP_MAX_RECORDS, MESHMAP_MAX_RESPONSE_BYTES } from "../../src/lib/nodeFeedLimits";
 
 const MESHMAP_PATH = "/meshmap/nodes.json";
 const MESHMAP_UPSTREAM = "https://meshmap.net/nodes.json";
 const SUCCESS_CACHE_CONTROL = "public, max-age=1800";
-
-const parsePerMinuteLimit = (raw: string | undefined, fallback: number): number => {
-  const parsed = Number(raw ?? "");
-  if (!Number.isFinite(parsed)) return fallback;
-  return Math.max(1, Math.floor(parsed));
-};
 
 const passiveHeaders = (
   contentType: string,
@@ -45,7 +41,7 @@ export const onRequest: PagesFunction<Env> = async ({ request, env }) => {
 
   const limiter = takeRateLimitToken({
     key: `proxy:meshmap:${getClientAddress(request)}`,
-    limit: parsePerMinuteLimit(env.PROXY_RATE_LIMIT_PER_MINUTE, 120),
+    limit: parsePerMinuteLimit(env.PROXY_RATE_LIMIT_PER_MINUTE, 120, 1),
   });
   if (!limiter.allowed) {
     return localError("Rate limit reached", 429, {
@@ -76,7 +72,19 @@ export const onRequest: PagesFunction<Env> = async ({ request, env }) => {
     return localError("MeshMap upstream returned an unsupported content type", 502);
   }
 
-  return new Response(request.method === "HEAD" ? null : response.body, {
+  let body: BodyInit | null = null;
+  if (request.method !== "HEAD") {
+    try {
+      body = (await readBoundedJsonResponse(response, {
+        maxBytes: MESHMAP_MAX_RESPONSE_BYTES,
+        maxRecords: MESHMAP_MAX_RECORDS,
+      })).bytes;
+    } catch {
+      return localError("MeshMap upstream returned an invalid or oversized node feed", 502);
+    }
+  }
+
+  return new Response(body, {
     status: response.status,
     statusText: response.statusText,
     headers: passiveHeaders("application/json; charset=utf-8", "nodes.json", SUCCESS_CACHE_CONTROL),

--- a/functions/node-sources/868-no.test.ts
+++ b/functions/node-sources/868-no.test.ts
@@ -7,6 +7,8 @@ const { getClientAddressMock, takeRateLimitTokenMock } = vi.hoisted(() => ({
 
 vi.mock("../_lib/rateLimit", () => ({
   getClientAddress: getClientAddressMock,
+  parsePerMinuteLimit: (raw: string | undefined, fallback: number, blankFallback = fallback) =>
+    raw === undefined || raw.trim() === "" ? blankFallback : Number(raw),
   takeRateLimitToken: takeRateLimitTokenMock,
 }));
 
@@ -28,7 +30,7 @@ const env = { DB: {}, PROXY_RATE_LIMIT_PER_MINUTE: "120" } as unknown as {
 
 const cacheMatch = vi.fn();
 const cachePut = vi.fn();
-const mkCtx = (request: Request) => ({ request, env } as unknown as Parameters<typeof onRequest>[0]);
+const mkCtx = (request: Request, routeEnv = env) => ({ request, env: routeEnv } as unknown as Parameters<typeof onRequest>[0]);
 
 beforeEach(() => {
   vi.useRealTimers();
@@ -42,6 +44,23 @@ beforeEach(() => {
 });
 
 describe("868.no Meshstellar snapshot", () => {
+  it.each([
+    [undefined, 1],
+    ["", 1],
+    ["   ", 1],
+    ["17", 17],
+  ])("preserves the deployed proxy limit for configured value %s", async (configured, expected) => {
+    await onRequest(mkCtx(
+      new Request("https://example.test/node-sources/868-no"),
+      { DB: {}, PROXY_RATE_LIMIT_PER_MINUTE: configured } as unknown as typeof env,
+    ));
+
+    expect(takeRateLimitTokenMock).toHaveBeenCalledWith({
+      key: "node-source:868-no:198.51.100.10",
+      limit: expected,
+    });
+  });
+
   it("extracts positioned nodes, decodes attributes, and keeps the newest duplicate", () => {
     const payload = [
       event(`<li><div data-geojson="${feature("abc123", 1_800_000_000)}"></div></li>`),
@@ -112,5 +131,57 @@ describe("868.no Meshstellar snapshot", () => {
 
     expect(response.status).toBe(200);
     expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(takeRateLimitTokenMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts 5,000 SSE events and rejects the 5,001st", async () => {
+    const exact = Array.from({ length: 5_000 }, (_, index) => event(`<li><div data-geojson="${feature(String(index), index + 1)}"></div></li>`)).join("");
+    await expect(readMeshstellarSnapshot(new Response(exact).body!)).resolves.toHaveLength(5_000);
+    await expect(readMeshstellarSnapshot(new Response(exact + "event: statistics\ndata: overflow\n\n").body!)).rejects.toThrow("event limit");
+    const unterminated = `event: update-node\ndata: <li><div data-geojson="${feature("overflow", 5_001)}"></div></li>`;
+    await expect(readMeshstellarSnapshot(new Response(exact + unterminated).body!)).rejects.toThrow("event limit");
+  });
+
+  it("parses a normal final update-node record without a trailing delimiter", async () => {
+    const unterminated = `event: update-node\ndata: <li><div data-geojson="${feature("final", 1)}"></div></li>`;
+    await expect(readMeshstellarSnapshot(new Response(unterminated).body!)).resolves.toEqual([
+      expect.objectContaining({ nodeId: "!final" }),
+    ]);
+  });
+
+  it("accepts exactly 5 MiB and rejects the next streamed byte", async () => {
+    const nodeEvent = event(`<li><div data-geojson="${feature("boundary", 1)}"></div></li>`);
+    const exact = nodeEvent + `:${"x".repeat(5 * 1024 * 1024 - nodeEvent.length - 2)}\n`;
+    await expect(readMeshstellarSnapshot(new Response(exact).body!)).resolves.toEqual([
+      expect.objectContaining({ nodeId: "!boundary" }),
+    ]);
+    await expect(readMeshstellarSnapshot(new Response(`${exact}x`).body!)).rejects.toThrow("size limit");
+  });
+
+  it("frames CRLF events split into single-byte chunks without accumulating timers", async () => {
+    const payload = [
+      event(`<li><div data-geojson="${feature("first", 1)}"></div></li>`),
+      event(`<li><div data-geojson="${feature("second", 2)}"></div></li>`),
+    ].join("").replaceAll("\n", "\r\n");
+    const bytes = new TextEncoder().encode(payload);
+    let offset = 0;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (offset >= bytes.length) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(bytes.slice(offset, ++offset));
+      },
+    });
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+
+    await expect(readMeshstellarSnapshot(stream)).resolves.toEqual([
+      expect.objectContaining({ nodeId: "!first" }),
+      expect.objectContaining({ nodeId: "!second" }),
+    ]);
+    expect(setTimeoutSpy).toHaveBeenCalledTimes(bytes.length + 1);
+    expect(clearTimeoutSpy).toHaveBeenCalledTimes(setTimeoutSpy.mock.calls.length);
   });
 });

--- a/functions/node-sources/868-no.ts
+++ b/functions/node-sources/868-no.ts
@@ -1,11 +1,14 @@
-import { getClientAddress, takeRateLimitToken } from "../_lib/rateLimit";
+import { getClientAddress, parsePerMinuteLimit, takeRateLimitToken } from "../_lib/rateLimit";
 import type { Env } from "../_lib/types";
+import {
+  MESHSTELLAR_MAX_EVENTS,
+  MESHSTELLAR_MAX_STREAM_BYTES,
+  MESHSTELLAR_SNAPSHOT_IDLE_MS,
+  MESHSTELLAR_SNAPSHOT_MAX_MS,
+} from "../../src/lib/nodeFeedLimits";
 
 const UPSTREAM_URL = "https://map.868.no/events";
 const CACHE_TTL_SEC = 300;
-const SNAPSHOT_IDLE_MS = 1_000;
-const SNAPSHOT_MAX_MS = 8_000;
-const MAX_STREAM_BYTES = 5 * 1024 * 1024;
 
 type MeshstellarNode = {
   nodeId: string;
@@ -103,38 +106,115 @@ export const readMeshstellarSnapshot = async (body: ReadableStream<Uint8Array>):
   const decoder = new TextDecoder();
   const startedAt = Date.now();
   let lastDataAt = startedAt;
-  let payload = "";
+  const payloadChunks: string[] = [];
+  let pendingPayloadParts: string[] = [];
+  let pendingPayloadLength = 0;
   let bytesRead = 0;
-  try {
-    while (Date.now() - startedAt < SNAPSHOT_MAX_MS) {
-      const waitMs = payload.includes("event: update-node")
-        ? Math.max(1, SNAPSHOT_IDLE_MS - (Date.now() - lastDataAt))
-        : Math.max(1, SNAPSHOT_MAX_MS - (Date.now() - startedAt));
-      const outcome = await Promise.race([
+  let eventsRead = 0;
+  let eventHasContent = false;
+  let lineHasContent = false;
+  let pendingCr = false;
+  let sawUpdateNode = false;
+  let updateMarkerTail = "";
+  const updateMarker = "event: update-node";
+
+  const appendPayload = (text: string) => {
+    if (!text) return;
+    pendingPayloadParts.push(text);
+    pendingPayloadLength += text.length;
+    if (pendingPayloadLength >= 64 * 1024) {
+      payloadChunks.push(pendingPayloadParts.join(""));
+      pendingPayloadParts = [];
+      pendingPayloadLength = 0;
+    }
+  };
+  const countCompletedEvent = () => {
+    if (eventHasContent) {
+      eventsRead += 1;
+      if (eventsRead > MESHSTELLAR_MAX_EVENTS) throw new Error("Meshstellar snapshot exceeded the event limit");
+      eventHasContent = false;
+    }
+  };
+  const scanNewline = () => {
+    if (!lineHasContent) countCompletedEvent();
+    lineHasContent = false;
+  };
+  const scanFraming = (text: string) => {
+    if (!sawUpdateNode) {
+      const searchable = updateMarkerTail + text;
+      sawUpdateNode = searchable.includes(updateMarker);
+      updateMarkerTail = searchable.slice(-(updateMarker.length - 1));
+    }
+    for (const char of text) {
+      if (pendingCr) {
+        pendingCr = false;
+        scanNewline();
+        if (char === "\n") continue;
+      }
+      if (char === "\r") {
+        pendingCr = true;
+      } else if (char === "\n") {
+        scanNewline();
+      } else {
+        lineHasContent = true;
+        eventHasContent = true;
+      }
+    }
+  };
+  const finishFraming = () => {
+    if (pendingCr) {
+      pendingCr = false;
+      scanNewline();
+    }
+    countCompletedEvent();
+  };
+  const readWithTimeout = async (waitMs: number) => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
         reader.read().then((result) => ({ type: "read" as const, result })),
-        new Promise<{ type: "timeout" }>((resolve) => setTimeout(() => resolve({ type: "timeout" }), waitMs)),
+        new Promise<{ type: "timeout" }>((resolve) => {
+          timer = setTimeout(() => resolve({ type: "timeout" }), waitMs);
+        }),
       ]);
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+    }
+  };
+
+  try {
+    while (true) {
+      const now = Date.now();
+      const absoluteRemainingMs = MESHSTELLAR_SNAPSHOT_MAX_MS - (now - startedAt);
+      if (absoluteRemainingMs <= 0) break;
+      const idleRemainingMs = sawUpdateNode
+        ? MESHSTELLAR_SNAPSHOT_IDLE_MS - (now - lastDataAt)
+        : absoluteRemainingMs;
+      if (idleRemainingMs <= 0) break;
+      const outcome = await readWithTimeout(Math.min(absoluteRemainingMs, idleRemainingMs));
       if (outcome.type === "timeout") break;
       if (outcome.result.done) {
-        payload += decoder.decode();
+        const finalText = decoder.decode();
+        appendPayload(finalText);
+        scanFraming(finalText);
         break;
       }
       bytesRead += outcome.result.value.byteLength;
-      if (bytesRead > MAX_STREAM_BYTES) throw new Error("Meshstellar snapshot exceeded the size limit");
-      payload += decoder.decode(outcome.result.value, { stream: true });
+      if (bytesRead > MESHSTELLAR_MAX_STREAM_BYTES) throw new Error("Meshstellar snapshot exceeded the size limit");
+      const text = decoder.decode(outcome.result.value, { stream: true });
+      appendPayload(text);
+      scanFraming(text);
       lastDataAt = Date.now();
     }
   } finally {
     await reader.cancel().catch(() => undefined);
   }
+  finishFraming();
+  if (pendingPayloadParts.length) payloadChunks.push(pendingPayloadParts.join(""));
+  const payload = payloadChunks.join("");
   const nodes = parseMeshstellarSnapshot(payload);
   if (!nodes.length) throw new Error("Meshstellar returned no positioned nodes");
   return nodes;
-};
-
-const parsePerMinuteLimit = (raw: string | undefined, fallback: number): number => {
-  const parsed = Number(raw ?? "");
-  return Number.isFinite(parsed) ? Math.max(1, Math.floor(parsed)) : fallback;
 };
 
 export const onRequest: PagesFunction<Env> = async ({ request, env }) => {
@@ -149,7 +229,7 @@ export const onRequest: PagesFunction<Env> = async ({ request, env }) => {
 
   const limiter = takeRateLimitToken({
     key: `node-source:868-no:${getClientAddress(request)}`,
-    limit: parsePerMinuteLimit(env.PROXY_RATE_LIMIT_PER_MINUTE, 30),
+    limit: parsePerMinuteLimit(env.PROXY_RATE_LIMIT_PER_MINUTE, 30, 1),
   });
   if (!limiter.allowed) {
     return new Response("Rate limit reached", {

--- a/src/components/MapView.overlayHandoff.test.tsx
+++ b/src/components/MapView.overlayHandoff.test.tsx
@@ -504,6 +504,34 @@ describe("MapView overlay handoff", () => {
     expect(useCoverageStore.getState().autoCalculateEnabled).toBe(false);
   });
 
+  it("stays mounted and skips terrain fetch for an over-cap site set", async () => {
+    const recommendAndFetchTerrainForCurrentArea = vi.fn(async () => undefined);
+    const wideSites = [-100, 0, 100].map((lon, index) => ({
+      ...site,
+      id: `wide-${index}`,
+      position: { lat: 10.1, lon },
+    }));
+    useAppStore.setState({
+      sites: wideSites,
+      selectedSiteId: wideSites[0].id,
+      selectedSiteIds: wideSites.map((entry) => entry.id),
+      recommendAndFetchTerrainForCurrentArea,
+    });
+
+    expect(() =>
+      render(
+        <MapView
+          canPersist
+          isMapExpanded={false}
+          onToggleMapExpanded={() => undefined}
+          showInspector={false}
+        />,
+      ),
+    ).not.toThrow();
+    await act(async () => undefined);
+    expect(recommendAndFetchTerrainForCurrentArea).not.toHaveBeenCalled();
+  });
+
   it("does not replay clouds when a completed signature is observed again", async () => {
     render(
       <MapView

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -64,6 +64,7 @@ import {
 } from "../lib/meshtasticMqtt";
 import { canShowSaveSelectedLinkAction } from "../lib/selectedPairActions";
 import {
+  buildBufferedSelectionArea,
   optionsForSelectionCount,
   resolveRequiredOverlayTerrainTileKeys,
   resolveOverlayRadiusOptionForSelectionTransition,
@@ -329,11 +330,6 @@ type OverlayRaster = {
   maxAreaKm2?: number;
 };
 
-type OverlayMaskArea = {
-  bounds: TerrainBounds;
-  contains: (lat: number, lon: number) => boolean;
-};
-
 const computeTerrainBounds = (sites: { position: { lat: number; lon: number } }[]): TerrainBounds => {
   const lats = sites.map((site) => site.position.lat);
   const lons = sites.map((site) => site.position.lon);
@@ -351,117 +347,6 @@ const computeTerrainBounds = (sites: { position: { lat: number; lon: number } }[
     minLon: minLon - lonPadding,
     maxLon: maxLon + lonPadding,
   };
-};
-
-const distanceKmBetween = (latA: number, lonA: number, latB: number, lonB: number): number => {
-  const dLat = (latB - latA) * 111.32;
-  const midLat = (latA + latB) / 2;
-  const dLon = (lonB - lonA) * 111.32 * Math.max(0.1, Math.cos((midLat * Math.PI) / 180));
-  return Math.sqrt(dLat * dLat + dLon * dLon);
-};
-
-const distancePointToSegmentKm = (
-  px: number,
-  py: number,
-  ax: number,
-  ay: number,
-  bx: number,
-  by: number,
-): number => {
-  const dx = bx - ax;
-  const dy = by - ay;
-  const lenSq = dx * dx + dy * dy;
-  if (lenSq <= 1e-9) return Math.sqrt((px - ax) ** 2 + (py - ay) ** 2);
-  const t = clamp(((px - ax) * dx + (py - ay) * dy) / lenSq, 0, 1);
-  const cx = ax + t * dx;
-  const cy = ay + t * dy;
-  return Math.sqrt((px - cx) ** 2 + (py - cy) ** 2);
-};
-
-const convexHull = (points: { x: number; y: number }[]): { x: number; y: number }[] => {
-  if (points.length <= 2) return [...points];
-  const sorted = [...points].sort((a, b) => (a.x === b.x ? a.y - b.y : a.x - b.x));
-  const cross = (o: { x: number; y: number }, a: { x: number; y: number }, b: { x: number; y: number }) =>
-    (a.x - o.x) * (b.y - o.y) - (a.y - o.y) * (b.x - o.x);
-  const lower: { x: number; y: number }[] = [];
-  for (const point of sorted) {
-    while (lower.length >= 2 && cross(lower[lower.length - 2], lower[lower.length - 1], point) <= 0) {
-      lower.pop();
-    }
-    lower.push(point);
-  }
-  const upper: { x: number; y: number }[] = [];
-  for (let index = sorted.length - 1; index >= 0; index -= 1) {
-    const point = sorted[index];
-    while (upper.length >= 2 && cross(upper[upper.length - 2], upper[upper.length - 1], point) <= 0) {
-      upper.pop();
-    }
-    upper.push(point);
-  }
-  lower.pop();
-  upper.pop();
-  return [...lower, ...upper];
-};
-
-const pointInPolygon = (x: number, y: number, polygon: { x: number; y: number }[]): boolean => {
-  let inside = false;
-  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
-    const xi = polygon[i].x;
-    const yi = polygon[i].y;
-    const xj = polygon[j].x;
-    const yj = polygon[j].y;
-    const intersects = yi > y !== yj > y && x < ((xj - xi) * (y - yi)) / ((yj - yi) || 1e-9) + xi;
-    if (intersects) inside = !inside;
-  }
-  return inside;
-};
-
-const buildBufferedSelectionArea = (sites: Site[], radiusKm: number): OverlayMaskArea | null => {
-  if (!sites.length) return null;
-  const centerLat = sites.reduce((sum, site) => sum + site.position.lat, 0) / sites.length;
-  const kmPerLat = 111.32;
-  const kmPerLon = Math.max(0.1, Math.cos((centerLat * Math.PI) / 180)) * 111.32;
-  const projected = sites.map((site) => ({
-    x: site.position.lon * kmPerLon,
-    y: site.position.lat * kmPerLat,
-    lat: site.position.lat,
-    lon: site.position.lon,
-  }));
-  const hull = convexHull(projected.map((point) => ({ x: point.x, y: point.y })));
-  const minLat = Math.min(...projected.map((point) => point.lat));
-  const maxLat = Math.max(...projected.map((point) => point.lat));
-  const minLon = Math.min(...projected.map((point) => point.lon));
-  const maxLon = Math.max(...projected.map((point) => point.lon));
-  const latDelta = Math.max(0.01, radiusKm / kmPerLat);
-  const lonDelta = Math.max(0.01, radiusKm / kmPerLon);
-  const bounds: TerrainBounds = {
-    minLat: minLat - latDelta,
-    maxLat: maxLat + latDelta,
-    minLon: minLon - lonDelta,
-    maxLon: maxLon + lonDelta,
-  };
-
-  const contains = (lat: number, lon: number): boolean => {
-    const x = lon * kmPerLon;
-    const y = lat * kmPerLat;
-    if (projected.length === 1) {
-      return distanceKmBetween(lat, lon, projected[0].lat, projected[0].lon) <= radiusKm;
-    }
-    if (hull.length <= 2) {
-      const a = hull[0];
-      const b = hull[1] ?? hull[0];
-      return distancePointToSegmentKm(x, y, a.x, a.y, b.x, b.y) <= radiusKm;
-    }
-    if (pointInPolygon(x, y, hull)) return true;
-    for (let index = 0; index < hull.length; index += 1) {
-      const a = hull[index];
-      const b = hull[(index + 1) % hull.length];
-      if (distancePointToSegmentKm(x, y, a.x, a.y, b.x, b.y) <= radiusKm) return true;
-    }
-    return false;
-  };
-
-  return { bounds, contains };
 };
 
 const computeCoverageBounds = (samples: CoverageSampleLite[]): TerrainBounds | null => {
@@ -1438,10 +1323,26 @@ export function MapView({
     () => new Set(srtmTiles.filter((tile) => tile.sourceId === "copernicus30").map((tile) => tile.key)),
     [srtmTiles],
   );
-  const requiredTargetRadiusTileKeys = useMemo(
-    () => resolveRequiredOverlayTerrainTileKeys(analysisTargetSites, targetRadiusKm),
-    [analysisTargetSites, targetRadiusKm],
-  );
+  const requiredTargetRadiusTileResolution = useMemo(() => {
+    try {
+      return {
+        keys: resolveRequiredOverlayTerrainTileKeys(analysisTargetSites, targetRadiusKm),
+        error: "",
+      };
+    } catch (error) {
+      return { keys: [] as string[], error: getUiErrorMessage(error) };
+    }
+  }, [analysisTargetSites, targetRadiusKm]);
+  const requiredTargetRadiusTileKeys = requiredTargetRadiusTileResolution.keys;
+  useEffect(() => {
+    if (!requiredTargetRadiusTileResolution.error) return;
+    onPublishNotice?.({
+      id: "terrain-area-too-large",
+      message: requiredTargetRadiusTileResolution.error,
+      tone: "error",
+      persistent: false,
+    });
+  }, [onPublishNotice, requiredTargetRadiusTileResolution.error]);
   const missingTargetRadiusTileKeys = useMemo(
     () => requiredTargetRadiusTileKeys.filter((key) => !loaded30mTileKeys.has(key)).sort(),
     [requiredTargetRadiusTileKeys, loaded30mTileKeys],

--- a/src/components/PanoramaChart.test.tsx
+++ b/src/components/PanoramaChart.test.tsx
@@ -2,6 +2,7 @@
 import { act, render, screen } from "@testing-library/react";
 import { Profiler, StrictMode, type ProfilerOnRenderCallback } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MeshmapNode } from "../lib/meshtasticMqtt";
 import type { Site } from "../types/radio";
 
 const testState = vi.hoisted(() => ({
@@ -39,10 +40,10 @@ const testState = vi.hoisted(() => ({
     rxSensitivityTargetDbm: -120,
     environmentLossDb: 0,
     siteDragPreview: {},
-    siteLibrary: [],
+    siteLibrary: [] as Array<Site & { visibility?: "private" | "public" | "shared" }>,
     discoveryLibraryVisible: false,
     discoveryMqttVisible: false,
-    mapDiscoveryMqttNodes: [],
+    mapDiscoveryMqttNodes: [] as MeshmapNode[],
     terrainLoadEpoch: 1,
   },
 }));
@@ -194,6 +195,10 @@ describe("PanoramaChart scheduling", () => {
       },
     ];
     testState.store.siteDragPreview = {};
+    testState.store.siteLibrary = [];
+    testState.store.discoveryLibraryVisible = false;
+    testState.store.discoveryMqttVisible = false;
+    testState.store.mapDiscoveryMqttNodes = [];
     testState.schedulers.length = 0;
     testState.buildPanorama.mockImplementation((input) =>
       panoramaResult(input.options.windowCenterDeg != null),
@@ -353,6 +358,49 @@ describe("PanoramaChart scheduling", () => {
       lat: 59.91,
       lon: 10.77,
     });
+  });
+
+  it("caps candidates before panorama calculation with simulation and library priority", async () => {
+    const candidatePosition = (distanceKm: number) => ({
+      lat: 59.91 + distanceKm / 111.195,
+      lon: 10.75,
+    });
+    testState.store.sites = [
+      testState.store.sites[0],
+      {
+        ...testState.store.sites[0],
+        id: "site-2",
+        name: "Simulation candidate",
+        position: candidatePosition(199),
+      },
+    ];
+    testState.store.siteLibrary = [
+      {
+        ...testState.store.sites[0],
+        id: "library-1",
+        name: "Library candidate",
+        visibility: "shared",
+        position: candidatePosition(199),
+      },
+    ];
+    testState.store.discoveryLibraryVisible = true;
+    testState.store.discoveryMqttVisible = true;
+    testState.store.mapDiscoveryMqttNodes = [
+      ...Array.from({ length: 1_100 }, (_, index) => ({
+        nodeId: String(index).padStart(4, "0"),
+        lat: candidatePosition(index % 2 ? 10 : 20).lat,
+        lon: 10.75,
+      })),
+      { nodeId: "outside", lat: candidatePosition(201).lat, lon: 10.75 },
+    ];
+
+    renderChart();
+
+    expect(await screen.findByRole("img", { name: "Panorama" })).toBeInTheDocument();
+    const candidates = testState.buildPanorama.mock.calls[0][0].nodeCandidates as Array<{ id: string }>;
+    expect(candidates).toHaveLength(1_000);
+    expect(candidates.slice(0, 2).map((candidate) => candidate.id)).toEqual(["sim:site-2", "lib:library-1"]);
+    expect(candidates.some((candidate) => candidate.id === "mqtt:outside")).toBe(false);
   });
 
   it("rebuilds panoramas for successive candidate drag positions", async () => {

--- a/src/components/PanoramaChart.tsx
+++ b/src/components/PanoramaChart.tsx
@@ -18,6 +18,7 @@ import {
   buildPanorama,
   qualityToSampling,
   resolvePanoramaSampling,
+  selectPanoramaNodeCandidates,
   type PanoramaNodeCandidate,
   type PanoramaNodeProjection,
   type PanoramaQuality,
@@ -319,7 +320,8 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
     : null;
 
   const nodeCandidates = useMemo<PanoramaNodeCandidate[]>(() => {
-    const povSiteId = selectedSiteEffective?.id;
+    if (!selectedSiteEffective) return [];
+    const povSiteId = selectedSiteEffective.id;
     const simulation = previewSites
       .filter((site) => site.id !== povSiteId)
       .map((site) => ({
@@ -374,7 +376,7 @@ export function PanoramaChart({ isExpanded, onToggleExpanded, showExpandToggle =
         }))
       : [];
 
-    return [...simulation, ...sharedLibrary, ...mqtt];
+    return selectPanoramaNodeCandidates(selectedSiteEffective.position, [...simulation, ...sharedLibrary, ...mqtt]);
   }, [previewSites, siteLibrary, mqttNodes, discoveryLibraryVisible, discoveryMqttVisible, selectedSiteEffective]);
 
   useEffect(() => {

--- a/src/lib/copernicusTerrainClient.test.ts
+++ b/src/lib/copernicusTerrainClient.test.ts
@@ -107,6 +107,37 @@ describe("Copernicus GLO-30 tile loading", () => {
     expect(maxActive).toBe(2);
   });
 
+  it("rejects more than 256 requested keys before catalog, cache, or tile requests", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const keys = Array.from({ length: 257 }, (_, index) =>
+      `${index < 180 ? "N00" : "N01"}E${String(index % 180).padStart(3, "0")}`,
+    );
+
+    await expect(loadCopernicus30TilesByKeys(keys)).rejects.toThrow("256 tiles");
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(caches.open).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid requested keys before catalog, cache, or tile requests", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(loadCopernicus30TilesByKeys(["invalid"])).rejects.toThrow("Invalid terrain tile key");
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(caches.open).not.toHaveBeenCalled();
+  });
+
+  it("rejects impossible requested coordinates before catalog, cache, or tile requests", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(loadCopernicus30TilesByKeys(["N90E000"])).rejects.toThrow("Invalid terrain tile key");
+    await expect(loadCopernicus30TilesByKeys(["N00E180"])).rejects.toThrow("Invalid terrain tile key");
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(caches.open).not.toHaveBeenCalled();
+  });
+
   it("retries one transient response but not a permanent 404", async () => {
     const fetchMock = vi
       .fn()

--- a/src/lib/copernicusTerrainClient.ts
+++ b/src/lib/copernicusTerrainClient.ts
@@ -1,6 +1,7 @@
 import { fromArrayBuffer } from "geotiff";
 import type { SrtmTile } from "../types/radio";
 import { copernicus30PathForTileKey } from "./copernicusTilePath";
+import { boundedUniqueTerrainTileKeys } from "./terrainTiles";
 
 export { copernicus30PathForTileKey } from "./copernicusTilePath";
 
@@ -407,7 +408,8 @@ export const loadCopernicus30TilesByKeys = async (
     onTileProgress?: (progress: CopernicusTileProgress) => void;
   } = {},
 ): Promise<CopernicusLoadResult> => {
-  const keys = Array.from(new Set(tileKeys));
+  throwIfAborted(options.signal);
+  const keys = boundedUniqueTerrainTileKeys(tileKeys);
   if (keys.length <= 0) {
     return { tiles: [], failedTiles: [], fetchedTiles: [], cacheHits: [], seaLevelTiles: [] };
   }

--- a/src/lib/coverage.test.ts
+++ b/src/lib/coverage.test.ts
@@ -14,6 +14,8 @@ import {
 import { haversineDistanceKm } from "./geo";
 import { defaultPropagationEnvironment } from "./propagationEnvironment";
 import { resolveSimulationSitesForSelection } from "./simulationArea";
+import { resolveRequiredOverlayTerrainTileKeys } from "./simulationOverlayRadius";
+import { normalizeLongitude } from "./terrainTiles";
 import type { Network, RadioSystem, Site } from "../types/radio";
 
 const sites: Site[] = [
@@ -231,6 +233,43 @@ describe("buildCoverage", () => {
         { overlayRadiusKm: 50, requireCompleteTerrain: true },
       ),
     ).rejects.toThrow("Terrain data is unavailable");
+  });
+
+  it("keeps complete-terrain contributor paths on the short antimeridian interval", () => {
+    const datelineSite: Site = {
+      ...sites[0],
+      id: "dateline-east",
+      position: { lat: 10.1, lon: 179.9 },
+      groundElevationM: 100,
+    };
+    const datelineNetwork: Network = {
+      ...network,
+      memberships: [{ siteId: datelineSite.id, systemId: systems[0].id }],
+    };
+    const sampledLongitudes: number[] = [];
+    const terrainSampler = ({ lon }: { lat: number; lon: number }) => {
+      const normalized = normalizeLongitude(lon);
+      sampledLongitudes.push(normalized);
+      return Math.abs(normalized) >= 179 ? 100 : null;
+    };
+    const [evaluator] = createCoverageContributorEvaluators(
+      datelineNetwork,
+      [datelineSite],
+      systems,
+      defaultPropagationEnvironment(),
+      terrainSampler,
+      { requireCompleteTerrain: true, terrainCacheKey: "dateline-complete" },
+    );
+
+    expect(() => evaluator.evaluatePoint(10.1, -179.9)).not.toThrow();
+    expect(sampledLongitudes.length).toBeGreaterThan(3);
+    expect(sampledLongitudes.every((lon) => Math.abs(lon) >= 179)).toBe(true);
+    expect(
+      resolveRequiredOverlayTerrainTileKeys(
+        [datelineSite, { ...datelineSite, id: "dateline-west", position: { lat: 10.1, lon: -179.9 } }],
+        20,
+      ).every((key) => key.endsWith("E179") || key.endsWith("W180")),
+    ).toBe(true);
   });
 
   it("uses single-site radius override for sampling bounds", () => {

--- a/src/lib/meshtasticMqtt.test.ts
+++ b/src/lib/meshtasticMqtt.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   formatPositionPrecision,
   getPositionPrecisionBounds,
   mergeMeshmapNodes,
   parseMeshmapLikeFeed,
+  fetchMeshmapNodes,
 } from "./meshtasticMqtt";
 
 describe("node feed normalization", () => {
@@ -109,5 +110,65 @@ describe("node feed normalization", () => {
       expect.objectContaining({ nodeId: "!abc123", longName: "Newer" }),
       expect.objectContaining({ nodeId: "!other" }),
     ]);
+  });
+
+  it("caps normalized sources at 20,000 and combined deduped nodes at 25,000", () => {
+    const source = Array.from({ length: 20_001 }, (_, index) => ({ nodeId: `!${String(index).padStart(5, "0")}`, lat: 60, lon: 10 }));
+    expect(parseMeshmapLikeFeed(source)).toHaveLength(20_000);
+    const left = source.slice(0, 20_000) as ReturnType<typeof parseMeshmapLikeFeed>;
+    const right = Array.from({ length: 20_000 }, (_, index) => ({ nodeId: `!r${String(index).padStart(5, "0")}`, lat: 61, lon: 11 }));
+    expect(mergeMeshmapNodes([left, right])).toHaveLength(25_000);
+  });
+
+  it("rejects oversized custom feeds and falls back only to a bounded cache", async () => {
+    const cache = new Map<string, string>();
+    vi.stubGlobal("localStorage", {
+      getItem: (key: string) => cache.get(key) ?? null,
+      setItem: (key: string, value: string) => cache.set(key, value),
+    });
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    try {
+      fetchMock.mockResolvedValueOnce(new Response("[]", { headers: { "content-length": String(5 * 1024 * 1024 + 1) } }));
+      await expect(fetchMeshmapNodes({ sourceUrl: "/declared-oversize" })).rejects.toThrow("size limit");
+
+      const chunkedOversize = () => new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array(5 * 1024 * 1024));
+          controller.enqueue(new Uint8Array(1));
+        },
+      });
+      fetchMock.mockResolvedValueOnce(new Response(chunkedOversize()));
+      await expect(fetchMeshmapNodes({ sourceUrl: "/chunked-oversize" })).rejects.toThrow("size limit");
+
+      const tooMany = Array.from({ length: 20_001 }, (_, index) => ({ nodeId: `!${index}`, lat: 60, lon: 10 }));
+      fetchMock.mockResolvedValueOnce(new Response(JSON.stringify(tooMany)));
+      await expect(fetchMeshmapNodes({ sourceUrl: "/record-oversize" })).rejects.toThrow("record limit");
+
+      const exact = Array.from({ length: 20_000 }, (_, index) => ({ nodeId: `!cache${String(index).padStart(5, "0")}`, lat: 60, lon: 10 }));
+      fetchMock.mockResolvedValueOnce(new Response(JSON.stringify(exact)));
+      const fresh = await fetchMeshmapNodes({ sourceUrl: "/bounded-source" });
+      expect(fresh.nodes).toHaveLength(20_000);
+      expect(JSON.parse(cache.get("rmw-node-source-cache-v1:/bounded-source")!).nodes).toHaveLength(20_000);
+
+      fetchMock.mockResolvedValueOnce(new Response("[]", { headers: { "content-length": String(5 * 1024 * 1024 + 1) } }));
+      const fallback = await fetchMeshmapNodes({ sourceUrl: "/bounded-source" });
+      expect(fallback).toMatchObject({ fromCache: true, networkError: true });
+      expect(fallback.nodes).toHaveLength(20_000);
+
+      fetchMock.mockResolvedValueOnce(new Response(chunkedOversize()));
+      expect(await fetchMeshmapNodes({ sourceUrl: "/bounded-source" })).toMatchObject({
+        fromCache: true,
+        networkError: true,
+      });
+
+      fetchMock.mockResolvedValueOnce(new Response(JSON.stringify(tooMany)));
+      expect(await fetchMeshmapNodes({ sourceUrl: "/bounded-source" })).toMatchObject({
+        fromCache: true,
+        networkError: true,
+      });
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 });

--- a/src/lib/meshtasticMqtt.ts
+++ b/src/lib/meshtasticMqtt.ts
@@ -1,3 +1,11 @@
+import {
+  MESHMAP_MAX_RECORDS,
+  MESHMAP_MAX_RESPONSE_BYTES,
+  NODE_FEED_MAX_COMBINED_RECORDS,
+  NODE_FEED_MAX_RECORDS_PER_SOURCE,
+  readBoundedJsonResponse,
+} from "./nodeFeedLimits";
+
 export type MeshmapNode = {
   nodeId: string;
   longName?: string;
@@ -70,6 +78,9 @@ const MESHMAP_CACHE_KEY = "rmw-meshmap-cache-v1";
 const NODE_SOURCE_CACHE_KEY_PREFIX = "rmw-node-source-cache-v1";
 const MESHMAP_SOURCE_URL_KEY = "rmw-meshmap-source-url-v1";
 
+const boundedSourceNodes = (nodes: MeshmapNode[]): MeshmapNode[] =>
+  nodes.slice().sort((a, b) => a.nodeId.localeCompare(b.nodeId)).slice(0, NODE_FEED_MAX_RECORDS_PER_SOURCE);
+
 const toNumber = (value: unknown): number | null => {
   const n = typeof value === "number" ? value : Number(value);
   return Number.isFinite(n) ? n : null;
@@ -126,7 +137,7 @@ const readCache = (sourceUrl: string): MeshmapCache | null => {
     if (!Number.isFinite(parsed.savedAt)) return null;
     if (typeof parsed.sourceUrl !== "string" || !parsed.sourceUrl.trim()) return null;
     if (!Array.isArray(parsed.nodes)) return null;
-    return parsed;
+    return { ...parsed, nodes: boundedSourceNodes(parsed.nodes) };
   } catch {
     return null;
   }
@@ -137,7 +148,7 @@ const writeCache = (sourceUrl: string, nodes: MeshmapNode[]): void => {
     const payload: MeshmapCache = {
       savedAt: Date.now(),
       sourceUrl,
-      nodes,
+      nodes: boundedSourceNodes(nodes),
     };
     localStorage.setItem(cacheKeyFor(sourceUrl), JSON.stringify(payload));
   } catch {
@@ -208,13 +219,13 @@ export const parseMeshmapLikeFeed = (payload: unknown): MeshmapNode[] => {
       if (parsed) out.push(parsed);
     }
   }
-  return out.sort((a, b) => a.nodeId.localeCompare(b.nodeId));
+  return out.sort((a, b) => a.nodeId.localeCompare(b.nodeId)).slice(0, NODE_FEED_MAX_RECORDS_PER_SOURCE);
 };
 
 export const mergeMeshmapNodes = (sources: MeshmapNode[][]): MeshmapNode[] => {
   const merged = new Map<string, MeshmapNode>();
   for (const nodes of sources) {
-    for (const node of nodes) {
+    for (const node of boundedSourceNodes(nodes)) {
       const nodeId = canonicalNodeId(node.nodeId);
       const candidate = { ...node, nodeId };
       const current = merged.get(nodeId);
@@ -223,7 +234,9 @@ export const mergeMeshmapNodes = (sources: MeshmapNode[][]): MeshmapNode[] => {
       }
     }
   }
-  return Array.from(merged.values()).sort((a, b) => a.nodeId.localeCompare(b.nodeId));
+  return Array.from(merged.values())
+    .sort((a, b) => a.nodeId.localeCompare(b.nodeId))
+    .slice(0, NODE_FEED_MAX_COMBINED_RECORDS);
 };
 
 export const getDefaultMeshmapFeedUrl = (): string => DEFAULT_MESHMAP_FEED_URL;
@@ -266,7 +279,10 @@ export const fetchMeshmapNodes = async (options: MeshmapFetchOptions = {}): Prom
     if (!response.ok) {
       throw new Error(`Feed error: ${response.status}`);
     }
-    const payload = (await response.json()) as unknown;
+    const { value: payload } = await readBoundedJsonResponse<unknown>(response, {
+      maxBytes: MESHMAP_MAX_RESPONSE_BYTES,
+      maxRecords: MESHMAP_MAX_RECORDS,
+    });
     const nodes = parseMeshmapLikeFeed(payload).map((node) => ({
       ...node,
       sourceId: options.sourceId,

--- a/src/lib/nodeFeedLimits.ts
+++ b/src/lib/nodeFeedLimits.ts
@@ -1,0 +1,79 @@
+export const MESHMAP_MAX_RESPONSE_BYTES = 5 * 1024 * 1024;
+export const MESHMAP_MAX_RECORDS = 20_000;
+
+export const MESHSTELLAR_MAX_STREAM_BYTES = 5 * 1024 * 1024;
+export const MESHSTELLAR_MAX_EVENTS = 5_000;
+export const MESHSTELLAR_SNAPSHOT_IDLE_MS = 1_000;
+export const MESHSTELLAR_SNAPSHOT_MAX_MS = 8_000;
+
+export const NODE_FEED_MAX_RECORDS_PER_SOURCE = 20_000;
+export const NODE_FEED_MAX_COMBINED_RECORDS = 25_000;
+
+export const PANORAMA_MAX_NODE_CANDIDATES = 1_000;
+export const PANORAMA_MAX_NODE_DISTANCE_KM = 200;
+
+export class BoundedUpstreamError extends Error {}
+
+type BoundedJsonOptions = {
+  maxBytes: number;
+  maxRecords: number;
+};
+
+const recordCount = (value: unknown): number | null => {
+  if (Array.isArray(value)) return value.length;
+  if (value !== null && typeof value === "object") return Object.keys(value).length;
+  return null;
+};
+
+export const readBoundedJsonResponse = async <T>(
+  response: Response,
+  options: BoundedJsonOptions,
+): Promise<{ bytes: Uint8Array; value: T }> => {
+  const contentLength = response.headers.get("content-length");
+  const declaredLength = contentLength === null ? null : Number(contentLength);
+  if (declaredLength !== null && Number.isFinite(declaredLength) && declaredLength > options.maxBytes) {
+    await response.body?.cancel().catch(() => undefined);
+    throw new BoundedUpstreamError("Upstream response exceeded the size limit");
+  }
+  if (!response.body) throw new BoundedUpstreamError("Upstream response body is missing");
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      totalBytes += value.byteLength;
+      if (totalBytes > options.maxBytes) {
+        await reader.cancel().catch(() => undefined);
+        throw new BoundedUpstreamError("Upstream response exceeded the size limit");
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const bytes = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  let value: T;
+  try {
+    value = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes)) as T;
+  } catch {
+    throw new BoundedUpstreamError("Upstream response must contain valid JSON");
+  }
+  const records = recordCount(value);
+  if (records === null) {
+    throw new BoundedUpstreamError("Upstream response JSON root must be an object or array");
+  }
+  if (records > options.maxRecords) {
+    throw new BoundedUpstreamError("Upstream response exceeded the record limit");
+  }
+  return { bytes, value };
+};

--- a/src/lib/panorama.test.ts
+++ b/src/lib/panorama.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { azimuthFromToDeg, buildPanorama, destinationForDistanceKm, earthCurvatureDropM, qualityToSampling, resolvePanoramaSampling } from "./panorama";
+import { azimuthFromToDeg, buildPanorama, destinationForDistanceKm, earthCurvatureDropM, qualityToSampling, resolvePanoramaSampling, selectPanoramaNodeCandidates } from "./panorama";
 import type { Link, PropagationEnvironment, Site } from "../types/radio";
 
 const site: Site = {
@@ -146,5 +146,28 @@ describe("panorama", () => {
     expect(result.rays.length).toBeLessThan(220);
     expect(result.rays.some((ray) => ray.azimuthDeg < 10)).toBe(true);
     expect(result.rays.some((ray) => ray.azimuthDeg > 340)).toBe(true);
+  });
+
+  it("deterministically caps candidates within 200 km by source, distance, and ID", () => {
+    const candidate = (id: string, distanceKm: number) => ({ id, name: id, lat: 0, lon: distanceKm / 6371 * 180 / Math.PI, groundElevationM: 0, antennaHeightM: 2, rxGainDbi: 2 });
+    const mqtt = Array.from({ length: 1_100 }, (_, index) => candidate(`mqtt:${String(index).padStart(4, "0")}`, index % 2 ? 10 : 20));
+    const selected = selectPanoramaNodeCandidates({ lat: 0, lon: 0 }, [candidate("lib:z", 199), candidate("sim:z", 199), candidate("mqtt:outside", 201), ...mqtt]);
+    expect(selected).toHaveLength(1_000);
+    expect(selected[0].id).toBe("sim:z");
+    expect(selected[1].id).toBe("lib:z");
+    expect(selected.some((entry) => entry.id === "mqtt:outside")).toBe(false);
+    const selectedMqtt = selected.slice(2);
+    expect(selectedMqtt[0].id).toBe("mqtt:0001");
+    expect(selectedMqtt[549].id).toBe("mqtt:1099");
+    expect(selectedMqtt[550].id).toBe("mqtt:0000");
+  });
+
+  it("includes the 200 km boundary and excludes candidates beyond it", () => {
+    const candidate = (id: string, distanceKm: number) => ({ id, name: id, lat: 0, lon: distanceKm / 6371 * 180 / Math.PI, groundElevationM: 0, antennaHeightM: 2, rxGainDbi: 2 });
+    const selected = selectPanoramaNodeCandidates(
+      { lat: 0, lon: 0 },
+      [candidate("mqtt:boundary", 200), candidate("mqtt:outside", 200.001)],
+    );
+    expect(selected.map((entry) => entry.id)).toEqual(["mqtt:boundary"]);
   });
 });

--- a/src/lib/panorama.ts
+++ b/src/lib/panorama.ts
@@ -1,6 +1,7 @@
 import { computeSourceCentricRxMetrics, classifyPassFailState, type PassFailState } from "./passFailState";
 import { haversineDistanceKm, initialBearingDeg } from "./geo";
 import { normalizeFovScale, FOV_SCALE_DEFAULT } from "./panoramaView";
+import { PANORAMA_MAX_NODE_CANDIDATES, PANORAMA_MAX_NODE_DISTANCE_KM } from "./nodeFeedLimits";
 import type { Link, PropagationEnvironment, Site } from "../types/radio";
 import type { SiteIconKey } from "./siteIcons";
 
@@ -24,6 +25,33 @@ export type PanoramaNodeCandidate = {
   antennaMaxAttenuationDb?: number;
   iconKey?: SiteIconKey;
 };
+
+const panoramaCandidateSourceRank = (id: string): number => {
+  if (id.startsWith("sim:")) return 0;
+  if (id.startsWith("lib:")) return 1;
+  if (id.startsWith("mqtt:")) return 2;
+  return 3;
+};
+
+export const selectPanoramaNodeCandidates = (
+  origin: { lat: number; lon: number },
+  candidates: PanoramaNodeCandidate[],
+): PanoramaNodeCandidate[] =>
+  candidates
+    .map((candidate) => ({
+      candidate,
+      distanceKm: haversineDistanceKm(origin, { lat: candidate.lat, lon: candidate.lon }),
+    }))
+    .filter(({ distanceKm }) => Number.isFinite(distanceKm) && distanceKm <= PANORAMA_MAX_NODE_DISTANCE_KM)
+    .sort((a, b) => {
+      const sourceRank = panoramaCandidateSourceRank(a.candidate.id) - panoramaCandidateSourceRank(b.candidate.id);
+      if (sourceRank !== 0) return sourceRank;
+      const distance = a.distanceKm - b.distanceKm;
+      if (distance !== 0) return distance;
+      return a.candidate.id.localeCompare(b.candidate.id);
+    })
+    .slice(0, PANORAMA_MAX_NODE_CANDIDATES)
+    .map(({ candidate }) => candidate);
 
 export type PanoramaNodeProjection = {
   id: string;

--- a/src/lib/simulationArea.test.ts
+++ b/src/lib/simulationArea.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { simulationAreaBoundsForSites } from "./simulationArea";
+import { boundsToViewport, simulationAreaBoundsForSites } from "./simulationArea";
 
 describe("simulationAreaBoundsForSites", () => {
   it("uses explicit single-site radius override when provided", () => {
@@ -32,5 +32,15 @@ describe("simulationAreaBoundsForSites", () => {
     );
     expect(bounds).not.toBeNull();
     expect((bounds?.latSpanDeg ?? 0) * 111.32).toBeGreaterThan(200);
+  });
+
+  it("centers antimeridian sites at the dateline instead of Greenwich", () => {
+    const bounds = simulationAreaBoundsForSites([
+      { position: { lat: 10.1, lon: 179.9 } },
+      { position: { lat: 10.2, lon: -179.9 } },
+    ]);
+    expect(bounds).not.toBeNull();
+    expect(Math.abs(boundsToViewport(bounds!).center.lon)).toBeCloseTo(180);
+    expect(bounds?.lonSpanDeg).toBeLessThan(1);
   });
 });

--- a/src/lib/simulationArea.ts
+++ b/src/lib/simulationArea.ts
@@ -1,4 +1,5 @@
 import type { MapViewport, Site } from "../types/radio";
+import { longitudeBoundsForCoordinates, normalizeLongitude } from "./terrainTiles";
 
 export type SimulationAreaBounds = {
   minLat: number;
@@ -43,22 +44,19 @@ export const simulationAreaBoundsForSites = (
     const lons = sites.map((site) => site.position.lon);
     const minLat = Math.min(...lats);
     const maxLat = Math.max(...lats);
-    const minLon = Math.min(...lons);
-    const maxLon = Math.max(...lons);
     const centerLat = (minLat + maxLat) / 2;
     const latDelta = Math.max(0.01, radiusKm / 111.32);
     const lonDelta = Math.max(0.01, radiusKm / (111.32 * Math.max(0.1, Math.cos((centerLat * Math.PI) / 180))));
     const outMinLat = minLat - latDelta;
     const outMaxLat = maxLat + latDelta;
-    const outMinLon = minLon - lonDelta;
-    const outMaxLon = maxLon + lonDelta;
+    const longitudeBounds = longitudeBoundsForCoordinates(lons, lonDelta);
     return {
       minLat: outMinLat,
       maxLat: outMaxLat,
-      minLon: outMinLon,
-      maxLon: outMaxLon,
+      minLon: longitudeBounds.unwrappedMinLon,
+      maxLon: longitudeBounds.unwrappedMaxLon,
       latSpanDeg: outMaxLat - outMinLat,
-      lonSpanDeg: outMaxLon - outMinLon,
+      lonSpanDeg: longitudeBounds.spanDeg,
       isCapped: false,
     };
   }
@@ -66,17 +64,16 @@ export const simulationAreaBoundsForSites = (
   const lons = sites.map((site) => site.position.lon);
   const minLatRaw = Math.min(...lats);
   const maxLatRaw = Math.max(...lats);
-  const minLonRaw = Math.min(...lons);
-  const maxLonRaw = Math.max(...lons);
+  const longitudeBounds = longitudeBoundsForCoordinates(lons, LON_PAD_DEG);
 
   const rawLatSpan = maxLatRaw - minLatRaw + LAT_PAD_DEG * 2;
-  const rawLonSpan = maxLonRaw - minLonRaw + LON_PAD_DEG * 2;
+  const rawLonSpan = longitudeBounds.spanDeg;
   const latSpanDeg = Math.min(MAX_SPAN_DEG, rawLatSpan);
   const lonSpanDeg = Math.min(MAX_SPAN_DEG, rawLonSpan);
   const isCapped = rawLatSpan > MAX_SPAN_DEG || rawLonSpan > MAX_SPAN_DEG;
 
   const latCenter = (minLatRaw + maxLatRaw) / 2;
-  const lonCenter = (minLonRaw + maxLonRaw) / 2;
+  const lonCenter = (longitudeBounds.unwrappedMinLon + longitudeBounds.unwrappedMaxLon) / 2;
 
   return {
     minLat: latCenter - latSpanDeg / 2,
@@ -104,7 +101,7 @@ export const boundsToViewport = (
   return {
     center: {
       lat: latCenter,
-      lon: (bounds.minLon + bounds.maxLon) / 2,
+      lon: normalizeLongitude((bounds.minLon + bounds.maxLon) / 2),
     },
     zoom,
   };

--- a/src/lib/simulationOverlayRadius.test.ts
+++ b/src/lib/simulationOverlayRadius.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildBufferedSelectionArea,
   defaultOptionForSelectionCount,
   normalizeOverlayRadiusOptionForSelectionCount,
   optionsForSelectionCount,
   resolveMissingOverlayTerrainTileKeys,
   resolveOverlayRadiusOptionForSelectionTransition,
+  resolveRequiredOverlayTerrainTileKeys,
   resolveTargetOverlayRadiusKm,
 } from "./simulationOverlayRadius";
 import type { Site, SrtmTile } from "../types/radio";
+import { loadingOverlayCoordinates } from "./simulationLoadingOverlay";
+import { tilesForBounds } from "./terrainTiles";
 
 const site: Pick<Site, "position"> = { position: { lat: 59.9, lon: 10.7 } };
 const mkTile = (key: string, sourceId = "copernicus30"): SrtmTile => ({
@@ -62,5 +66,62 @@ describe("simulationOverlayRadius", () => {
 
     expect(missing.length).toBeGreaterThan(1);
     expect(missing).not.toContain("N59E010");
+  });
+
+  it("resolves adjacent terrain keys for sites across the antimeridian", () => {
+    const keys = resolveRequiredOverlayTerrainTileKeys(
+      [
+        { position: { lat: 10.1, lon: 179.9 } },
+        { position: { lat: 10.2, lon: -179.9 } },
+      ],
+      20,
+    );
+
+    expect(keys.length).toBeGreaterThan(0);
+    expect(keys.every((key) => key.endsWith("E179") || key.endsWith("W180"))).toBe(true);
+  });
+
+  it("rejects an ordinary wide site set at the terrain tile cap", () => {
+    expect(() =>
+      resolveRequiredOverlayTerrainTileKeys(
+        [
+          { position: { lat: 10.1, lon: -100 } },
+          { position: { lat: 10.1, lon: 0 } },
+          { position: { lat: 10.1, lon: 100 } },
+        ],
+        20,
+      ),
+    ).toThrow("256 tiles");
+  });
+
+  it("builds a short dateline mask that contains nearby samples but not Greenwich", () => {
+    const area = buildBufferedSelectionArea(
+      [
+        { position: { lat: 10.1, lon: 179.9 } },
+        { position: { lat: 10.2, lon: -179.9 } },
+      ],
+      20,
+    );
+
+    expect(area).not.toBeNull();
+    expect(area?.bounds.minLon).toBeGreaterThan(-181);
+    expect(area?.bounds.minLon).toBeLessThan(-180);
+    expect(area?.bounds.maxLon).toBeGreaterThan(-180);
+    expect(area?.bounds.maxLon).toBeLessThan(-179);
+    const coordinates = loadingOverlayCoordinates(area!.bounds);
+    const sourceLongitudes = coordinates.map(([lon]) => lon);
+    expect((Math.min(...sourceLongitudes) + Math.max(...sourceLongitudes)) / 2).toBeCloseTo(-180);
+    expect(Math.max(...sourceLongitudes) - Math.min(...sourceLongitudes)).toBeLessThan(1);
+    expect(
+      tilesForBounds(
+        area!.bounds.minLat,
+        area!.bounds.maxLat,
+        area!.bounds.minLon,
+        area!.bounds.maxLon,
+      ).every((key) => key.endsWith("E179") || key.endsWith("W180")),
+    ).toBe(true);
+    expect(area?.contains(10.15, 179.95)).toBe(true);
+    expect(area?.contains(10.15, -179.95)).toBe(true);
+    expect(area?.contains(10.15, 0)).toBe(false);
   });
 });

--- a/src/lib/simulationOverlayRadius.ts
+++ b/src/lib/simulationOverlayRadius.ts
@@ -1,8 +1,17 @@
 import { simulationAreaBoundsForSites } from "./simulationArea";
-import { tilesForBounds } from "./terrainTiles";
+import {
+  longitudeBoundsForCoordinates,
+  tilesForBounds,
+  unwrapLongitudeToInterval,
+} from "./terrainTiles";
 import type { Site, SrtmTile } from "../types/radio";
 
 export type SimulationOverlayRadiusOption = "20" | "50" | "100" | "200";
+
+export type BufferedSelectionArea = {
+  bounds: { minLat: number; maxLat: number; minLon: number; maxLon: number };
+  contains: (lat: number, lon: number) => boolean;
+};
 
 const SHARED_OPTIONS: SimulationOverlayRadiusOption[] = ["20", "50", "100", "200"];
 
@@ -67,4 +76,98 @@ export const resolveMissingOverlayTerrainTileKeys = (
   return resolveRequiredOverlayTerrainTileKeys(sites, targetRadiusKm).filter(
     (key) => !loaded30m.has(key),
   );
+};
+
+const distancePointToSegmentKm = (
+  px: number,
+  py: number,
+  ax: number,
+  ay: number,
+  bx: number,
+  by: number,
+): number => {
+  const dx = bx - ax;
+  const dy = by - ay;
+  const lenSq = dx * dx + dy * dy;
+  if (lenSq <= 1e-9) return Math.sqrt((px - ax) ** 2 + (py - ay) ** 2);
+  const t = Math.max(0, Math.min(1, ((px - ax) * dx + (py - ay) * dy) / lenSq));
+  const cx = ax + t * dx;
+  const cy = ay + t * dy;
+  return Math.sqrt((px - cx) ** 2 + (py - cy) ** 2);
+};
+
+const convexHull = (points: { x: number; y: number }[]): { x: number; y: number }[] => {
+  if (points.length <= 2) return [...points];
+  const sorted = [...points].sort((a, b) => (a.x === b.x ? a.y - b.y : a.x - b.x));
+  const cross = (o: { x: number; y: number }, a: { x: number; y: number }, b: { x: number; y: number }) =>
+    (a.x - o.x) * (b.y - o.y) - (a.y - o.y) * (b.x - o.x);
+  const lower: { x: number; y: number }[] = [];
+  for (const point of sorted) {
+    while (lower.length >= 2 && cross(lower[lower.length - 2], lower[lower.length - 1], point) <= 0) lower.pop();
+    lower.push(point);
+  }
+  const upper: { x: number; y: number }[] = [];
+  for (let index = sorted.length - 1; index >= 0; index -= 1) {
+    const point = sorted[index];
+    while (upper.length >= 2 && cross(upper[upper.length - 2], upper[upper.length - 1], point) <= 0) upper.pop();
+    upper.push(point);
+  }
+  lower.pop();
+  upper.pop();
+  return [...lower, ...upper];
+};
+
+const pointInPolygon = (x: number, y: number, polygon: { x: number; y: number }[]): boolean => {
+  let inside = false;
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+    const { x: xi, y: yi } = polygon[i];
+    const { x: xj, y: yj } = polygon[j];
+    if (yi > y !== yj > y && x < ((xj - xi) * (y - yi)) / ((yj - yi) || 1e-9) + xi) inside = !inside;
+  }
+  return inside;
+};
+
+export const buildBufferedSelectionArea = (
+  sites: Pick<Site, "position">[],
+  radiusKm: number,
+): BufferedSelectionArea | null => {
+  if (!sites.length) return null;
+  const centerLat = sites.reduce((sum, site) => sum + site.position.lat, 0) / sites.length;
+  const kmPerLat = 111.32;
+  const kmPerLon = Math.max(0.1, Math.cos((centerLat * Math.PI) / 180)) * 111.32;
+  const latDelta = Math.max(0.01, radiusKm / kmPerLat);
+  const lonDelta = Math.max(0.01, radiusKm / kmPerLon);
+  const longitudeBounds = longitudeBoundsForCoordinates(
+    sites.map((site) => site.position.lon),
+    lonDelta,
+  );
+  const projected = sites.map((site) => {
+    const lon = unwrapLongitudeToInterval(site.position.lon, longitudeBounds);
+    return { x: lon * kmPerLon, y: site.position.lat * kmPerLat };
+  });
+  const hull = convexHull(projected);
+  const minLat = Math.min(...sites.map((site) => site.position.lat));
+  const maxLat = Math.max(...sites.map((site) => site.position.lat));
+  const contains = (lat: number, lon: number): boolean => {
+    const x = unwrapLongitudeToInterval(lon, longitudeBounds) * kmPerLon;
+    const y = lat * kmPerLat;
+    if (hull.length <= 2) {
+      const a = hull[0];
+      const b = hull[1] ?? hull[0];
+      return distancePointToSegmentKm(x, y, a.x, a.y, b.x, b.y) <= radiusKm;
+    }
+    if (pointInPolygon(x, y, hull)) return true;
+    return hull.some((point, index) =>
+      distancePointToSegmentKm(x, y, point.x, point.y, hull[(index + 1) % hull.length].x, hull[(index + 1) % hull.length].y) <= radiusKm,
+    );
+  };
+  return {
+    bounds: {
+      minLat: minLat - latDelta,
+      maxLat: maxLat + latDelta,
+      minLon: longitudeBounds.unwrappedMinLon,
+      maxLon: longitudeBounds.unwrappedMaxLon,
+    },
+    contains,
+  };
 };

--- a/src/lib/srtm.test.ts
+++ b/src/lib/srtm.test.ts
@@ -1,6 +1,26 @@
-import { describe, expect, it } from "vitest";
+import { zipSync } from "fflate";
+import { describe, expect, it, vi } from "vitest";
 import type { SrtmTile } from "../types/radio";
-import { sampleSrtmElevation } from "./srtm";
+import { parseSrtmTile, parseSrtmZip, sampleSrtmElevation } from "./srtm";
+
+const SRTM3_BYTE_LENGTH = 1201 * 1201 * 2;
+const SRTM1_BYTE_LENGTH = 3601 * 3601 * 2;
+const toArrayBuffer = (bytes: Uint8Array): ArrayBuffer =>
+  bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+
+const findSignature = (bytes: Uint8Array, signature: number, fromEnd = false): number => {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  if (fromEnd) {
+    for (let offset = bytes.byteLength - 4; offset >= 0; offset -= 1) {
+      if (view.getUint32(offset, true) === signature) return offset;
+    }
+    return -1;
+  }
+  for (let offset = 0; offset <= bytes.byteLength - 4; offset += 1) {
+    if (view.getUint32(offset, true) === signature) return offset;
+  }
+  return -1;
+};
 
 const makeTile = (params: {
   key: string;
@@ -113,5 +133,223 @@ describe("sampleSrtmElevation", () => {
       sourceId: "copernicus30",
     });
     expect(sampleSrtmElevation([tile], 59.4, 10.4)).toBeNull();
+  });
+
+  it("normalizes unwrapped longitudes when sampling antimeridian terrain", () => {
+    const tile = makeTile({
+      key: "N10W180",
+      latStart: 10,
+      lonStart: -180,
+      size: 2,
+      values: [5, 5, 5, 5],
+    });
+
+    expect(sampleSrtmElevation([tile], 10.5, 180.1)).toBe(5);
+  });
+
+  it("samples a saved +180 coordinate from an E179-only tile", () => {
+    const east = makeTile({
+      key: "N10E179",
+      latStart: 10,
+      lonStart: 179,
+      size: 2,
+      values: [1, 7, 1, 7],
+      sourceKind: "manual-upload",
+    });
+
+    expect(sampleSrtmElevation([east], 10.5, 180)).toBe(7);
+  });
+
+  it("samples a saved -180 coordinate from a W180-only tile", () => {
+    const west = makeTile({
+      key: "N10W180",
+      latStart: 10,
+      lonStart: -180,
+      size: 2,
+      values: [8, 1, 8, 1],
+      sourceKind: "manual-upload",
+    });
+
+    expect(sampleSrtmElevation([west], 10.5, -180)).toBe(8);
+  });
+
+  it("deterministically applies terrain precedence when both dateline tiles are present", () => {
+    const east = makeTile({
+      key: "N10E179",
+      latStart: 10,
+      lonStart: 179,
+      size: 2,
+      values: [1, 7, 1, 7],
+      sourceId: "copernicus30",
+      arcSecondSpacing: 1,
+    });
+    const west = makeTile({
+      key: "N10W180",
+      latStart: 10,
+      lonStart: -180,
+      size: 2,
+      values: [8, 1, 8, 1],
+      sourceKind: "manual-upload",
+      arcSecondSpacing: 1,
+    });
+
+    expect(sampleSrtmElevation([east, west], 10.5, 180)).toBe(8);
+    expect(sampleSrtmElevation([west, east], 10.5, -180)).toBe(8);
+  });
+});
+
+describe("SRTM ingestion bounds", () => {
+  it.each([
+    ["N59E010.hgt", SRTM3_BYTE_LENGTH, 1201],
+    ["N59E010.hgt", SRTM1_BYTE_LENGTH, 3601],
+  ])("accepts %s with exact %i-byte size", async (name, byteLength, size) => {
+    const arrayBuffer = vi.fn(async () => new ArrayBuffer(byteLength));
+    const file = { name, size: byteLength, arrayBuffer } as unknown as File;
+
+    await expect(parseSrtmTile(file)).resolves.toMatchObject({ size });
+    expect(arrayBuffer).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects an unsupported raw HGT size before reading its body", async () => {
+    const arrayBuffer = vi.fn(async () => new ArrayBuffer(1));
+    const file = { name: "N59E010.hgt", size: 1, arrayBuffer } as unknown as File;
+
+    await expect(parseSrtmTile(file)).rejects.toThrow("Unsupported SRTM tile dimensions");
+    expect(arrayBuffer).not.toHaveBeenCalled();
+  });
+
+  it("rejects an oversized ZIP before reading its body", async () => {
+    const arrayBuffer = vi.fn(async () => new ArrayBuffer(1));
+    const file = {
+      name: "terrain.zip",
+      size: 32 * 1024 * 1024 + 1,
+      arrayBuffer,
+    } as unknown as File;
+
+    await expect(parseSrtmTile(file)).rejects.toThrow("32 MiB");
+    expect(arrayBuffer).not.toHaveBeenCalled();
+  });
+
+  it("accepts an exact 32 MiB ZIP through preflight before parsing its body", async () => {
+    const arrayBuffer = vi.fn(async () => new ArrayBuffer(1));
+    const file = {
+      name: "terrain.zip",
+      size: 32 * 1024 * 1024,
+      arrayBuffer,
+    } as unknown as File;
+
+    await expect(parseSrtmTile(file)).rejects.toThrow();
+    expect(arrayBuffer).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts exactly 16 central entries while extracting only the supported HGT", () => {
+    const metadata = Object.fromEntries(
+      Array.from({ length: 15 }, (_, index) => [`metadata-${index}.txt`, new Uint8Array([index])]),
+    );
+    const zip = zipSync({ ...metadata, "nested/N59E010.hgt": new Uint8Array(SRTM3_BYTE_LENGTH) });
+
+    expect(parseSrtmZip("terrain.zip", toArrayBuffer(zip)).key).toBe("N59E010");
+  });
+
+  it("rejects forged supported size metadata when actual expansion exceeds the maximum", () => {
+    const zip = zipSync(
+      { "N59E010.hgt": new Uint8Array(SRTM1_BYTE_LENGTH + 64 * 1024) },
+      { level: 9 },
+    );
+    const forged = zip.slice();
+    const view = new DataView(forged.buffer, forged.byteOffset, forged.byteLength);
+    let centralOffset = -1;
+    for (let offset = forged.byteLength - 22; offset >= 0; offset -= 1) {
+      if (view.getUint32(offset, true) === 0x02014b50) {
+        centralOffset = offset;
+        break;
+      }
+    }
+    expect(centralOffset).toBeGreaterThanOrEqual(0);
+    view.setUint32(centralOffset + 24, SRTM1_BYTE_LENGTH, true);
+    const localOffset = findSignature(forged, 0x04034b50);
+    expect(localOffset).toBeGreaterThanOrEqual(0);
+    view.setUint32(localOffset + 22, SRTM1_BYTE_LENGTH, true);
+
+    expect(() => parseSrtmZip("forged.zip", toArrayBuffer(forged))).toThrow("expanded data limit");
+  });
+
+  it("rejects ZIPs with more than 16 entries", () => {
+    const entries = Object.fromEntries(
+      Array.from({ length: 16 }, (_, index) => [`metadata-${index}.txt`, new Uint8Array([index])]),
+    );
+    const zip = zipSync({ ...entries, "N59E010.hgt": new Uint8Array(SRTM3_BYTE_LENGTH) });
+
+    expect(() => parseSrtmZip("terrain.zip", toArrayBuffer(zip))).toThrow("16 entries");
+  });
+
+  it("rejects an EOCD entry count that underreports 17 local entries", () => {
+    const metadata = Object.fromEntries(
+      Array.from({ length: 16 }, (_, index) => [`metadata-${index}.txt`, new Uint8Array([index])]),
+    );
+    const forged = zipSync({ "N59E010.hgt": new Uint8Array(SRTM3_BYTE_LENGTH), ...metadata }).slice();
+    const eocdOffset = findSignature(forged, 0x06054b50, true);
+    expect(eocdOffset).toBeGreaterThanOrEqual(0);
+    const view = new DataView(forged.buffer, forged.byteOffset, forged.byteLength);
+    view.setUint16(eocdOffset + 8, 1, true);
+    view.setUint16(eocdOffset + 10, 1, true);
+
+    expect(() => parseSrtmZip("underreported.zip", toArrayBuffer(forged))).toThrow("16 entries");
+  });
+
+  it("rejects central and local HGT name mismatches", () => {
+    const forged = zipSync({ "N59E010.hgt": new Uint8Array(SRTM3_BYTE_LENGTH) }).slice();
+    const centralOffset = findSignature(forged, 0x02014b50);
+    expect(centralOffset).toBeGreaterThanOrEqual(0);
+    forged.set(new TextEncoder().encode("N60E010.hgt"), centralOffset + 46);
+
+    expect(() => parseSrtmZip("mismatch.zip", toArrayBuffer(forged))).toThrow("central/local");
+  });
+
+  it("rejects a local original size that disagrees with valid central metadata", () => {
+    const forged = zipSync({ "N59E010.hgt": new Uint8Array(SRTM3_BYTE_LENGTH) }).slice();
+    const localOffset = findSignature(forged, 0x04034b50);
+    expect(localOffset).toBeGreaterThanOrEqual(0);
+    new DataView(forged.buffer, forged.byteOffset, forged.byteLength).setUint32(localOffset + 22, 1, true);
+
+    expect(() => parseSrtmZip("local-size.zip", toArrayBuffer(forged))).toThrow("central/local");
+  });
+
+  it("rejects local compression that disagrees with central metadata", () => {
+    const forged = zipSync({ "N59E010.hgt": new Uint8Array(SRTM3_BYTE_LENGTH) }).slice();
+    const localOffset = findSignature(forged, 0x04034b50);
+    expect(localOffset).toBeGreaterThanOrEqual(0);
+    new DataView(forged.buffer, forged.byteOffset, forged.byteLength).setUint16(localOffset + 8, 0, true);
+
+    expect(() => parseSrtmZip("local-compression.zip", toArrayBuffer(forged))).toThrow("central/local");
+  });
+
+  it("rejects a second local HGT omitted from central HGT metadata", () => {
+    const forged = zipSync({
+      "N59E010.hgt": new Uint8Array(SRTM3_BYTE_LENGTH),
+      "other00.txt": new Uint8Array([1]),
+    }).slice();
+    const firstLocalOffset = findSignature(forged, 0x04034b50);
+    const secondLocalOffset = findSignature(forged.subarray(firstLocalOffset + 4), 0x04034b50);
+    expect(secondLocalOffset).toBeGreaterThanOrEqual(0);
+    const absoluteSecondOffset = firstLocalOffset + 4 + secondLocalOffset;
+    forged.set(new TextEncoder().encode("N60E010.hgt"), absoluteSecondOffset + 30);
+
+    expect(() => parseSrtmZip("local-duplicate.zip", toArrayBuffer(forged))).toThrow(
+      "exactly one local .hgt",
+    );
+  });
+
+  it("rejects ZIPs with multiple HGT entries or unsupported declared HGT sizes", () => {
+    const multiple = zipSync({
+      "N59E010.hgt": new Uint8Array(SRTM3_BYTE_LENGTH),
+      "N60E010.hgt": new Uint8Array(SRTM3_BYTE_LENGTH),
+    });
+    const unsupported = zipSync({ "N59E010.hgt": new Uint8Array([1, 2]) });
+
+    expect(() => parseSrtmZip("multiple.zip", toArrayBuffer(multiple))).toThrow("exactly one .hgt");
+    expect(() => parseSrtmZip("unsupported.zip", toArrayBuffer(unsupported))).toThrow(
+      "Unsupported SRTM tile dimensions",
+    );
   });
 });

--- a/src/lib/srtm.ts
+++ b/src/lib/srtm.ts
@@ -1,8 +1,22 @@
 import type { SrtmTile } from "../types/radio";
-import { unzipSync } from "fflate";
+import { Unzip, UnzipInflate, unzipSync } from "fflate";
 import { choosePreferredTerrainTile } from "./terrainTileRank";
+import { normalizeLongitude } from "./terrainTiles";
 
 const HGT_FILENAME = /^([NS])(\d{2})([EW])(\d{3})\.hgt$/i;
+const SRTM3_BYTE_LENGTH = 1201 * 1201 * 2;
+const SRTM1_BYTE_LENGTH = 3601 * 3601 * 2;
+const SUPPORTED_HGT_BYTE_LENGTHS = new Set([SRTM3_BYTE_LENGTH, SRTM1_BYTE_LENGTH]);
+const MAX_SRTM_ZIP_BYTES = 32 * 1024 * 1024;
+const MAX_SRTM_ZIP_ENTRIES = 16;
+const ZIP_STREAM_CHUNK_BYTES = 1024;
+
+type ZipEntryMetadata = {
+  name: string;
+  size: number;
+  originalSize: number;
+  compression: number;
+};
 
 const normalizeName = (name: string): string => name.trim().split("/").pop()?.toLowerCase() ?? "";
 
@@ -32,6 +46,14 @@ const detectTileSize = (byteLength: number): { size: number; arcSecondSpacing: 1
   return null;
 };
 
+const assertSupportedHgtSize = (fileName: string, byteLength: number): void => {
+  if (!SUPPORTED_HGT_BYTE_LENGTHS.has(byteLength)) {
+    throw new Error(
+      `Unsupported SRTM tile dimensions for ${fileName}. Expected 1201x1201 or 3601x3601 samples.`,
+    );
+  }
+};
+
 const readInt16BigEndian = (buffer: ArrayBuffer): Int16Array => {
   const view = new DataView(buffer);
   const out = new Int16Array(buffer.byteLength / 2);
@@ -41,14 +63,110 @@ const readInt16BigEndian = (buffer: ArrayBuffer): Int16Array => {
   return out;
 };
 
+const extractBoundedHgt = (
+  zipBytes: Uint8Array,
+  centralEntryNames: readonly string[],
+  selectedMetadata: ZipEntryMetadata,
+): ArrayBuffer => {
+  const { name: selectedName, originalSize: declaredSize } = selectedMetadata;
+  const output = new Uint8Array(declaredSize);
+  let actualSize = 0;
+  let localEntryCount = 0;
+  let localHgtCount = 0;
+  let selectedEntries = 0;
+  let completed = false;
+  const localEntryNames: string[] = [];
+  const unzip = new Unzip((file) => {
+    localEntryCount += 1;
+    if (localEntryCount > MAX_SRTM_ZIP_ENTRIES) {
+      throw new Error(`SRTM ZIP exceeds the ${MAX_SRTM_ZIP_ENTRIES} entries limit.`);
+    }
+    localEntryNames.push(file.name);
+    if (file.name.toLowerCase().endsWith(".hgt")) {
+      localHgtCount += 1;
+      if (localHgtCount > 1) {
+        throw new Error(`SRTM archive must contain exactly one local .hgt file: ${selectedName}`);
+      }
+      if (!parseHeaderFromFilename(file.name) || file.name !== selectedName) {
+        throw new Error(`SRTM ZIP central/local HGT mismatch: ${selectedName} / ${file.name}`);
+      }
+    }
+    if (file.name !== selectedName) return;
+    if (
+      file.compression !== selectedMetadata.compression ||
+      (typeof file.size === "number" && file.size !== selectedMetadata.size) ||
+      (typeof file.originalSize === "number" && file.originalSize !== selectedMetadata.originalSize)
+    ) {
+      throw new Error(`SRTM ZIP central/local metadata mismatch: ${selectedName}`);
+    }
+    selectedEntries += 1;
+    if (selectedEntries > 1) {
+      throw new Error(`SRTM archive contains duplicate local entry: ${selectedName}`);
+    }
+    file.ondata = (error, data, final) => {
+      if (error) throw error;
+      const nextSize = actualSize + data.byteLength;
+      if (nextSize > SRTM1_BYTE_LENGTH) {
+        file.terminate();
+        throw new Error(`SRTM ZIP expanded data limit exceeded for ${selectedName}.`);
+      }
+      if (nextSize > declaredSize) {
+        file.terminate();
+        throw new Error(`Expanded SRTM size does not match its ZIP declaration: ${selectedName}`);
+      }
+      output.set(data, actualSize);
+      actualSize = nextSize;
+      if (!final) return;
+      if (actualSize !== declaredSize) {
+        throw new Error(`Expanded SRTM size does not match its ZIP declaration: ${selectedName}`);
+      }
+      completed = true;
+    };
+    file.start();
+  });
+  unzip.register(UnzipInflate);
+  for (let offset = 0; offset < zipBytes.byteLength; offset += ZIP_STREAM_CHUNK_BYTES) {
+    const end = Math.min(zipBytes.byteLength, offset + ZIP_STREAM_CHUNK_BYTES);
+    unzip.push(zipBytes.subarray(offset, end), end === zipBytes.byteLength);
+  }
+
+  if (selectedEntries !== 1 || !completed) {
+    throw new Error(`SRTM ZIP did not yield the declared entry: ${selectedName}`);
+  }
+  if (localHgtCount !== 1) {
+    throw new Error(`SRTM archive must contain exactly one local .hgt file: ${selectedName}`);
+  }
+  const remainingCentralNames = new Map<string, number>();
+  for (const name of centralEntryNames) {
+    remainingCentralNames.set(name, (remainingCentralNames.get(name) ?? 0) + 1);
+  }
+  for (const name of localEntryNames) {
+    const remaining = remainingCentralNames.get(name) ?? 0;
+    if (remaining <= 0) {
+      throw new Error(`SRTM ZIP central/local entry mismatch: ${name}`);
+    }
+    if (remaining === 1) remainingCentralNames.delete(name);
+    else remainingCentralNames.set(name, remaining - 1);
+  }
+  if (localEntryCount !== centralEntryNames.length || remainingCentralNames.size > 0) {
+    throw new Error("SRTM ZIP central/local entry count mismatch.");
+  }
+  return output.buffer;
+};
+
 export const parseSrtmTile = async (file: File): Promise<SrtmTile> => {
-  const buffer = await file.arrayBuffer();
   const name = file.name.toLowerCase();
 
   if (name.endsWith(".zip")) {
+    if (file.size > MAX_SRTM_ZIP_BYTES) {
+      throw new Error(`SRTM ZIP exceeds the ${MAX_SRTM_ZIP_BYTES / 1024 / 1024} MiB limit.`);
+    }
+    const buffer = await file.arrayBuffer();
     return parseSrtmZip(file.name, buffer);
   }
 
+  assertSupportedHgtSize(file.name, file.size);
+  const buffer = await file.arrayBuffer();
   return parseSrtmBuffer(file.name, buffer);
 };
 
@@ -79,18 +197,47 @@ export const parseSrtmBuffer = (fileName: string, buffer: ArrayBuffer): SrtmTile
 };
 
 export const parseSrtmZip = (archiveName: string, zipBuffer: ArrayBuffer): SrtmTile => {
-  const files = unzipSync(new Uint8Array(zipBuffer));
-  const entry = Object.entries(files).find(([name]) => name.toLowerCase().endsWith(".hgt"));
+  if (zipBuffer.byteLength > MAX_SRTM_ZIP_BYTES) {
+    throw new Error(`SRTM ZIP exceeds the ${MAX_SRTM_ZIP_BYTES / 1024 / 1024} MiB limit.`);
+  }
 
-  if (!entry) {
+  let entryCount = 0;
+  const centralEntryNames: string[] = [];
+  let hgtEntryMetadata: ZipEntryMetadata | null = null;
+  const zipBytes = new Uint8Array(zipBuffer);
+  unzipSync(zipBytes, {
+    filter: (entry) => {
+      entryCount += 1;
+      if (entryCount > MAX_SRTM_ZIP_ENTRIES) {
+        throw new Error(`SRTM ZIP exceeds the ${MAX_SRTM_ZIP_ENTRIES} entries limit.`);
+      }
+      centralEntryNames.push(entry.name);
+      if (!entry.name.toLowerCase().endsWith(".hgt")) return false;
+      if (hgtEntryMetadata) {
+        throw new Error(`SRTM archive must contain exactly one .hgt file: ${archiveName}`);
+      }
+      if (!parseHeaderFromFilename(entry.name)) {
+        throw new Error(`Unsupported SRTM file name: ${entry.name}. Expected e.g. N45W073.hgt`);
+      }
+      assertSupportedHgtSize(entry.name, entry.originalSize);
+      hgtEntryMetadata = {
+        name: entry.name,
+        size: entry.size,
+        originalSize: entry.originalSize,
+        compression: entry.compression,
+      };
+      return false;
+    },
+  });
+
+  const selectedMetadata = hgtEntryMetadata as ZipEntryMetadata | null;
+  if (!selectedMetadata) {
     throw new Error(`No .hgt file found in SRTM archive: ${archiveName}`);
   }
 
-  const [internalName, raw] = entry;
-  const normalized = Uint8Array.from(raw);
-  const hgtBuffer = normalized.buffer;
+  const hgtBuffer = extractBoundedHgt(zipBytes, centralEntryNames, selectedMetadata);
 
-  return parseSrtmBuffer(internalName, hgtBuffer);
+  return parseSrtmBuffer(selectedMetadata.name, hgtBuffer);
 };
 
 const inTile = (tile: SrtmTile, lat: number, lon: number): boolean =>
@@ -185,16 +332,40 @@ const pickTileForCoordinate = (
   return chosen;
 };
 
+const pickTileAndLongitudeForCoordinate = (
+  lookup: Map<string, SrtmTile>,
+  lat: number,
+  lon: number,
+): { tile: SrtmTile; lon: number } | null => {
+  const normalizedLon = normalizeLongitude(lon);
+  const candidateLongitudes = normalizedLon === -180 ? [-180, 180] : [normalizedLon];
+  let chosen: { tile: SrtmTile; lon: number } | null = null;
+
+  for (const candidateLon of candidateLongitudes) {
+    const candidate = pickTileForCoordinate(lookup, lat, candidateLon);
+    if (!candidate) continue;
+    if (!chosen) {
+      chosen = { tile: candidate, lon: candidateLon };
+      continue;
+    }
+    if (choosePreferredTerrainTile(chosen.tile, candidate) === candidate) {
+      chosen = { tile: candidate, lon: candidateLon };
+    }
+  }
+
+  return chosen;
+};
+
 export const sampleSrtmElevation = (
   tiles: ReadonlyArray<SrtmTile>,
   lat: number,
   lon: number,
 ): number | null => {
   const lookup = tileLookupFor(tiles);
-  const tile = pickTileForCoordinate(lookup, lat, lon);
-  if (!tile) return null;
+  const selected = pickTileAndLongitudeForCoordinate(lookup, lat, lon);
+  if (!selected) return null;
 
-  const raw = sampleFromTile(tile, lat, lon);
+  const raw = sampleFromTile(selected.tile, lat, selected.lon);
   if (raw <= -32760) return null;
   return raw;
 };

--- a/src/lib/terrainLoss.ts
+++ b/src/lib/terrainLoss.ts
@@ -1,4 +1,5 @@
 import { haversineDistanceKm } from "./geo";
+import { longitudeBoundsForCoordinates, unwrapLongitudeToInterval } from "./terrainTiles";
 import type { Coordinates, Polarization } from "../types/radio";
 
 const clamp = (value: number, min: number, max: number): number =>
@@ -64,6 +65,13 @@ type TerrainLosInput = {
   clutterHeightM?: number;
 };
 
+const shortestLongitudeSpan = (fromLon: number, toLon: number): { fromLon: number; span: number } => {
+  const bounds = longitudeBoundsForCoordinates([fromLon, toLon]);
+  const unwrappedFrom = unwrapLongitudeToInterval(fromLon, bounds);
+  const unwrappedTo = unwrapLongitudeToInterval(toLon, bounds);
+  return { fromLon: unwrappedFrom, span: unwrappedTo - unwrappedFrom };
+};
+
 export const estimateTerrainExcessLossDb = ({
   from,
   to,
@@ -87,11 +95,11 @@ export const estimateTerrainExcessLossDb = ({
     terrainSamplerAt ??
     ((lat: number, lon: number) => terrainSampler({ lat, lon }));
   const latSpan = to.lat - from.lat;
-  const lonSpan = to.lon - from.lon;
+  const longitude = shortestLongitudeSpan(from.lon, to.lon);
   for (let i = 0; i < sampleCount; i += 1) {
     const t = sampleCount <= 1 ? 0 : i / (sampleCount - 1);
     const lat = from.lat + latSpan * t;
-    const lon = from.lon + lonSpan * t;
+    const lon = longitude.fromLon + longitude.span * t;
     const terrain = sampleTerrainAt(lat, lon);
     if (terrain === null) continue;
     trace.push({
@@ -184,12 +192,12 @@ export const isTerrainLineObstructed = ({
     terrainSamplerAt ??
     ((lat: number, lon: number) => terrainSampler({ lat, lon }));
   const latSpan = to.lat - from.lat;
-  const lonSpan = to.lon - from.lon;
+  const longitude = shortestLongitudeSpan(from.lon, to.lon);
 
   for (let i = 1; i < sampleCount - 1; i += 1) {
     const t = i / (sampleCount - 1);
     const lat = from.lat + latSpan * t;
-    const lon = from.lon + lonSpan * t;
+    const lon = longitude.fromLon + longitude.span * t;
     const terrain = sampleTerrainAt(lat, lon);
     if (terrain === null) continue;
     const d1 = distanceM * t;

--- a/src/lib/terrainTiles.test.ts
+++ b/src/lib/terrainTiles.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  boundedUniqueTerrainTileKeys,
+  longitudeBoundsForCoordinates,
+  tilesForBounds,
+} from "./terrainTiles";
+
+describe("terrain tile workload bounds", () => {
+  it("enumerates the short side of an antimeridian-crossing area", () => {
+    expect(tilesForBounds(10.1, 10.2, 179.8, -179.8)).toEqual(["N10E179", "N10W180"]);
+  });
+
+  it("returns explicit wrapped longitude bounds for antimeridian coordinates", () => {
+    const bounds = longitudeBoundsForCoordinates([179.9, -179.9], 0.1);
+
+    expect(bounds.minLon).toBeGreaterThan(bounds.maxLon);
+    expect(bounds.centerLon).toBe(-180);
+    expect(bounds.spanDeg).toBeCloseTo(0.4);
+  });
+
+  it("rejects more than 256 unique tiles while enumerating", () => {
+    expect(() => tilesForBounds(-80, 80, 0, 2)).toThrow("256 tiles");
+  });
+
+  it("accepts exactly 256 tiles and rejects the 257th", () => {
+    expect(tilesForBounds(0, 15, 0, 15)).toHaveLength(256);
+    expect(() => tilesForBounds(0, 15, 0, 16)).toThrow("256 tiles");
+  });
+
+  it("does not reinterpret an ordinary wide rectangle as its complement", () => {
+    expect(() => tilesForBounds(10.1, 10.2, -179.8, 179.8)).toThrow("256 tiles");
+  });
+
+  it("rejects non-finite bounds", () => {
+    expect(() => tilesForBounds(0, Number.POSITIVE_INFINITY, 0, 1)).toThrow("finite");
+  });
+
+  it("deduplicates valid tile keys and rejects excess or invalid keys", () => {
+    expect(boundedUniqueTerrainTileKeys(["N10E010", "N10E010", "S01W001"])).toEqual([
+      "N10E010",
+      "S01W001",
+    ]);
+    for (const invalid of ["bad", "N99E999", "N90E000", "N00E180", "S00E000", "N00W000"]) {
+      expect(() => boundedUniqueTerrainTileKeys([invalid])).toThrow("Invalid terrain tile key");
+    }
+    expect(boundedUniqueTerrainTileKeys(["S90W180", "N89E179"])).toEqual([
+      "S90W180",
+      "N89E179",
+    ]);
+    expect(() =>
+      boundedUniqueTerrainTileKeys(
+        Array.from({ length: 257 }, (_, index) =>
+          `${index < 180 ? "N00" : "N01"}E${String(index % 180).padStart(3, "0")}`,
+        ),
+      ),
+    ).toThrow("256 tiles");
+  });
+});

--- a/src/lib/terrainTiles.ts
+++ b/src/lib/terrainTiles.ts
@@ -1,7 +1,130 @@
+export const MAX_TERRAIN_TILE_KEYS = 256;
+
+const TERRAIN_TILE_KEY = /^([NS])(\d{2})([EW])(\d{3})$/;
+
+const isTerrainTileKey = (key: string): boolean => {
+  const match = TERRAIN_TILE_KEY.exec(key);
+  if (!match) return false;
+  const [, latitudeHemisphere, latitudeRaw, longitudeHemisphere, longitudeRaw] = match;
+  const latitude = Number(latitudeRaw);
+  const longitude = Number(longitudeRaw);
+  const validLatitude = latitudeHemisphere === "N"
+    ? latitude <= 89
+    : latitude >= 1 && latitude <= 90;
+  const validLongitude = longitudeHemisphere === "E"
+    ? longitude <= 179
+    : longitude >= 1 && longitude <= 180;
+  return validLatitude && validLongitude;
+};
+
 const tileKey = (lat: number, lon: number): string => {
   const ns = lat >= 0 ? "N" : "S";
   const ew = lon >= 0 ? "E" : "W";
   return `${ns}${String(Math.floor(Math.abs(lat))).padStart(2, "0")}${ew}${String(Math.floor(Math.abs(lon))).padStart(3, "0")}`;
+};
+
+export const normalizeLongitude = (lon: number): number => {
+  const normalized = ((lon + 180) % 360 + 360) % 360 - 180;
+  return Object.is(normalized, -0) ? 0 : normalized;
+};
+
+export type LongitudeBounds = {
+  minLon: number;
+  maxLon: number;
+  unwrappedMinLon: number;
+  unwrappedMaxLon: number;
+  spanDeg: number;
+  centerLon: number;
+};
+
+export const longitudeBoundsForCoordinates = (
+  longitudes: readonly number[],
+  paddingDeg = 0,
+): LongitudeBounds => {
+  if (longitudes.length === 0 || !longitudes.every(Number.isFinite) || !Number.isFinite(paddingDeg)) {
+    throw new Error("Longitude bounds require finite coordinates.");
+  }
+  const padding = Math.max(0, paddingDeg);
+  const sorted = Array.from(new Set(longitudes.map((lon) => ((lon % 360) + 360) % 360))).sort(
+    (a, b) => a - b,
+  );
+  let start = sorted[0];
+  let span = 0;
+  if (sorted.length > 1) {
+    let largestGap = -1;
+    for (let index = 0; index < sorted.length; index += 1) {
+      const current = sorted[index];
+      const next = index + 1 < sorted.length ? sorted[index + 1] : sorted[0] + 360;
+      const gap = next - current;
+      if (gap > largestGap) {
+        largestGap = gap;
+        start = next % 360;
+      }
+    }
+    span = 360 - largestGap;
+  }
+
+  const paddedSpan = Math.min(360, span + padding * 2);
+  if (paddedSpan >= 360) {
+    return {
+      minLon: -180,
+      maxLon: 180,
+      unwrappedMinLon: -180,
+      unwrappedMaxLon: 180,
+      spanDeg: 360,
+      centerLon: 0,
+    };
+  }
+  let unwrappedMinLon = normalizeLongitude(start - padding);
+  let unwrappedMaxLon = unwrappedMinLon + paddedSpan;
+  if ((unwrappedMinLon + unwrappedMaxLon) / 2 >= 180) {
+    unwrappedMinLon -= 360;
+    unwrappedMaxLon -= 360;
+  }
+  return {
+    minLon: normalizeLongitude(unwrappedMinLon),
+    maxLon: normalizeLongitude(unwrappedMaxLon),
+    unwrappedMinLon,
+    unwrappedMaxLon,
+    spanDeg: paddedSpan,
+    centerLon: normalizeLongitude(unwrappedMinLon + paddedSpan / 2),
+  };
+};
+
+export const unwrapLongitudeToInterval = (lon: number, bounds: LongitudeBounds): number => {
+  if (!Number.isFinite(lon)) throw new Error("Longitude must be finite.");
+  const normalized = normalizeLongitude(lon);
+  const center = (bounds.unwrappedMinLon + bounds.unwrappedMaxLon) / 2;
+  return normalized + Math.round((center - normalized) / 360) * 360;
+};
+
+const longitudeEnumeration = (minLon: number, maxLon: number): { start: number; span: number } => {
+  if (minLon <= maxLon) {
+    const directSpan = maxLon - minLon;
+    if (directSpan >= 360) return { start: -180, span: 360 };
+    return { start: normalizeLongitude(minLon), span: directSpan };
+  }
+
+  const wrappedSpan = ((maxLon - minLon) % 360 + 360) % 360;
+  return { start: normalizeLongitude(minLon), span: wrappedSpan };
+};
+
+const addBoundedKey = (keys: Set<string>, key: string): void => {
+  keys.add(key);
+  if (keys.size > MAX_TERRAIN_TILE_KEYS) {
+    throw new Error(`Terrain area exceeds maximum of ${MAX_TERRAIN_TILE_KEYS} tiles.`);
+  }
+};
+
+export const boundedUniqueTerrainTileKeys = (tileKeys: Iterable<string>): string[] => {
+  const keys = new Set<string>();
+  for (const key of tileKeys) {
+    if (!isTerrainTileKey(key)) {
+      throw new Error(`Invalid terrain tile key: ${key}`);
+    }
+    addBoundedKey(keys, key);
+  }
+  return Array.from(keys);
 };
 
 export const tilesForBounds = (
@@ -10,15 +133,23 @@ export const tilesForBounds = (
   minLon: number,
   maxLon: number,
 ): string[] => {
+  if (![minLat, maxLat, minLon, maxLon].every(Number.isFinite)) {
+    throw new Error("Terrain bounds must be finite numbers.");
+  }
+  if (minLat > maxLat) {
+    throw new Error("Terrain latitude bounds are reversed.");
+  }
+
   const keys = new Set<string>();
-  const latStart = Math.floor(minLat);
-  const latEnd = Math.floor(maxLat);
-  const lonStart = Math.floor(minLon);
-  const lonEnd = Math.floor(maxLon);
+  const latStart = Math.max(-90, Math.floor(minLat));
+  const latEnd = Math.min(89, Math.floor(maxLat));
+  const longitude = longitudeEnumeration(minLon, maxLon);
+  const lonStart = Math.floor(longitude.start);
+  const lonEnd = Math.floor(longitude.start + longitude.span);
 
   for (let lat = latStart; lat <= latEnd; lat += 1) {
     for (let lon = lonStart; lon <= lonEnd; lon += 1) {
-      keys.add(tileKey(lat, lon));
+      addBoundedKey(keys, tileKey(lat, normalizeLongitude(lon)));
     }
   }
   return Array.from(keys).sort();

--- a/src/store/appStore.terrainLoading.test.ts
+++ b/src/store/appStore.terrainLoading.test.ts
@@ -22,7 +22,13 @@ const terrainClient = vi.hoisted(() => ({
   clearCopernicusCache: vi.fn(async () => undefined),
 }));
 
+const srtmParser = vi.hoisted(() => ({ parseSrtmTile: vi.fn() }));
+
 vi.mock("../lib/copernicusTerrainClient", () => terrainClient);
+vi.mock("../lib/srtm", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/srtm")>();
+  return { ...actual, parseSrtmTile: srtmParser.parseSrtmTile };
+});
 vi.mock("../lib/coverage", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../lib/coverage")>();
   return { ...actual, buildCoverage: vi.fn(() => []), clearTerrainLossCache: vi.fn() };
@@ -188,5 +194,90 @@ describe("appStore GLO-30 terrain lifecycle", () => {
     expect(useAppStore.getState().terrainFetchStatus).toContain("1 sea-level");
     expect(useAppStore.getState().terrainFetchStatus).not.toContain("unavailable");
     expect(useAppStore.getState().isHighResTerrainLoaded).toBe(true);
+  });
+
+  it("requests only adjacent terrain keys for sites across the antimeridian", async () => {
+    useAppStore.setState({
+      sites: [
+        { ...useAppStore.getState().sites[0], id: "east", position: { lat: 10.1, lon: 179.9 } },
+        { ...useAppStore.getState().sites[0], id: "west", position: { lat: 10.2, lon: -179.9 } },
+      ],
+      srtmTiles: [],
+    });
+    terrainClient.loadCopernicus30TilesByKeys.mockResolvedValue({
+      tiles: [],
+      failedTiles: [],
+      fetchedTiles: [],
+      cacheHits: [],
+      seaLevelTiles: [],
+    });
+
+    await useAppStore.getState().recommendAndFetchTerrainForCurrentArea(20);
+
+    const requested = terrainClient.loadCopernicus30TilesByKeys.mock.calls[0]?.[0] as string[];
+    expect(requested.length).toBeGreaterThan(0);
+    expect(requested.every((key) => key.endsWith("E179") || key.endsWith("W180"))).toBe(true);
+  });
+
+  it("reports an over-cap terrain area without starting a request", async () => {
+    useAppStore.setState({
+      sites: [-100, 0, 100].map((lon, index) => ({
+        ...useAppStore.getState().sites[0],
+        id: `wide-${index}`,
+        position: { lat: 10.1, lon },
+      })),
+      srtmTiles: [],
+    });
+
+    await expect(useAppStore.getState().recommendAndFetchTerrainForCurrentArea(20)).resolves.toBeUndefined();
+
+    expect(terrainClient.loadCopernicus30TilesByKeys).not.toHaveBeenCalled();
+    expect(useAppStore.getState().terrainFetchStatus).toContain("256 tiles");
+    expect(useAppStore.getState().isTerrainFetching).toBe(false);
+  });
+
+  it("rejects more than eight manual files before parsing any file", async () => {
+    const files = Array.from({ length: 9 }, (_, index) => ({ name: `${index}.hgt` }) as File);
+
+    await expect(useAppStore.getState().ingestSrtmFiles(files)).rejects.toThrow("8 files");
+    expect(srtmParser.parseSrtmTile).not.toHaveBeenCalled();
+  });
+
+  it("parses manual files sequentially and commits only after all succeed", async () => {
+    let releaseFirst: ((value: SrtmTile) => void) | undefined;
+    srtmParser.parseSrtmTile
+      .mockReturnValueOnce(new Promise<SrtmTile>((resolve) => { releaseFirst = resolve; }))
+      .mockResolvedValueOnce(tile("N60E010"));
+    const initialTiles = useAppStore.getState().srtmTiles;
+    const loading = useAppStore.getState().ingestSrtmFiles([
+      { name: "N60E009.hgt" } as File,
+      { name: "N60E010.hgt" } as File,
+    ]);
+
+    await Promise.resolve();
+    expect(srtmParser.parseSrtmTile).toHaveBeenCalledTimes(1);
+    expect(useAppStore.getState().srtmTiles).toBe(initialTiles);
+    releaseFirst?.(tile("N60E009"));
+    await loading;
+
+    expect(srtmParser.parseSrtmTile).toHaveBeenCalledTimes(2);
+    expect(useAppStore.getState().srtmTiles.map((entry) => entry.key)).toEqual(
+      expect.arrayContaining(["N60E009", "N60E010"]),
+    );
+  });
+
+  it("does not commit earlier manual files when a later parse fails", async () => {
+    srtmParser.parseSrtmTile
+      .mockResolvedValueOnce(tile("N60E009"))
+      .mockRejectedValueOnce(new Error("bad tile"));
+    const initialTiles = useAppStore.getState().srtmTiles;
+
+    await expect(
+      useAppStore.getState().ingestSrtmFiles([
+        { name: "N60E009.hgt" } as File,
+        { name: "bad.hgt" } as File,
+      ]),
+    ).rejects.toThrow("bad tile");
+    expect(useAppStore.getState().srtmTiles).toBe(initialTiles);
   });
 });

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -35,7 +35,7 @@ import {
 import { analyzeLink, buildProfile } from "../lib/propagation";
 import { BUILTIN_SCENARIOS, defaultScenario, DEMO_SCENARIO, getScenarioById } from "../lib/scenarios";
 import { boundsToViewport, simulationAreaBoundsForSites } from "../lib/simulationArea";
-import { tilesForBounds } from "../lib/terrainTiles";
+import { longitudeBoundsForCoordinates, tilesForBounds } from "../lib/terrainTiles";
 import { mergeSrtmTiles } from "../lib/terrainMerge";
 import { parseSrtmTile, sampleSrtmElevation } from "../lib/srtm";
 import { DEFAULT_BASEMAP_STYLE_ID, BASEMAP_STYLE_REGISTRY } from "../lib/basemaps";
@@ -1388,16 +1388,16 @@ const bufferedBoundsForSites = (sites: Site[], radiusKm: number): TerrainFetchBo
   if (!sites.length) return null;
   const minLat = Math.min(...sites.map((site) => site.position.lat));
   const maxLat = Math.max(...sites.map((site) => site.position.lat));
-  const minLon = Math.min(...sites.map((site) => site.position.lon));
-  const maxLon = Math.max(...sites.map((site) => site.position.lon));
+  const longitudes = sites.map((site) => site.position.lon);
   const centerLat = (minLat + maxLat) / 2;
   const latDelta = Math.max(0.01, radiusKm / 111.32);
   const lonDelta = Math.max(0.01, radiusKm / (111.32 * Math.max(0.1, Math.cos((centerLat * Math.PI) / 180))));
+  const longitudeBounds = longitudeBoundsForCoordinates(longitudes, lonDelta);
   return {
     minLat: minLat - latDelta,
     maxLat: maxLat + latDelta,
-    minLon: minLon - lonDelta,
-    maxLon: maxLon + lonDelta,
+    minLon: longitudeBounds.minLon,
+    maxLon: longitudeBounds.maxLon,
   };
 };
 
@@ -3927,19 +3927,21 @@ export const useAppStore = create<AppState>((set, get) => ({
       terrainProgressBytesEstimated: 0,
     });
     try {
+      if (files.length > 8) {
+        throw new Error("Manual terrain ingestion is limited to 8 files at a time.");
+      }
       const list = Array.from(files);
-      const parsed = await Promise.all(
-        list.map(async (file) => {
-          const tile = await parseSrtmTile(file);
-          return {
-            ...tile,
-            sourceKind: "manual-upload" as const,
-            sourceId: "manual-upload",
-            sourceLabel: "Manual upload",
-            sourceDetail: file.name,
-          };
-        }),
-      );
+      const parsed: SrtmTile[] = [];
+      for (const file of list) {
+        const tile = await parseSrtmTile(file);
+        parsed.push({
+          ...tile,
+          sourceKind: "manual-upload" as const,
+          sourceId: "manual-upload",
+          sourceLabel: "Manual upload",
+          sourceDetail: file.name,
+        });
+      }
 
       set((state) => {
         const nextTiles = mergeSrtmTiles(state.srtmTiles, parsed);
@@ -3965,7 +3967,18 @@ export const useAppStore = create<AppState>((set, get) => ({
     const bounds = bufferedBoundsForSites(sites, radiusKm);
     if (!bounds) return;
 
-    const requiredTileKeys = tilesForBounds(bounds.minLat, bounds.maxLat, bounds.minLon, bounds.maxLon);
+    let requiredTileKeys: string[];
+    try {
+      requiredTileKeys = tilesForBounds(bounds.minLat, bounds.maxLat, bounds.minLon, bounds.maxLon);
+    } catch (error) {
+      set({
+        terrainFetchStatus: `Terrain fetch failed: ${getUiErrorMessage(error)}`,
+        isTerrainFetching: false,
+        isTerrainRecommending: false,
+        isHighResTerrainLoaded: false,
+      });
+      return;
+    }
     const existingTileKeys = new Set(
       srtmTiles.filter((tile) => tile.sourceId === "copernicus30").map((tile) => tile.key),
     );

--- a/src/store/coverageStore.test.ts
+++ b/src/store/coverageStore.test.ts
@@ -191,6 +191,47 @@ describe("coverageStore simulation progress phases", () => {
     expect(useCoverageStore.getState().simulationErrorMessage).toContain("terrain");
   });
 
+  it("settles a queued run when the requested terrain area exceeds the tile cap", async () => {
+    const buildSpy = vi.spyOn(coverageLib, "buildCoverageAsync").mockResolvedValue([]);
+    const bridgeSetState = vi.fn();
+    const wideSites = [-100, 0, 100].map((lon, index) => ({
+      ...site,
+      id: `wide-${index}`,
+      position: { lat: site.position.lat, lon },
+    }));
+    bridgeState.sites = wideSites;
+    bridgeState.selectedSiteIds = wideSites.map(({ id }) => id);
+    bridgeState.srtmTiles = [];
+    setAppStoreBridge({
+      getState: () => bridgeState as unknown as Record<string, unknown>,
+      setState: bridgeSetState,
+    });
+    useCoverageStore.setState({
+      coverageSamples: [{ lat: site.position.lat, lon: site.position.lon, valueDbm: -80 }],
+    });
+
+    useCoverageStore.getState().startManualCalculation();
+    vi.advanceTimersByTime(220);
+    await flushAsyncTicks();
+
+    expect(buildSpy).not.toHaveBeenCalled();
+    expect(useCoverageStore.getState()).toMatchObject({
+      coverageSamples: [],
+      isSimulationRecomputing: false,
+      simulationProgress: 0,
+      simulationStepLabel: "",
+      simulationSamplesDone: 0,
+      simulationSamplesTotal: 0,
+      simulationRunToken: "",
+      completedCoverageRunToken: "",
+      calculationCycleSource: null,
+    });
+    expect(useCoverageStore.getState().simulationErrorMessage).toContain("maximum of 256 tiles");
+    expect(bridgeSetState).toHaveBeenCalledWith({
+      terrainFetchStatus: expect.stringContaining("maximum of 256 tiles"),
+    });
+  });
+
   it("accepts zero-elevation Copernicus ocean cells as complete 100 km terrain", async () => {
     const buildSpy = vi.spyOn(coverageLib, "buildCoverageAsync").mockResolvedValue([]);
     const terrainTiles = completeTerrainTiles(100);

--- a/src/store/coverageStore.ts
+++ b/src/store/coverageStore.ts
@@ -19,6 +19,7 @@ import {
 } from "../lib/simulationPerf";
 import { antennaPatternSignature } from "../lib/antennaPattern";
 import { sampleSrtmElevation } from "../lib/srtm";
+import { getUiErrorMessage } from "../lib/uiError";
 import type { CoverageSample, Network, RadioSystem, Site, SrtmTile } from "../types/radio";
 
 const COVERAGE_RECOMPUTE_DEBOUNCE_MS = 140;
@@ -268,6 +269,25 @@ const initializeRunState = (set: (patch: Partial<CoverageState>) => void, runId:
   });
 };
 
+const failQueuedCoverageRun = (message: string): void => {
+  coverageRerunQueued = false;
+  coverageRunInFlight = false;
+  useCoverageStore.setState({
+    coverageSamples: [],
+    isSimulationRecomputing: false,
+    simulationProgress: 0,
+    simulationProgressMode: "indeterminate",
+    simulationStepLabel: "",
+    simulationSamplesDone: 0,
+    simulationSamplesTotal: 0,
+    simulationRunToken: "",
+    completedCoverageRunToken: "",
+    calculationCycleSource: null,
+    simulationErrorMessage: message,
+  });
+  appStoreBridge?.setState({ terrainFetchStatus: message });
+};
+
 const queueCoverageRunFlush = (delay = COVERAGE_RECOMPUTE_DEBOUNCE_MS): void => {
   if (coverageRecomputeTimer !== null) {
     window.clearTimeout(coverageRecomputeTimer);
@@ -275,7 +295,9 @@ const queueCoverageRunFlush = (delay = COVERAGE_RECOMPUTE_DEBOUNCE_MS): void => 
   }
   coverageRecomputeTimer = window.setTimeout(() => {
     coverageRecomputeTimer = null;
-    void flushCoverageRunQueue();
+    void flushCoverageRunQueue().catch((error) => {
+      failQueuedCoverageRun(getUiErrorMessage(error));
+    });
   }, Math.max(0, delay));
 };
 
@@ -466,22 +488,8 @@ const flushCoverageRunQueue = async (): Promise<void> => {
     inputs.srtmTiles,
   );
   if (missingTerrainTileKeys.length > 0) {
-    coverageRerunQueued = false;
     const message = `The ${targetRadiusKm} km Simulation could not be completed because ${missingTerrainTileKeys.length} required GLO-30 terrain tile${missingTerrainTileKeys.length === 1 ? " is" : "s are"} unavailable.`;
-    useCoverageStore.setState({
-      coverageSamples: [],
-      isSimulationRecomputing: false,
-      simulationProgress: 0,
-      simulationProgressMode: "indeterminate",
-      simulationStepLabel: "",
-      simulationSamplesDone: 0,
-      simulationSamplesTotal: 0,
-      simulationRunToken: "",
-      completedCoverageRunToken: "",
-      calculationCycleSource: null,
-      simulationErrorMessage: message,
-    });
-    appStoreBridge.setState({ terrainFetchStatus: message });
+    failQueuedCoverageRun(message);
     return;
   }
   const runSignature = coverageInputSignature(inputs);


### PR DESCRIPTION
## Summary

- bound MeshMap JSON to 5 MiB / 20,000 root records and 868.no SSE to its existing 5 MiB / 8-second / 1-second-idle limits plus 5,000 events
- bound normalized node caches to 20,000 per source / 25,000 combined and Panorama work to 1,000 deterministic candidates within the existing 200 km range
- validate SRTM raw sizes and bounded ZIP extraction, limit manual ingestion to 8 sequential files, and prevent partial commits
- cap canonical terrain enumeration at 256 keys before catalog/cache/fetch work, including antimeridian-safe terrain and overlay bounds
- preserve existing rate keys and values, retry/concurrency, catalog-confirmed ocean behavior, AbortSignal/deadline handling, calculations, and UI

## Validation

- `npm test` — 172 files / 1,274 tests passed
- focused compatibility suite — 20 files / 269 tests passed
- `npm run build` — passed as `0.27.0+a587a07a`
- targeted changed-file ESLint — passed; separate whole-file `MapView.tsx` and `appStore.ts` findings are unchanged from the base
- `git diff --check` — passed
- `npm run dev:check` — no LinkSim dev/watch servers found
- independent pre-merge review of exact SHA `a587a07af823bf8d52ea944af279def24c45ec8a` — PASS, no actionable findings

## Scope

No new UI, schema migration, version bump, deployment, or production change. Issue #1053 remains open for the remaining batch.

Refs #1053

— Forge · AI coding agent
<!-- linksim-ai:v1 agent=Forge bot=true run=a64e96b5-272e-4a96-bd39-0b21b4bd8d2b source=pr:1053-batch-4 commit=a587a07af823bf8d52ea944af279def24c45ec8a -->
