### PR TITLE
Bound avatar and geocode workloads

### DIFF
--- a/docs/legal/SOURCE_COMPLIANCE.md
+++ b/docs/legal/SOURCE_COMPLIANCE.md
@@ -18,9 +18,10 @@ This document defines operating rules when LinkSim consumes external data/servic
 
 ## Geocoding and elevation APIs
 
-- Route requests through guarded server endpoints when available.
-- Apply request caps and short-lived cache where practical.
-- Handle upstream failures with explicit user messaging and fallback behavior.
+- Route browser geocoding through the guarded same-origin endpoint; production clients do not fall back directly to Nominatim.
+- Cache normalized geocoding queries for five minutes and cap provider responses at six results and 64 KiB.
+- Apply the configured per-caller limit (60 requests per minute by default) plus a one-request-per-second cache-miss gate per running isolate. These controls are per environment/isolate, not an application-global guarantee.
+- Preserve explicit provider throttling and failure messages without silently retrying.
 
 ## Mesh feeds and external node directories
 

--- a/docs/legal/SOURCE_COMPLIANCE.md
+++ b/docs/legal/SOURCE_COMPLIANCE.md
@@ -18,7 +18,7 @@ This document defines operating rules when LinkSim consumes external data/servic
 
 ## Geocoding and elevation APIs
 
-- Route browser geocoding through the guarded same-origin endpoint; production clients do not fall back directly to Nominatim.
+- Route browser forward location search through the guarded same-origin endpoint; production clients do not fall back directly to Nominatim for forward search.
 - Cache normalized geocoding queries for five minutes and cap provider responses at six results and 64 KiB.
 - Apply the configured per-caller limit (60 requests per minute by default) plus a one-request-per-second cache-miss gate per running isolate. These controls are per environment/isolate, not an application-global guarantee.
 - Preserve explicit provider throttling and failure messages without silently retrying.

--- a/docs/repository-guide.md
+++ b/docs/repository-guide.md
@@ -204,7 +204,7 @@ npm run refresh:staging:r2
 ## Data/Service Notes
 
 - Terrain data is fetched on demand and cached client-side.
-- API proxies and geocode endpoints include method/rate-limit safeguards.
+- Browser geocoding uses the same-origin API, with bounded provider responses, a five-minute cache, configured per-caller limiting, and a per-isolate cache-miss gate.
 - In local runtimes without edge functions, some cloud behaviors are emulated/fallback.
 - Basemap provider failures auto-fallback to CARTO with a non-blocking warning.
 

--- a/docs/repository-guide.md
+++ b/docs/repository-guide.md
@@ -204,7 +204,7 @@ npm run refresh:staging:r2
 ## Data/Service Notes
 
 - Terrain data is fetched on demand and cached client-side.
-- Browser geocoding uses the same-origin API, with bounded provider responses, a five-minute cache, configured per-caller limiting, and a per-isolate cache-miss gate.
+- Browser forward location search uses the same-origin API, with bounded provider responses, a five-minute cache, configured per-caller limiting, and a per-isolate cache-miss gate.
 - In local runtimes without edge functions, some cloud behaviors are emulated/fallback.
 - Basemap provider failures auto-fallback to CARTO with a non-blocking warning.
 

--- a/functions/_lib/db.sharedSimulation.test.ts
+++ b/functions/_lib/db.sharedSimulation.test.ts
@@ -5,6 +5,7 @@ import {
   fetchLibraryForUser,
   fetchPublicSimulationBundle,
   fetchResourceChanges,
+  listCollaboratorDirectory,
   listUsers,
   revertResourceFromChangeCopy,
   setSimulationLifecycleStatus,
@@ -316,6 +317,15 @@ class FakeDb {
       return (TABLE_COLUMNS[table] ?? []).map((name) => ({ name }));
     }
     if (sql.includes("FROM users ORDER BY created_at DESC")) return this.users;
+    if (sql.includes("CASE WHEN email_public = 1") && sql.includes("FROM users")) {
+      return this.users.map((row) => ({
+        id: row.id,
+        username: row.username,
+        visible_email: row.email_public === 1 ? row.email ?? row.idp_email ?? "" : "",
+        avatar_url: row.avatar_url ?? "",
+        avatar_thumb_key: row.avatar_thumb_key ?? null,
+      }));
+    }
     if (sql.includes("SELECT id, owner_user_id, visibility FROM sites WHERE id IN")) {
       return bound.map((id) => this.sites.get(String(id))).filter((row): row is AnyRow => Boolean(row));
     }
@@ -349,11 +359,15 @@ class FakeDb {
       const [kind, resourceId] = bound;
       return this.resourceChanges
         .filter((change) => change.resource_kind === kind && change.resource_id === resourceId)
-        .map((change) => ({
-          ...change,
-          actor_name: String(change.actor_user_id),
-          actor_avatar_url: "",
-        }));
+        .map((change) => {
+          const user = this.users.find((candidate) => candidate.id === change.actor_user_id);
+          return {
+            ...change,
+            actor_name: String(change.actor_user_id),
+            actor_avatar_url: user?.avatar_url ?? "",
+            actor_avatar_thumb_key: user?.avatar_thumb_key ?? null,
+          };
+        });
     }
     if (sql.includes("SELECT s.id") && sql.includes("s.status = 'deleted'")) {
       const userId = String(bound[1] ?? "");
@@ -389,17 +403,22 @@ class FakeDb {
           ...row,
           role: null,
           owner_name: String(row.owner_user_id),
-          owner_avatar_url: "",
+          owner_avatar_url: row.owner_avatar_url ?? "",
+          owner_avatar_thumb_key: row.owner_avatar_thumb_key ?? null,
           created_by_name: null,
-          created_by_avatar_url: null,
+          created_by_avatar_url: row.created_by_avatar_url ?? null,
+          created_by_avatar_thumb_key: row.created_by_avatar_thumb_key ?? null,
           first_actor_user_id: null,
           first_actor_name: null,
-          first_actor_avatar_url: null,
+          first_actor_avatar_url: row.first_actor_avatar_url ?? null,
+          first_actor_avatar_thumb_key: row.first_actor_avatar_thumb_key ?? null,
           last_edited_by_name: null,
-          last_edited_by_avatar_url: null,
+          last_edited_by_avatar_url: row.last_edited_by_avatar_url ?? null,
+          last_edited_by_avatar_thumb_key: row.last_edited_by_avatar_thumb_key ?? null,
           last_actor_user_id: null,
           last_actor_name: null,
-          last_actor_avatar_url: null,
+          last_actor_avatar_url: row.last_actor_avatar_url ?? null,
+          last_actor_avatar_thumb_key: row.last_actor_avatar_thumb_key ?? null,
         }));
     }
     if (sql.includes("SELECT s.payload_json") && sql.includes("FROM sites s")) return [];
@@ -590,6 +609,11 @@ const userRow = (overrides: AnyRow = {}): AnyRow => ({
   created_at: "2026-01-01", updated_at: "2026-01-01", ...overrides,
 });
 
+const avatarObjectKey = "users/123e4567-e89b-42d3-a456-426614174000/avatar-0123456789abcdef.webp";
+const avatarThumbKey = "users/123e4567-e89b-42d3-a456-426614174000/avatar-0123456789abcdef-thumb.webp";
+const avatarUrl = `/api/avatar/${avatarObjectKey}`;
+const avatarThumbUrl = `/api/avatar/${avatarThumbKey}`;
+
 describe("user identity privacy and diagnostic access", () => {
   it("redacts private profile and IdP email from moderator directory reads", async () => {
     const db = new FakeDb();
@@ -613,6 +637,26 @@ describe("user identity privacy and diagnostic access", () => {
       idpEmail: "verified@example.test",
       idpEmailVerified: true,
     });
+  });
+
+  it("uses the stored thumbnail for user list DTOs while preserving the avatarUrl field", async () => {
+    const db = new FakeDb();
+    db.users.push(userRow({ avatar_url: avatarUrl, avatar_thumb_key: avatarThumbKey }));
+
+    const [profile] = await listUsers({ DB: db } as unknown as Parameters<typeof listUsers>[0], false);
+
+    expect(profile?.avatarUrl).toBe(avatarThumbUrl);
+  });
+
+  it("uses the stored thumbnail for collaborator directory DTOs", async () => {
+    const db = new FakeDb();
+    db.users.push(userRow({ avatar_url: avatarUrl, avatar_thumb_key: avatarThumbKey }));
+
+    const [profile] = await listCollaboratorDirectory(
+      { DB: db } as unknown as Parameters<typeof listCollaboratorDirectory>[0],
+    );
+
+    expect(profile?.avatarUrl).toBe(avatarThumbUrl);
   });
 
   it("reads current diagnostic authority directly from DB role and revocation state", async () => {
@@ -1233,6 +1277,23 @@ describe("upsertLibrarySnapshot shared simulations", () => {
     );
   });
 
+  it("uses stored thumbnails for compact Library attribution DTOs", async () => {
+    const db = createPrivateBundleDb();
+    db.simulations.set("sim-private", {
+      ...db.simulations.get("sim-private"),
+      owner_avatar_url: avatarUrl,
+      owner_avatar_thumb_key: avatarThumbKey,
+    });
+    const env = { DB: db } as unknown as Parameters<typeof fetchLibraryForUser>[0];
+
+    const library = await fetchLibraryForUser(env, "owner-1");
+
+    expect(library.simulationPresets[0]).toMatchObject({
+      createdByAvatarUrl: avatarThumbUrl,
+      lastEditedByAvatarUrl: avatarThumbUrl,
+    });
+  });
+
   afterEach(() => {
     vi.useRealTimers();
   });
@@ -1405,6 +1466,19 @@ describe("resource change authorization", () => {
     db.siteRoles.delete("site-1:viewer-1");
     await expect(fetchResourceChanges(env, "site", "site-1", actor("viewer-1")))
       .resolves.toEqual({ ok: false, reason: "forbidden" });
+  });
+
+  it("uses stored thumbnails for resource-change actor DTOs", async () => {
+    const db = createResourceHistoryDb();
+    db.users.push(userRow({ id: "owner-1", avatar_url: avatarUrl, avatar_thumb_key: avatarThumbKey }));
+    const env = { DB: db } as unknown as Parameters<typeof fetchResourceChanges>[0];
+
+    const result = await fetchResourceChanges(env, "site", "site-1", actor("owner-1"));
+
+    expect(result).toMatchObject({
+      ok: true,
+      changes: [{ actorAvatarUrl: avatarThumbUrl }],
+    });
   });
 
   it("authorizes active Simulation history and keeps deleted history administrator-only", async () => {

--- a/functions/_lib/db.ts
+++ b/functions/_lib/db.ts
@@ -16,6 +16,7 @@ import {
   LIBRARY_SITE_MAX_BYTES,
   LibraryValidationError,
 } from "../../src/lib/libraryLimits";
+import { thumbnailAvatarUrl } from "../../src/lib/avatarLimits";
 
 const VISIBILITIES: Visibility[] = ["private", "public", "shared"];
 const DB_VISIBILITIES: DbVisibility[] = ["private", "public_read", "public_write"];
@@ -1477,6 +1478,7 @@ export const listUsers = async (env: Env, includePrivateIdentity: boolean) => {
     const { idpEmail, idpEmailVerified, ...ordinaryProfile } = profile;
     return {
       ...ordinaryProfile,
+      avatarUrl: thumbnailAvatarUrl(profile.avatarUrl, profile.avatarThumbKey),
       email: includePrivateIdentity || row.email_public === 1 ? profile.email : "",
       ...(includePrivateIdentity ? { idpEmail, idpEmailVerified } : {}),
     };
@@ -1489,19 +1491,20 @@ export const listCollaboratorDirectory = async (env: Env) => {
     .prepare(
       `SELECT id, username,
               CASE WHEN email_public = 1 THEN COALESCE(email, idp_email, '') ELSE '' END AS visible_email,
-              COALESCE(avatar_url, '') AS avatar_url
+              COALESCE(avatar_url, '') AS avatar_url,
+              avatar_thumb_key
        FROM users
        WHERE (is_admin = 1 OR is_moderator = 1 OR is_approved = 1)
          AND (approved_by_user_id IS NULL OR approved_by_user_id NOT LIKE 'revoked:%')
        ORDER BY username COLLATE NOCASE ASC
        LIMIT 4000`,
     )
-    .all<{ id: string; username: string; visible_email: string; avatar_url: string }>();
+    .all<{ id: string; username: string; visible_email: string; avatar_url: string; avatar_thumb_key: string | null }>();
   return rows.results.map((row) => ({
     id: row.id,
     username: row.username,
     email: row.visible_email,
-    avatarUrl: row.avatar_url,
+    avatarUrl: thumbnailAvatarUrl(row.avatar_url, row.avatar_thumb_key),
   }));
 };
 
@@ -2459,20 +2462,25 @@ type LibraryRow = {
   owner_user_id: string;
   owner_name: string | null;
   owner_avatar_url: string | null;
+  owner_avatar_thumb_key: string | null;
   visibility: DbVisibility;
   role: string | null;
   created_by_user_id: string | null;
   created_by_name: string | null;
   created_by_avatar_url: string | null;
+  created_by_avatar_thumb_key: string | null;
   first_actor_user_id: string | null;
   first_actor_name: string | null;
   first_actor_avatar_url: string | null;
+  first_actor_avatar_thumb_key: string | null;
   last_edited_by_user_id: string | null;
   last_edited_by_name: string | null;
   last_edited_by_avatar_url: string | null;
+  last_edited_by_avatar_thumb_key: string | null;
   last_actor_user_id: string | null;
   last_actor_name: string | null;
   last_actor_avatar_url: string | null;
+  last_actor_avatar_thumb_key: string | null;
   created_at: string | null;
   last_edited_at: string | null;
   status?: "active" | "deleted";
@@ -2507,18 +2515,23 @@ export const fetchLibraryForUser = async (
       `SELECT s.payload_json, s.id, s.owner_user_id, s.visibility, r.role,
               owner_u.username AS owner_name,
               owner_u.avatar_url AS owner_avatar_url,
+              owner_u.avatar_thumb_key AS owner_avatar_thumb_key,
               s.created_by_user_id,
               (SELECT u.username FROM users u WHERE u.id = s.created_by_user_id) AS created_by_name,
               (SELECT u.avatar_url FROM users u WHERE u.id = s.created_by_user_id) AS created_by_avatar_url,
+              (SELECT u.avatar_thumb_key FROM users u WHERE u.id = s.created_by_user_id) AS created_by_avatar_thumb_key,
               (SELECT rc.actor_user_id FROM resource_changes rc WHERE rc.resource_kind = 'site' AND rc.resource_id = s.id ORDER BY rc.changed_at ASC LIMIT 1) AS first_actor_user_id,
               (SELECT u.username FROM users u WHERE u.id = (SELECT rc.actor_user_id FROM resource_changes rc WHERE rc.resource_kind = 'site' AND rc.resource_id = s.id ORDER BY rc.changed_at ASC LIMIT 1)) AS first_actor_name,
               (SELECT u.avatar_url FROM users u WHERE u.id = (SELECT rc.actor_user_id FROM resource_changes rc WHERE rc.resource_kind = 'site' AND rc.resource_id = s.id ORDER BY rc.changed_at ASC LIMIT 1)) AS first_actor_avatar_url,
+              (SELECT u.avatar_thumb_key FROM users u WHERE u.id = (SELECT rc.actor_user_id FROM resource_changes rc WHERE rc.resource_kind = 'site' AND rc.resource_id = s.id ORDER BY rc.changed_at ASC LIMIT 1)) AS first_actor_avatar_thumb_key,
               s.last_edited_by_user_id,
               (SELECT u.username FROM users u WHERE u.id = s.last_edited_by_user_id) AS last_edited_by_name,
               (SELECT u.avatar_url FROM users u WHERE u.id = s.last_edited_by_user_id) AS last_edited_by_avatar_url,
+              (SELECT u.avatar_thumb_key FROM users u WHERE u.id = s.last_edited_by_user_id) AS last_edited_by_avatar_thumb_key,
               (SELECT rc.actor_user_id FROM resource_changes rc WHERE rc.resource_kind = 'site' AND rc.resource_id = s.id ORDER BY rc.changed_at DESC LIMIT 1) AS last_actor_user_id,
               (SELECT u.username FROM users u WHERE u.id = (SELECT rc.actor_user_id FROM resource_changes rc WHERE rc.resource_kind = 'site' AND rc.resource_id = s.id ORDER BY rc.changed_at DESC LIMIT 1)) AS last_actor_name,
               (SELECT u.avatar_url FROM users u WHERE u.id = (SELECT rc.actor_user_id FROM resource_changes rc WHERE rc.resource_kind = 'site' AND rc.resource_id = s.id ORDER BY rc.changed_at DESC LIMIT 1)) AS last_actor_avatar_url,
+              (SELECT u.avatar_thumb_key FROM users u WHERE u.id = (SELECT rc.actor_user_id FROM resource_changes rc WHERE rc.resource_kind = 'site' AND rc.resource_id = s.id ORDER BY rc.changed_at DESC LIMIT 1)) AS last_actor_avatar_thumb_key,
               s.created_at,
               s.last_edited_at
        FROM sites s
@@ -2579,18 +2592,23 @@ export const fetchLibraryForUser = async (
       `SELECT s.payload_json, s.id, s.owner_user_id, s.visibility, s.status, r.role,
               owner_u.username AS owner_name,
               owner_u.avatar_url AS owner_avatar_url,
+              owner_u.avatar_thumb_key AS owner_avatar_thumb_key,
               s.created_by_user_id,
               (SELECT u.username FROM users u WHERE u.id = s.created_by_user_id) AS created_by_name,
               (SELECT u.avatar_url FROM users u WHERE u.id = s.created_by_user_id) AS created_by_avatar_url,
+              (SELECT u.avatar_thumb_key FROM users u WHERE u.id = s.created_by_user_id) AS created_by_avatar_thumb_key,
               (SELECT rc.actor_user_id FROM resource_changes rc WHERE rc.resource_kind = 'simulation' AND rc.resource_id = s.id ORDER BY rc.changed_at ASC LIMIT 1) AS first_actor_user_id,
               (SELECT u.username FROM users u WHERE u.id = (SELECT rc.actor_user_id FROM resource_changes rc WHERE rc.resource_kind = 'simulation' AND rc.resource_id = s.id ORDER BY rc.changed_at ASC LIMIT 1)) AS first_actor_name,
               (SELECT u.avatar_url FROM users u WHERE u.id = (SELECT rc.actor_user_id FROM resource_changes rc WHERE rc.resource_kind = 'simulation' AND rc.resource_id = s.id ORDER BY rc.changed_at ASC LIMIT 1)) AS first_actor_avatar_url,
+              (SELECT u.avatar_thumb_key FROM users u WHERE u.id = (SELECT rc.actor_user_id FROM resource_changes rc WHERE rc.resource_kind = 'simulation' AND rc.resource_id = s.id ORDER BY rc.changed_at ASC LIMIT 1)) AS first_actor_avatar_thumb_key,
               s.last_edited_by_user_id,
               (SELECT u.username FROM users u WHERE u.id = s.last_edited_by_user_id) AS last_edited_by_name,
               (SELECT u.avatar_url FROM users u WHERE u.id = s.last_edited_by_user_id) AS last_edited_by_avatar_url,
+              (SELECT u.avatar_thumb_key FROM users u WHERE u.id = s.last_edited_by_user_id) AS last_edited_by_avatar_thumb_key,
               (SELECT rc.actor_user_id FROM resource_changes rc WHERE rc.resource_kind = 'simulation' AND rc.resource_id = s.id ORDER BY rc.changed_at DESC LIMIT 1) AS last_actor_user_id,
               (SELECT u.username FROM users u WHERE u.id = (SELECT rc.actor_user_id FROM resource_changes rc WHERE rc.resource_kind = 'simulation' AND rc.resource_id = s.id ORDER BY rc.changed_at DESC LIMIT 1)) AS last_actor_name,
               (SELECT u.avatar_url FROM users u WHERE u.id = (SELECT rc.actor_user_id FROM resource_changes rc WHERE rc.resource_kind = 'simulation' AND rc.resource_id = s.id ORDER BY rc.changed_at DESC LIMIT 1)) AS last_actor_avatar_url,
+              (SELECT u.avatar_thumb_key FROM users u WHERE u.id = (SELECT rc.actor_user_id FROM resource_changes rc WHERE rc.resource_kind = 'simulation' AND rc.resource_id = s.id ORDER BY rc.changed_at DESC LIMIT 1)) AS last_actor_avatar_thumb_key,
               s.created_at,
               s.last_edited_at
        FROM simulations s
@@ -2615,8 +2633,11 @@ export const fetchLibraryForUser = async (
             row.created_by_name ?? row.first_actor_name ?? row.owner_name,
             createdByUserId ?? row.owner_user_id,
           );
+          const ownerAvatarUrl = thumbnailAvatarUrl(row.owner_avatar_url, row.owner_avatar_thumb_key);
           const createdByAvatarUrl =
-            row.created_by_avatar_url ?? row.first_actor_avatar_url ?? row.owner_avatar_url ?? "";
+            thumbnailAvatarUrl(row.created_by_avatar_url, row.created_by_avatar_thumb_key)
+            || thumbnailAvatarUrl(row.first_actor_avatar_url, row.first_actor_avatar_thumb_key)
+            || ownerAvatarUrl;
           const lastEditedByUserId =
             row.last_edited_by_user_id ?? row.last_actor_user_id ?? createdByUserId ?? row.owner_user_id;
           const lastEditedByName = userDisplayFallback(
@@ -2624,7 +2645,10 @@ export const fetchLibraryForUser = async (
             lastEditedByUserId ?? createdByUserId ?? row.owner_user_id,
           );
           const lastEditedByAvatarUrl =
-            row.last_edited_by_avatar_url ?? row.last_actor_avatar_url ?? createdByAvatarUrl ?? row.owner_avatar_url ?? "";
+            thumbnailAvatarUrl(row.last_edited_by_avatar_url, row.last_edited_by_avatar_thumb_key)
+            || thumbnailAvatarUrl(row.last_actor_avatar_url, row.last_actor_avatar_thumb_key)
+            || createdByAvatarUrl
+            || ownerAvatarUrl;
           return {
             ...parsed,
             ownerUserId: row.owner_user_id,
@@ -2918,7 +2942,8 @@ export const fetchResourceChanges = async (
     .prepare(
       `SELECT c.id, c.action, c.changed_at, c.note, c.actor_user_id, c.details_json,
               u.username AS actor_name,
-              u.avatar_url AS actor_avatar_url
+              u.avatar_url AS actor_avatar_url,
+              u.avatar_thumb_key AS actor_avatar_thumb_key
        FROM resource_changes c
        LEFT JOIN users u ON u.id = c.actor_user_id
        WHERE c.resource_kind = ? AND c.resource_id = ?
@@ -2935,6 +2960,7 @@ export const fetchResourceChanges = async (
       details_json: string | null;
       actor_name: string | null;
       actor_avatar_url: string | null;
+      actor_avatar_thumb_key: string | null;
     }>();
 
   return {
@@ -2946,7 +2972,7 @@ export const fetchResourceChanges = async (
       note: row.note,
       actorUserId: row.actor_user_id,
       actorName: row.actor_name,
-      actorAvatarUrl: row.actor_avatar_url,
+      actorAvatarUrl: thumbnailAvatarUrl(row.actor_avatar_url, row.actor_avatar_thumb_key),
       details: readDisplayableChangeDetails(row.details_json),
     })),
   };

--- a/functions/api/avatar-upload.test.ts
+++ b/functions/api/avatar-upload.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AVATAR_REQUEST_MAX_BYTES } from "../../src/lib/avatarLimits";
 
 const { verifyAuthMock, ensureUserMock, fetchUserProfileMock, getUserAvatarKeysMock, setUserAvatarAssetsMock } = vi.hoisted(() => ({
   verifyAuthMock: vi.fn(), ensureUserMock: vi.fn(), fetchUserProfileMock: vi.fn(),
@@ -12,7 +13,27 @@ vi.mock("../_lib/db", () => ({
 
 import { onRequestPost } from "./avatar-upload";
 
-describe("avatar upload privacy", () => {
+const pngDataUrl = (size = 8) => {
+  const bytes = new Uint8Array(size);
+  bytes.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  let binary = "";
+  for (let offset = 0; offset < bytes.length; offset += 32_768) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + 32_768));
+  }
+  return `data:image/png;base64,${btoa(binary)}`;
+};
+
+const makeEnv = (overrides: Record<string, unknown> = {}) => ({
+  DB: {}, AVATAR_BUCKET: { put: vi.fn(), delete: vi.fn() }, ...overrides,
+} as unknown as Parameters<typeof onRequestPost>[0]["env"]);
+const call = (env: Parameters<typeof onRequestPost>[0]["env"], body: string) => onRequestPost({
+  request: new Request("https://example.test/api/avatar-upload", {
+    method: "POST", headers: { "content-type": "application/json" }, body,
+  }),
+  env,
+} as never);
+
+describe("avatar upload bounds", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     verifyAuthMock.mockResolvedValue({ userId: "hidden@example.com", tokenPayload: {}, source: "headers" });
@@ -21,24 +42,50 @@ describe("avatar upload privacy", () => {
     setUserAvatarAssetsMock.mockImplementation(async (_env, _id, avatar) => ({ id: "hidden@example.com", ...avatar }));
   });
 
-  it("uses opaque keys and URLs that do not disclose an email-shaped user ID", async () => {
-    const puts: string[] = [];
-    const env = {
-      DB: {},
-      AVATAR_BUCKET: { put: vi.fn(async (key: string) => { puts.push(key); }), delete: vi.fn() },
-    } as unknown as Parameters<typeof onRequestPost>[0]["env"];
-    const image = `data:image/png;base64,${btoa("png")}`;
-    const response = await onRequestPost({
-      request: new Request("https://example.test/api/avatar-upload", {
-        method: "POST", headers: { "content-type": "application/json" },
-        body: JSON.stringify({ originalDataUrl: image, thumbDataUrl: image }),
-      }),
-      env,
-    } as never);
+  it("accepts exactly 8,000,090 UTF-8 bytes at depth 1 and rejects +1 or depth 2", async () => {
+    const image = pngDataUrl();
+    const base = JSON.stringify({ originalDataUrl: image, thumbDataUrl: image, padding: "" });
+    const exact = base.replace('""}', `"${"x".repeat(AVATAR_REQUEST_MAX_BYTES - new TextEncoder().encode(base).byteLength)}"}`);
+    expect(new TextEncoder().encode(exact)).toHaveLength(AVATAR_REQUEST_MAX_BYTES);
+    expect((await call(makeEnv(), exact)).status).toBe(200);
+    expect((await call(makeEnv(), `${exact} `)).status).toBe(413);
+    expect((await call(makeEnv(), JSON.stringify({ originalDataUrl: image, thumbDataUrl: image, extra: { nested: true } }))).status).toBe(422);
+  });
 
+  it("accepts exact decoded limits and rejects the next byte or MIME/magic mismatch", async () => {
+    expect((await call(makeEnv(), JSON.stringify({ originalDataUrl: pngDataUrl(5_000_000), thumbDataUrl: pngDataUrl(1_000_000) }))).status).toBe(200);
+    expect((await call(makeEnv(), JSON.stringify({ originalDataUrl: pngDataUrl(5_000_001), thumbDataUrl: pngDataUrl() }))).status).toBe(413);
+    expect((await call(makeEnv(), JSON.stringify({ originalDataUrl: pngDataUrl(), thumbDataUrl: pngDataUrl(1_000_001) }))).status).toBe(413);
+    const mismatch = `data:image/jpeg;base64,${pngDataUrl().split(",")[1]}`;
+    expect((await call(makeEnv(), JSON.stringify({ originalDataUrl: mismatch, thumbDataUrl: pngDataUrl() }))).status).toBe(400);
+  });
+
+  it("uses opaque keys without disclosing the user identity", async () => {
+    const puts: string[] = [];
+    const env = makeEnv({ AVATAR_BUCKET: { put: vi.fn(async (key: string) => { puts.push(key); }), delete: vi.fn() } });
+    const image = pngDataUrl();
+    const response = await call(env, JSON.stringify({ originalDataUrl: image, thumbDataUrl: image }));
     expect(response.status).toBe(200);
     expect(puts).toHaveLength(2);
     expect(puts.join(" ")).not.toContain("hidden@example.com");
     expect(JSON.stringify(await response.json())).not.toContain("hidden%40example.com");
+  });
+
+  it("cleans only newly written objects when storage or profile update fails", async () => {
+    getUserAvatarKeysMock.mockResolvedValue({ avatarObjectKey: "users/prior/full.webp", avatarThumbKey: "users/prior/thumb.webp" });
+    const deleteMock = vi.fn();
+    let env = makeEnv({ AVATAR_BUCKET: { put: vi.fn().mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error("thumb failed")), delete: deleteMock } });
+    expect((await call(env, JSON.stringify({ originalDataUrl: pngDataUrl(), thumbDataUrl: pngDataUrl() }))).status).toBe(500);
+    expect(deleteMock).toHaveBeenCalledTimes(1);
+    expect(deleteMock).not.toHaveBeenCalledWith(expect.stringContaining("prior"));
+
+    vi.clearAllMocks();
+    getUserAvatarKeysMock.mockResolvedValue({ avatarObjectKey: "users/prior/full.webp", avatarThumbKey: "users/prior/thumb.webp" });
+    setUserAvatarAssetsMock.mockRejectedValueOnce(new Error("db failed"));
+    const deletes = vi.fn();
+    env = makeEnv({ AVATAR_BUCKET: { put: vi.fn(), delete: deletes } });
+    expect((await call(env, JSON.stringify({ originalDataUrl: pngDataUrl(), thumbDataUrl: pngDataUrl() }))).status).toBe(500);
+    expect(deletes).toHaveBeenCalledTimes(2);
+    expect(deletes).not.toHaveBeenCalledWith(expect.stringContaining("prior"));
   });
 });

--- a/functions/api/avatar-upload.ts
+++ b/functions/api/avatar-upload.ts
@@ -1,28 +1,15 @@
 import { verifyAuth } from "../_lib/auth";
 import { ensureUser, fetchUserProfile, getUserAvatarKeys, setUserAvatarAssets } from "../_lib/db";
-import { errorResponse, handleOptions, json, withCors } from "../_lib/http";
+import { ApiRequestError, errorResponse, handleOptions, json, readBoundedJson, withCors } from "../_lib/http";
 import type { Env } from "../_lib/types";
-
-const SUPPORTED_CONTENT_TYPES = new Set(["image/webp", "image/png", "image/jpeg"]);
-
-type ParsedDataUrl = {
-  contentType: string;
-  bytes: Uint8Array;
-};
-
-const parseDataUrl = (value: unknown): ParsedDataUrl => {
-  if (typeof value !== "string") throw new Error("Image payload must be a data URL.");
-  const trimmed = value.trim();
-  const match = /^data:(image\/(?:webp|png|jpeg));base64,([A-Za-z0-9+/=]+)$/.exec(trimmed);
-  if (!match) throw new Error("Unsupported image format. Use webp, png, or jpeg.");
-  const contentType = match[1].toLowerCase();
-  if (!SUPPORTED_CONTENT_TYPES.has(contentType)) throw new Error("Unsupported image type.");
-  const base64 = match[2];
-  const binary = atob(base64);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
-  return { contentType, bytes };
-};
+import {
+  AVATAR_FULL_MAX_BYTES,
+  AVATAR_REQUEST_JSON_DEPTH,
+  AVATAR_REQUEST_MAX_BYTES,
+  AVATAR_THUMB_MAX_BYTES,
+  avatarUrlForObjectKey,
+  parseAvatarDataUrl,
+} from "../../src/lib/avatarLimits";
 
 const toHex = (bytes: Uint8Array): string =>
   Array.from(bytes)
@@ -49,16 +36,20 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
     const me = await fetchUserProfile(env, auth.userId);
     if (!me) return withCors(request, json({ error: "Unauthorized" }, { status: 401 }));
 
-    const body = (await request.json()) as {
+    const body = await readBoundedJson<{
       originalDataUrl?: unknown;
       thumbDataUrl?: unknown;
-    };
+    }>(request, { maxBytes: AVATAR_REQUEST_MAX_BYTES, maxDepth: AVATAR_REQUEST_JSON_DEPTH });
 
-    const original = parseDataUrl(body.originalDataUrl);
-    const thumb = parseDataUrl(body.thumbDataUrl);
-
-    if (original.bytes.byteLength > 5_000_000) throw new Error("Avatar image too large.");
-    if (thumb.bytes.byteLength > 1_000_000) throw new Error("Avatar thumbnail too large.");
+    let original: ReturnType<typeof parseAvatarDataUrl>;
+    let thumb: ReturnType<typeof parseAvatarDataUrl>;
+    try {
+      original = parseAvatarDataUrl(body.originalDataUrl, AVATAR_FULL_MAX_BYTES);
+      thumb = parseAvatarDataUrl(body.thumbDataUrl, AVATAR_THUMB_MAX_BYTES);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Avatar payload is invalid.";
+      throw new ApiRequestError(message, message.includes("too large") ? 413 : 400, "invalid_avatar");
+    }
 
     const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", original.bytes));
     const hash = toHex(digest);
@@ -68,37 +59,37 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
     const objectKey = `users/${opaqueKey}/avatar-${hash.slice(0, 16)}.${ext}`;
     const thumbKey = `users/${opaqueKey}/avatar-${hash.slice(0, 16)}-thumb.${thumbExt}`;
 
-    await env.AVATAR_BUCKET.put(objectKey, original.bytes, {
-      httpMetadata: { contentType: original.contentType, cacheControl: "public, max-age=31536000, immutable" },
-      customMetadata: { userId: auth.userId, variant: "full", hash },
-    });
-    await env.AVATAR_BUCKET.put(thumbKey, thumb.bytes, {
-      httpMetadata: { contentType: thumb.contentType, cacheControl: "public, max-age=31536000, immutable" },
-      customMetadata: { userId: auth.userId, variant: "thumb", hash },
-    });
-
-    const base = (env.AVATAR_PUBLIC_BASE_URL ?? "").trim().replace(/\/$/, "");
-    const avatarUrl = base
-      ? `${base}/${encodeURIComponent(objectKey)}`
-      : `/api/avatar/${objectKey.split("/").map((part) => encodeURIComponent(part)).join("/")}`;
-
     const prev = await getUserAvatarKeys(env, auth.userId);
-
-    const user = await setUserAvatarAssets(env, auth.userId, {
-      avatarUrl,
-      avatarObjectKey: objectKey,
-      avatarThumbKey: thumbKey,
-      avatarHash: hash,
-      avatarBytes: original.bytes.byteLength,
-      avatarContentType: original.contentType,
-    });
-
-    if (prev.avatarObjectKey && prev.avatarObjectKey !== objectKey) {
-      await env.AVATAR_BUCKET.delete(prev.avatarObjectKey);
+    const avatarUrl = avatarUrlForObjectKey(objectKey, env.AVATAR_PUBLIC_BASE_URL);
+    const writtenKeys: string[] = [];
+    let user: Awaited<ReturnType<typeof setUserAvatarAssets>>;
+    try {
+      await env.AVATAR_BUCKET.put(objectKey, original.bytes, {
+        httpMetadata: { contentType: original.contentType, cacheControl: "public, max-age=31536000, immutable" },
+        customMetadata: { userId: auth.userId, variant: "full", hash },
+      });
+      writtenKeys.push(objectKey);
+      await env.AVATAR_BUCKET.put(thumbKey, thumb.bytes, {
+        httpMetadata: { contentType: thumb.contentType, cacheControl: "public, max-age=31536000, immutable" },
+        customMetadata: { userId: auth.userId, variant: "thumb", hash },
+      });
+      writtenKeys.push(thumbKey);
+      user = await setUserAvatarAssets(env, auth.userId, {
+        avatarUrl,
+        avatarObjectKey: objectKey,
+        avatarThumbKey: thumbKey,
+        avatarHash: hash,
+        avatarBytes: original.bytes.byteLength,
+        avatarContentType: original.contentType,
+      });
+    } catch (error) {
+      await Promise.allSettled(writtenKeys.map((key) => env.AVATAR_BUCKET!.delete(key)));
+      throw error;
     }
-    if (prev.avatarThumbKey && prev.avatarThumbKey !== thumbKey) {
-      await env.AVATAR_BUCKET.delete(prev.avatarThumbKey);
-    }
+    await Promise.allSettled([
+      ...(prev.avatarObjectKey && prev.avatarObjectKey !== objectKey ? [env.AVATAR_BUCKET.delete(prev.avatarObjectKey)] : []),
+      ...(prev.avatarThumbKey && prev.avatarThumbKey !== thumbKey ? [env.AVATAR_BUCKET.delete(prev.avatarThumbKey)] : []),
+    ]);
 
     return withCors(
       request,

--- a/functions/api/avatar/[[path]].test.ts
+++ b/functions/api/avatar/[[path]].test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { onRequestGet } from "./[[path]]";
+
+const key = "users/123e4567-e89b-12d3-a456-426614174000/avatar-0123456789abcdef.webp";
+const thumbKey = "users/123e4567-e89b-12d3-a456-426614174000/avatar-0123456789abcdef-thumb.webp";
+const png = Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const pngBytes = (size: number) => {
+  const bytes = new Uint8Array(size);
+  bytes.set(png);
+  return bytes;
+};
+const object = (bytes = png, contentType = "image/png") => ({
+  body: new Response(bytes).body,
+  httpEtag: '"etag"',
+  writeHttpMetadata: (headers: Headers) => headers.set("content-type", contentType),
+});
+const request = (path = key) => new Request(`https://example.test/api/avatar/${path}`);
+const context = (bucket: { get: ReturnType<typeof vi.fn> }, extra = {}) => ({
+  request: request(),
+  env: { DB: {}, AVATAR_BUCKET: bucket, ...extra },
+} as never);
+
+beforeEach(() => vi.stubGlobal("fetch", vi.fn()));
+
+describe("avatar delivery", () => {
+  it("validates keys before storage access", async () => {
+    const get = vi.fn();
+    for (const invalid of ["../secret", `${key}%2fextra`, `${key}%252fextra`, `${key}\\extra`, "%zz"]) {
+      const response = await onRequestGet({ ...context({ get }), request: request(invalid) });
+      expect(response.status).toBe(400);
+    }
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it("bounds and validates stored avatar bytes", async () => {
+    const get = vi.fn().mockResolvedValue(object(pngBytes(5_000_000)));
+    const response = await onRequestGet(context({ get }));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+    await expect(response.arrayBuffer()).resolves.toHaveProperty("byteLength", 5_000_000);
+
+    get.mockResolvedValueOnce(object(new Uint8Array(5_000_001)));
+    expect((await onRequestGet(context({ get }))).status).toBe(502);
+    get.mockResolvedValueOnce(object(pngBytes(1_000_000)));
+    expect((await onRequestGet({ ...context({ get }), request: request(thumbKey) })).status).toBe(200);
+    get.mockResolvedValueOnce(object(pngBytes(1_000_001)));
+    expect((await onRequestGet({ ...context({ get }), request: request(thumbKey) })).status).toBe(502);
+    get.mockResolvedValueOnce(object(Uint8Array.from([0xff, 0xd8, 0xff]), "image/png"));
+    expect((await onRequestGet(context({ get }))).status).toBe(502);
+  });
+
+  it("rejects recursive or redirecting fallback and strips upstream headers", async () => {
+    const get = vi.fn().mockResolvedValue(null);
+    expect((await onRequestGet(context({ get }, { AVATAR_FALLBACK_ORIGIN: "https://example.test" }))).status).toBe(404);
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(new Response(null, { status: 302, headers: { location: "https://evil.test" } }));
+    expect((await onRequestGet(context({ get }, { AVATAR_FALLBACK_ORIGIN: "https://fallback.test" }))).status).toBe(404);
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(new Response(png, { headers: { "content-type": "image/png", "set-cookie": "secret=1", "x-secret": "x" } }));
+    const response = await onRequestGet(context({ get }, { AVATAR_FALLBACK_ORIGIN: "https://fallback.test" }));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("set-cookie")).toBeNull();
+    expect(response.headers.get("x-secret")).toBeNull();
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(globalThis.fetch).toHaveBeenLastCalledWith(expect.stringContaining("fallback.test/api/avatar/"), expect.objectContaining({ redirect: "manual" }));
+
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(new Response(pngBytes(1_000_000), { headers: { "content-type": "image/png" } }));
+    expect((await onRequestGet({ ...context({ get }, { AVATAR_FALLBACK_ORIGIN: "https://fallback.test" }), request: request(thumbKey) })).status).toBe(200);
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(new Response(pngBytes(1_000_001), { headers: { "content-type": "image/png" } }));
+    expect((await onRequestGet({ ...context({ get }, { AVATAR_FALLBACK_ORIGIN: "https://fallback.test" }), request: request(thumbKey) })).status).toBe(404);
+  });
+});

--- a/functions/api/avatar/[[path]].ts
+++ b/functions/api/avatar/[[path]].ts
@@ -1,5 +1,12 @@
 import { handleOptions, withCors } from "../../_lib/http";
 import type { Env } from "../../_lib/types";
+import {
+  assertAvatarFormat,
+  avatarUrlForObjectKey,
+  avatarVariantMaxBytes,
+  parseAvatarObjectKey,
+  readBoundedAvatarBody,
+} from "../../../src/lib/avatarLimits";
 
 export const onRequestOptions: PagesFunction<Env> = async ({ request }) => handleOptions(request);
 
@@ -10,30 +17,44 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
   const url = new URL(request.url);
   const prefix = "/api/avatar/";
   const raw = url.pathname.startsWith(prefix) ? url.pathname.slice(prefix.length) : "";
-  const key = raw
-    .split("/")
-    .map((part) => decodeURIComponent(part))
-    .join("/")
-    .trim();
-  if (!key) {
-    return withCors(request, new Response("Missing avatar key", { status: 400 }));
+  let key: string;
+  try {
+    if (!raw) throw new Error("missing");
+    key = parseAvatarObjectKey(raw);
+  } catch {
+    return withCors(request, new Response(raw ? "Invalid avatar key" : "Missing avatar key", { status: 400 }));
   }
   const object = await env.AVATAR_BUCKET.get(key);
   if (!object?.body) {
-    const fallbackOrigin = (env.AVATAR_FALLBACK_ORIGIN ?? "").trim().replace(/\/+$/, "");
+    const fallbackRaw = (env.AVATAR_FALLBACK_ORIGIN ?? "").trim();
+    let fallbackOrigin = "";
+    try {
+      const parsed = new URL(fallbackRaw);
+      if ((parsed.protocol === "https:" || parsed.protocol === "http:") && !parsed.username && !parsed.password
+        && parsed.pathname === "/" && !parsed.search && !parsed.hash && parsed.origin !== url.origin) {
+        fallbackOrigin = parsed.origin;
+      }
+    } catch {
+      // Invalid fallback configuration is treated as unavailable.
+    }
     if (fallbackOrigin) {
-      const fallbackUrl = `${fallbackOrigin}/api/avatar/${key
-        .split("/")
-        .map((part) => encodeURIComponent(part))
-        .join("/")}`;
+      const fallbackUrl = `${fallbackOrigin}${avatarUrlForObjectKey(key)}`;
       try {
         const upstream = await fetch(fallbackUrl, {
           headers: { accept: request.headers.get("accept") ?? "*/*" },
+          redirect: "manual",
         });
         if (upstream.ok && upstream.body) {
-          const headers = new Headers(upstream.headers);
-          if (!headers.has("cache-control")) headers.set("cache-control", "public, max-age=3600");
-          return withCors(request, new Response(upstream.body, { status: 200, headers }));
+          const bytes = await readBoundedAvatarBody(upstream, avatarVariantMaxBytes(key));
+          const contentType = assertAvatarFormat(upstream.headers.get("content-type") ?? "", bytes);
+          const headers = new Headers({
+            "cache-control": upstream.headers.get("cache-control") ?? "public, max-age=3600",
+            "content-type": contentType,
+            "x-content-type-options": "nosniff",
+          });
+          const etag = upstream.headers.get("etag");
+          if (etag) headers.set("etag", etag);
+          return withCors(request, new Response(bytes, { status: 200, headers }));
         }
       } catch {
         // Fall through to standard not-found.
@@ -42,9 +63,19 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
     return withCors(request, new Response("Not found", { status: 404 }));
   }
 
-  const headers = new Headers();
-  object.writeHttpMetadata(headers);
-  headers.set("etag", object.httpEtag);
-  if (!headers.has("cache-control")) headers.set("cache-control", "public, max-age=31536000, immutable");
-  return withCors(request, new Response(object.body, { status: 200, headers }));
+  try {
+    const headers = new Headers();
+    object.writeHttpMetadata(headers);
+    const bytes = await readBoundedAvatarBody(new Response(object.body, { headers }), avatarVariantMaxBytes(key));
+    const contentType = assertAvatarFormat(headers.get("content-type") ?? "", bytes);
+    const safeHeaders = new Headers({
+      "cache-control": headers.get("cache-control") ?? "public, max-age=31536000, immutable",
+      "content-type": contentType,
+      "etag": object.httpEtag,
+      "x-content-type-options": "nosniff",
+    });
+    return withCors(request, new Response(bytes, { status: 200, headers: safeHeaders }));
+  } catch {
+    return withCors(request, new Response("Invalid avatar object", { status: 502, headers: { "cache-control": "no-store" } }));
+  }
 };

--- a/functions/api/geocode.test.ts
+++ b/functions/api/geocode.test.ts
@@ -1,91 +1,131 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const { getClientAddressMock, parsePerMinuteLimitMock, takeRateLimitTokenMock } = vi.hoisted(() => ({
+  getClientAddressMock: vi.fn(() => "198.51.100.10"),
+  parsePerMinuteLimitMock: vi.fn((raw: string | undefined, fallback: number) => raw ? Number(raw) : fallback),
+  takeRateLimitTokenMock: vi.fn(() => ({ allowed: true, remaining: 59, retryAfterSec: 0 })),
+}));
+vi.mock("../_lib/rateLimit", () => ({
+  getClientAddress: getClientAddressMock,
+  parsePerMinuteLimit: parsePerMinuteLimitMock,
+  takeRateLimitToken: takeRateLimitTokenMock,
+}));
+
 import { onRequestGet } from "./geocode";
 
-const env = { DB: {} } as unknown as { DB: D1Database };
-
-const mkCtx = (request: Request) => ({ request, env } as unknown as Parameters<typeof onRequestGet>[0]);
-
-type CacheLike = {
-  match: ReturnType<typeof vi.fn>;
-  put: ReturnType<typeof vi.fn>;
-};
-
-const setCache = (cache: CacheLike) => {
-  Object.defineProperty(globalThis, "caches", {
-    configurable: true,
-    value: { default: cache },
-  });
-};
-
-beforeEach(() => {
-  vi.clearAllMocks();
-  setCache({
-    match: vi.fn().mockResolvedValue(undefined),
-    put: vi.fn().mockResolvedValue(undefined),
-  });
-  vi.stubGlobal("fetch", vi.fn());
+type CacheLike = { match: ReturnType<typeof vi.fn>; put: ReturnType<typeof vi.fn> };
+const setCache = (cache: CacheLike) => vi.stubGlobal("caches", { default: cache });
+const env = (rate?: string) => ({ DB: {}, GEOCODE_RATE_LIMIT_PER_MINUTE: rate } as unknown as Parameters<typeof onRequestGet>[0]["env"]);
+const call = (query: string, routeEnv = env()) => onRequestGet({
+  request: new Request(`https://example.test/api/geocode?q=${encodeURIComponent(query)}`),
+  env: routeEnv,
+} as never);
+const result = (overrides = {}) => ({
+  place_id: 101,
+  display_name: "Oslo, Norway",
+  lat: "59.91",
+  lon: "10.75",
+  boundingbox: ["59.8", "60.0", "10.6", "10.9"],
+  ...overrides,
 });
 
-describe("api/geocode", () => {
-  it("returns empty results for blank query", async () => {
-    const req = new Request("https://example.test/api/geocode?q=");
-    const res = await onRequestGet(mkCtx(req));
-    expect(res.status).toBe(200);
-    await expect(res.json()).resolves.toEqual({ results: [] });
+beforeEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+  setCache({ match: vi.fn().mockResolvedValue(undefined), put: vi.fn().mockResolvedValue(undefined) });
+  vi.stubGlobal("fetch", vi.fn());
+  takeRateLimitTokenMock.mockReturnValue({ allowed: true, remaining: 59, retryAfterSec: 0 });
+});
+
+describe("api/geocode bounds", () => {
+  it("normalizes NFC, case, and whitespace and enforces 3-256 characters", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(new Response(JSON.stringify([result()]), { headers: { "content-type": "application/json" } }));
+    expect((await call("ab")).status).toBe(400);
+    expect((await call("x".repeat(257))).status).toBe(400);
+    expect((await call("  O\u0308SLO   Sentrum  ")).status).toBe(200);
+    expect(String(vi.mocked(globalThis.fetch).mock.calls[0]?.[0])).toContain("q=%C3%B6slo+sentrum");
   });
 
-  it("returns 400 for short query", async () => {
-    const req = new Request("https://example.test/api/geocode?q=ab");
-    const res = await onRequestGet(mkCtx(req));
-    expect(res.status).toBe(400);
-    await expect(res.json()).resolves.toMatchObject({ error: "Search query must be at least 3 characters." });
-  });
-
-  it("serves cached response without upstream fetch", async () => {
-    const cached = new Response(JSON.stringify({ results: [{ id: "1", label: "Cached", lat: 59.9, lon: 10.7 }] }), {
-      headers: { "content-type": "application/json" },
-    });
-    const cache = {
-      match: vi.fn().mockResolvedValue(cached),
-      put: vi.fn().mockResolvedValue(undefined),
-    };
-    setCache(cache);
-
-    const req = new Request("https://example.test/api/geocode?q=Oslo");
-    const res = await onRequestGet(mkCtx(req));
-
-    expect(res.status).toBe(200);
-    await expect(res.json()).resolves.toMatchObject({ results: [{ id: "1", label: "Cached" }] });
+  it("serves cache hits before either rate gate", async () => {
+    const cached = new Response(JSON.stringify({ results: [{ id: "1", label: "Cached", lat: 59.9, lon: 10.7 }] }));
+    setCache({ match: vi.fn().mockResolvedValue(cached), put: vi.fn() });
+    expect((await call("Oslo")).status).toBe(200);
+    expect(takeRateLimitTokenMock).not.toHaveBeenCalled();
     expect(globalThis.fetch).not.toHaveBeenCalled();
-    expect(cache.put).not.toHaveBeenCalled();
   });
 
-  it("maps upstream payload and writes edge cache", async () => {
-    const cache = {
-      match: vi.fn().mockResolvedValue(undefined),
-      put: vi.fn().mockResolvedValue(undefined),
-    };
-    setCache(cache);
+  it("applies configured caller defense and a one-per-second isolate miss gate", async () => {
+    takeRateLimitTokenMock
+      .mockReturnValueOnce({ allowed: true, remaining: 16, retryAfterSec: 0 })
+      .mockReturnValueOnce({ allowed: true, remaining: 0, retryAfterSec: 0 })
+      .mockReturnValueOnce({ allowed: true, remaining: 15, retryAfterSec: 0 })
+      .mockReturnValueOnce({ allowed: false, remaining: 0, retryAfterSec: 1 });
+    vi.mocked(globalThis.fetch).mockResolvedValue(new Response(JSON.stringify([result()]), { headers: { "content-type": "application/json" } }));
+    expect((await call("Oslo", env("17"))).status).toBe(200);
+    expect(parsePerMinuteLimitMock).toHaveBeenCalledWith("17", 60);
+    expect(takeRateLimitTokenMock).toHaveBeenCalledWith({ key: "geocode:198.51.100.10", limit: 17 });
+    expect(takeRateLimitTokenMock).toHaveBeenCalledWith({ key: "geocode:provider-cache-miss", limit: 1, windowMs: 1_000 });
+    const gated = await call("Bergen");
+    expect(gated.status).toBe(429);
+    expect(gated.headers.get("retry-after")).toBe("1");
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
 
-    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
-      new Response(
-        JSON.stringify([
-          { place_id: 101, display_name: "Oslo, Norway", lat: "59.91", lon: "10.75" },
-          { place_id: 102, display_name: "Invalid", lat: "oops", lon: "10.75" },
-        ]),
-        { status: 200, headers: { "content-type": "application/json" } },
-      ),
-    );
+  it("preserves caller 429 retry behavior", async () => {
+    takeRateLimitTokenMock.mockReturnValueOnce({ allowed: false, remaining: 0, retryAfterSec: 7 });
+    const response = await call("Oslo");
+    expect(response.status).toBe(429);
+    expect(response.headers.get("retry-after")).toBe("7");
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
 
-    const req = new Request("https://example.test/api/geocode?q=Oslo");
-    const res = await onRequestGet(mkCtx(req));
+  it("preserves upstream 429 with a sanitized retry value", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(new Response("limited", {
+      status: 429,
+      headers: { "retry-after": "99999" },
+    }));
+    const response = await call("Oslo");
+    expect(response.status).toBe(429);
+    expect(response.headers.get("retry-after")).toBe("1");
+    expect(response.headers.get("cache-control")).toBe("no-store");
+  });
 
-    expect(res.status).toBe(200);
-    expect(res.headers.get("cache-control")).toContain("max-age=300");
-    await expect(res.json()).resolves.toEqual({
-      results: [{ id: "101", label: "Oslo, Norway", lat: 59.91, lon: 10.75 }],
-    });
-    expect(cache.put).toHaveBeenCalledTimes(1);
+  it("accepts exact response boundaries and rejects bytes, depth, records, types, or ranges beyond them", async () => {
+    const exactSix = Array.from({ length: 6 }, (_, index) => result({ place_id: index + 1 }));
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(new Response(JSON.stringify(exactSix), { headers: { "content-type": "application/json" } }));
+    expect((await call("first")).status).toBe(200);
+
+    setCache({ match: vi.fn().mockResolvedValue(undefined), put: vi.fn() });
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(new Response(JSON.stringify([...exactSix, result({ place_id: 7 })]), { headers: { "content-type": "application/json" } }));
+    expect((await call("records")).status).toBe(502);
+
+    for (const [query, payload] of [
+      ["depth", [result({ extra: { nested: { tooDeep: true } } })]],
+      ["type", [result({ display_name: 42 })]],
+      ["range", [result({ lat: "91" })]],
+    ] as const) {
+      setCache({ match: vi.fn().mockResolvedValue(undefined), put: vi.fn() });
+      vi.mocked(globalThis.fetch).mockResolvedValueOnce(new Response(JSON.stringify(payload), { headers: { "content-type": "application/json" } }));
+      expect((await call(query)).status).toBe(502);
+    }
+
+    const base = JSON.stringify([result()]);
+    const exactBytes = `${base}${" ".repeat(64 * 1024 - base.length)}`;
+    setCache({ match: vi.fn().mockResolvedValue(undefined), put: vi.fn() });
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(new Response(exactBytes, { headers: { "content-type": "application/json" } }));
+    expect((await call("bytes exact")).status).toBe(200);
+    setCache({ match: vi.fn().mockResolvedValue(undefined), put: vi.fn() });
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(new Response(`${exactBytes} `, { headers: { "content-type": "application/json" } }));
+    expect((await call("bytes overflow")).status).toBe(502);
+  });
+
+  it("aborts the provider after ten seconds", async () => {
+    vi.useFakeTimers();
+    vi.mocked(globalThis.fetch).mockImplementation((_url, init) => new Promise((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")));
+    }));
+    const pending = call("timeout");
+    await vi.advanceTimersByTimeAsync(10_001);
+    expect((await pending).status).toBe(504);
   });
 });

--- a/functions/api/geocode.test.ts
+++ b/functions/api/geocode.test.ts
@@ -128,4 +128,27 @@ describe("api/geocode bounds", () => {
     await vi.advanceTimersByTimeAsync(10_001);
     expect((await pending).status).toBe(504);
   });
+
+  it("keeps the ten-second deadline active while the response body is streaming", async () => {
+    vi.useFakeTimers();
+    let bodyAborted = false;
+    vi.mocked(globalThis.fetch).mockImplementation((_url, init) => {
+      const signal = init?.signal;
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          signal?.addEventListener("abort", () => {
+            bodyAborted = true;
+            controller.error(new DOMException("Aborted", "AbortError"));
+          });
+        },
+      });
+      return Promise.resolve(new Response(body, { headers: { "content-type": "application/json" } }));
+    });
+
+    const pending = call("stream timeout");
+    await vi.advanceTimersByTimeAsync(10_001);
+
+    expect((await pending).status).toBe(504);
+    expect(bodyAborted).toBe(true);
+  });
 });

--- a/functions/api/geocode.ts
+++ b/functions/api/geocode.ts
@@ -1,35 +1,54 @@
-import { errorResponse, handleOptions, json, withCors } from "../_lib/http";
+import { readBoundedJsonResponse } from "../_lib/boundedUpstream";
+import { ApiRequestError, errorResponse, handleOptions, json, withCors } from "../_lib/http";
+import { getClientAddress, parsePerMinuteLimit, takeRateLimitToken } from "../_lib/rateLimit";
 import type { Env } from "../_lib/types";
-
-type NominatimResult = {
-  place_id: number;
-  display_name: string;
-  lat: string;
-  lon: string;
-};
-
-const CACHE_TTL_SEC = 300;
+import {
+  GEOCODE_CACHE_TTL_MS,
+  GEOCODE_PROVIDER_TIMEOUT_MS,
+  GEOCODE_QUERY_MAX_CHARS,
+  GEOCODE_QUERY_MIN_CHARS,
+  GEOCODE_RESPONSE_MAX_BYTES,
+  GEOCODE_RESPONSE_MAX_DEPTH,
+  GEOCODE_RESULT_MAX_RECORDS,
+  normalizeGeocodeQuery,
+  validateNominatimResults,
+} from "../../src/lib/geocodeLimits";
 
 export const onRequestOptions: PagesFunction<Env> = async ({ request }) => handleOptions(request);
 
 export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
   try {
     const url = new URL(request.url);
-    const query = (url.searchParams.get("q") ?? "").trim();
+    const query = normalizeGeocodeQuery(url.searchParams.get("q") ?? "");
 
     if (!query) return withCors(request, json({ results: [] }));
-    if (query.length < 3) {
-      return withCors(request, json({ error: "Search query must be at least 3 characters." }, { status: 400 }));
+    if (query.length < GEOCODE_QUERY_MIN_CHARS || query.length > GEOCODE_QUERY_MAX_CHARS) {
+      return withCors(request, json({ error: "Search query must be between 3 and 256 characters." }, { status: 400 }));
     }
 
-    const normalized = query.toLowerCase();
     const cacheUrl = new URL(request.url);
     cacheUrl.search = "";
-    cacheUrl.searchParams.set("q", normalized);
+    cacheUrl.searchParams.set("q", query);
     const cacheKey = new Request(cacheUrl.toString(), { method: "GET" });
     const cache = caches.default;
     const cached = await cache.match(cacheKey);
     if (cached) return withCors(request, cached);
+
+    const callerLimit = parsePerMinuteLimit(env.GEOCODE_RATE_LIMIT_PER_MINUTE, 60);
+    const caller = takeRateLimitToken({ key: `geocode:${getClientAddress(request)}`, limit: callerLimit });
+    if (!caller.allowed) {
+      return withCors(request, json({ error: "Search rate limit reached. Please wait a moment." }, {
+        status: 429,
+        headers: { "cache-control": "no-store", "retry-after": String(caller.retryAfterSec) },
+      }));
+    }
+    const providerGate = takeRateLimitToken({ key: "geocode:provider-cache-miss", limit: 1, windowMs: 1_000 });
+    if (!providerGate.allowed) {
+      return withCors(request, json({ error: "Search rate limit reached. Please wait a moment." }, {
+        status: 429,
+        headers: { "cache-control": "no-store", "retry-after": String(providerGate.retryAfterSec) },
+      }));
+    }
 
     const upstream = new URL("https://nominatim.openstreetmap.org/search");
     upstream.searchParams.set("q", query);
@@ -37,31 +56,53 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
     upstream.searchParams.set("limit", "6");
     upstream.searchParams.set("addressdetails", "0");
 
-    const response = await fetch(upstream.toString(), {
-      headers: {
-        accept: "application/json",
-        "user-agent": "LinkSim/1.0 (https://linksim.link; geocode lookup)",
-      },
-    });
-    if (!response.ok) {
-      throw new Error(`Geocode lookup failed (${response.status})`);
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), GEOCODE_PROVIDER_TIMEOUT_MS);
+    let response: Response;
+    try {
+      response = await fetch(upstream.toString(), {
+        headers: {
+          accept: "application/json",
+          "user-agent": "LinkSim/1.0 (https://linksim.link; geocode lookup)",
+        },
+        signal: controller.signal,
+      });
+    } catch (error) {
+      if (controller.signal.aborted) throw new ApiRequestError("Geocode lookup timed out.", 504, "geocode_timeout");
+      throw error;
+    } finally {
+      clearTimeout(timer);
     }
-
-    const payload = (await response.json()) as NominatimResult[];
-    const results = payload
-      .map((item) => ({
-        id: String(item.place_id),
-        label: item.display_name,
-        lat: Number(item.lat),
-        lon: Number(item.lon),
-      }))
-      .filter((item) => Number.isFinite(item.lat) && Number.isFinite(item.lon));
+    if (response.status === 429) {
+      const rawRetry = response.headers.get("retry-after") ?? "";
+      const retryAfter = /^\d{1,4}$/u.test(rawRetry) && Number(rawRetry) >= 1 && Number(rawRetry) <= 3_600 ? rawRetry : "1";
+      await response.body?.cancel().catch(() => undefined);
+      return withCors(request, json({ error: "Search rate limit reached. Please wait a moment." }, {
+        status: 429,
+        headers: { "cache-control": "no-store", "retry-after": retryAfter },
+      }));
+    }
+    if (!response.ok) throw new ApiRequestError(`Geocode lookup failed (${response.status}).`, 502, "geocode_upstream");
+    if (response.headers.get("content-type")?.split(";", 1)[0].trim().toLowerCase() !== "application/json") {
+      throw new ApiRequestError("Geocode provider returned an invalid response.", 502, "geocode_upstream");
+    }
+    let results;
+    try {
+      const { value } = await readBoundedJsonResponse<unknown>(response, {
+        maxBytes: GEOCODE_RESPONSE_MAX_BYTES,
+        maxRecords: GEOCODE_RESULT_MAX_RECORDS,
+        maxDepth: GEOCODE_RESPONSE_MAX_DEPTH,
+      });
+      results = validateNominatimResults(value);
+    } catch {
+      throw new ApiRequestError("Geocode provider returned an invalid response.", 502, "geocode_upstream");
+    }
 
     const apiResponse = json(
       { results },
       {
         headers: {
-          "cache-control": `public, max-age=${CACHE_TTL_SEC}`,
+          "cache-control": `public, max-age=${Math.floor(GEOCODE_CACHE_TTL_MS / 1_000)}`,
         },
       },
     );

--- a/functions/api/geocode.ts
+++ b/functions/api/geocode.ts
@@ -58,44 +58,46 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
 
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), GEOCODE_PROVIDER_TIMEOUT_MS);
-    let response: Response;
+    let results: ReturnType<typeof validateNominatimResults>;
     try {
-      response = await fetch(upstream.toString(), {
+      const response = await fetch(upstream.toString(), {
         headers: {
           accept: "application/json",
           "user-agent": "LinkSim/1.0 (https://linksim.link; geocode lookup)",
         },
         signal: controller.signal,
       });
+      if (response.status === 429) {
+        const rawRetry = response.headers.get("retry-after") ?? "";
+        const retryAfter = /^\d{1,4}$/u.test(rawRetry) && Number(rawRetry) >= 1 && Number(rawRetry) <= 3_600 ? rawRetry : "1";
+        await response.body?.cancel().catch(() => undefined);
+        return withCors(request, json({ error: "Search rate limit reached. Please wait a moment." }, {
+          status: 429,
+          headers: { "cache-control": "no-store", "retry-after": retryAfter },
+        }));
+      }
+      if (!response.ok) throw new ApiRequestError(`Geocode lookup failed (${response.status}).`, 502, "geocode_upstream");
+      if (response.headers.get("content-type")?.split(";", 1)[0].trim().toLowerCase() !== "application/json") {
+        throw new ApiRequestError("Geocode provider returned an invalid response.", 502, "geocode_upstream");
+      }
+      try {
+        const { value } = await readBoundedJsonResponse<unknown>(response, {
+          maxBytes: GEOCODE_RESPONSE_MAX_BYTES,
+          maxRecords: GEOCODE_RESULT_MAX_RECORDS,
+          maxDepth: GEOCODE_RESPONSE_MAX_DEPTH,
+        });
+        results = validateNominatimResults(value);
+      } catch (error) {
+        if (controller.signal.aborted || (error instanceof Error && error.name === "AbortError")) throw error;
+        throw new ApiRequestError("Geocode provider returned an invalid response.", 502, "geocode_upstream");
+      }
     } catch (error) {
-      if (controller.signal.aborted) throw new ApiRequestError("Geocode lookup timed out.", 504, "geocode_timeout");
+      if (controller.signal.aborted || (error instanceof Error && error.name === "AbortError")) {
+        throw new ApiRequestError("Geocode lookup timed out.", 504, "geocode_timeout");
+      }
       throw error;
     } finally {
       clearTimeout(timer);
-    }
-    if (response.status === 429) {
-      const rawRetry = response.headers.get("retry-after") ?? "";
-      const retryAfter = /^\d{1,4}$/u.test(rawRetry) && Number(rawRetry) >= 1 && Number(rawRetry) <= 3_600 ? rawRetry : "1";
-      await response.body?.cancel().catch(() => undefined);
-      return withCors(request, json({ error: "Search rate limit reached. Please wait a moment." }, {
-        status: 429,
-        headers: { "cache-control": "no-store", "retry-after": retryAfter },
-      }));
-    }
-    if (!response.ok) throw new ApiRequestError(`Geocode lookup failed (${response.status}).`, 502, "geocode_upstream");
-    if (response.headers.get("content-type")?.split(";", 1)[0].trim().toLowerCase() !== "application/json") {
-      throw new ApiRequestError("Geocode provider returned an invalid response.", 502, "geocode_upstream");
-    }
-    let results;
-    try {
-      const { value } = await readBoundedJsonResponse<unknown>(response, {
-        maxBytes: GEOCODE_RESPONSE_MAX_BYTES,
-        maxRecords: GEOCODE_RESULT_MAX_RECORDS,
-        maxDepth: GEOCODE_RESPONSE_MAX_DEPTH,
-      });
-      results = validateNominatimResults(value);
-    } catch {
-      throw new ApiRequestError("Geocode provider returned an invalid response.", 502, "geocode_upstream");
     }
 
     const apiResponse = json(

--- a/functions/api/stats.test.ts
+++ b/functions/api/stats.test.ts
@@ -11,7 +11,7 @@ vi.mock("../_lib/pathLeaderboard", () => ({
 import { onRequestGet } from "./stats";
 
 type MockTable = {
-  users: Array<{ id: string; username: string | null; avatar_url: string | null; created_at: string }>;
+  users: Array<{ id: string; username: string | null; avatar_url: string | null; avatar_thumb_key?: string | null; created_at: string }>;
   sites: Array<{ id: string; owner_user_id: string; created_at: string | null; visibility: string; payload_json: string }>;
   simulations: Array<{ id: string; owner_user_id: string; created_at: string | null; name?: string; visibility: string; payload_json: string }>;
 };
@@ -137,6 +137,35 @@ afterEach(() => {
 });
 
 describe("api/stats", () => {
+  it("uses validated internal thumbnails for rendered user lists and safely falls back", async () => {
+    const owner = "123e4567-e89b-42d3-a456-426614174000";
+    const fullKey = `users/${owner}/avatar-0123456789abcdef.webp`;
+    const thumbKey = `users/${owner}/avatar-0123456789abcdef-thumb.webp`;
+    tables.users = [
+      { id: "u1", username: "Thumb", avatar_url: `/api/avatar/${fullKey}`, avatar_thumb_key: thumbKey, created_at: "2026-02-10T04:00:00.000Z" },
+      { id: "u2", username: "Malformed", avatar_url: `/api/avatar/${fullKey}`, avatar_thumb_key: "../thumb.webp", created_at: "2026-02-10T03:00:00.000Z" },
+      { id: "u3", username: "External", avatar_url: "https://images.example.test/avatar.png", avatar_thumb_key: thumbKey, created_at: "2026-02-10T02:00:00.000Z" },
+      { id: "u4", username: "Missing", avatar_url: `/api/avatar/${fullKey}`, avatar_thumb_key: null, created_at: "2026-02-10T01:00:00.000Z" },
+    ];
+
+    const response = await onRequestGet(mkCtx());
+    const body = await response.json() as {
+      highlights: {
+        topContributors: Array<{ userId: string; avatarUrl: string }>;
+        newestMembers: Array<{ userId: string; avatarUrl: string }>;
+      };
+    };
+
+    expect(body.highlights.topContributors.find((user) => user.userId === "u1")?.avatarUrl)
+      .toBe(`/api/avatar/${thumbKey}`);
+    expect(body.highlights.newestMembers).toEqual(expect.arrayContaining([
+      expect.objectContaining({ userId: "u1", avatarUrl: `/api/avatar/${thumbKey}` }),
+      expect.objectContaining({ userId: "u2", avatarUrl: `/api/avatar/${fullKey}` }),
+      expect.objectContaining({ userId: "u3", avatarUrl: "https://images.example.test/avatar.png" }),
+      expect.objectContaining({ userId: "u4", avatarUrl: `/api/avatar/${fullKey}` }),
+    ]));
+  });
+
   it("returns public aggregate stats without auth", async () => {
     const res = await onRequestGet(mkCtx());
     expect(res.status).toBe(200);

--- a/functions/api/stats.ts
+++ b/functions/api/stats.ts
@@ -1,11 +1,13 @@
 import { errorResponse, handleOptions, json, withCors } from "../_lib/http";
 import { listStatsPathLeaderboardEntries } from "../_lib/pathLeaderboard";
 import type { DbVisibility, Env } from "../_lib/types";
+import { thumbnailAvatarUrl } from "../../src/lib/avatarLimits";
 
 type UserRow = {
   id: string;
   username: string | null;
   avatar_url: string | null;
+  avatar_thumb_key: string | null;
   created_at: string;
 };
 
@@ -353,7 +355,7 @@ export const onRequestOptions: PagesFunction<Env> = async ({ request }) => handl
 export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
   try {
     const [usersResult, sitesResult, simulationsResult, longestPassingPaths] = await Promise.all([
-      env.DB.prepare("SELECT id, username, avatar_url, created_at FROM users").all<UserRow>(),
+      env.DB.prepare("SELECT id, username, avatar_url, avatar_thumb_key, created_at FROM users").all<UserRow>(),
       env.DB.prepare("SELECT id, owner_user_id, created_at, visibility, payload_json FROM sites").all<ResourceRow>(),
       env.DB.prepare("SELECT id, owner_user_id, created_at, name, visibility, payload_json FROM simulations WHERE status = 'active'").all<ResourceRow>(),
       listStatsPathLeaderboardEntries(env),
@@ -371,7 +373,7 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
       const current = contributorCounts.get(userId) ?? {
         userId,
         username: user.username?.trim() || "Unknown user",
-        avatarUrl: user.avatar_url ?? "",
+        avatarUrl: thumbnailAvatarUrl(user.avatar_url, user.avatar_thumb_key),
         contributions: 0,
       };
       current.contributions += 1;
@@ -465,7 +467,7 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
       .map((user) => ({
         userId: user.id,
         username: user.username?.trim() || "Unknown user",
-        avatarUrl: user.avatar_url ?? "",
+        avatarUrl: thumbnailAvatarUrl(user.avatar_url, user.avatar_thumb_key),
         createdAt: user.created_at,
       }));
 

--- a/src/components/AvatarBadge.test.tsx
+++ b/src/components/AvatarBadge.test.tsx
@@ -1,0 +1,14 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { AvatarBadge } from "./AvatarBadge";
+
+describe("AvatarBadge", () => {
+  it("loads avatar images lazily without referrer data", () => {
+    render(<AvatarBadge name="Ada" avatarUrl="/api/avatar/example" imageClassName="avatar" />);
+    const image = screen.getByRole("img", { name: "Ada" });
+    expect(image).toHaveAttribute("loading", "lazy");
+    expect(image).toHaveAttribute("decoding", "async");
+    expect(image).toHaveAttribute("referrerpolicy", "no-referrer");
+  });
+});

--- a/src/components/AvatarBadge.tsx
+++ b/src/components/AvatarBadge.tsx
@@ -18,7 +18,7 @@ export function AvatarBadge({
   fallbackRawText = false,
 }: AvatarBadgeProps) {
   if (avatarUrl && avatarUrl.trim()) {
-    return <img alt={name} className={imageClassName} src={avatarUrl} />;
+    return <img alt={name} className={imageClassName} src={avatarUrl} loading="lazy" decoding="async" referrerPolicy="no-referrer" />;
   }
   if (fallbackRawText) {
     return <>{toInitials(name)}</>;

--- a/src/components/settings/AvatarDropZone.test.tsx
+++ b/src/components/settings/AvatarDropZone.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { uploadAvatarMock, updateMyProfileMock } = vi.hoisted(() => ({
+  uploadAvatarMock: vi.fn(),
+  updateMyProfileMock: vi.fn(),
+}));
+vi.mock("../../lib/cloudUser", () => ({
+  uploadAvatar: uploadAvatarMock,
+  updateMyProfile: updateMyProfileMock,
+}));
+
+import { AvatarDropZone } from "./AvatarDropZone";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal("URL", {
+    ...URL,
+    createObjectURL: vi.fn(() => "blob:test"),
+    revokeObjectURL: vi.fn(),
+  });
+});
+
+describe("AvatarDropZone HEIC selection", () => {
+  it("offers HEIC/HEIF selection and reports browser decode failure through the existing error UI", async () => {
+    class FailingImage {
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      set src(_value: string) { queueMicrotask(() => this.onerror?.()); }
+    }
+    vi.stubGlobal("Image", FailingImage);
+    const view = render(<AvatarDropZone name="Ada" avatarUrl="" onUpdated={vi.fn()} />);
+    const input = view.container.querySelector('input[type="file"]') as HTMLInputElement;
+    expect(input.accept).toBe("image/*,.heic,.heif");
+    expect(screen.getByText(/HEIC/)).toBeInTheDocument();
+
+    fireEvent.change(input, { target: { files: [new File(["heic"], "photo.heic", { type: "image/heic" })] } });
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Unable to decode image.");
+    await waitFor(() => expect(URL.revokeObjectURL).toHaveBeenCalled());
+    expect(uploadAvatarMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/settings/AvatarDropZone.tsx
+++ b/src/components/settings/AvatarDropZone.tsx
@@ -29,6 +29,9 @@ const stepProgress: Record<Step, number | "indeterminate" | null> = {
   error: null,
 };
 
+const isAvatarFileSelection = (file: File): boolean =>
+  file.type.startsWith("image/") || /\.(?:heic|heif)$/iu.test(file.name);
+
 const loadImageFromFile = async (file: File): Promise<HTMLImageElement> => {
   const objectUrl = URL.createObjectURL(file);
   try {
@@ -146,7 +149,7 @@ export function AvatarDropZone({ name, avatarUrl, onUpdated }: AvatarDropZonePro
     if (busy) return;
     const file = event.dataTransfer?.files?.[0];
     if (!file) return;
-    if (!file.type.startsWith("image/")) {
+    if (!isAvatarFileSelection(file)) {
       setStep("error");
       setErrorMessage("Please drop an image file.");
       return;
@@ -208,12 +211,12 @@ export function AvatarDropZone({ name, avatarUrl, onUpdated }: AvatarDropZonePro
             <ImagePlus size={16} strokeWidth={2} aria-hidden="true" />
             <span>Drop an image or click to upload</span>
           </div>
-          <div className="avatar-dropzone-hint">PNG, JPG, or WebP · resized automatically</div>
+          <div className="avatar-dropzone-hint">PNG, JPG, WebP, HEIC, or HEIF where supported · resized automatically</div>
         </div>
         <input
           ref={inputRef}
           type="file"
-          accept="image/*"
+          accept="image/*,.heic,.heif"
           className="avatar-dropzone-input"
           onChange={(event) => {
             const file = event.target.files?.[0];

--- a/src/lib/avatarLimits.test.ts
+++ b/src/lib/avatarLimits.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  AVATAR_FULL_MAX_BYTES,
+  AVATAR_OBJECT_KEY_MAX_CHARS,
+  avatarUrlForObjectKey,
+  parseAvatarDataUrl,
+  parseAvatarObjectKey,
+  thumbnailAvatarUrl,
+} from "./avatarLimits";
+
+const dataUrl = (type: string, bytes: number[]) => {
+  const binary = String.fromCharCode(...bytes);
+  return `data:${type};base64,${btoa(binary)}`;
+};
+
+describe("avatar limits", () => {
+  it("accepts matching PNG, JPEG, and WebP magic and strict base64", () => {
+    expect(parseAvatarDataUrl(dataUrl("image/png", [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]), AVATAR_FULL_MAX_BYTES).contentType).toBe("image/png");
+    expect(parseAvatarDataUrl(dataUrl("image/jpeg", [0xff, 0xd8, 0xff, 0xe0]), AVATAR_FULL_MAX_BYTES).contentType).toBe("image/jpeg");
+    expect(parseAvatarDataUrl(dataUrl("image/webp", [0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x45, 0x42, 0x50]), AVATAR_FULL_MAX_BYTES).contentType).toBe("image/webp");
+    expect(() => parseAvatarDataUrl("data:image/png;base64,iVBORw0KGgo", AVATAR_FULL_MAX_BYTES)).toThrow("base64");
+    expect(() => parseAvatarDataUrl(dataUrl("image/png", [0xff, 0xd8, 0xff]), AVATAR_FULL_MAX_BYTES)).toThrow("does not match");
+  });
+
+  it("accepts current and legacy opaque keys while rejecting path tricks", () => {
+    const owner = "123e4567-e89b-12d3-a456-426614174000";
+    const current = `users/${owner}/avatar-0123456789abcdef.webp`;
+    const legacy = `users/${owner}/avatar-1712345678901-0123456789abcdef-thumb.webp`;
+    expect(parseAvatarObjectKey(current)).toBe(current);
+    expect(parseAvatarObjectKey(legacy)).toBe(legacy);
+    expect(legacy).toHaveLength(AVATAR_OBJECT_KEY_MAX_CHARS);
+    for (const invalid of [
+      `admins/${owner}/avatar-0123456789abcdef.webp`,
+      `users/${owner}/../avatar-0123456789abcdef.webp`,
+      `users/${owner}\\avatar-0123456789abcdef.webp`,
+      `users/${owner}/avatar-0123456789abcdef.webp%252fextra`,
+      `users/${owner}/avatar-0123456789abcdef.webp%2fextra`,
+      `users/${owner}/avatar-0123456789abcdef.gif`,
+    ]) expect(() => parseAvatarObjectKey(invalid)).toThrow("key");
+  });
+
+  it("uses encoded internal segments and preserves external full-image URLs", () => {
+    const key = "users/123e4567-e89b-12d3-a456-426614174000/avatar-0123456789abcdef-thumb.webp";
+    expect(avatarUrlForObjectKey(key)).toBe(`/api/avatar/${key}`);
+    expect(avatarUrlForObjectKey(key, "https://cdn.example.test/")).toBe(`https://cdn.example.test/${encodeURIComponent(key)}`);
+    expect(() => avatarUrlForObjectKey(key, "javascript:alert(1)")).toThrow("URL");
+    expect(() => avatarUrlForObjectKey(key, "https://secret@cdn.example.test")).toThrow("URL");
+    expect(thumbnailAvatarUrl("/api/avatar/full", key)).toBe(`/api/avatar/${key}`);
+    expect(thumbnailAvatarUrl("https://external.test/full.png", key)).toBe("https://external.test/full.png");
+    expect(thumbnailAvatarUrl("/api/avatar/full", "bad-key")).toBe("/api/avatar/full");
+  });
+});

--- a/src/lib/avatarLimits.ts
+++ b/src/lib/avatarLimits.ts
@@ -1,0 +1,151 @@
+export const AVATAR_REQUEST_MAX_BYTES = 8_000_090;
+export const AVATAR_REQUEST_JSON_DEPTH = 1;
+export const AVATAR_FULL_MAX_BYTES = 5_000_000;
+export const AVATAR_THUMB_MAX_BYTES = 1_000_000;
+export const AVATAR_OBJECT_KEY_MAX_CHARS = 91;
+
+export const AVATAR_CONTENT_TYPES = ["image/webp", "image/png", "image/jpeg"] as const;
+export type AvatarContentType = (typeof AVATAR_CONTENT_TYPES)[number];
+
+const contentTypes = new Set<string>(AVATAR_CONTENT_TYPES);
+const uuid = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
+const avatarKeyPattern = new RegExp(
+  `^users/(${uuid})/avatar-(?:[0-9a-f]{16}|[0-9]{13}-[0-9a-f]{16})(?:-thumb)?\\.(?:webp|png|jpg)$`,
+  "u",
+);
+
+const hasMagic = (contentType: AvatarContentType, bytes: Uint8Array): boolean => {
+  if (contentType === "image/png") {
+    const signature = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+    return signature.every((value, index) => bytes[index] === value);
+  }
+  if (contentType === "image/jpeg") return bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff;
+  return bytes[0] === 0x52 && bytes[1] === 0x49 && bytes[2] === 0x46 && bytes[3] === 0x46
+    && bytes[8] === 0x57 && bytes[9] === 0x45 && bytes[10] === 0x42 && bytes[11] === 0x50;
+};
+
+export const assertAvatarFormat = (contentType: string, bytes: Uint8Array): AvatarContentType => {
+  const normalized = contentType.split(";", 1)[0].trim().toLowerCase();
+  if (!contentTypes.has(normalized)) throw new Error("Unsupported avatar image type.");
+  if (!hasMagic(normalized as AvatarContentType, bytes)) {
+    throw new Error("Avatar image data does not match its declared format.");
+  }
+  return normalized as AvatarContentType;
+};
+
+export const parseAvatarDataUrl = (
+  value: unknown,
+  maxBytes: number,
+): { contentType: AvatarContentType; bytes: Uint8Array } => {
+  if (typeof value !== "string") throw new Error("Image payload must be a data URL.");
+  const trimmed = value.trim();
+  const comma = trimmed.indexOf(",");
+  const header = comma >= 0 ? trimmed.slice(0, comma) : "";
+  const contentType = header.startsWith("data:") && header.endsWith(";base64")
+    ? header.slice(5, -7).toLowerCase()
+    : "";
+  if (!contentTypes.has(contentType)) throw new Error("Unsupported image format. Use webp, png, or jpeg.");
+  const base64 = trimmed.slice(comma + 1);
+  const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  const padding = base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0;
+  if (!base64 || base64.length % 4 !== 0) throw new Error("Image payload must use strict base64 encoding.");
+  for (let index = 0; index < base64.length - padding; index += 1) {
+    const code = base64.charCodeAt(index);
+    const valid = (code >= 0x41 && code <= 0x5a) || (code >= 0x61 && code <= 0x7a)
+      || (code >= 0x30 && code <= 0x39) || code === 0x2b || code === 0x2f;
+    if (!valid) throw new Error("Image payload must use strict base64 encoding.");
+  }
+  for (let index = base64.length - padding; index < base64.length; index += 1) {
+    if (base64[index] !== "=") throw new Error("Image payload must use strict base64 encoding.");
+  }
+  if ((base64.endsWith("==") && (alphabet.indexOf(base64.at(-3) ?? "") & 0x0f) !== 0)
+    || (base64.endsWith("=") && !base64.endsWith("==") && (alphabet.indexOf(base64.at(-2) ?? "") & 0x03) !== 0)) {
+    throw new Error("Image payload must use strict base64 encoding.");
+  }
+  const estimatedBytes = Math.floor(base64.length / 4) * 3 - (base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0);
+  if (estimatedBytes > maxBytes) throw new Error("Avatar image too large.");
+  let binary: string;
+  try {
+    binary = atob(base64);
+  } catch {
+    throw new Error("Image payload must use strict base64 encoding.");
+  }
+  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+  if (bytes.byteLength > maxBytes) throw new Error("Avatar image too large.");
+  const validatedType = assertAvatarFormat(contentType, bytes);
+  return { contentType: validatedType, bytes };
+};
+
+export const parseAvatarObjectKey = (value: string): string => {
+  if (typeof value !== "string" || !value || value.length > AVATAR_OBJECT_KEY_MAX_CHARS
+    || value.includes("%") || value.includes("\\") || !avatarKeyPattern.test(value)) {
+    throw new Error("Avatar key is invalid.");
+  }
+  return value;
+};
+
+export const avatarUrlForObjectKey = (key: string, publicBaseUrl = ""): string => {
+  const validKey = parseAvatarObjectKey(key);
+  const rawBase = publicBaseUrl.trim();
+  let base = "";
+  if (rawBase) {
+    try {
+      const parsed = new URL(rawBase);
+      if ((parsed.protocol !== "https:" && parsed.protocol !== "http:") || parsed.username || parsed.password
+        || parsed.search || parsed.hash) throw new Error("invalid");
+      base = parsed.toString().replace(/\/+$/u, "");
+    } catch {
+      throw new Error("Avatar public URL is invalid.");
+    }
+  }
+  return base
+    ? `${base}/${encodeURIComponent(validKey)}`
+    : `/api/avatar/${validKey.split("/").map((part) => encodeURIComponent(part)).join("/")}`;
+};
+
+export const avatarVariantMaxBytes = (key: string): number =>
+  parseAvatarObjectKey(key).includes("-thumb.") ? AVATAR_THUMB_MAX_BYTES : AVATAR_FULL_MAX_BYTES;
+
+export const readBoundedAvatarBody = async (response: Response, maxBytes: number): Promise<Uint8Array> => {
+  const rawLength = response.headers.get("content-length");
+  const declaredLength = rawLength === null ? null : Number(rawLength);
+  if (declaredLength !== null && Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+    await response.body?.cancel().catch(() => undefined);
+    throw new Error("Avatar response exceeds its size limit.");
+  }
+  if (!response.body) throw new Error("Avatar response body is missing.");
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel().catch(() => undefined);
+        throw new Error("Avatar response exceeds its size limit.");
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+};
+
+export const thumbnailAvatarUrl = (avatarUrl: string | null | undefined, thumbKey: string | null | undefined): string => {
+  const full = typeof avatarUrl === "string" ? avatarUrl : "";
+  if (!full.startsWith("/api/avatar/") || !thumbKey) return full;
+  try {
+    return avatarUrlForObjectKey(thumbKey);
+  } catch {
+    return full;
+  }
+};

--- a/src/lib/geocode.test.ts
+++ b/src/lib/geocode.test.ts
@@ -1,68 +1,66 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const loadSearchLocations = async () => {
-  const module = await import("./geocode");
-  return module.searchLocations;
-};
+const loadSearchLocations = async () => (await import("./geocode")).searchLocations;
+const response = (id = "1") => new Response(JSON.stringify({
+  results: [{ id, label: `Place ${id}`, lat: 59.91, lon: 10.75 }],
+}), { headers: { "content-type": "application/json" } });
 
 beforeEach(() => {
   vi.restoreAllMocks();
   vi.resetModules();
   Object.defineProperty(globalThis, "window", {
     configurable: true,
-    value: { location: { origin: "https://app.example.test" } },
+    value: { location: { origin: "https://app.example.test", hostname: "app.example.test" } },
   });
   vi.stubGlobal("fetch", vi.fn());
 });
 
 describe("searchLocations", () => {
-  it("returns empty results for blank and too-short queries", async () => {
+  it("normalizes queries and rejects values outside 3-256 without fetching", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(response());
     const searchLocations = await loadSearchLocations();
-
-    await expect(searchLocations("")).resolves.toEqual([]);
     await expect(searchLocations("ab")).resolves.toEqual([]);
-    expect(globalThis.fetch).not.toHaveBeenCalled();
+    await expect(searchLocations("x".repeat(257))).resolves.toEqual([]);
+    await searchLocations("  O\u0308SLO   Sentrum ");
+    expect(String(vi.mocked(globalThis.fetch).mock.calls[0]?.[0])).toContain("q=%C3%B6slo+sentrum");
   });
 
-  it("uses local API and reuses in-memory cache", async () => {
-    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
-      new Response(JSON.stringify({ results: [{ id: "1", label: "Oslo", lat: 59.91, lon: 10.75 }] }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      }),
-    );
-
+  it("coalesces identical in-flight calls and reuses the five-minute cache", async () => {
+    let resolve!: (value: Response) => void;
+    vi.mocked(globalThis.fetch).mockReturnValueOnce(new Promise((done) => { resolve = done; }));
     const searchLocations = await loadSearchLocations();
-    const first = await searchLocations("Oslo");
-    const second = await searchLocations("oslo");
-
-    expect(first).toEqual([{ id: "1", label: "Oslo", lat: 59.91, lon: 10.75 }]);
-    expect(second).toEqual(first);
+    const first = searchLocations("Oslo");
+    const second = searchLocations("  oslo ");
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    resolve(response());
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      [{ id: "1", label: "Place 1", lat: 59.91, lon: 10.75 }],
+      [{ id: "1", label: "Place 1", lat: 59.91, lon: 10.75 }],
+    ]);
+    await searchLocations("OSLO");
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
   });
 
-  it("falls back to upstream nominatim when local endpoint is unavailable", async () => {
-    vi.mocked(globalThis.fetch)
-      .mockResolvedValueOnce(new Response("Not found", { status: 404 }))
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify([{ place_id: 7, display_name: "Bergen", lat: "60.39", lon: "5.32" }]), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-      );
-
+  it("bounds the client cache at 300 entries", async () => {
+    vi.mocked(globalThis.fetch).mockImplementation(async (input) => response(new URL(String(input)).searchParams.get("q")!));
     const searchLocations = await loadSearchLocations();
-    const results = await searchLocations("Bergen");
-
-    expect(results).toEqual([{ id: "7", label: "Bergen", lat: 60.39, lon: 5.32 }]);
-    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
-    expect(String(vi.mocked(globalThis.fetch).mock.calls[1]?.[0])).toContain("nominatim.openstreetmap.org/search");
+    for (let index = 0; index < 301; index += 1) await searchLocations(`place ${String(index).padStart(3, "0")}`);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(301);
+    await searchLocations("place 000");
+    expect(globalThis.fetch).toHaveBeenCalledTimes(302);
   });
 
-  it("surfaces local rate-limit responses without upstream fallback", async () => {
-    vi.mocked(globalThis.fetch).mockResolvedValueOnce(new Response("Too many requests", { status: 429 }));
+  it("never falls back directly to Nominatim from a production browser", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(new Response("Not found", { status: 404 }));
     const searchLocations = await loadSearchLocations();
+    await expect(searchLocations("Bergen")).rejects.toThrow("Geocode lookup failed (404)");
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(String(vi.mocked(globalThis.fetch).mock.calls[0]?.[0])).not.toContain("nominatim.openstreetmap.org");
+  });
 
+  it("surfaces stable local rate-limit responses", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(new Response("Too many requests", { status: 429, headers: { "retry-after": "1" } }));
+    const searchLocations = await loadSearchLocations();
     await expect(searchLocations("Trondheim")).rejects.toThrow("Search rate limit reached. Please wait a moment.");
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
   });

--- a/src/lib/geocode.ts
+++ b/src/lib/geocode.ts
@@ -1,87 +1,61 @@
-export type GeocodeResult = {
-  id: string;
-  label: string;
-  lat: number;
-  lon: number;
-};
+import {
+  GEOCODE_CACHE_TTL_MS,
+  GEOCODE_CLIENT_CACHE_MAX_ENTRIES,
+  GEOCODE_QUERY_MAX_CHARS,
+  GEOCODE_QUERY_MIN_CHARS,
+  normalizeGeocodeQuery,
+  validateGeocodeApiResults,
+  type GeocodeResultValue,
+} from "./geocodeLimits";
 
-type NominatimResult = {
-  place_id: number;
-  display_name: string;
-  lat: string;
-  lon: string;
-};
+export type GeocodeResult = GeocodeResultValue;
 
-const CACHE_TTL_MS = 5 * 60_000;
 const cache = new Map<string, { expiresAt: number; results: GeocodeResult[] }>();
+const inFlight = new Map<string, Promise<GeocodeResult[]>>();
 
-const mapNominatimResults = (payload: NominatimResult[]): GeocodeResult[] =>
-  payload
-    .map((item) => ({
-      id: String(item.place_id),
-      label: item.display_name,
-      lat: Number(item.lat),
-      lon: Number(item.lon),
-    }))
-    .filter((item) => Number.isFinite(item.lat) && Number.isFinite(item.lon));
+const cacheResults = (key: string, results: GeocodeResult[]): void => {
+  cache.delete(key);
+  while (cache.size >= GEOCODE_CLIENT_CACHE_MAX_ENTRIES) cache.delete(cache.keys().next().value!);
+  cache.set(key, { expiresAt: Date.now() + GEOCODE_CACHE_TTL_MS, results });
+};
 
 export const searchLocations = async (query: string): Promise<GeocodeResult[]> => {
-  const trimmed = query.trim();
-  if (!trimmed) return [];
-  if (trimmed.length < 3) return [];
+  const key = normalizeGeocodeQuery(query);
+  if (key.length < GEOCODE_QUERY_MIN_CHARS || key.length > GEOCODE_QUERY_MAX_CHARS) return [];
 
-  const key = trimmed.toLowerCase();
   const cached = cache.get(key);
-  if (cached && cached.expiresAt > Date.now()) return cached.results;
+  if (cached && cached.expiresAt > Date.now()) {
+    cache.delete(key);
+    cache.set(key, cached);
+    return cached.results;
+  }
   if (cached && cached.expiresAt <= Date.now()) cache.delete(key);
+  const pending = inFlight.get(key);
+  if (pending) return pending;
 
   const localApiUrl = new URL("/api/geocode", window.location.origin);
-  localApiUrl.searchParams.set("q", trimmed);
+  localApiUrl.searchParams.set("q", key);
 
-  try {
+  const request = (async () => {
     const response = await fetch(localApiUrl.toString(), {
       headers: {
         accept: "application/json",
       },
     });
     if (response.ok) {
-      const payload = (await response.json()) as { results?: GeocodeResult[] } | NominatimResult[];
-      const results = Array.isArray(payload)
-        ? mapNominatimResults(payload)
-        : Array.isArray(payload.results)
-          ? payload.results
-          : [];
-      cache.set(key, { expiresAt: Date.now() + CACHE_TTL_MS, results });
+      const results = validateGeocodeApiResults(await response.json());
+      cacheResults(key, results);
       return results;
     }
     if (response.status === 429) {
       throw new Error("Search rate limit reached. Please wait a moment.");
     }
-    if (response.status !== 404) {
-      throw new Error(`Geocode lookup failed (${response.status})`);
-    }
-  } catch (error) {
-    const message = error instanceof Error ? error.message : "";
-    if (message.includes("rate limit")) throw error;
-    // Fall through to direct upstream lookup for local Vite dev without Functions.
+    throw new Error(`Geocode lookup failed (${response.status})`);
+  })();
+  inFlight.set(key, request);
+  try {
+    return await request;
+  } finally {
+    if (inFlight.get(key) === request) inFlight.delete(key);
   }
-
-  const upstreamUrl = new URL("https://nominatim.openstreetmap.org/search");
-  upstreamUrl.searchParams.set("q", trimmed);
-  upstreamUrl.searchParams.set("format", "jsonv2");
-  upstreamUrl.searchParams.set("limit", "6");
-  upstreamUrl.searchParams.set("addressdetails", "0");
-
-  const upstreamResponse = await fetch(upstreamUrl.toString(), {
-    headers: {
-      accept: "application/json",
-    },
-  });
-  if (!upstreamResponse.ok) {
-    throw new Error(`Geocode lookup failed (${upstreamResponse.status})`);
-  }
-  const upstreamPayload = (await upstreamResponse.json()) as NominatimResult[];
-  const results = mapNominatimResults(upstreamPayload);
-  cache.set(key, { expiresAt: Date.now() + CACHE_TTL_MS, results });
-  return results;
 };

--- a/src/lib/geocodeLimits.ts
+++ b/src/lib/geocodeLimits.ts
@@ -1,0 +1,52 @@
+export const GEOCODE_QUERY_MIN_CHARS = 3;
+export const GEOCODE_QUERY_MAX_CHARS = 256;
+export const GEOCODE_RESULT_MAX_RECORDS = 6;
+export const GEOCODE_RESPONSE_MAX_BYTES = 64 * 1024;
+export const GEOCODE_RESPONSE_MAX_DEPTH = 3;
+export const GEOCODE_CACHE_TTL_MS = 5 * 60_000;
+export const GEOCODE_CLIENT_CACHE_MAX_ENTRIES = 300;
+export const GEOCODE_PROVIDER_TIMEOUT_MS = 10_000;
+
+export type GeocodeResultValue = { id: string; label: string; lat: number; lon: number };
+
+export const normalizeGeocodeQuery = (value: string): string =>
+  value.normalize("NFC").trim().replace(/\s+/gu, " ").toLowerCase();
+
+const coordinatePattern = /^-?(?:\d+(?:\.\d*)?|\.\d+)$/u;
+
+export const validateNominatimResults = (payload: unknown): GeocodeResultValue[] => {
+  if (!Array.isArray(payload) || payload.length > GEOCODE_RESULT_MAX_RECORDS) throw new Error("Geocode provider response must be a bounded array.");
+  return payload.map((raw) => {
+    if (!raw || typeof raw !== "object") throw new Error("Geocode provider result is invalid.");
+    const item = raw as { place_id?: unknown; display_name?: unknown; lat?: unknown; lon?: unknown };
+    if (!Number.isSafeInteger(item.place_id) || (item.place_id as number) < 0
+      || typeof item.display_name !== "string" || !item.display_name.trim() || item.display_name.length > 512
+      || typeof item.lat !== "string" || item.lat.length > 32 || !coordinatePattern.test(item.lat)
+      || typeof item.lon !== "string" || item.lon.length > 32 || !coordinatePattern.test(item.lon)) {
+      throw new Error("Geocode provider result fields are invalid.");
+    }
+    const lat = Number(item.lat);
+    const lon = Number(item.lon);
+    if (!Number.isFinite(lat) || lat < -90 || lat > 90 || !Number.isFinite(lon) || lon < -180 || lon > 180) {
+      throw new Error("Geocode provider coordinates are out of range.");
+    }
+    return { id: String(item.place_id), label: item.display_name.trim(), lat, lon };
+  });
+};
+
+export const validateGeocodeApiResults = (payload: unknown): GeocodeResultValue[] => {
+  if (!payload || typeof payload !== "object" || !Array.isArray((payload as { results?: unknown }).results)) throw new Error("Geocode API response is invalid.");
+  const results = (payload as { results: unknown[] }).results;
+  if (results.length > GEOCODE_RESULT_MAX_RECORDS) throw new Error("Geocode API response has too many results.");
+  return results.map((raw) => {
+    if (!raw || typeof raw !== "object") throw new Error("Geocode API result is invalid.");
+    const item = raw as Partial<GeocodeResultValue>;
+    if (typeof item.id !== "string" || !item.id || item.id.length > 64
+      || typeof item.label !== "string" || !item.label.trim() || item.label.length > 512
+      || typeof item.lat !== "number" || !Number.isFinite(item.lat) || item.lat < -90 || item.lat > 90
+      || typeof item.lon !== "number" || !Number.isFinite(item.lon) || item.lon < -180 || item.lon > 180) {
+      throw new Error("Geocode API result fields are invalid.");
+    }
+    return { id: item.id, label: item.label.trim(), lat: item.lat, lon: item.lon };
+  });
+};

--- a/src/lib/nodeFeedLimits.ts
+++ b/src/lib/nodeFeedLimits.ts
@@ -17,6 +17,7 @@ export class BoundedUpstreamError extends Error {}
 type BoundedJsonOptions = {
   maxBytes: number;
   maxRecords: number;
+  maxDepth?: number;
 };
 
 const recordCount = (value: unknown): number | null => {
@@ -74,6 +75,19 @@ export const readBoundedJsonResponse = async <T>(
   }
   if (records > options.maxRecords) {
     throw new BoundedUpstreamError("Upstream response exceeded the record limit");
+  }
+  if (options.maxDepth !== undefined) {
+    const pending: Array<{ value: unknown; depth: number }> = [{ value, depth: 1 }];
+    while (pending.length) {
+      const current = pending.pop()!;
+      if (current.depth > options.maxDepth) throw new BoundedUpstreamError("Upstream response exceeded the JSON depth limit");
+      const children = Array.isArray(current.value)
+        ? current.value
+        : current.value !== null && typeof current.value === "object" ? Object.values(current.value) : [];
+      for (const item of children) {
+        if (item !== null && typeof item === "object") pending.push({ value: item, depth: current.depth + 1 });
+      }
+    }
   }
   return { bytes, value };
 };


### PR DESCRIPTION
## Summary

- bound avatar upload JSON, decoded image data, object keys, R2 delivery, and one-hop fallback behavior
- verify WebP, PNG, and JPEG signatures while preserving browser-decoded HEIC/HEIF selection and legacy production avatar keys
- serve validated thumbnails through existing rendered list DTOs and add lazy, asynchronous, no-referrer image loading
- bound and normalize forward geocoding with a 64 KiB / 6-result / 10-second provider contract, five-minute cache, coalescing, and existing per-environment rate helpers
- remove production browser fallback to direct forward Nominatim requests and document the actual non-global throttle boundary

## Limits and compatibility

- avatar request: 8,000,090 UTF-8 bytes, JSON depth 1
- avatar decoded data: 5,000,000-byte original and 1,000,000-byte thumbnail
- avatar keys: current and observed UUID-based legacy forms, maximum 91 characters
- geocode query: 3–256 normalized characters
- geocode response: 64 KiB, JSON depth 3, maximum 6 records, 10-second absolute upstream deadline
- geocode client cache: five minutes, maximum 300 entries
- geocode rate defense: configured per-caller limit (60/minute fallback) plus one cache miss/second per running isolate; no global coordination is claimed

No new UI, schema, infrastructure, provider, production change, cleanup migration, or server-side HEIF decoder is included.

## Verification

- `npm test` — 176 files / 1,295 tests passed
- required deep-link, calculate API, and app-store compatibility tests passed
- `npm run build` passed
- changed-file ESLint passed
- `git diff --check` passed
- `npm run dev:check` found no LinkSim dev/watch server
- independent pre-PR review: PASS at `fc78b12c3b8f2560fb74a945eb94bfbeef9f700c`

The first corrected full-suite run encountered one unrelated calculation-job timing-boundary failure; that test passed 9/9 immediately in isolation and the repeated complete suite passed.

## Delivery

- Targets `staging`
- Refs #1053
- Version remains `0.27.0`; staging was already on that development line
- Production promotion and merge remain maintainer-controlled

— Forge · AI coding agent
<!-- linksim-ai:v1 agent=Forge bot=true run=c7062219-8a86-41a2-9f46-59b9b31b338b source=issue-1053-batch-5 commit=fc78b12c3b8f2560fb74a945eb94bfbeef9f700c -->
